### PR TITLE
Rectilinear grid: chunk-driven auto-padding + run enablement (WIP)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # 3.14+ intentionally excluded: numpy 2.2.6 (pinned for the arm64 Lambda
+        # layer) has no cp314 wheels -> ABI mismatch / silent wrong results (#31).
+        # Lambda runtime is 3.12; keep the dev/CI matrix on supported pairings.
         python-version: ['3.12', '3.13']
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,10 @@ name = "zagg"
 dynamic = ["version"]
 description = "Multi-resolution aggregation for ICESat-2 ATL06 data using morton/healpix indexing"
 readme = "README.md"
-requires-python = ">=3.12"
+# Upper bound excludes 3.14+: numpy is pinned to 2.2.6 for the arm64 Lambda layer
+# (see deployment/aws/build_layer.sh), and 2.2.6 has no CPython 3.14 support — the
+# ABI mismatch silently corrupts results (issue #31). Lambda runtime is 3.12.
+requires-python = ">=3.12,<3.14"
 license = {file = "LICENSE"}
 authors = [
     {name = "Shane Grigsby", email = "refuge@rocktalus.com"},

--- a/src/zagg/grids/rectilinear.py
+++ b/src/zagg/grids/rectilinear.py
@@ -32,6 +32,8 @@ filter rejects them, so they fall out of the pipeline silently.
 """
 from __future__ import annotations
 
+import math
+
 import numpy as np
 from affine import Affine
 from odc.geo.geobox import GeoBox, GeoboxTiles
@@ -95,18 +97,20 @@ class RectilinearGrid:
         span_y = self.ymax - self.ymin
         if span_x <= 0 or span_y <= 0:
             raise ValueError("bounds must have xmax > xmin and ymax > ymin")
-        # Width / height in cells, rounded down to whole cells.
-        self.width = int(span_x // self.res_x)
-        self.height = int(span_y // self.res_y)
-        if self.width == 0 or self.height == 0:
+        # Cells needed to cover the requested extent (round up; the 1e-9 guards
+        # an exactly-divisible span from rounding up on float fuzz).
+        raw_w = int(math.ceil(span_x / self.res_x - 1e-9))
+        raw_h = int(math.ceil(span_y / self.res_y - 1e-9))
+        if raw_w == 0 or raw_h == 0:
             raise ValueError("resolution larger than bounds span")
-        # Chunk grid must divide the cell grid evenly (one chunk == one shard).
-        if self.height % self.chunk_h != 0 or self.width % self.chunk_w != 0:
-            raise ValueError(
-                f"chunk_shape ({self.chunk_h}, {self.chunk_w}) must divide "
-                f"grid shape ({self.height}, {self.width}). Adjust bounds, "
-                f"resolution, or chunk_shape."
-            )
+        # Zero-pad the far edges up to a whole number of chunks so one chunk ==
+        # one shard. The origin (xmin, ymax) is preserved, so cell/chunk
+        # alignment and `nests_with` stay valid; the extra cells are empty.
+        self.width = -(-raw_w // self.chunk_w) * self.chunk_w
+        self.height = -(-raw_h // self.chunk_h) * self.chunk_h
+        # Extend the far bounds (xmax, ymin) to match the padded grid.
+        self.xmax = self.xmin + self.width * self.res_x
+        self.ymin = self.ymax - self.height * self.res_y
         self.n_row_blocks = self.height // self.chunk_h
         self.n_col_blocks = self.width // self.chunk_w
 
@@ -224,12 +228,16 @@ class RectilinearGrid:
         valid = leaf_ids != OOB_SENTINEL
         if not np.any(valid):
             return out
-        v = leaf_ids[valid]
+        # Work around a signed-int64 miscompute that corrupts the chained index
+        # math on arrays >= 2**15 elements (see issue #31; observed on an
+        # unsupported numpy/CPython-3.14 pairing). Valid leaf ids are
+        # non-negative, so uint64 is exact and uses the unaffected kernel.
+        v = leaf_ids[valid].astype(np.uint64)
         rows = v // self.width
         cols = v % self.width
         rb = rows // self.chunk_h
         cb = cols // self.chunk_w
-        out[valid] = rb * self.n_col_blocks + cb
+        out[valid] = (rb * self.n_col_blocks + cb).astype(np.int64)
         return out
 
     def shard_of(self, leaf_ids) -> int:

--- a/tests/test_rectilinear.py
+++ b/tests/test_rectilinear.py
@@ -34,15 +34,49 @@ class TestConstruction:
         assert grid.array_shape == (1280, 1280)
         assert grid.chunk_shape == (256, 256)
 
-    def test_uneven_chunk_rejected(self, cfg):
-        with pytest.raises(ValueError, match="chunk_shape.*must divide"):
-            RectilinearGrid(
-                crs="EPSG:3031",
-                resolution=5000,
-                bounds=(-3_200_000, -3_200_000, 3_200_000, 3_200_000),
-                chunk_shape=(300, 300),
-                config=cfg,
-            )
+    def test_clean_config_not_padded(self, grid):
+        # 1280 == 5*256 already, so auto-pad is a no-op and bounds are unchanged.
+        assert grid.array_shape == (1280, 1280)
+        assert (grid.xmin, grid.ymax, grid.xmax, grid.ymin) == (
+            -3_200_000, 3_200_000, 3_200_000, -3_200_000
+        )
+
+    def test_uneven_chunk_padded(self, cfg):
+        # 1280x1280 cells, chunk 300 doesn't divide -> zero-pad up to 1500 (5*300).
+        g = RectilinearGrid(
+            crs="EPSG:3031",
+            resolution=5000,
+            bounds=(-3_200_000, -3_200_000, 3_200_000, 3_200_000),
+            chunk_shape=(300, 300),
+            config=cfg,
+        )
+        assert g.array_shape == (1500, 1500)
+        assert g.height % g.chunk_h == 0 and g.width % g.chunk_w == 0
+        assert g.n_row_blocks == 5 and g.n_col_blocks == 5
+        # origin (xmin, ymax) preserved; far edges (xmax, ymin) extended to fit.
+        assert (g.xmin, g.ymax) == (-3_200_000, 3_200_000)
+        assert g.xmax == -3_200_000 + 1500 * 5000
+        assert g.ymin == 3_200_000 - 1500 * 5000
+
+    def test_partial_extent_rounds_up_to_cover(self, cfg):
+        # span not a whole multiple of resolution -> round cells UP to cover it
+        # (chunk_shape (1,1) isolates the cover-rounding from chunk-padding).
+        g = RectilinearGrid(
+            crs="EPSG:3031", resolution=5000,
+            bounds=(0, 0, 5000 * 130 + 100, 5000 * 130 + 100),
+            chunk_shape=(1, 1), config=cfg,
+        )
+        assert g.array_shape == (131, 131)  # ceil(130.02) -> 131
+
+    def test_signature_reflects_padding(self, cfg):
+        g = RectilinearGrid(
+            crs="EPSG:3031", resolution=5000,
+            bounds=(-3_200_000, -3_200_000, 3_200_000, 3_200_000),
+            chunk_shape=(300, 300), config=cfg,
+        )
+        sig = g.signature()
+        assert sig["shape"] == [1500, 1500]
+        assert sig["chunk_shape"] == [300, 300]
 
     def test_invalid_bounds(self, cfg):
         with pytest.raises(ValueError, match="bounds"):


### PR DESCRIPTION
Enables the rectilinear (`odc.geo.GeoBox`) output grid path end-to-end — it had never been run before, so this clears the gaps found along the way. **WIP**: more commits to follow (the runner/config/CI fixes below are still being staged).

## Changes
- **Default-on auto-padding** (`RectilinearGrid.__init__`): set `chunk_shape` + a rough `bounds` and the grid zero-pads the extent up to a whole number of chunks (origin preserved, so alignment / `nests_with` stay valid). No more hand-calculating bounds so `(span/res)` divides evenly. Cross-grid resolution-nesting (`nests_with`, whole-number ratios) is unchanged.
- **Runner**: `child_order` is a morton/HEALPix concept; rect grids (GeoBox) don't have it. Made it optional for non-HEALPix, mirroring the existing `parent_order` handling.
- **`shards_of` uint64 cast**: works around a signed-int64 miscompute on an unsupported numpy/CPython-3.14 pairing (see #31). Valid leaf ids are non-negative, so it's exact; belt-and-suspenders once the env is on a supported pair.
- **`requires-python = ">=3.12,<3.14"`** + CI note: the Lambda layer pins `numpy==2.2.6` (`<2.3`, arm64 page-alignment), which has no cp314 wheels → ABI mismatch / silent wrong results (#31). Lambda runtime is 3.12; keep dev/CI on supported pairings.
- **Tests**: auto-pad (clean no-op, uneven→padded, partial-extent cover-rounding, signature-reflects-padding) + the children/shards_of round-trip.

## Validation
Rectilinear cycle-22 ATL06 (EPSG:3031, W. Antarctica bbox) on the **local** backend:
`93 granules → 10,665,504 obs, 0 errors`, output a correct `(1280×1280)` GeoZarr (`x`/`y` projection coords, plausible heights −309…2428 m). All 37 rect unit tests pass.

## Related / remaining
- #31 — numpy/py3.14 ABI bug (worked around here; real fix is the python bound + recreating the dev venv on 3.12/3.13).
- Full-Antarctic rect shardmap is blocked on a persistent CMR-STAC 500 (server-side); small-bbox shardmap + a persisted geoparquet catalog (`--catalog-out`) work.
- Lambda-backend rect run still needs a function rebuild with rect handler support (event schema currently HEALPix-shaped).
