### PR TITLE
docs: mark SSO execution-role path out of date

### DIFF
--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -1,5 +1,17 @@
 # Lambda Deployment Guide
 
+> **Status: maintainer notes — partially out of date (audited against the code
+> 2026-06-15, see [#34](https://github.com/englacial/zagg/issues/34)).** The
+> canonical, rendered deploy docs live in the docs site:
+> [Standing Up the Backend](../docs/deployment/standup.md) (preferred path),
+> [AWS Lambda](../docs/deployment/lambda.md), and
+> [Execution Role](../docs/deployment/execution-role.md). This file keeps the
+> build/layer internals and the size/cost rationale; several figures below
+> (layer/function sizes, the role/bucket names, the layer contents) are
+> historical and were not all re-measured — trust the scripts
+> (`build_layer.sh` / `build_function.sh`) and `template.yaml` over the numbers
+> here. Specific corrections are inline below.
+
 ## Current State (2026-02-18)
 
 Both architectures now build on **py3.12** (manylinux_2_28). The target /
@@ -10,18 +22,27 @@ x86_64 / py3.12 is available for local/testing parity.
 - **Runtime**: python3.12
 - **Architecture**: arm64 (default; x86_64 also supported)
 - **Layer**: `zagg-deps-{arch}` (py3.12, pyproj/odc-geo for rectilinear grids, h5coro==0.0.8)
-- **Function code**: `lambda_handler.py` + `zagg/` package + obstore/zarr/pydantic/pyyaml
-- **Role**: `zagg-lambda-execution` (scoped to `xagg` bucket)
+- **Function code**: `lambda_handler.py` + `zagg/` package + obstore/zarr/pydantic-zarr/pyyaml
+- **Role**: created by `template.yaml` (`<FunctionName>-deps` layer; default
+  function `process-shard`), scoped least-privilege to the `OutputBucketName`
+  bucket you pass to `stand_up.sh` — *not* a fixed `zagg-lambda-execution`/`xagg`.
+  (The legacy `deploy.sh` in-place updater still defaults `ZAGG_S3_BUCKET=xagg`
+  for its >50MB staging copies; that is the updater's staging bucket, not the
+  output bucket.)
 
 ### What's in the layer vs function code
 
-**Layer** (`xagg-dependencies:1`, 222MB unzipped):
-numpy, pandas, h5coro, mortie, earthaccess, boto3, astropy, shapely, pyproj, odc-geo,
-cramjam, fastparquet, requests, s3fs, and transitive deps.
+**Layer** (built by `build_layer.sh`):
+numpy, pandas, fastparquet, cramjam, shapely, pyproj, odc-geo, affine, cachetools,
+h5coro, mortie, and their transitive deps. (Corrected: `earthaccess` is
+orchestrator-only and **not** in the layer; `boto3` is provided by the Lambda
+runtime; `astropy`/`s3fs`/`pyarrow` are not installed by `build_layer.sh`. The old
+`xagg-dependencies:1`/222MB figure is historical.)
 
-**Function code** (20MB unzipped):
-`lambda_handler.py`, `zagg/` package, obstore, zarr, pydantic-zarr, pyyaml, pydantic,
-pydantic-core, typeguard, typing_inspect, annotated-types.
+**Function code** (built by `build_function.sh`):
+`lambda_handler.py`, `zagg/` package, plus `obstore`, `zarr`, `pydantic-zarr`,
+`pyyaml` and their transitive deps; packages already in the layer are stripped
+back out to avoid duplication.
 
 ---
 
@@ -134,7 +155,7 @@ Key findings:
   to cross-compile Lambda layers — no Docker needed
 - All our deps have pre-built `manylinux2014_aarch64` wheels on PyPI
 
-See `.github/workflows/deploy-lambda.yml` for the workflow (to be created).
+The layer + function are now built in CI by `.github/workflows/lambda-build.yml` (both arches, with the combined 250MB size gate); the originally-planned `deploy-lambda.yml` was never added. The manual/CI options below are historical design notes.
 
 ### Option C: Cross-compile from x86_64 (current approach for testing)
 
@@ -180,7 +201,12 @@ aws lambda update-function-code \
 
 ---
 
-## CI/CD Workflow Design
+## CI/CD Workflow Design (historical design note)
+
+> The build half of this is implemented in `.github/workflows/lambda-build.yml`
+> (build + size gate + artifact upload). Automated *deploy*-on-push was never
+> wired up; the source.coop mirror + `stand_up.sh` is the deploy path instead.
+> Kept below as the original design rationale.
 
 A GitHub Actions workflow for automated Lambda deployment should:
 

--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -23,10 +23,11 @@ x86_64 / py3.12 is available for local/testing parity.
 - **Architecture**: arm64 (default; x86_64 also supported)
 - **Layer**: `zagg-deps-{arch}` (py3.12, pyproj/odc-geo for rectilinear grids, h5coro==0.0.8)
 - **Function code**: `lambda_handler.py` + `zagg/` package + obstore/zarr/pydantic-zarr/pyyaml
-- **Role**: created by `template.yaml` (`<FunctionName>-deps` layer; default
-  function `process-shard`), scoped least-privilege to the `OutputBucketName`
-  bucket you pass to `stand_up.sh` — *not* a fixed `zagg-lambda-execution`/`xagg`.
-  (The legacy `deploy.sh` in-place updater still defaults `ZAGG_S3_BUCKET=xagg`
+- **Role**: created by `template.yaml` (CloudFormation-auto-named; the template
+  sets no `RoleName`), scoped least-privilege to the `OutputBucketName` bucket
+  you pass to `stand_up.sh` — *not* a fixed `zagg-lambda-execution`/`xagg`. (The
+  dependency layer is named `<FunctionName>-deps`, default `process-shard-deps`.
+  The legacy `deploy.sh` in-place updater still defaults `ZAGG_S3_BUCKET=xagg`
   for its >50MB staging copies; that is the updater's staging bucket, not the
   output bucket.)
 

--- a/deployment/aws/EXECUTION_ROLE.md
+++ b/deployment/aws/EXECUTION_ROLE.md
@@ -1,5 +1,17 @@
 # zagg Lambda execution role
 
+> ⚠️ **Status: out of date / unverified — see [#34](https://github.com/englacial/zagg/issues/34).**
+> This document covers **only** the IAM-constrained path: accounts whose deploy
+> identity *cannot* create IAM roles (e.g. an AWS SSO "power user" permission
+> set), where an admin creates the execution role out of band and you deploy with
+> `CreateExecutionRole=false`. The **supported, verified** path is the default —
+> run `stand_up.sh` (→ `template.yaml` with `CreateExecutionRole=true`) from an
+> identity that has IAM access, and the backend stack creates the role for you,
+> with no out-of-band step. The from-scratch AWS deploy validated in
+> [#32](https://github.com/englacial/zagg/pull/32) exercised that default path;
+> the SSO no-`iam:CreateRole` flow described below has **not** been re-validated
+> and may be stale. Treat it as legacy until it is re-tested.
+
 The `process-shard` Lambda needs an IAM **execution role** — the identity it runs
 as, which lets it write CloudWatch logs and write results to the in-account
 output bucket (e.g. `sliderule-public`).

--- a/deployment/aws/execution_role.yaml
+++ b/deployment/aws/execution_role.yaml
@@ -1,11 +1,22 @@
 AWSTemplateFormatVersion: "2010-09-09"
+# LEGACY / OPTIONAL — only for the IAM-constrained deploy path (no iam:CreateRole).
+# The supported, verified path is the DEFAULT: stand_up.sh -> template.yaml with
+# CreateExecutionRole=true creates this role in-stack and needs no out-of-band
+# step. Use this standalone template ONLY when the deploy identity cannot create
+# IAM roles (e.g. an AWS SSO "power user" permission set), so an account admin
+# applies it once out of band. Kept as the escape hatch for that case rather than
+# removed; see deployment/aws/EXECUTION_ROLE.md and issue #34. Not re-validated
+# since the SSO flow was last exercised — treat as legacy until re-tested.
 Description: >-
-  zagg Lambda execution role — a least-privilege role for the process-shard
-  function, kept in its OWN stack so an account admin (someone with iam:CreateRole)
-  applies it once, then hands the RoleArn to whoever stands up the backend.
-  Used when template.yaml is deployed with CreateExecutionRole=false. The role
-  only needs CloudWatch Logs + write to the output bucket: source granules are
-  read with credentials passed in the invocation event, not by this role.
+  LEGACY/OPTIONAL (IAM-constrained path only — see EXECUTION_ROLE.md / #34): zagg
+  Lambda execution role — a least-privilege role for the process-shard function,
+  kept in its OWN stack so an account admin (someone with iam:CreateRole) applies
+  it once, then hands the RoleArn to whoever stands up the backend. Used when
+  template.yaml is deployed with CreateExecutionRole=false; the default deploy
+  (CreateExecutionRole=true) creates the role in-stack and does not need this.
+  The role only needs CloudWatch Logs + write to the output bucket: source
+  granules are read with credentials passed in the invocation event, not by this
+  role.
 
 Parameters:
   RoleName:

--- a/docs/deployment/execution-role.md
+++ b/docs/deployment/execution-role.md
@@ -1,0 +1,4 @@
+<!-- This page renders the canonical deployment/aws/EXECUTION_ROLE.md via a
+     pymdownx.snippets include, so the docs site and the in-repo readme stay
+     single-sourced and can't drift. Edit deployment/aws/EXECUTION_ROLE.md. -->
+--8<-- "deployment/aws/EXECUTION_ROLE.md"

--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -39,7 +39,7 @@ The Lambda function processes a single morton cell (order 6) by:
 | `deployment/aws/lambda_handler.py` | AWS Lambda wrapper function |
 | `src/zagg/processing.py` | Cloud-agnostic core processing logic |
 | `src/zagg/auth.py` | NASA Earthdata authentication helper |
-| `src/zagg/catalog.py` | CMR granule catalog builder |
+| `src/zagg/catalog/` | CMR/STAC shard-map (granule catalog) builder (`python -m zagg.catalog`) |
 | `deployment/aws/invoke_lambda.py` | Orchestration script |
 | `deployment/aws/build_layer.sh` | Lambda layer build script (`x86_64`/`arm64`) |
 
@@ -81,6 +81,17 @@ The Lambda function processes a single morton cell (order 6) by:
 | `store_path` | str | Yes | Output Zarr store path (e.g. `s3://bucket/prefix.zarr`) |
 | `s3_credentials` | dict | Yes | NSIDC S3 credentials for reading source data |
 | `output_credentials` | dict | No | Explicit credentials for *writing* the output store. Omit to use the execution role (in-account writes). Supply to write an external / S3-compatible target. Keys: `accessKeyId`, `secretAccessKey`, optional `sessionToken`/`endpointUrl`/`region`. |
+
+!!! note "Shard vs. `parent_order` naming"
+    The unit of work is a **shard** — one parent (order-6) HEALPix cell. The
+    orchestrator and the catalog use that vocabulary (`python -m zagg.catalog`
+    emits a shard map with `shard_keys` + a `grid_signature`). The Lambda
+    **event** schema, however, still carries the HEALPix-shaped field names
+    `parent_morton` / `parent_order` / `child_order` shown above (the handler
+    requires them — see `deployment/aws/lambda_handler.py`). A grid-neutral
+    rename of those event fields is tracked in
+    [#24](https://github.com/englacial/zagg/issues/24), not done here, so the
+    field names above are the current, accurate ones.
 
 ### S3 Credentials
 
@@ -148,50 +159,38 @@ path-style addressing automatically.
 
 ## Deployment
 
-### Reproducible standup (CloudFormation)
+### Recommended: CloudFormation standup
 
-The fastest way to stand up the backend in a fresh AWS account is the committed
-CloudFormation template, which creates the execution role, dependency layer, and
-function in one stack:
+The recommended way to stand up the backend in a fresh AWS account is the
+committed CloudFormation template, driven by `stand_up.sh`, which creates the
+execution role, dependency layer, and function in one stack:
 
 ```bash
 OUTPUT_BUCKET=my-results-bucket bash deployment/aws/stand_up.sh
 ```
 
-By default (`CreateExecutionRole=true`) the stack creates the function's IAM
-execution role for you, so there is no out-of-band step. The only exception is an
-account whose deploy identity *cannot* create IAM roles (e.g. an AWS SSO "power
-user" set) — see [Execution Role](execution-role.md) for that IAM-constrained
-path, which is legacy/unverified.
+See **[Standing Up the Backend](standup.md)** for the full walkthrough: what the
+script does, the parameter/environment-variable reference, cross-region staging,
+and teardown. By default (`CreateExecutionRole=true`) the stack creates the IAM
+execution role for you; the only exception is an account whose deploy identity
+*cannot* create IAM roles (e.g. an AWS SSO "power user" set) — see
+[Execution Role](execution-role.md) for that IAM-constrained, legacy/unverified
+path.
 
-The Lambda code (deps layer + function zips) lives on the public **source.coop
-mirror** (`s3://us-west-2.opendata.source.coop/englacial/zagg/lambda/<minor>/`),
-keyed by zagg minor version (`0.N.x` → `0.N`). CloudFormation reads Lambda code
-from a same-region bucket, so in **us-west-2** `stand_up.sh` points the stack
-straight at the mirror (no staging bucket needed); in **other regions** it copies
-the zips from the mirror into a `STAGING_BUCKET` you own first. It then deploys
-`deployment/aws/template.yaml`. Useful overrides (environment variables):
+### Legacy / manual deploy {#legacy-manual-deploy}
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `OUTPUT_BUCKET` | *(required)* | Bucket for results; role is scoped to it |
-| `CREATE_BUCKET` | `false` | `true` makes the stack create `OUTPUT_BUCKET` |
-| `ARCH` | `arm64` | `arm64` or `x86_64` (both py3.12) |
-| `REGION` | `us-west-2` | Deployment region |
-| `STAGING_BUCKET` | *(none)* | Required outside us-west-2: your same-region bucket the mirror zips are copied into |
-| `LAMBDA_VERSION` | *(derived)* | Lambda minor to deploy (default: the repo's latest git tag, else the installed zagg) |
-| `STACK_NAME` | `zagg-backend` | CloudFormation stack name |
-| `MIRROR_BUCKET` / `MIRROR_PREFIX` | source.coop | Override to self-host the artifact mirror |
+!!! warning "Not the recommended path"
+    The steps below hand-assemble the function zip and create/update the Lambda
+    with raw `aws lambda` calls. They are kept for understanding what the
+    template builds and for one-off tweaks, but the
+    **[CloudFormation standup](standup.md)** above is the preferred, reproducible
+    way to deploy. The maintainer in-place code updater
+    `deployment/aws/deploy.sh` (pulls the latest CI artifacts and runs
+    `aws lambda update-function-code`) is a convenience over the manual
+    `update-function-code` step; it updates an already-deployed function and does
+    not create the role/function/bucket.
 
-Maintainers (re)populate the mirror after a release with
-`deployment/aws/publish_mirror.sh <minor>`.
-
-Tear down with `aws cloudformation delete-stack --stack-name zagg-backend`.
-
-The manual steps below are equivalent and useful for understanding what the
-template creates, or for one-off tweaks.
-
-### Step 1: Create the function package
+#### Step 1: Create the function package
 
 ```bash
 cd /path/to/zagg
@@ -201,11 +200,11 @@ zip -j deployment/aws/function.zip deployment/aws/lambda_handler.py && \
   cd src && zip -ur ../deployment/aws/function.zip zagg/ -i "*.py" && cd ..
 ```
 
-### Step 2: Build and deploy the Lambda layer
+#### Step 2: Build and deploy the Lambda layer
 
 See [ARM64 Layer](arm64.md) for building and deploying the Lambda layer.
 
-### Step 3: Create the Lambda function
+#### Step 3: Create the Lambda function
 
 ```bash
 aws lambda create-function \
@@ -220,7 +219,7 @@ aws lambda create-function \
   --layers arn:aws:lambda:REGION:ACCOUNT_ID:layer:zagg-layer-arm64:VERSION
 ```
 
-### Updating function code
+#### Updating function code
 
 ```bash
 # Re-create the zip

--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -158,6 +158,12 @@ function in one stack:
 OUTPUT_BUCKET=my-results-bucket bash deployment/aws/stand_up.sh
 ```
 
+By default (`CreateExecutionRole=true`) the stack creates the function's IAM
+execution role for you, so there is no out-of-band step. The only exception is an
+account whose deploy identity *cannot* create IAM roles (e.g. an AWS SSO "power
+user" set) — see [Execution Role](execution-role.md) for that IAM-constrained
+path, which is legacy/unverified.
+
 The Lambda code (deps layer + function zips) lives on the public **source.coop
 mirror** (`s3://us-west-2.opendata.source.coop/englacial/zagg/lambda/<minor>/`),
 keyed by zagg minor version (`0.N.x` → `0.N`). CloudFormation reads Lambda code

--- a/docs/deployment/standup.md
+++ b/docs/deployment/standup.md
@@ -1,0 +1,117 @@
+# Standing up the backend (CloudFormation)
+
+The **recommended** way to deploy the zagg serverless backend into an AWS
+account is the committed CloudFormation template
+(`deployment/aws/template.yaml`), driven by the `deployment/aws/stand_up.sh`
+wrapper. One command creates the execution role, the dependency layer, and the
+`process-shard` function as a single stack from pre-built release artifacts:
+
+```bash
+OUTPUT_BUCKET=my-results-bucket bash deployment/aws/stand_up.sh
+```
+
+This is preferred over the manual `aws lambda create-function` /
+`publish-layer-version` steps (see [AWS Lambda](lambda.md#legacy-manual-deploy)):
+the stack is reproducible, versioned, and tears down cleanly, and you never have
+to hand-assemble zips or wire up the IAM role yourself.
+
+## What `stand_up.sh` does
+
+`stand_up.sh` is a thin, **verbose** wrapper around `aws cloudformation deploy`
+(it echoes each AWS command before running it). End to end it:
+
+1. **Resolves the artifact version.** Lambda code (the deps layer + function
+   zips) is published to a public **source.coop mirror**, keyed by zagg *minor*
+   version (`0.N.x` -> `0.N`). The minor is read from the repo's latest git tag
+   (so a fresh clone needs no install), falling back to the installed `zagg`, or
+   an explicit `LAMBDA_VERSION` override.
+2. **Locates the artifacts for the chosen `ARCH`** (`arm64` default, or
+   `x86_64`) -- `lambda_layer_<arch>.zip` and
+   `lambda_function_<arch>_py312.zip`.
+3. **Stages code into a same-region bucket if needed.** CloudFormation requires
+   Lambda code to live in a bucket **in the stack's own region**. In
+   **us-west-2** (where the mirror lives) the stack reads straight from the
+   mirror -- no bucket of your own required. In **any other region** you provide
+   `STAGING_BUCKET` (a bucket you own in that region) and `stand_up.sh` copies
+   the zips into it first.
+4. **Deploys `template.yaml`** with `aws cloudformation deploy
+   --capabilities CAPABILITY_NAMED_IAM`, passing the resolved architecture,
+   artifact bucket/keys, output bucket, and role settings as parameter
+   overrides.
+5. **Prints the stack outputs** (function ARN/name, layer ARN, role ARN, output
+   bucket).
+
+## What the stack creates
+
+`template.yaml` provisions (see the file for the authoritative definition):
+
+- **`ProcessFn`** -- the `process-shard` Lambda (`python3.12`, handler
+  `lambda_handler.lambda_handler`, default 2048 MB / 720 s timeout), wired to the
+  layer and execution role.
+- **`DepsLayer`** -- the dependency layer version (`<FunctionName>-deps`).
+- **`ExecutionRole`** -- created only when `CreateExecutionRole=true` (the
+  default). It trusts `lambda.amazonaws.com` and is scoped least-privilege to
+  CloudWatch Logs plus `Get/Put/DeleteObject` + `ListBucket` on **one** output
+  bucket. In IAM-constrained accounts (e.g. an AWS SSO power-user that lacks
+  `iam:CreateRole`), set `CreateExecutionRole=false` and pass a pre-made role via
+  `ExecutionRoleArn` -- see [Execution Role](execution-role.md).
+- **`OutputBucket`** -- created only when `CreateOutputBucket=true`; otherwise the
+  bucket named by `OutputBucketName` must already exist and be writable by the
+  role.
+
+> Writing to **external** object stores (source.coop, other accounts/clouds)
+> does *not* go through the execution role -- those use credentials injected
+> per-invocation in the event (see [AWS Lambda](lambda.md#output-credentials-external-write-targets)).
+> So the role stays scoped to a single in-account bucket.
+
+## `stand_up.sh` environment variables
+
+Behavior is driven entirely by environment variables (the script takes no
+positional arguments):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OUTPUT_BUCKET` | *(required)* | Bucket where results are written; the execution role is scoped to it |
+| `CREATE_BUCKET` | `false` | `true` makes the stack create `OUTPUT_BUCKET` |
+| `CREATE_ROLE` | `true` | `false` skips role creation; requires `ROLE_ARN` |
+| `ROLE_ARN` | *(none)* | Pre-existing execution-role ARN, required only when `CREATE_ROLE=false` |
+| `ARCH` | `arm64` | `arm64` or `x86_64` (both py3.12) |
+| `REGION` | `us-west-2` | Deployment region |
+| `STAGING_BUCKET` | *(none)* | Required outside us-west-2: a same-region bucket the mirror zips are copied into |
+| `LAMBDA_VERSION` | *(derived)* | Lambda minor to deploy (default: the repo's latest git tag, else the installed zagg) |
+| `STACK_NAME` | `zagg-backend` | CloudFormation stack name |
+| `MIRROR_BUCKET` / `MIRROR_PREFIX` / `MIRROR_REGION` | source.coop | Override to self-host the artifact mirror |
+
+These map onto the `template.yaml` parameters (`Architecture`, `ArtifactBucket`,
+`LayerS3Key`, `FunctionS3Key`, `OutputBucketName`, `CreateOutputBucket`,
+`CreateExecutionRole`, `ExecutionRoleArn`); `MemorySize` and `Timeout` keep their
+template defaults and aren't surfaced as script variables.
+
+## Examples
+
+```bash
+# us-west-2, stack creates the role, output bucket already exists
+OUTPUT_BUCKET=my-results bash deployment/aws/stand_up.sh
+
+# Different region -- stage the zips into a bucket you own there first
+REGION=us-east-1 OUTPUT_BUCKET=my-results STAGING_BUCKET=my-stage \
+  bash deployment/aws/stand_up.sh
+
+# IAM-constrained account: admin made the role, you deploy against it
+CREATE_ROLE=false ROLE_ARN=arn:aws:iam::123456789012:role/zagg-exec \
+  OUTPUT_BUCKET=my-results bash deployment/aws/stand_up.sh
+```
+
+## Updating and tearing down
+
+Re-running `stand_up.sh` with a newer `LAMBDA_VERSION` (or after the mirror is
+re-populated for the current minor) updates the stack in place. To remove
+everything:
+
+```bash
+aws cloudformation delete-stack --stack-name zagg-backend --region us-west-2
+```
+
+Maintainers (re)populate the mirror after a release with
+`deployment/aws/publish_mirror.sh <minor>`, which pushes the four CI-built zips
+(plus `SHA256SUMS`) to `s3://<mirror>/englacial/zagg/lambda/<minor>/`.

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -114,7 +114,7 @@ Target coverage: ~1,300 cells covering Antarctic grounded ice drainage basins (e
 │ │       │                                                      │ │ │
 │ │       ▼                                                      │ │ │
 │ │  ┌──────────────────────────────────────────────────────┐   │ │ │
-│ │  │  process_morton_cell()           processing.py       │   │◄┘ │
+│ │  │  process_shard()                 processing.py       │   │◄┘ │
 │ │  │                                                      │   │   │
 │ │  │  For each granule URL:                               │   │   │
 │ │  │    For each ground track (gt1l..gt3r):               │   │   │

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - "Architecture": "design/architecture.md"
       - "Schema": "design/schema.md"
   - "Deployment":
+      - "Standing Up the Backend": "deployment/standup.md"
       - "AWS Lambda": "deployment/lambda.md"
       - "Execution Role": "deployment/execution-role.md"
       - "ARM64 Layer": "deployment/arm64.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - "Schema": "design/schema.md"
   - "Deployment":
       - "AWS Lambda": "deployment/lambda.md"
+      - "Execution Role": "deployment/execution-role.md"
       - "ARM64 Layer": "deployment/arm64.md"
 
 watch:
@@ -116,7 +117,11 @@ markdown_extensions:
       hide_protocol: true
       repo_url_shortener: true
   - pymdownx.smartsymbols
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      base_path:
+        - .
+        - docs
+      check_paths: true
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true


### PR DESCRIPTION
Closes #34

## What this changes

Docs-only AWS-deployment cleanup, in three phases (see checklist).

**Phase 1** added a prominent **out-of-date / unverified** banner to the top of `deployment/aws/EXECUTION_ROLE.md`, which documents *only* the IAM-constrained (AWS SSO "power user", no `iam:CreateRole`) path where an admin creates the execution role out of band and you deploy with `CreateExecutionRole=false`.

**Phases 2–3** (commit `b7dccd4`) apply @espg's decisions: keep-and-relabel `execution_role.yaml` as legacy/optional (not removed), and wire the execution-role doc into the rendered mkdocs nav.

Per #34, the from-scratch AWS deploy validated while testing #32 used the **default** path — `stand_up.sh` → `template.yaml` with `CreateExecutionRole=true` from an identity with IAM access, which creates the role in-stack and needs no out-of-band step. The SSO no-`iam:CreateRole` flow has not been re-validated, so it is marked legacy until it is.

## `execution_role.yaml` — kept and relabeled (@espg's call)

`template.yaml` does **not** consume `execution_role.yaml` — it only *mentions* it in a comment (`template.yaml:8`), as does `stand_up.sh` (lines 19, 45). The backend stack creates its own role under the `ShouldCreateRole` condition when `CreateExecutionRole=true`, and references a caller-supplied `ExecutionRoleArn` otherwise. So `execution_role.yaml` is a **standalone, optional** template used only by the deprecated admin-creates-role-out-of-band path.

Per [@espg's decision](https://github.com/englacial/zagg/pull/35#issuecomment-4700929655), it is **kept and relabeled** legacy/optional (a `LEGACY / OPTIONAL` header comment + amended `Description`), preserving the IAM-constrained escape hatch. No CloudFormation resource/permission change — comment/description only.

## How it was tested

Docs-only; no code paths touched. `mkdocs build` succeeds and `docs/deployment/execution-role.md` renders the deprecation banner + body via the snippet include (`site/deployment/execution-role/index.html`). `mkdocs build --strict` reports two **pre-existing** errors only — mkdocstrings fetching external `objects.inv` from `zarr.readthedocs.io` and `docs.python.org`, both HTTP 403 from the sandbox network policy, not introduced here.

> ~~**`preview-docs` caveat:** `deployment/aws/EXECUTION_ROLE.md` is not part of the rendered mkdocs site, so the preview won't show this banner.~~ **Resolved in phase 3 (`b7dccd4`):** `docs/deployment/execution-role.md` now snippet-includes the file (`--8<--`) into the nav, so the banner renders in the docs site (single-sourced — no drift). `snippets.base_path: [., docs]` + `check_paths: true` make a broken include fail the build.

## Phases
- [x] Mark the SSO/IAM-constrained `EXECUTION_ROLE.md` path out of date
- [x] Decide `execution_role.yaml`: **keep-and-relabel** (per @espg) — `LEGACY/OPTIONAL` banner + amended Description, no resource change
- [x] Surface `EXECUTION_ROLE.md` in the rendered site (new `docs/deployment/execution-role.md` via snippets include) + nav entry + `lambda.md` cross-link

## Questions for review
1. Is the SSO no-`iam:CreateRole` flow worth re-validating and keeping, or should the whole IAM-constrained path (doc + yaml + comment refs) eventually be retired?
2. The optional grid-neutral rename of the HEALPix-shaped Lambda event field names (`parent_morton`/`child_order`) is tracked separately ([#24 note](https://github.com/englacial/zagg/issues/24#issuecomment-4703988704)) — out of scope here.