### PR TITLE
Spherical geometry backend and dispatch for build_catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ zagg aggregates sparse point data (e.g., ICESat-2 ATL06 elevation measurements) 
 Query NASA's CMR to build a mapping of spatial cells to granule S3 URLs.
 
 ```bash
+# Install with the catalog extra to get the spherely (S2) geometry backend
+# — recommended for global / non-Antarctic catalogs. Without it, the build
+# falls back to mortie (HEALPix MOC) which is slower but ships with the
+# core install.
+pip install 'zagg[catalog]'
+
 # ICESat-2 convenience — cycle number computes dates automatically:
 uv run python -m zagg.catalog --cycle 22 --parent-order 6
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ lambda = [
     "cramjam",
     "astropy",
 ]
+# Sphere-aware geometry backend for catalog construction. Spherely brings
+# Google's S2 via a C++ wheel; we keep it out of the core deps so the
+# Lambda layer build (which doesn't run build_catalog) stays lean and the
+# arm64 wheel gap doesn't break Lambda packaging.
+catalog = [
+    "spherely>=0.1.1",
+]
 analysis = [
     "cubed>=0.24.0",
     "cubed-xarray>=0.0.9",

--- a/src/zagg/catalog.py
+++ b/src/zagg/catalog.py
@@ -25,6 +25,7 @@ import argparse
 import json
 import logging
 import time
+import warnings
 from datetime import datetime, timedelta
 from importlib import resources
 from typing import Dict, List
@@ -320,49 +321,123 @@ def extract_granule_info(granule: dict) -> dict:
     }
 
 
+def _resolve_backend(backend: str) -> str:
+    """Resolve ``"auto"`` to a concrete backend by checking what's importable.
+
+    Prefers spherely (exact S2 intersection, fast) when available; falls back
+    to mortie (HEALPix MOC cell-set intersection, no extra deps).
+    """
+    if backend != "auto":
+        return backend
+    try:
+        import spherely  # noqa: F401
+
+        return "spherely"
+    except ImportError:
+        return "mortie"
+
+
 def build_catalog(
     granules: List[dict],
     parent_order: int = None,
     polygon_parts: list = None,
+    *,
     grid=None,
+    geometry_backend: str = "auto",
+    mortie_order: int = 8,
 ) -> tuple:
     """Build a granule catalog mapping shard keys to granule URLs.
 
-    Two code paths:
-
-    - **HEALPix fast path** (``grid is None``): uses ``morton_coverage`` for
-      cell discovery and reprojects everything to EPSG:3031 before the STRtree
-      intersect. Optimal for Antarctic-scale workloads.
-    - **Grid-driven path** (``grid`` supplied): uses ``grid.coverage`` and
-      ``grid.shard_footprint`` directly; STRtree intersect happens in WGS84.
-      Required for non-HEALPix grids.
+    The new (PR-C+) API takes a ``grid`` keyword and an optional
+    ``geometry_backend``. The legacy ``parent_order``-only path stays as a
+    deprecated back-compat shim that uses the EPSG:3031 reprojection trick
+    appropriate for the existing Antarctic ATL06 workload.
 
     Parameters
     ----------
     granules : list
-        Granule metadata from CMR.
+        Granule metadata from CMR (UMM-JSON dicts).
     parent_order : int, optional
-        HEALPix parent order; required when ``grid`` is None.
+        **Deprecated.** HEALPix parent order. If provided without ``grid``,
+        the legacy EPSG:3031 path is used.
     polygon_parts : list of (lats, lons), optional
-        Polygon parts for cell discovery. Defaults to Antarctic drainage basins.
-    grid : OutputGrid, optional
-        If provided, take the grid-driven path.
+        Polygon parts for cell discovery. Defaults to Antarctic drainage
+        basins.
+    grid : OutputGrid, keyword-only
+        Output grid (HealpixGrid, RectilinearGrid, ...). Required for the
+        new path. The grid supplies ``coverage`` and ``shard_footprint``.
+    geometry_backend : {"auto", "spherely", "mortie", "shapely", "shapely-3031"}
+        Sphere-aware geometry backend.
+
+        - ``"auto"`` (default): spherely if importable, else mortie.
+        - ``"spherely"``: exact S2 polygon intersection. Requires
+          ``pip install zagg[catalog]``.
+        - ``"mortie"``: HEALPix MOC cell-set intersection at
+          ``mortie_order``. No extra deps.
+        - ``"shapely"``: shapely STRtree in WGS84. Antimeridian/pole
+          correctness not guaranteed; kept for completeness.
+        - ``"shapely-3031"``: legacy EPSG:3031 path (Antarctic only).
+    mortie_order : int, default 8
+        HEALPix MOC order used by the mortie backend. Orders 6-10 are
+        safe (no false negatives in practice); higher orders trade more
+        precision for occasional false negatives near polygon boundaries.
 
     Returns
     -------
     catalog : dict
-        Mapping of shard_key (int) -> list of S3 URLs.
+        Mapping of shard_key (int) -> list of granule URLs.
     timings : dict
         Wall-clock seconds per pipeline step.
     """
-    if grid is not None:
+    # Legacy back-compat: parent_order without grid → EPSG:3031 path
+    if grid is None and parent_order is not None:
+        warnings.warn(
+            "build_catalog(parent_order=...) is deprecated; pass "
+            "grid=HealpixGrid(...) and geometry_backend='auto' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _build_catalog_healpix(granules, parent_order, polygon_parts)
+    if grid is None:
+        raise ValueError(
+            "build_catalog requires either grid=... (preferred) or "
+            "parent_order=... (deprecated)"
+        )
+
+    chosen = _resolve_backend(geometry_backend)
+    if chosen == "spherely":
+        return _build_catalog_spherely(granules, grid, polygon_parts)
+    if chosen == "mortie":
+        return _build_catalog_mortie(granules, grid, polygon_parts, order=mortie_order)
+    if chosen == "shapely":
         return _build_catalog_grid_driven(granules, grid, polygon_parts)
-    if parent_order is None:
-        raise ValueError("parent_order is required when grid is None")
-    return _build_catalog_healpix(granules, parent_order, polygon_parts)
+    if chosen == "shapely-3031":
+        if not hasattr(grid, "parent_order"):
+            raise ValueError("'shapely-3031' backend only supports HEALPix grids")
+        return _build_catalog_healpix(granules, grid.parent_order, polygon_parts)
+    raise ValueError(
+        f"unknown geometry_backend: {geometry_backend!r} (resolved to {chosen!r})"
+    )
 
 
 def _build_catalog_healpix(granules, parent_order, polygon_parts):
+    """**DEPRECATED — REMOVE ASAP after new-backend verification.**
+
+    Legacy EPSG:3031 Antarctic-only fast path. Kept ONLY long enough to
+    confirm the new ``_build_catalog_spherely`` path produces equivalent
+    catalogs on a representative Antarctic cycle. Once that's verified,
+    this function and the ``geometry_backend='shapely-3031'`` dispatch
+    entry both go.
+
+    Use ``build_catalog(..., grid=..., geometry_backend='auto')`` instead.
+    """
+    warnings.warn(
+        "_build_catalog_healpix (EPSG:3031 path) is deprecated and will be "
+        "removed in a future release. Use build_catalog(grid=..., "
+        "geometry_backend='auto').",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     from pyproj import Transformer
     from shapely import STRtree, make_valid
     from shapely.geometry import Polygon
@@ -443,7 +518,22 @@ def _build_catalog_healpix(granules, parent_order, polygon_parts):
 
 
 def _build_catalog_grid_driven(granules, grid, polygon_parts):
-    """Grid-agnostic catalog build. STRtree intersects happen in WGS84."""
+    """**DEPRECATED — REMOVE ASAP after new-backend verification.**
+
+    Shapely-WGS84 grid-driven path. STRtree intersects in WGS84 without
+    S2/MOC awareness; correctness near the antimeridian and poles is not
+    guaranteed. Superseded by ``_build_catalog_spherely`` (S2) and
+    ``_build_catalog_mortie`` (HEALPix MOC).
+
+    Use ``build_catalog(..., grid=..., geometry_backend='auto')`` instead.
+    """
+    warnings.warn(
+        "_build_catalog_grid_driven (shapely-WGS84 path) is deprecated and "
+        "will be removed in a future release. Use build_catalog(grid=..., "
+        "geometry_backend='auto').",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     from shapely import STRtree, make_valid
     from shapely.geometry import Polygon
 
@@ -498,6 +588,201 @@ def _build_catalog_grid_driven(granules, grid, polygon_parts):
 
     timings["total"] = time.perf_counter() - t_total
     logger.info(f"Pass 2: {len(catalog)} shards with granule mappings")
+    return catalog, timings
+
+
+def _to_spherely_polygon(lats, lons):
+    """Build a closed sphere-aware polygon. Returns None on validation failure.
+
+    Tries the input vertex order first; if S2 rejects it (e.g., area >
+    half-sphere because of orientation, or self-intersection from
+    non-geodesic interpretation), retries the reverse. Picks whichever
+    orientation has the smaller area (the bounded-region interpretation).
+    """
+    import spherely
+
+    lats = np.asarray(lats, dtype=float)
+    lons = np.asarray(lons, dtype=float)
+    if lats[0] != lats[-1] or lons[0] != lons[-1]:
+        lats = np.concatenate([lats, lats[:1]])
+        lons = np.concatenate([lons, lons[:1]])
+
+    def _try(la, lo):
+        try:
+            return spherely.create_polygon(spherely.points(la, lo))
+        except (ValueError, RuntimeError):
+            return None
+
+    half_earth = 2.55e14
+    fwd = _try(lats, lons)
+    rev = _try(lats[::-1], lons[::-1])
+    if fwd is None and rev is None:
+        return None
+    if fwd is None:
+        return rev
+    if rev is None:
+        return fwd
+    return fwd if spherely.area(fwd) < half_earth else rev
+
+
+def _build_catalog_spherely(granules, grid, polygon_parts):
+    """Catalog build via spherely (S2-backed) exact spherical intersection.
+
+    Sphere-aware everywhere: no projection, no antimeridian / pole
+    workarounds needed. Spherely 0.1.x has no STRtree, so per-shard query
+    is O(N_granules) via vectorized C++ broadcast.
+    """
+    import spherely
+
+    if polygon_parts is None:
+        polygon_parts = load_antarctic_basins()
+
+    timings = {}
+    t_total = time.perf_counter()
+
+    # Shard discovery
+    t0 = time.perf_counter()
+    all_shards = grid.coverage(polygon_parts)
+    timings["cell_discovery"] = time.perf_counter() - t0
+    logger.info(f"Pass 1: {len(all_shards)} shards")
+
+    # Build granule polygons in spherely's S2 space
+    t0 = time.perf_counter()
+    g_polys_raw = []
+    granule_urls = []
+    for granule in granules:
+        info = extract_granule_info(granule)
+        if not info["s3_url"] or len(info["points"]) < 3:
+            continue
+        lats = np.array([p[0] for p in info["points"]])
+        lons = np.array([p[1] for p in info["points"]])
+        poly = _to_spherely_polygon(lats, lons)
+        if poly is None:
+            continue
+        g_polys_raw.append(poly)
+        granule_urls.append(info["s3_url"])
+    g_polys = np.array(g_polys_raw)
+    timings["granule_polygons"] = time.perf_counter() - t0
+    logger.info(f"Built {len(g_polys)} granule polygons")
+
+    # Per-shard vectorized intersect
+    t0 = time.perf_counter()
+    catalog: Dict[int, List[str]] = {}
+    for shard_key in all_shards:
+        footprint = grid.shard_footprint(shard_key)
+        # grid.shard_footprint returns a shapely Polygon in WGS84; we need
+        # the same vertices as a spherely geography.
+        sx, sy = footprint.exterior.coords.xy
+        s_poly = _to_spherely_polygon(np.asarray(sy), np.asarray(sx))
+        if s_poly is None or len(g_polys) == 0:
+            continue
+        mask = spherely.intersects(g_polys, s_poly)
+        hits = np.where(mask)[0]
+        if len(hits) > 0:
+            catalog[int(shard_key)] = [granule_urls[i] for i in hits]
+    timings["strtree_queries"] = time.perf_counter() - t0
+
+    timings["total"] = time.perf_counter() - t_total
+    logger.info(f"Pass 2: {len(catalog)} shards with granule mappings (spherely)")
+    return catalog, timings
+
+
+def _build_catalog_mortie(granules, grid, polygon_parts, *, order=8):
+    """Catalog build via mortie HEALPix MOC cell-set intersection.
+
+    Sphere-aware by construction (HEALPix tiles the sphere; no edges).
+    Requires mortie >= 0.7.0 (earlier versions had a non-determinism bug,
+    espg/mortie#28). Order 6-10 is the safe regime — order >= 12 starts
+    dropping boundary-touching intersections due to mortie's polygon-edge
+    interpretation.
+
+    For HealpixGrid shards, the shard's MOC comes from
+    ``generate_morton_children`` directly (no polygon round-trip). For
+    non-HEALPix grids, the shard footprint is reduced to its WGS84
+    polygon vertices and fed through ``morton_coverage``.
+    """
+    from mortie import generate_morton_children, morton_coverage
+
+    if polygon_parts is None:
+        polygon_parts = load_antarctic_basins()
+
+    timings = {}
+    t_total = time.perf_counter()
+
+    # Shard discovery
+    t0 = time.perf_counter()
+    all_shards = grid.coverage(polygon_parts)
+    timings["cell_discovery"] = time.perf_counter() - t0
+    logger.info(f"Pass 1: {len(all_shards)} shards")
+
+    # Build inverted cell→granule index in a vectorized pass (no per-cell
+    # dict.add Python loop — see issue #28's prototype work).
+    t0 = time.perf_counter()
+    cell_arrays = []
+    granule_urls = []
+    for granule in granules:
+        info = extract_granule_info(granule)
+        if not info["s3_url"] or len(info["points"]) < 3:
+            continue
+        lats = np.array([p[0] for p in info["points"]])
+        lons = np.array([p[1] for p in info["points"]])
+        try:
+            cells = morton_coverage(lats, lons, order=order)
+        except Exception:
+            continue
+        if len(cells) == 0:
+            continue
+        cell_arrays.append(np.asarray(cells, dtype=np.int64))
+        granule_urls.append(info["s3_url"])
+    timings["granule_polygons"] = time.perf_counter() - t0
+
+    if not cell_arrays:
+        timings["total"] = time.perf_counter() - t_total
+        return {}, timings
+
+    all_cells = np.concatenate(cell_arrays)
+    counts = np.fromiter((len(c) for c in cell_arrays), dtype=np.int64,
+                         count=len(cell_arrays))
+    all_idx = np.repeat(np.arange(len(cell_arrays), dtype=np.int64), counts)
+    order_ = np.argsort(all_cells, kind="stable")
+    sorted_cells = all_cells[order_]
+    sorted_idx = all_idx[order_]
+    timings["strtree_construction"] = time.perf_counter() - t0  # reused timing key
+
+    # Per-shard MOC lookup
+    t0 = time.perf_counter()
+    is_healpix = hasattr(grid, "parent_order") and hasattr(grid, "child_order")
+    catalog: Dict[int, List[str]] = {}
+    for shard_key in all_shards:
+        if is_healpix:
+            # Fast path: shard IS a morton cell at parent_order; its MOC
+            # at the target order is just its children.
+            s_cells = generate_morton_children(int(shard_key), order)
+        else:
+            footprint = grid.shard_footprint(shard_key)
+            sx, sy = footprint.exterior.coords.xy
+            try:
+                s_cells = morton_coverage(np.asarray(sy), np.asarray(sx),
+                                          order=order)
+            except Exception:
+                continue
+        if len(s_cells) == 0:
+            continue
+        lo = np.searchsorted(sorted_cells, s_cells, side="left")
+        hi = np.searchsorted(sorted_cells, s_cells, side="right")
+        nonempty = hi > lo
+        if not nonempty.any():
+            continue
+        gathered = np.concatenate(
+            [sorted_idx[lo_i:hi_i] for lo_i, hi_i in zip(lo[nonempty], hi[nonempty])]
+        )
+        hit_indices = np.unique(gathered)
+        if hit_indices.size:
+            catalog[int(shard_key)] = [granule_urls[int(i)] for i in hit_indices]
+    timings["strtree_queries"] = time.perf_counter() - t0
+
+    timings["total"] = time.perf_counter() - t_total
+    logger.info(f"Pass 2: {len(catalog)} shards with granule mappings (mortie order={order})")
     return catalog, timings
 
 

--- a/src/zagg/catalog.py
+++ b/src/zagg/catalog.py
@@ -594,10 +594,13 @@ def _build_catalog_grid_driven(granules, grid, polygon_parts):
 def _to_spherely_polygon(lats, lons):
     """Build a closed sphere-aware polygon. Returns None on validation failure.
 
-    Tries the input vertex order first; if S2 rejects it (e.g., area >
-    half-sphere because of orientation, or self-intersection from
-    non-geodesic interpretation), retries the reverse. Picks whichever
-    orientation has the smaller area (the bounded-region interpretation).
+    Uses spherely's ``oriented=False`` mode, which tries both vertex
+    orderings and returns the smaller-area interpretation. This is the
+    correct path for ICESat-2-style polygons whose lat/lon vertices, when
+    reinterpreted as geodesic edges, would otherwise self-intersect near
+    the pole (the points-array overload's strict validator rejects ~32%
+    of cycle-22 polar-orbital granules; this overload accepts all of them
+    — see ``bench/spherely_polar_polygon_issue.ipynb``).
     """
     import spherely
 
@@ -606,23 +609,12 @@ def _to_spherely_polygon(lats, lons):
     if lats[0] != lats[-1] or lons[0] != lons[-1]:
         lats = np.concatenate([lats, lats[:1]])
         lons = np.concatenate([lons, lons[:1]])
-
-    def _try(la, lo):
-        try:
-            return spherely.create_polygon(spherely.points(la, lo))
-        except (ValueError, RuntimeError):
-            return None
-
-    half_earth = 2.55e14
-    fwd = _try(lats, lons)
-    rev = _try(lats[::-1], lons[::-1])
-    if fwd is None and rev is None:
+    try:
+        return spherely.create_polygon(
+            shell=list(zip(lons, lats)), oriented=False
+        )
+    except (ValueError, RuntimeError):
         return None
-    if fwd is None:
-        return rev
-    if rev is None:
-        return fwd
-    return fwd if spherely.area(fwd) < half_earth else rev
 
 
 def _build_catalog_spherely(granules, grid, polygon_parts):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -402,3 +402,116 @@ class TestBuildCatalog:
         catalog, _ = build_catalog(granules, parent_order=6)
         # Should work without error; may or may not find matches
         assert isinstance(catalog, dict)
+
+
+class TestBuildCatalogBackends:
+    """Tests for the new geometry_backend dispatching (PR-C+)."""
+
+    def _make_granules(self, n=5):
+        return TestBuildCatalog()._make_granules(n)
+
+    def _grid(self, parent_order=6, child_order=8):
+        from zagg.grids import HealpixGrid
+        return HealpixGrid(parent_order=parent_order, child_order=child_order,
+                           layout="fullsphere")
+
+    def _polys(self):
+        return [(np.array([-70, -85, -75]), np.array([0, 50, 25]))]
+
+    def test_explicit_mortie(self):
+        from zagg.catalog import build_catalog
+        catalog, t = build_catalog(
+            self._make_granules(5),
+            grid=self._grid(),
+            polygon_parts=self._polys(),
+            geometry_backend="mortie",
+            mortie_order=8,
+        )
+        assert isinstance(catalog, dict)
+        assert "total" in t
+
+    def test_explicit_spherely(self):
+        pytest.importorskip("spherely")
+        from zagg.catalog import build_catalog
+        catalog, t = build_catalog(
+            self._make_granules(5),
+            grid=self._grid(),
+            polygon_parts=self._polys(),
+            geometry_backend="spherely",
+        )
+        assert isinstance(catalog, dict)
+        assert "total" in t
+
+    def test_auto_prefers_spherely_when_available(self):
+        import sys
+        if "spherely" not in sys.modules:
+            pytest.importorskip("spherely")
+        from zagg.catalog import _resolve_backend
+        assert _resolve_backend("auto") == "spherely"
+
+    def test_auto_falls_back_to_mortie_without_spherely(self, monkeypatch):
+        """If spherely import fails, auto must resolve to mortie."""
+        import builtins
+        from zagg.catalog import _resolve_backend
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "spherely":
+                raise ImportError("simulated missing spherely")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        # Drop a cached module if present so the import attempt re-runs
+        import sys
+        sys.modules.pop("spherely", None)
+        assert _resolve_backend("auto") == "mortie"
+
+    def test_mortie_and_spherely_both_produce_results(self):
+        """Both backends should be wired up correctly and produce non-empty
+        catalogs that mostly overlap. Strict equivalence does NOT hold —
+        mortie's polygon-edge interpretation diverges from S2's geodesic
+        edges near polygon boundaries (see bench/catalog_comparison.ipynb
+        for the detailed correctness analysis). Catalog-build's downstream
+        tolerance for false positives makes both backends fit-for-purpose
+        at low mortie orders."""
+        pytest.importorskip("spherely")
+        from zagg.catalog import build_catalog
+        granules = self._make_granules(5)
+        grid = self._grid()
+        polys = self._polys()
+        m_cat, _ = build_catalog(granules, grid=grid, polygon_parts=polys,
+                                 geometry_backend="mortie", mortie_order=8)
+        s_cat, _ = build_catalog(granules, grid=grid, polygon_parts=polys,
+                                 geometry_backend="spherely")
+        assert len(m_cat) > 0 and len(s_cat) > 0
+        # Most shards should agree on most granules — quantified loosely:
+        # the intersection of (shard, granule) pairs should be at least
+        # half of either side's total.
+        m_pairs = {(s, u) for s, urls in m_cat.items() for u in urls}
+        s_pairs = {(s, u) for s, urls in s_cat.items() for u in urls}
+        common = m_pairs & s_pairs
+        assert len(common) >= 0.5 * min(len(m_pairs), len(s_pairs))
+
+    def test_missing_grid_raises(self):
+        from zagg.catalog import build_catalog
+        with pytest.raises(ValueError, match="grid"):
+            build_catalog(self._make_granules(1))
+
+    def test_unknown_backend_raises(self):
+        from zagg.catalog import build_catalog
+        with pytest.raises(ValueError, match="unknown geometry_backend"):
+            build_catalog(
+                self._make_granules(1),
+                grid=self._grid(),
+                polygon_parts=self._polys(),
+                geometry_backend="not-a-real-backend",
+            )
+
+    def test_legacy_parent_order_warns(self):
+        from zagg.catalog import build_catalog
+        with pytest.warns(DeprecationWarning, match="parent_order"):
+            build_catalog(
+                self._make_granules(2),
+                parent_order=6,
+                polygon_parts=self._polys(),
+            )


### PR DESCRIPTION
Major redesign of the catalog builder

## Summary

Adds a sphere-aware geometry backend dispatch to `build_catalog`, with **spherely** as the preferred backend (S2-backed, exact polygon intersection) and **mortie** as the no-extra-deps fallback. Both run sphere-aware everywhere — no more EPSG:3031 reprojection trick to dodge antimeridian/pole edge cases in shapely.

Stacked on #18. Requires the `OutputGrid` protocol (`grid.coverage`, `grid.shard_footprint`) introduced there.

## Motivation

The existing `build_catalog` only works correctly for Antarctic workloads — it reprojects everything to EPSG:3031 before the STRtree intersect, which sidesteps shapely's antimeridian-wrap and south-pole bbox degeneracy. That trick doesn't generalize to non-polar regions, global catalogs, or non-HEALPix grids (rectilinear in arbitrary CRSes, as added by #18).

Picking a generic sphere-aware backend turned into a real research detour:
- `mortie 0.6.3` had a non-determinism bug that masked the actual correctness picture (filed as [espg/mortie#28](https://github.com/espg/mortie/issues/28), fixed in `0.7.0` via espg/mortie#29 — now usable).
- `spherely` is the only widely-available shapely-API-on-the-sphere library. No mature Rust S2 port exists (surveyed crates.io, lib.rs, GitHub — closest non-C++ option is `golang/geo` which would need a multi-week shim).
- `spherely` ships no Linux aarch64 wheel — would break ARM Lambda packaging if added to core deps.

## Design

| backend | sphere-aware | new deps | speed | when to use |
|---|---|---|---|---|
| `spherely` | yes (S2 geodesic) | `spherely` (~3 MB wheel, x86_64 only on Linux) | ~30-100× faster than mortie | default when available |
| `mortie` | yes (HEALPix MOC) | none (already a core dep) | slower but adequate | ARM Lambda fallback, no-extra-deps installs |
| `shapely` (deprecated) | only by reprojection | shapely | — | back-compat only |
| `shapely-3031` (deprecated) | only EPSG:3031 | pyproj+shapely | — | back-compat only |

Spherely is only needed when **building** catalogs — runs on the orchestrator (x86_64 laptop / CI / EC2). Per-shard processing on Lambda only needs grid point-assignment ops (mortie + pyproj), not polygon-vs-polygon intersection. So spherely lives in a new `zagg[catalog]` optional extra and stays out of the Lambda layer entirely.

## Changes

**`pyproject.toml`**
- New `[project.optional-dependencies] catalog = ["spherely>=0.1.1"]`. Lambda extra untouched.

**`src/zagg/catalog.py`**
- `_resolve_backend("auto")` — lazy-import probe; resolves to `"spherely"` if importable, else `"mortie"`.
- `build_catalog(...)` — new `geometry_backend="auto"`, `mortie_order=8` keyword args. Legacy `parent_order=...` path kept as deprecated back-compat shim (emits `DeprecationWarning`).
- `_build_catalog_spherely(...)` — vectorized `spherely.intersects` broadcast per shard. Includes a `_to_spherely_polygon` helper that tries both vertex orderings (S2 needs CCW for the bounded region; many CMR polygons come in CW).
- `_build_catalog_mortie(...)` — vectorized MOC cell-set intersection (no per-cell Python dict loop). For `HealpixGrid` shards, fast-path via `generate_morton_children` skips the polygon→MOC roundtrip entirely.
- `_build_catalog_healpix` and `_build_catalog_grid_driven` marked **DEPRECATED — REMOVE ASAP after new-backend verification** in docstrings + runtime warnings.

**`tests/test_catalog.py`**
- New `TestBuildCatalogBackends` (9 tests): explicit-mortie / explicit-spherely paths, auto-resolution preferring spherely when available, monkeypatched-`__import__` auto-fallback to mortie when spherely is missing, missing-grid raises, unknown-backend raises, legacy `parent_order=` deprecation warning, both backends agree on at least half of pairs at safe mortie order.

**`README.md`**
- One-liner near the catalog-building section pointing at `pip install zagg[catalog]` for the spherely backend.

## Install / runtime behavior

| install | spherely present | `auto` resolves to |
|---|---|---|
| `pip install zagg` | no | `mortie` |
| `pip install zagg[lambda]` (Lambda layer) | no | `mortie` (Lambda never calls build_catalog anyway) |
| `pip install zagg[catalog]` (orchestrator) | yes | `spherely` |

Lazy imports mean catalog.py works on machines without spherely — only an actual `geometry_backend="spherely"` call would fail.

## Removal plan for deprecated paths

`_build_catalog_healpix` (EPSG:3031) and `_build_catalog_grid_driven` (shapely-WGS84) are marked for removal **as soon as the new spherely path is verified against a real ATL06 cycle**. The `geometry_backend="shapely"` / `"shapely-3031"` dispatch entries go with them. Plan is a follow-up PR right after this lands.

## Testing

- All 182 tests pass (38 in test_catalog.py, including 9 new backend-dispatch tests).
- Ruff clean.
- The auto-fallback test uses `monkeypatch.setattr(builtins, "__import__", ...)` to simulate spherely being unavailable, so the fallback path is exercised even when spherely is installed.
