### PR TITLE
Add bring-your-own-role path for IAM-constrained deploys; creds handling for external s3 bucket writes

### DIFF
--- a/deployment/aws/EXECUTION_ROLE.md
+++ b/deployment/aws/EXECUTION_ROLE.md
@@ -1,0 +1,136 @@
+# zagg Lambda execution role
+
+The `process-shard` Lambda needs an IAM **execution role** — the identity it runs
+as, which lets it write CloudWatch logs and write results to the in-account
+output bucket (e.g. `sliderule-public`).
+
+By default you don't have to think about this: `stand_up.sh` deploys
+`template.yaml` with `CreateExecutionRole=true`, and the stack creates the role
+for you. **This document is only for the other case** — accounts where the
+identity running the deploy *cannot create IAM roles* (for example an AWS SSO
+"power user" permission set, which grants everything except IAM). There, an
+account admin creates the role once, out of band, and hands you its ARN.
+
+## Who does what
+
+| Step | Who | Needs `iam:CreateRole`? |
+|------|-----|-------------------------|
+| Create the execution role (`execution_role.yaml`) | account **admin** | yes |
+| Deploy the backend against that role (`stand_up.sh`) | **you** | no |
+
+The role lives in its **own** small stack, owned by the admin. The backend stack
+(`zagg-backend`) then contains **zero IAM resources**, so every future
+update you make to it — new layer, new function code — is pure Lambda/S3/CloudFormation
+and needs no admin involvement ever again.
+
+> Do **not** ask the admin to run `stand_up.sh` for you. That would fold the IAM
+> role into the backend stack, making the admin a recurring dependency for any
+> later update that touches the role. Keep the role in its own stack.
+
+## What the role grants (least privilege)
+
+The role trusts `lambda.amazonaws.com` and allows exactly:
+
+- **CloudWatch Logs** — create/write the function's own log group.
+- **S3 write** — `Get/Put/DeleteObject` + `ListBucket` on **one** output bucket
+  (`OutputBucketName`, e.g. `sliderule-public`) and nothing else.
+
+It deliberately stays scoped to a single in-account bucket. **Writing to
+external object stores (source.coop, other accounts/clouds) does NOT go through
+this role** — those use credentials injected per-invocation in the event (see
+[issue #26](https://github.com/englacial/zagg/issues/26)). So there is never a
+reason to widen this role to reach external buckets; keep it fail-closed.
+
+## Creating the role (admin)
+
+### Option A — CloudFormation (preferred)
+
+`execution_role.yaml` is a standalone CloudFormation template. Deploy it as its
+own stack:
+
+```bash
+aws cloudformation deploy \
+  --template-file execution_role.yaml \
+  --stack-name zagg-exec-role \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides OutputBucketName=sliderule-public \
+  --region us-west-2
+```
+
+Parameters:
+
+| Parameter | Default | Notes |
+|-----------|---------|-------|
+| `OutputBucketName` | *(required)* | Bucket the function may write into, e.g. `sliderule-public`. |
+| `RoleName` | `zagg-process-shard-exec` | Name of the created role. |
+| `FunctionName` | `process-shard` | Used only to scope the log-group ARN; must match `FunctionName` in `template.yaml`. |
+
+> `CAPABILITY_NAMED_IAM` is required because the template sets an explicit
+> `RoleName`. If your account's guardrails dislike named IAM resources, drop the
+> `RoleName` property and deploy with plain `CAPABILITY_IAM` instead.
+
+Then read the role ARN back out:
+
+```bash
+aws cloudformation describe-stacks --stack-name zagg-exec-role \
+  --region us-west-2 --query 'Stacks[0].Outputs[?OutputKey==`RoleArn`].OutputValue' \
+  --output text
+```
+
+### Option B — manual / console
+
+If you'd rather not use CloudFormation, create a role that trusts Lambda and
+attach an inline policy. Trust policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow",
+      "Principal": { "Service": "lambda.amazonaws.com" },
+      "Action": "sts:AssumeRole" }
+  ]
+}
+```
+
+Permissions policy (replace the account id, region, and bucket name):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Sid": "WriteFunctionLogs",
+      "Effect": "Allow",
+      "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+      "Resource": "arn:aws:logs:us-west-2:ACCOUNT_ID:log-group:/aws/lambda/process-shard:*" },
+    { "Sid": "WriteOutputObjects",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::sliderule-public/*" },
+    { "Sid": "ListOutputBucket",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::sliderule-public" }
+  ]
+}
+```
+
+## Deploying the backend against the role (you)
+
+With the role ARN in hand, stand up the backend with role creation turned off:
+
+```bash
+CREATE_ROLE=false \
+ROLE_ARN=arn:aws:iam::ACCOUNT_ID:role/zagg-process-shard-exec \
+OUTPUT_BUCKET=sliderule-public \
+./stand_up.sh
+```
+
+`stand_up.sh` passes these through to `template.yaml` as
+`CreateExecutionRole=false` and `ExecutionRoleArn=<arn>`; the backend stack then
+references your role instead of creating one.
+
+> The `OUTPUT_BUCKET` you pass here is informational in this path — the binding
+> constraint is the role's own policy. Keep them matching: invoking with a
+> `store_path` outside the bucket the role allows fails at runtime with
+> `AccessDenied`.

--- a/deployment/aws/execution_role.yaml
+++ b/deployment/aws/execution_role.yaml
@@ -1,0 +1,73 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  zagg Lambda execution role — a least-privilege role for the process-shard
+  function, kept in its OWN stack so an account admin (someone with iam:CreateRole)
+  applies it once, then hands the RoleArn to whoever stands up the backend.
+  Used when template.yaml is deployed with CreateExecutionRole=false. The role
+  only needs CloudWatch Logs + write to the output bucket: source granules are
+  read with credentials passed in the invocation event, not by this role.
+
+Parameters:
+  RoleName:
+    Type: String
+    Default: zagg-process-shard-exec
+    Description: Name of the execution role to create.
+
+  FunctionName:
+    Type: String
+    Default: process-shard
+    Description: >-
+      Lambda function name — used only to scope the CloudWatch Logs permissions
+      to that function's log group. Must match FunctionName in template.yaml.
+
+  OutputBucketName:
+    Type: String
+    Description: >-
+      Bucket the function writes results (parquet/zarr) into. The role is scoped
+      to write here and nowhere else. (For SlideRule this is sliderule-public.)
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: logs-and-output-s3
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: WriteFunctionLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${FunctionName}:*"
+              - Sid: WriteOutputObjects
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource: !Sub "arn:aws:s3:::${OutputBucketName}/*"
+              - Sid: ListOutputBucket
+                Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub "arn:aws:s3:::${OutputBucketName}"
+
+Outputs:
+  RoleArn:
+    Description: >-
+      Pass this to stand_up.sh as ROLE_ARN (with CREATE_ROLE=false), or to
+      template.yaml as ExecutionRoleArn (with CreateExecutionRole=false).
+    Value: !GetAtt ExecutionRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-RoleArn"

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -11,10 +11,17 @@ Event payload (default / process mode):
     "child_order": int,
     "granule_urls": [str, ...],
     "store_path": str,          # e.g. "s3://bucket/prefix.zarr"
-    "s3_credentials": {
+    "s3_credentials": {         # creds for reading NSIDC source data
         "accessKeyId": str,
         "secretAccessKey": str,
         "sessionToken": str
+    },
+    "output_credentials": {     # OPTIONAL -- creds for writing the output store;
+        "accessKeyId": str,     #   omit to use the execution role (in-account).
+        "secretAccessKey": str, #   Supply to write an external/S3-compatible
+        "sessionToken": str,    #   target (e.g. source.coop). sessionToken,
+        "endpointUrl": str,     #   endpointUrl, and region are optional.
+        "region": str
     },
     "config": dict (optional, pipeline config as dict)
 }
@@ -28,12 +35,14 @@ Setup mode (creates the zarr template once before per-cell fan-out):
     "n_parent_cells": int,
     "overwrite": bool,
     "config": dict,
+    "output_credentials": dict (optional, same shape as process mode),
 }
 
 Finalize mode (consolidates zarr metadata after all cells complete):
 {
     "mode": "finalize",
     "store_path": str,
+    "output_credentials": dict (optional, same shape as process mode),
 }
 
 Setup and finalize exist so callers without direct S3 write access to the
@@ -54,6 +63,43 @@ from zagg.store import open_store
 # Set up structured logging
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+
+def _output_store_kwargs(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve open_store kwargs for the output store from an event.
+
+    Symmetric to the read side: an optional ``output_credentials`` block
+    (camelCase ``accessKeyId``/``secretAccessKey``/``sessionToken``, plus
+    optional ``endpointUrl``/``region``) injects explicit write credentials.
+    When absent, falls back to the execution role and the AWS region env var.
+
+    Returns
+    -------
+    dict
+        Keyword arguments for ``open_store`` (always includes ``region``;
+        ``credentials`` and ``endpoint_url`` only when supplied).
+
+    Raises
+    ------
+    ValueError
+        If ``output_credentials`` is present but missing required keys.
+    """
+    region = os.environ.get("AWS_REGION", "us-west-2")
+    creds = event.get("output_credentials")
+    if not creds:
+        return {"region": region}
+    missing = [k for k in ("accessKeyId", "secretAccessKey") if k not in creds]
+    if missing:
+        raise ValueError(
+            f"output_credentials missing keys: {', '.join(missing)}"
+        )
+    kwargs: Dict[str, Any] = {
+        "region": creds.get("region", region),
+        "credentials": creds,
+    }
+    if creds.get("endpointUrl"):
+        kwargs["endpoint_url"] = creds["endpointUrl"]
+    return kwargs
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -77,8 +123,7 @@ def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
     logger.info(f"Setup mode: creating template at {event.get('store_path')}")
     try:
         config = load_config_from_dict(event["config"])
-        region = os.environ.get("AWS_REGION", "us-west-2")
-        store = open_store(event["store_path"], region=region)
+        store = open_store(event["store_path"], **_output_store_kwargs(event))
         grid_type = config.output.get("grid", {}).get("type", "healpix")
         if grid_type == "healpix":
             # n_parent_cells signals dense layout; populated_shards identities
@@ -112,8 +157,7 @@ def _handle_finalize(event: Dict[str, Any]) -> Dict[str, Any]:
 
     logger.info(f"Finalize mode: consolidating metadata at {event.get('store_path')}")
     try:
-        region = os.environ.get("AWS_REGION", "us-west-2")
-        store = open_store(event["store_path"], region=region)
+        store = open_store(event["store_path"], **_output_store_kwargs(event))
         consolidate_metadata(store, zarr_format=3)
         return {"statusCode": 200, "body": json.dumps({"ok": True, "mode": "finalize"})}
     except Exception as e:
@@ -199,8 +243,7 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # Write Zarr to store
         if not df_out.empty:
             store_path = event["store_path"]
-            region = os.environ.get("AWS_REGION", "us-west-2")
-            store = open_store(store_path, region=region)
+            store = open_store(store_path, **_output_store_kwargs(event))
 
             # Validate that Zarr template exists before writing
             template_key = f"{grid.group_path}/zarr.json"

--- a/deployment/aws/stand_up.sh
+++ b/deployment/aws/stand_up.sh
@@ -13,9 +13,15 @@
 # clone and the minor is read from the latest tag (no install needed); otherwise
 # set LAMBDA_VERSION (e.g. LAMBDA_VERSION=0.2).
 #
+# By default the stack creates its own Lambda execution role (needs
+# iam:CreateRole — fine if you admin your own account). In IAM-constrained
+# accounts (e.g. an SSO power-user), set CREATE_ROLE=false and pass ROLE_ARN, an
+# execution role an admin made once (see execution_role.yaml / EXECUTION_ROLE.md).
+#
 # Usage:
-#   OUTPUT_BUCKET=my-results ./stand_up.sh                              # us-west-2
+#   OUTPUT_BUCKET=my-results ./stand_up.sh                              # us-west-2, stack makes the role
 #   REGION=us-east-1 OUTPUT_BUCKET=my-results STAGING_BUCKET=my-stage ./stand_up.sh
+#   CREATE_ROLE=false ROLE_ARN=arn:aws:iam::123:role/zagg-exec OUTPUT_BUCKET=my-results ./stand_up.sh
 #
 # Requires: aws CLI (configured).
 
@@ -30,7 +36,19 @@ STACK_NAME="${STACK_NAME:-zagg-backend}"
 REGION="${REGION:-us-west-2}"
 OUTPUT_BUCKET="${OUTPUT_BUCKET:?Set OUTPUT_BUCKET to the bucket where results go}"
 CREATE_BUCKET="${CREATE_BUCKET:-false}"              # true => the stack creates OUTPUT_BUCKET
+CREATE_ROLE="${CREATE_ROLE:-true}"                   # true => the stack creates the exec role
+ROLE_ARN="${ROLE_ARN:-}"                             # required only when CREATE_ROLE=false
 STAGING_BUCKET="${STAGING_BUCKET:-}"                 # required only outside the mirror region
+
+# When the stack can't create IAM roles (e.g. an SSO power-user without
+# iam:CreateRole), set CREATE_ROLE=false and pass ROLE_ARN — an execution role
+# an account admin created once (see execution_role.yaml / EXECUTION_ROLE.md).
+if [ "$CREATE_ROLE" != "true" ] && [ -z "$ROLE_ARN" ]; then
+    echo "ERROR: CREATE_ROLE=$CREATE_ROLE but ROLE_ARN is empty."
+    echo "       Set ROLE_ARN to a pre-existing Lambda execution role ARN, or set"
+    echo "       CREATE_ROLE=true to have the stack create one (needs iam:CreateRole)."
+    exit 1
+fi
 
 # Public mirror (override to self-host a copy).
 MIRROR_BUCKET="${MIRROR_BUCKET:-us-west-2.opendata.source.coop}"
@@ -109,7 +127,9 @@ run aws cloudformation deploy \
         LayerS3Key="$LAYER_S3KEY" \
         FunctionS3Key="$FUNC_S3KEY" \
         OutputBucketName="$OUTPUT_BUCKET" \
-        CreateOutputBucket="$CREATE_BUCKET"
+        CreateOutputBucket="$CREATE_BUCKET" \
+        CreateExecutionRole="$CREATE_ROLE" \
+        ExecutionRoleArn="$ROLE_ARN"
 
 echo ""
 run aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -1,9 +1,14 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
-  zagg serverless backend — IAM execution role, dependency layer, and the
-  process-shard Lambda function. Layer and function code are pulled from a
-  same-region S3 bucket (ArtifactBucket); use stand_up.sh to populate it from a
-  GitHub Release, or point it at your own copy of the zips.
+  zagg serverless backend — Lambda execution role, dependency layer, and the
+  process-shard Lambda function. By default the stack creates its own execution
+  role (self-contained, clean teardown — the path for self-hosters who admin
+  their own account). In IAM-constrained accounts (e.g. an SSO power-user that
+  lacks iam:CreateRole), set CreateExecutionRole=false and pass an admin-created
+  role via ExecutionRoleArn — see execution_role.yaml / EXECUTION_ROLE.md.
+  Layer and function code are pulled from a same-region S3 bucket
+  (ArtifactBucket); use stand_up.sh to populate it from a GitHub Release, or
+  point it at your own copy of the zips.
 
 Parameters:
   FunctionName:
@@ -36,15 +41,34 @@ Parameters:
   OutputBucketName:
     Type: String
     Description: >-
-      Bucket where results (parquet/zarr) are written. The execution role is
-      scoped to this bucket. Set CreateOutputBucket=true to have the stack
-      create it; otherwise it must already exist and be writable by you.
+      Bucket where results (parquet/zarr) are written. A stack-created execution
+      role is scoped to this bucket. Set CreateOutputBucket=true to have the
+      stack create it; otherwise it must already exist and be writable by the
+      execution role.
 
   CreateOutputBucket:
     Type: String
     Default: "false"
     AllowedValues: ["true", "false"]
     Description: Whether to create OutputBucketName as part of this stack.
+
+  CreateExecutionRole:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      Whether the stack creates the Lambda execution role (needs iam:CreateRole).
+      Set to false in IAM-constrained accounts and supply ExecutionRoleArn
+      instead.
+
+  ExecutionRoleArn:
+    Type: String
+    Default: ""
+    Description: >-
+      ARN of a pre-existing Lambda execution role to use when
+      CreateExecutionRole=false. Must trust lambda.amazonaws.com and allow
+      CloudWatch Logs + write to OutputBucketName. Ignored when
+      CreateExecutionRole=true.
 
   MemorySize:
     Type: Number
@@ -58,6 +82,7 @@ Parameters:
 
 Conditions:
   ShouldCreateBucket: !Equals [!Ref CreateOutputBucket, "true"]
+  ShouldCreateRole: !Equals [!Ref CreateExecutionRole, "true"]
 
 Resources:
   OutputBucket:
@@ -68,6 +93,7 @@ Resources:
 
   ExecutionRole:
     Type: AWS::IAM::Role
+    Condition: ShouldCreateRole
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -117,7 +143,7 @@ Resources:
       Architectures: [!Ref Architecture]
       MemorySize: !Ref MemorySize
       Timeout: !Ref Timeout
-      Role: !GetAtt ExecutionRole.Arn
+      Role: !If [ShouldCreateRole, !GetAtt ExecutionRole.Arn, !Ref ExecutionRoleArn]
       Layers: [!Ref DepsLayer]
       Code:
         S3Bucket: !Ref ArtifactBucket
@@ -134,8 +160,8 @@ Outputs:
     Description: ARN of the published dependency layer version.
     Value: !Ref DepsLayer
   RoleArn:
-    Description: ARN of the Lambda execution role.
-    Value: !GetAtt ExecutionRole.Arn
+    Description: ARN of the Lambda execution role (created or supplied).
+    Value: !If [ShouldCreateRole, !GetAtt ExecutionRole.Arn, !Ref ExecutionRoleArn]
   OutputBucket:
     Description: Bucket where results are written.
     Value: !Ref OutputBucketName

--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -59,6 +59,13 @@ The Lambda function processes a single morton cell (order 6) by:
     "accessKeyId": "ASIA...",
     "secretAccessKey": "...",
     "sessionToken": "..."
+  },
+  "output_credentials": {
+    "accessKeyId": "ASIA...",
+    "secretAccessKey": "...",
+    "sessionToken": "...",
+    "endpointUrl": "https://...",
+    "region": "us-west-2"
   }
 }
 ```
@@ -73,6 +80,7 @@ The Lambda function processes a single morton cell (order 6) by:
 | `granule_urls` | list | Yes | Pre-computed list of S3 URLs from catalog |
 | `store_path` | str | Yes | Output Zarr store path (e.g. `s3://bucket/prefix.zarr`) |
 | `s3_credentials` | dict | Yes | NSIDC S3 credentials for reading source data |
+| `output_credentials` | dict | No | Explicit credentials for *writing* the output store. Omit to use the execution role (in-account writes). Supply to write an external / S3-compatible target. Keys: `accessKeyId`, `secretAccessKey`, optional `sessionToken`/`endpointUrl`/`region`. |
 
 ### S3 Credentials
 
@@ -96,6 +104,47 @@ event = {
 ```
 
 This approach avoids rate limiting from 1,872 simultaneous NASA logins and eliminates an AWS Secrets Manager dependency.
+
+### Output Credentials (external write targets)
+
+By default the function writes the output store with its **execution role**
+against the in-account bucket; omit `output_credentials` entirely to keep this
+behavior. To write an **external or S3-compatible target** (another account, or
+e.g. source.coop) without changing the execution role, supply
+`output_credentials` in the event — symmetric to how `s3_credentials` injects
+read credentials:
+
+```python
+from zagg import load_config, agg
+
+results = agg(
+    config, catalog="catalog.json", backend="lambda",
+    store="s3://us-west-2.opendata.source.coop/org/dataset.zarr",
+    output_credentials={  # runtime-only; never store in config/YAML
+        "accessKeyId": "ASIA...",
+        "secretAccessKey": "...",
+        "sessionToken": "...",        # optional
+        # "endpointUrl": "https://...",  # optional: R2/MinIO etc.
+        # "region": "us-west-2",         # optional
+    },
+)
+```
+
+From the CLI, point `--output-creds` at a JSON file holding that dict (keeps
+secrets out of shell history):
+
+```bash
+python -m zagg --config atl06.yaml --catalog catalog.json --backend lambda \
+  --store s3://us-west-2.opendata.source.coop/org/dataset.zarr \
+  --output-creds /path/to/output-creds.json
+```
+
+The non-secret `endpoint_url` / `region` may also be set in the config's
+`output:` section (overridable at runtime); **credentials are runtime-only**.
+source.coop uses the standard AWS S3 endpoint with injected STS credentials —
+`endpointUrl` is only needed for non-AWS S3-compatible stores. Dotted bucket
+names (e.g. `us-west-2.opendata.source.coop`) and custom endpoints use
+path-style addressing automatically.
 
 ## Deployment
 

--- a/src/zagg/__main__.py
+++ b/src/zagg/__main__.py
@@ -8,6 +8,7 @@ Usage:
 """
 
 import argparse
+import json
 import logging
 import os
 
@@ -41,6 +42,12 @@ examples:
     parser.add_argument("--dry-run", action="store_true", help="Show what would be processed")
     parser.add_argument("--region", default="us-west-2", help="AWS region (default: us-west-2)")
     parser.add_argument(
+        "--output-creds", default=None, metavar="PATH",
+        help="Path to a JSON file with credentials for writing the output store "
+             "(keys: accessKeyId, secretAccessKey, optional sessionToken/"
+             "endpointUrl/region). Omit to use the ambient/execution-role creds.",
+    )
+    parser.add_argument(
         "--function-name",
         default=os.environ.get("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard"),
         help="Lambda function name (default: env ZAGG_LAMBDA_FUNCTION_NAME or 'process-shard')",
@@ -50,6 +57,14 @@ examples:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     config = load_config(args.config)
+
+    # Load output credentials from a JSON file (kept out of shell history).
+    output_credentials = None
+    output_endpoint_url = None
+    if args.output_creds:
+        with open(args.output_creds) as f:
+            output_credentials = json.load(f)
+        output_endpoint_url = output_credentials.get("endpointUrl")
 
     results = agg(
         config,
@@ -64,6 +79,8 @@ examples:
         dry_run=args.dry_run,
         function_name=args.function_name,
         region=args.region,
+        output_credentials=output_credentials,
+        output_endpoint_url=output_endpoint_url,
     )
 
     if args.dry_run:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -427,6 +427,37 @@ def get_store_path(config: PipelineConfig) -> str | None:
     return config.output.get("store")
 
 
+def get_output_endpoint_url(config: PipelineConfig) -> str | None:
+    """Return the output S3 endpoint URL from the output config, or None.
+
+    Non-secret S3-compatible endpoint (e.g. R2, MinIO). Credentials are never
+    stored in config; they are supplied at runtime.
+
+    Parameters
+    ----------
+    config : PipelineConfig
+
+    Returns
+    -------
+    str or None
+    """
+    return config.output.get("endpoint_url")
+
+
+def get_output_region(config: PipelineConfig) -> str | None:
+    """Return the output S3 region from the output config, or None.
+
+    Parameters
+    ----------
+    config : PipelineConfig
+
+    Returns
+    -------
+    str or None
+    """
+    return config.output.get("region")
+
+
 def evaluate_expression(expression: str, columns: dict[str, np.ndarray]) -> float:
     """Evaluate an expression string in a restricted namespace.
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -26,6 +26,8 @@ from zagg.config import (
     get_child_order,
     get_driver,
     get_layout,
+    get_output_endpoint_url,
+    get_output_region,
     get_parent_order,
     get_store_path,
 )
@@ -60,6 +62,8 @@ def agg(
     dry_run: bool = False,
     function_name: str | None = None,
     region: str = "us-west-2",
+    output_credentials: dict | None = None,
+    output_endpoint_url: str | None = None,
 ) -> dict:
     """Run the aggregation pipeline.
 
@@ -93,6 +97,16 @@ def agg(
         or ``"process-shard"``. Only used with ``backend="lambda"``.
     region : str
         AWS region for S3 and Lambda. Default ``"us-west-2"``.
+    output_credentials : dict, optional
+        Explicit credentials for writing the output store (camelCase
+        ``accessKeyId``/``secretAccessKey``/``sessionToken``). Omit to use
+        the ambient credential chain / execution role (writes to in-account
+        buckets, unchanged behavior). Supply to write an external or
+        S3-compatible target (e.g. source.coop). Runtime-only -- never read
+        from config.
+    output_endpoint_url : str, optional
+        Custom S3-compatible endpoint for the output store (e.g. R2, MinIO).
+        Overrides ``output.endpoint_url`` in the config.
 
     Returns
     -------
@@ -114,6 +128,12 @@ def agg(
     # Resolve driver: kwarg > config > default
     resolved_driver = driver or get_driver(config)
 
+    # Output endpoint/region are non-secret: runtime kwarg > config.
+    resolved_endpoint = output_endpoint_url or get_output_endpoint_url(config)
+    config_region = get_output_region(config)
+    if config_region and region == "us-west-2":
+        region = config_region
+
     # Load catalog and determine cell count for worker capping
     catalog_data = _load_catalog(catalog_path)
     n_cells = len(_select_cells(
@@ -129,6 +149,8 @@ def agg(
             max_cells=max_cells, morton_cell=morton_cell,
             max_workers=max_workers, overwrite=overwrite,
             dry_run=dry_run, region=region, driver=resolved_driver,
+            output_credentials=output_credentials,
+            output_endpoint_url=resolved_endpoint,
         )
     elif backend == "lambda":
         if max_workers is None:
@@ -144,6 +166,8 @@ def agg(
             max_workers=max_workers, overwrite=overwrite,
             dry_run=dry_run, region=region,
             function_name=function_name,
+            output_credentials=output_credentials,
+            output_endpoint_url=resolved_endpoint,
         )
     else:
         raise ValueError(f"Unknown backend: {backend!r} (expected 'local' or 'lambda')")
@@ -266,7 +290,7 @@ def _process_and_write(shard_key, chunk_idx, records, grid,
 
 def _run_local(config, catalog_data, store_path, child_order, *,
                max_cells, morton_cell, max_workers, overwrite, dry_run, region,
-               driver="s3"):
+               driver="s3", output_credentials=None, output_endpoint_url=None):
     """Run processing locally with ThreadPoolExecutor."""
     all_shards = list(catalog_data["shard_keys"])
 
@@ -293,7 +317,10 @@ def _run_local(config, catalog_data, store_path, child_order, *,
     else:
         grid = from_config(config)
     _check_signature(grid, catalog_data)
-    zarr_store = open_store(store_path, region=region)
+    zarr_store = open_store(
+        store_path, region=region,
+        credentials=output_credentials, endpoint_url=output_endpoint_url,
+    )
     zarr_store = grid.emit_template(zarr_store, overwrite=overwrite)
 
     start_time = time.time()
@@ -350,7 +377,8 @@ def _run_local(config, catalog_data, store_path, child_order, *,
 
 def _run_lambda(config, catalog_data, store_path, child_order, *,
                 max_cells, morton_cell, max_workers, overwrite, dry_run,
-                region, function_name):
+                region, function_name,
+                output_credentials=None, output_endpoint_url=None):
     """Run processing via AWS Lambda invocation."""
     from dataclasses import asdict
 
@@ -385,6 +413,12 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
     _check_signature(grid, catalog_data)
     config_dict = asdict(config)
 
+    # Build the optional output_credentials event block (write side, symmetric
+    # to s3_credentials on the read side). None -> execution-role writes.
+    output_creds_event = _build_output_creds_event(
+        output_credentials, output_endpoint_url, region,
+    )
+
     # Configure boto3 client (created early so we can use it for setup/finalize)
     boto_config = Config(
         read_timeout=900,
@@ -405,6 +439,7 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
         parent_order=parent_order, child_order=child_order,
         n_parent_cells=len(all_shards) if grid_type == "healpix" and layout == "dense" else None,
         overwrite=overwrite, config_dict=config_dict,
+        output_creds_event=output_creds_event,
     )
 
     start_time = time.time()
@@ -423,6 +458,7 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
                 _resolve_urls(records, "s3"), store_path, s3_creds,
                 function_name=function_name,
                 config_dict=config_dict,
+                output_creds_event=output_creds_event,
             ): shard_key
             for shard_key, records in cells
         }
@@ -448,7 +484,8 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
 
     # Consolidate metadata via Lambda (same rationale as setup -- avoids
     # requiring orchestrator-side S3 access).
-    _invoke_lambda_finalize(lambda_client, function_name, store_path)
+    _invoke_lambda_finalize(lambda_client, function_name, store_path,
+                            output_creds_event=output_creds_event)
     wall_time = time.time() - start_time
 
     # Cost estimate: arm64 pricing = $0.0000133334/GB-second
@@ -477,9 +514,30 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
     return summary
 
 
+def _build_output_creds_event(credentials, endpoint_url, region):
+    """Build the optional ``output_credentials`` event block, or None.
+
+    Normalizes runtime credentials + non-secret endpoint/region into the
+    camelCase event shape the handler expects. Returns ``None`` when no
+    explicit credentials are supplied (execution-role writes, unchanged).
+    """
+    if not credentials:
+        return None
+    block = {
+        "accessKeyId": credentials["accessKeyId"],
+        "secretAccessKey": credentials["secretAccessKey"],
+        "region": credentials.get("region", region),
+    }
+    if credentials.get("sessionToken"):
+        block["sessionToken"] = credentials["sessionToken"]
+    if endpoint_url:
+        block["endpointUrl"] = endpoint_url
+    return block
+
+
 def _invoke_lambda_setup(lambda_client, function_name, store_path, *,
                          parent_order, child_order, n_parent_cells,
-                         overwrite, config_dict):
+                         overwrite, config_dict, output_creds_event=None):
     """Invoke Lambda in setup mode to create the zarr template."""
     event = {
         "mode": "setup",
@@ -490,6 +548,8 @@ def _invoke_lambda_setup(lambda_client, function_name, store_path, *,
         "overwrite": overwrite,
         "config": config_dict,
     }
+    if output_creds_event is not None:
+        event["output_credentials"] = output_creds_event
     response = lambda_client.invoke(
         FunctionName=function_name,
         InvocationType="RequestResponse",
@@ -503,9 +563,12 @@ def _invoke_lambda_setup(lambda_client, function_name, store_path, *,
         raise RuntimeError(f"Lambda setup error: {result.get('body')}")
 
 
-def _invoke_lambda_finalize(lambda_client, function_name, store_path):
+def _invoke_lambda_finalize(lambda_client, function_name, store_path,
+                            output_creds_event=None):
     """Invoke Lambda in finalize mode to consolidate zarr metadata."""
     event = {"mode": "finalize", "store_path": store_path}
+    if output_creds_event is not None:
+        event["output_credentials"] = output_creds_event
     response = lambda_client.invoke(
         FunctionName=function_name,
         InvocationType="RequestResponse",
@@ -522,7 +585,7 @@ def _invoke_lambda_finalize(lambda_client, function_name, store_path):
 def _invoke_lambda_cell(
     lambda_client, chunk_idx, parent_morton, parent_order, child_order,
     granule_urls, store_path, s3_credentials, *,
-    function_name, config_dict, max_retries=3,
+    function_name, config_dict, output_creds_event=None, max_retries=3,
 ):
     """Invoke Lambda for a single cell with retry logic."""
     wall_start = time.time()
@@ -542,6 +605,8 @@ def _invoke_lambda_cell(
     }
     if config_dict is not None:
         event["config"] = config_dict
+    if output_creds_event is not None:
+        event["output_credentials"] = output_creds_event
 
     last_error = None
     for attempt in range(max_retries):

--- a/src/zagg/store.py
+++ b/src/zagg/store.py
@@ -6,7 +6,13 @@ from zarr.abc.store import Store
 from zarr.storage import LocalStore
 
 
-def open_store(path: str, read_only: bool = False, **kwargs) -> Store:
+def open_store(
+    path: str,
+    read_only: bool = False,
+    credentials: dict | None = None,
+    endpoint_url: str | None = None,
+    **kwargs,
+) -> Store:
     """Open a Zarr store from a path string.
 
     Parameters
@@ -16,6 +22,14 @@ def open_store(path: str, read_only: bool = False, **kwargs) -> Store:
         all other paths open a local filesystem store.
     read_only : bool
         Whether to open in read-only mode.
+    credentials : dict, optional
+        Explicit S3 credentials (camelCase keys ``accessKeyId``,
+        ``secretAccessKey``, optional ``sessionToken``). When omitted the
+        store falls back to the ambient credential chain (execution role).
+        Ignored for local stores.
+    endpoint_url : str, optional
+        Custom S3-compatible endpoint (e.g. Cloudflare R2, MinIO). Ignored
+        for local stores.
     **kwargs
         For S3 stores: ``region`` (default ``"us-west-2"``).
 
@@ -24,26 +38,65 @@ def open_store(path: str, read_only: bool = False, **kwargs) -> Store:
     Store
     """
     if path.startswith("s3://"):
-        return _open_s3_store(path, read_only=read_only, **kwargs)
+        return _open_s3_store(
+            path,
+            read_only=read_only,
+            credentials=credentials,
+            endpoint_url=endpoint_url,
+            **kwargs,
+        )
     return LocalStore(Path(path).resolve(), read_only=read_only)
 
 
-def _open_s3_store(path: str, read_only: bool = False, **kwargs) -> Store:
-    """Open an S3-backed Zarr store."""
-    from obstore.auth.boto3 import Boto3CredentialProvider
+def _open_s3_store(
+    path: str,
+    read_only: bool = False,
+    credentials: dict | None = None,
+    endpoint_url: str | None = None,
+    **kwargs,
+) -> Store:
+    """Open an S3-backed Zarr store.
+
+    With no ``credentials`` and no ``endpoint_url`` the store behaves exactly
+    as before: ambient credentials via ``Boto3CredentialProvider`` against the
+    default AWS endpoint. When explicit ``credentials`` and/or an
+    ``endpoint_url`` are supplied, the store is opened with those instead and
+    path-style addressing is enabled (so dotted bucket names and
+    S3-compatible endpoints work over TLS).
+    """
     from obstore.store import S3Store
     from zarr.storage import ObjectStore
 
     bucket, prefix = parse_s3_path(path)
     region = kwargs.pop("region", "us-west-2")
 
-    s3 = S3Store(
-        bucket,
-        prefix=prefix,
-        region=region,
-        credential_provider=Boto3CredentialProvider(),
-        **kwargs,
-    )
+    if credentials or endpoint_url:
+        opts = {
+            "bucket": bucket,
+            "prefix": prefix,
+            "region": region,
+            # Path-style addressing: required for dotted bucket names (TLS) and
+            # for non-AWS S3-compatible endpoints.
+            "virtual_hosted_style_request": False,
+        }
+        if credentials:
+            opts["access_key_id"] = credentials["accessKeyId"]
+            opts["secret_access_key"] = credentials["secretAccessKey"]
+            if credentials.get("sessionToken"):
+                opts["session_token"] = credentials["sessionToken"]
+        if endpoint_url:
+            opts["endpoint"] = endpoint_url
+        s3 = S3Store(**opts, **kwargs)
+    else:
+        from obstore.auth.boto3 import Boto3CredentialProvider
+
+        s3 = S3Store(
+            bucket,
+            prefix=prefix,
+            region=region,
+            credential_provider=Boto3CredentialProvider(),
+            **kwargs,
+        )
     return ObjectStore(store=s3, read_only=read_only)
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -151,3 +151,26 @@ class TestConfigFallbacks:
         cfg.output["store"] = "./configured.zarr"
         result = agg(cfg, catalog=catalog_file, dry_run=True)
         assert result["store_path"] == "./configured.zarr"
+
+
+class TestOutputCredsEvent:
+    """Normalization of the Lambda ``output_credentials`` event block."""
+
+    def test_none_when_no_creds(self):
+        from zagg.runner import _build_output_creds_event
+        assert _build_output_creds_event(None, None, "us-west-2") is None
+
+    def test_camelcase_passthrough(self):
+        from zagg.runner import _build_output_creds_event
+        creds = {"accessKeyId": "AKIA", "secretAccessKey": "s", "sessionToken": "t"}
+        block = _build_output_creds_event(creds, None, "us-west-2")
+        assert block == {"accessKeyId": "AKIA", "secretAccessKey": "s",
+                         "region": "us-west-2", "sessionToken": "t"}
+
+    def test_endpoint_and_region_override(self):
+        from zagg.runner import _build_output_creds_event
+        creds = {"accessKeyId": "AKIA", "secretAccessKey": "s", "region": "eu-west-1"}
+        block = _build_output_creds_event(creds, "https://r2.example", "us-west-2")
+        assert block["endpointUrl"] == "https://r2.example"
+        assert block["region"] == "eu-west-1"
+        assert "sessionToken" not in block

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,11 +1,28 @@
 """Tests for the store factory."""
 
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from zarr.storage import LocalStore
 
 from zagg.store import open_store, parse_s3_path
+
+
+@pytest.fixture
+def mock_s3(monkeypatch):
+    """Patch obstore S3Store / Boto3CredentialProvider / zarr ObjectStore.
+
+    Returns the (S3Store, Boto3CredentialProvider) mocks so tests can assert
+    on the kwargs ``_open_s3_store`` passes to ``S3Store``.
+    """
+    s3_cls = mock.MagicMock(name="S3Store")
+    prov_cls = mock.MagicMock(name="Boto3CredentialProvider")
+    obj_cls = mock.MagicMock(name="ObjectStore")
+    monkeypatch.setattr("obstore.store.S3Store", s3_cls)
+    monkeypatch.setattr("obstore.auth.boto3.Boto3CredentialProvider", prov_cls)
+    monkeypatch.setattr("zarr.storage.ObjectStore", obj_cls)
+    return s3_cls, prov_cls
 
 
 class TestOpenStore:
@@ -24,6 +41,68 @@ class TestOpenStore:
         p.mkdir()
         store = open_store(str(p), read_only=True)
         assert isinstance(store, LocalStore)
+
+
+class TestOpenS3Store:
+    """Assert the credential/endpoint branching in ``_open_s3_store``."""
+
+    def test_no_creds_uses_credential_provider(self, mock_s3):
+        s3_cls, prov_cls = mock_s3
+        open_store("s3://bucket/prefix.zarr")
+        _, kwargs = s3_cls.call_args
+        # Ambient path: credential_provider set, no explicit keys.
+        assert kwargs["credential_provider"] is prov_cls.return_value
+        assert "access_key_id" not in kwargs
+        assert "secret_access_key" not in kwargs
+        assert "session_token" not in kwargs
+        assert "endpoint" not in kwargs
+        # Default addressing unchanged (no path-style forced).
+        assert "virtual_hosted_style_request" not in kwargs
+
+    def test_explicit_creds(self, mock_s3):
+        s3_cls, prov_cls = mock_s3
+        creds = {
+            "accessKeyId": "AKIA",
+            "secretAccessKey": "secret",
+            "sessionToken": "tok",
+        }
+        open_store("s3://us-west-2.opendata.source.coop/foo.zarr", credentials=creds)
+        _, kwargs = s3_cls.call_args
+        assert kwargs["access_key_id"] == "AKIA"
+        assert kwargs["secret_access_key"] == "secret"
+        assert kwargs["session_token"] == "tok"
+        assert "credential_provider" not in kwargs
+        # Path-style addressing for dotted bucket names / external targets.
+        assert kwargs["virtual_hosted_style_request"] is False
+        prov_cls.assert_not_called()
+
+    def test_explicit_creds_no_session_token(self, mock_s3):
+        s3_cls, _ = mock_s3
+        creds = {"accessKeyId": "AKIA", "secretAccessKey": "secret"}
+        open_store("s3://bucket/foo.zarr", credentials=creds)
+        _, kwargs = s3_cls.call_args
+        assert "session_token" not in kwargs
+
+    def test_custom_endpoint(self, mock_s3):
+        s3_cls, prov_cls = mock_s3
+        creds = {"accessKeyId": "AKIA", "secretAccessKey": "secret"}
+        open_store(
+            "s3://bucket/foo.zarr",
+            credentials=creds,
+            endpoint_url="https://acct.r2.cloudflarestorage.com",
+        )
+        _, kwargs = s3_cls.call_args
+        assert kwargs["endpoint"] == "https://acct.r2.cloudflarestorage.com"
+        assert kwargs["virtual_hosted_style_request"] is False
+
+    def test_endpoint_only_no_creds(self, mock_s3):
+        # endpoint_url alone (no creds) still takes the explicit branch.
+        s3_cls, prov_cls = mock_s3
+        open_store("s3://bucket/foo.zarr", endpoint_url="https://minio.local")
+        _, kwargs = s3_cls.call_args
+        assert kwargs["endpoint"] == "https://minio.local"
+        assert kwargs["virtual_hosted_style_request"] is False
+        assert "credential_provider" not in kwargs
 
 
 class TestParseS3Path:


### PR DESCRIPTION
template.yaml gains CreateExecutionRole/ExecutionRoleArn so the stack
can reference an admin-created execution role instead of minting one,
for accounts lacking iam:CreateRole (e.g. SSO power-user). stand_up.sh
gains CREATE_ROLE/ROLE_ARN. execution_role.yaml is a standalone template
for an admin to create the least-privilege role in its own stack;
EXECUTION_ROLE.md documents the workflow. Default stays CreateExecutionRole=true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)