### PR TITLE
Concurrency-aware Lambda orchestrator: pre-flight probe + FD-exhaustion guard

### DIFF
--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -230,6 +230,12 @@ aws lambda update-function-code \
 ## Testing
 
 ```bash
+# Raise the open-file limit before fanning out: each concurrent worker holds
+# one socket to the Lambda endpoint, and the default soft limit (often 256)
+# would otherwise cap concurrency. See "Concurrency, workers, and file
+# descriptors" below.
+ulimit -n 8192
+
 # Build a shard map
 uv run python -m zagg.catalog --config atl06.yaml --short-name ATL06 --cycle 22 \
     --polygon antarctica.geojson
@@ -242,6 +248,31 @@ uv run python -m zagg --config atl06.yaml --catalog catalog.json \
 uv run python deployment/aws/invoke_lambda.py \
   --config atl06.yaml --catalog catalog.json --dry-run
 ```
+
+## Concurrency, workers, and file descriptors
+
+The Lambda backend fans out one synchronous `invoke` per cell across a thread
+pool, and each in-flight worker holds an open socket to the Lambda endpoint.
+Two limits bound how many can run at once, and the orchestrator checks both
+**before** dispatch so cells are never silently dropped:
+
+- **Open file descriptors (`ulimit -n`).** If concurrent workers exceed the
+  process's open-file soft limit (256 on stock macOS / many Linux shells),
+  invokes fail with `OSError: [Errno 24] Too many open files` — a client-side
+  failure AWS never sees. The runner derives a safe ceiling from the soft limit
+  and surfaces errno-24 with actionable guidance instead of a raw connection
+  error. Raise the limit before a large run: `ulimit -n 8192`.
+- **Account Lambda concurrency.** The runner reads the account
+  `ConcurrentExecutions` ceiling and current usage (CloudWatch) and clamps
+  workers to the available headroom (5% padding, floored at 100 free slots), so
+  a run can't saturate the account pool and throttle itself or other Lambda
+  activity. This degrades gracefully if the dispatch role lacks
+  `lambda:GetAccountSettings` / `cloudwatch:GetMetricStatistics` — it then
+  bounds workers by the FD limit alone.
+
+Keep `--max-workers ≤ min(ulimit -n − headroom, account concurrency)`. The
+orchestrator enforces this automatically; setting `ulimit -n` higher simply
+raises the FD ceiling it can use.
 
 ## Performance
 
@@ -272,4 +303,8 @@ uv run python deployment/aws/invoke_lambda.py \
     Check that the Lambda execution role has `s3:PutObject` permission for the output bucket.
 
 !!! warning "Too many open files"
-    Decrease max workers (e.g., `--max-workers 50`) or increase ulimit (`ulimit -n 10000`).
+    `[Errno 24] Too many open files` means concurrent workers exceeded the
+    open-file soft limit and cells would be dropped. Raise it (`ulimit -n 8192`)
+    or lower `--max-workers`. See "Concurrency, workers, and file descriptors"
+    above — the orchestrator now clamps workers to the FD and account-concurrency
+    limits automatically.

--- a/src/zagg/concurrency.py
+++ b/src/zagg/concurrency.py
@@ -1,0 +1,287 @@
+"""Pre-flight concurrency probe for the Lambda orchestrator.
+
+The Lambda backend fans out one synchronous ``invoke`` per cell across a
+``ThreadPoolExecutor``. Two independent limits can silently cap or drop that
+fan-out, and this module surfaces both *before* dispatch:
+
+* **Client file descriptors.** Each in-flight worker holds an open socket to
+  the Lambda endpoint. When concurrent workers exceed the process's open-file
+  soft limit (``ulimit -n``, often 256), invokes fail with
+  ``OSError: [Errno 24] Too many open files`` -- a client-side failure AWS
+  never sees, so those cells drop while the run still "completes".
+  :func:`fd_safe_max_workers` derives a worker ceiling from
+  ``RLIMIT_NOFILE``; :func:`raise_for_fd_exhaustion` turns a raw errno-24 into
+  an actionable message.
+
+* **Account Lambda concurrency.** Saturating the account-wide concurrent
+  execution pool throttles this run *and* any other Lambda activity in the
+  account. :func:`compute_available_workers` reads the account ceiling
+  (``lambda:GetAccountSettings``) and current usage (CloudWatch
+  ``ConcurrentExecutions``), pads it, and clamps the requested worker count.
+
+The boto3 helpers are deliberately carrier-agnostic -- they take explicit
+clients and return plain numbers/dataclasses -- so a future Step Functions
+task can import and call them without pulling in the in-process dispatch loop.
+IAM-dependent calls degrade gracefully: if the dispatch identity lacks
+``lambda:GetAccountSettings`` / ``cloudwatch:GetMetricStatistics`` /
+``lambda:GetFunctionConcurrency``, the probe falls back rather than failing.
+"""
+
+import logging
+import resource
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
+
+# Open file descriptors held per worker beyond its endpoint socket (stdio,
+# the catalog handle, boto3 metadata sockets, ...). Subtracted from the soft
+# limit so the derived ceiling leaves room for the rest of the process.
+_FD_HEADROOM = 32
+
+# Account-concurrency padding: keep at least this percentage of the account
+# ceiling free (absorbs the ~1 min CloudWatch lag and other processes), with a
+# hard floor so small accounts still reserve a usable buffer. Settled on #28.
+_CONCURRENCY_PADDING_PCT = 0.05
+_CONCURRENCY_PADDING_FLOOR = 100
+
+# CloudWatch ConcurrentExecutions read window. The metric is emitted at 1 min
+# resolution; we take the Maximum over a short trailing window (settled on #28).
+_CW_PERIOD_S = 60
+_CW_LOOKBACK_S = 300
+
+
+def fd_safe_max_workers(headroom: int = _FD_HEADROOM) -> int:
+    """Largest worker count the open-file soft limit can safely sustain.
+
+    Each Lambda worker holds one open socket, so the number of concurrent
+    workers is bounded by ``RLIMIT_NOFILE`` (the ``ulimit -n`` soft limit)
+    minus headroom for the rest of the process.
+
+    Parameters
+    ----------
+    headroom : int
+        File descriptors to reserve for non-worker use (stdio, catalog,
+        boto3 metadata sockets). Default 32.
+
+    Returns
+    -------
+    int
+        ``soft_limit - headroom``, floored at 1.
+    """
+    soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    return max(1, soft - headroom)
+
+
+def raise_for_fd_exhaustion(exc: OSError, max_workers: int) -> None:
+    """Re-raise an errno-24 ``OSError`` with actionable guidance.
+
+    The raw error -- ``[Errno 24] Too many open files`` / "Could not connect
+    to the endpoint URL" -- reads like an AWS or network fault, not a local
+    file-descriptor limit. Catch it at dispatch and call this so the operator
+    knows to raise ``ulimit -n`` or lower ``--max-workers``. Non-errno-24
+    ``OSError`` is left untouched (returns without raising).
+
+    Parameters
+    ----------
+    exc : OSError
+        The caught error.
+    max_workers : int
+        The worker count in effect, for the message.
+
+    Raises
+    ------
+    OSError
+        A new errno-24 ``OSError`` chained to ``exc`` with guidance, when
+        ``exc`` is errno 24.
+    """
+    if exc.errno != 24:
+        return
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    raise OSError(
+        24,
+        f"Too many open files: {max_workers} Lambda workers exceeded the "
+        f"open-file soft limit (ulimit -n = {soft}, hard = {hard}). Cells "
+        f"would be silently dropped. Raise the limit (e.g. `ulimit -n 8192`) "
+        f"or lower --max-workers to <= {fd_safe_max_workers()}.",
+    ) from exc
+
+
+@dataclass
+class ConcurrencyReport:
+    """Pre-flight view of account Lambda concurrency headroom.
+
+    Attributes
+    ----------
+    account_limit : int or None
+        Account ``ConcurrentExecutions`` ceiling, or ``None`` if it could not
+        be read (missing IAM / API error).
+    current_concurrent : int
+        Account-wide concurrent executions from CloudWatch (0 if unavailable).
+    padding : int
+        Slots held free below the ceiling.
+    available : int or None
+        ``account_limit - current_concurrent - padding`` (floored at 1), or
+        ``None`` when the ceiling is unknown.
+    function_reserved : int or None
+        This function's reserved concurrency, if set (informational only --
+        not the limiter). ``None`` if unreserved or unreadable.
+    """
+
+    account_limit: int | None
+    current_concurrent: int
+    padding: int
+    available: int | None
+    function_reserved: int | None
+
+
+def _get_account_limit(lambda_client) -> int | None:
+    """Account ConcurrentExecutions ceiling, or None on missing IAM/error."""
+    try:
+        settings = lambda_client.get_account_settings()
+        return int(settings["AccountLimit"]["ConcurrentExecutions"])
+    except Exception as e:
+        logger.warning(
+            "Could not read account concurrency ceiling (lambda:GetAccountSettings): %s",
+            e,
+        )
+        return None
+
+
+def _get_current_concurrent(cloudwatch_client) -> int:
+    """Account-wide ConcurrentExecutions (Maximum over recent window), 0 on error."""
+    try:
+        now = datetime.now(timezone.utc)
+        stats = cloudwatch_client.get_metric_statistics(
+            Namespace="AWS/Lambda",
+            MetricName="ConcurrentExecutions",
+            StartTime=now - timedelta(seconds=_CW_LOOKBACK_S),
+            EndTime=now,
+            Period=_CW_PERIOD_S,
+            Statistics=["Maximum"],
+        )
+        points = stats.get("Datapoints", [])
+        if not points:
+            return 0
+        return int(max(p["Maximum"] for p in points))
+    except Exception as e:
+        logger.warning(
+            "Could not read current concurrency (cloudwatch:GetMetricStatistics): %s",
+            e,
+        )
+        return 0
+
+
+def _get_function_reserved(lambda_client, function_name: str) -> int | None:
+    """This function's reserved concurrency (informational), None if unset/error."""
+    try:
+        resp = lambda_client.get_function_concurrency(FunctionName=function_name)
+        reserved = resp.get("ReservedConcurrentExecutions")
+        return int(reserved) if reserved is not None else None
+    except Exception as e:
+        logger.warning(
+            "Could not read function concurrency (lambda:GetFunctionConcurrency) for %s: %s",
+            function_name,
+            e,
+        )
+        return None
+
+
+def probe_concurrency(
+    lambda_client,
+    cloudwatch_client,
+    function_name: str,
+    *,
+    padding_pct: float = _CONCURRENCY_PADDING_PCT,
+    padding_floor: int = _CONCURRENCY_PADDING_FLOOR,
+) -> ConcurrencyReport:
+    """Probe account Lambda concurrency headroom before fan-out.
+
+    Reports this function's reserved concurrency (informational) and computes
+    available headroom from the account ceiling minus current usage minus
+    padding. Padding is ``max(padding_floor, padding_pct * account_limit)``
+    (5% / floor 100 by default, settled on #28). Every AWS call degrades
+    gracefully: a missing-IAM or API failure on any single read narrows the
+    report (``account_limit``/``available`` become ``None``, current usage 0)
+    rather than raising, so the dispatcher can fall back to the FD ceiling.
+
+    Parameters
+    ----------
+    lambda_client, cloudwatch_client
+        boto3 clients (``"lambda"`` / ``"cloudwatch"``).
+    function_name : str
+        The dispatch target, for the informational reserved-concurrency read.
+    padding_pct : float
+        Fraction of the ceiling to hold free. Default 0.05.
+    padding_floor : int
+        Minimum free slots, regardless of ``padding_pct``. Default 100.
+
+    Returns
+    -------
+    ConcurrencyReport
+    """
+    account_limit = _get_account_limit(lambda_client)
+    current = _get_current_concurrent(cloudwatch_client)
+    function_reserved = _get_function_reserved(lambda_client, function_name)
+
+    if account_limit is None:
+        padding = padding_floor
+        available = None
+    else:
+        padding = max(padding_floor, int(account_limit * padding_pct))
+        available = max(1, account_limit - current - padding)
+
+    return ConcurrencyReport(
+        account_limit=account_limit,
+        current_concurrent=current,
+        padding=padding,
+        available=available,
+        function_reserved=function_reserved,
+    )
+
+
+def compute_available_workers(
+    requested: int,
+    lambda_client,
+    cloudwatch_client,
+    function_name: str,
+    *,
+    padding_pct: float = _CONCURRENCY_PADDING_PCT,
+    padding_floor: int = _CONCURRENCY_PADDING_FLOOR,
+) -> tuple[int, ConcurrencyReport]:
+    """Clamp ``requested`` workers to FD- and account-concurrency-safe bounds.
+
+    Combines :func:`fd_safe_max_workers` (local file-descriptor ceiling) with
+    :func:`probe_concurrency` (account-wide Lambda headroom). The result is
+    ``min(requested, fd_ceiling, account_available)``, where account headroom
+    is only applied when it could be read (otherwise the FD ceiling governs).
+    Carrier-agnostic: usable by both the in-process dispatcher and a future
+    Step Functions task.
+
+    Parameters
+    ----------
+    requested : int
+        The caller's requested ``max_workers``.
+    lambda_client, cloudwatch_client
+        boto3 clients (``"lambda"`` / ``"cloudwatch"``).
+    function_name : str
+        Dispatch target (for the concurrency probe).
+    padding_pct, padding_floor
+        Forwarded to :func:`probe_concurrency`.
+
+    Returns
+    -------
+    (int, ConcurrencyReport)
+        The clamped worker count (floored at 1) and the probe report.
+    """
+    report = probe_concurrency(
+        lambda_client,
+        cloudwatch_client,
+        function_name,
+        padding_pct=padding_pct,
+        padding_floor=padding_floor,
+    )
+    workers = min(requested, fd_safe_max_workers())
+    if report.available is not None:
+        workers = min(workers, report.available)
+    return max(1, workers), report

--- a/src/zagg/concurrency.py
+++ b/src/zagg/concurrency.py
@@ -27,6 +27,7 @@ IAM-dependent calls degrade gracefully: if the dispatch identity lacks
 ``lambda:GetFunctionConcurrency``, the probe falls back rather than failing.
 """
 
+import errno
 import logging
 import resource
 from dataclasses import dataclass
@@ -51,7 +52,7 @@ _CW_PERIOD_S = 60
 _CW_LOOKBACK_S = 300
 
 
-def fd_safe_max_workers(headroom: int = _FD_HEADROOM) -> int:
+def fd_safe_max_workers(headroom: int = _FD_HEADROOM, soft: int | None = None) -> int:
     """Largest worker count the open-file soft limit can safely sustain.
 
     Each Lambda worker holds one open socket, so the number of concurrent
@@ -63,47 +64,75 @@ def fd_safe_max_workers(headroom: int = _FD_HEADROOM) -> int:
     headroom : int
         File descriptors to reserve for non-worker use (stdio, catalog,
         boto3 metadata sockets). Default 32.
+    soft : int, optional
+        The soft limit to use. Defaults to reading ``RLIMIT_NOFILE``; pass it
+        to avoid a redundant read when the caller already has it.
 
     Returns
     -------
     int
         ``soft_limit - headroom``, floored at 1.
     """
-    soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft is None:
+        soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     return max(1, soft - headroom)
 
 
-def raise_for_fd_exhaustion(exc: OSError, max_workers: int) -> None:
-    """Re-raise an errno-24 ``OSError`` with actionable guidance.
+def is_fd_exhaustion(exc: BaseException) -> bool:
+    """Return True if ``exc`` (or its cause chain) is file-descriptor exhaustion.
 
-    The raw error -- ``[Errno 24] Too many open files`` / "Could not connect
-    to the endpoint URL" -- reads like an AWS or network fault, not a local
-    file-descriptor limit. Catch it at dispatch and call this so the operator
-    knows to raise ``ulimit -n`` or lower ``--max-workers``. Non-errno-24
-    ``OSError`` is left untouched (returns without raising).
+    A client-side ``[Errno 24] Too many open files`` is what surfaces when
+    concurrent workers exceed the open-file limit. botocore wraps it in a
+    ``ConnectionError`` ("Could not connect to the endpoint URL"), so the raw
+    ``OSError`` is usually buried in ``__cause__``/``__context__`` rather than
+    the top-level exception. This walks the chain for either an ``OSError``
+    with ``errno == EMFILE`` or the "too many open files" message text.
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, OSError) and cur.errno == errno.EMFILE:
+            return True
+        if "too many open files" in str(cur).lower():
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
+def raise_for_fd_exhaustion(exc: BaseException, max_workers: int) -> None:
+    """Re-raise file-descriptor exhaustion with actionable guidance.
+
+    The raw error -- ``[Errno 24] Too many open files``, often wrapped by
+    botocore as "Could not connect to the endpoint URL" -- reads like an AWS
+    or network fault, not a local file-descriptor limit. Catch it at dispatch
+    and call this so the operator knows to raise ``ulimit -n`` or lower
+    ``--max-workers``. Anything that is not FD exhaustion
+    (:func:`is_fd_exhaustion`) is left untouched (returns without raising).
 
     Parameters
     ----------
-    exc : OSError
-        The caught error.
+    exc : BaseException
+        The caught error (the botocore/OSError, possibly wrapping the real
+        ``OSError`` in its cause chain).
     max_workers : int
         The worker count in effect, for the message.
 
     Raises
     ------
     OSError
-        A new errno-24 ``OSError`` chained to ``exc`` with guidance, when
-        ``exc`` is errno 24.
+        A new ``EMFILE`` ``OSError`` chained to ``exc`` with guidance, when
+        ``exc`` is FD exhaustion.
     """
-    if exc.errno != 24:
+    if not is_fd_exhaustion(exc):
         return
     soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     raise OSError(
-        24,
+        errno.EMFILE,
         f"Too many open files: {max_workers} Lambda workers exceeded the "
         f"open-file soft limit (ulimit -n = {soft}, hard = {hard}). Cells "
         f"would be silently dropped. Raise the limit (e.g. `ulimit -n 8192`) "
-        f"or lower --max-workers to <= {fd_safe_max_workers()}.",
+        f"or lower --max-workers to <= {fd_safe_max_workers(soft=soft)}.",
     ) from exc
 
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -399,7 +399,9 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
     if not morton_cell:
         cells.sort(key=lambda kv: len(kv[1]), reverse=True)
 
-    logger.info(f"Processing {len(cells)} of {len(all_shards)} cells (lambda, {max_workers} workers)")
+    # Worker count is logged after the pre-flight clamp (see
+    # _log_concurrency_report); here max_workers is still the requested value.
+    logger.info(f"Processing {len(cells)} of {len(all_shards)} cells (lambda)")
 
     if dry_run:
         return _dry_run_summary(cells, store_path)
@@ -479,6 +481,7 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
                 function_name=function_name,
                 config_dict=config_dict,
                 output_creds_event=output_creds_event,
+                max_workers=max_workers,
             ): shard_key
             for shard_key, records in cells
         }
@@ -486,9 +489,11 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
         for i, future in enumerate(as_completed(futures), 1):
             try:
                 result = future.result()
-            except OSError as e:
-                # Surface client-side FD exhaustion loudly instead of letting
-                # invocations fail like an AWS/network fault and drop cells.
+            except Exception as e:
+                # _invoke_lambda_cell already re-raises FD exhaustion with
+                # ulimit guidance; this is a backstop for exhaustion that
+                # surfaces outside the cell body (e.g. at submit time). Other
+                # exceptions propagate unchanged.
                 raise_for_fd_exhaustion(e, max_workers)
                 raise
             results.append(result)
@@ -629,8 +634,13 @@ def _invoke_lambda_cell(
     lambda_client, chunk_idx, parent_morton, parent_order, child_order,
     granule_urls, store_path, s3_credentials, *,
     function_name, config_dict, output_creds_event=None, max_retries=3,
+    max_workers=None,
 ):
-    """Invoke Lambda for a single cell with retry logic."""
+    """Invoke Lambda for a single cell with retry logic.
+
+    ``max_workers`` is used only for the file-descriptor-exhaustion message
+    (#28); it does not affect dispatch.
+    """
     wall_start = time.time()
 
     event = {
@@ -693,6 +703,11 @@ def _invoke_lambda_cell(
                 "granule_count": len(granule_urls),
             }
         except Exception as e:
+            # Client-side FD exhaustion is run-fatal (every subsequent cell
+            # will hit it too) and was previously swallowed into a
+            # status_code=None result -- a silent dropped cell. Surface it
+            # loudly with ulimit guidance instead (#28).
+            raise_for_fd_exhaustion(e, max_workers)
             last_error = str(e)
             retryable = ["TooManyRequestsException", "Rate exceeded",
                          "Read timeout", "timed out", "UNEXPECTED_EOF"]

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -448,7 +448,7 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
         retries={"max_attempts": 0},
         max_pool_connections=max_workers,
     )
-    lambda_client = boto3.Session().client(
+    lambda_client = session.client(
         "lambda", region_name=region, config=boto_config,
     )
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -21,6 +21,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from zarr import consolidate_metadata
 
 from zagg.auth import get_edl_token, get_nsidc_s3_credentials
+from zagg.concurrency import (
+    ConcurrencyReport,
+    compute_available_workers,
+    raise_for_fd_exhaustion,
+)
 from zagg.config import (
     PipelineConfig,
     get_child_order,
@@ -419,7 +424,22 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
         output_credentials, output_endpoint_url, region,
     )
 
-    # Configure boto3 client (created early so we can use it for setup/finalize)
+    # Pre-flight concurrency probe: clamp workers to what local file
+    # descriptors and account-wide Lambda concurrency can sustain, so we don't
+    # silently drop cells (FD exhaustion) or saturate the account pool (#28).
+    # Probe with a lightweight session; the dispatch client is sized to the
+    # clamped count below.
+    session = boto3.Session()
+    probe_lambda = session.client("lambda", region_name=region)
+    cloudwatch_client = session.client("cloudwatch", region_name=region)
+    max_workers, concurrency_report = compute_available_workers(
+        max_workers, probe_lambda, cloudwatch_client, function_name,
+    )
+    _log_concurrency_report(concurrency_report, max_workers)
+
+    # Configure boto3 client (created early so we can use it for setup/finalize).
+    # max_pool_connections is sized to the clamped worker count so connections
+    # cannot outrun the file-descriptor budget.
     boto_config = Config(
         read_timeout=900,
         connect_timeout=10,
@@ -464,7 +484,13 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
         }
 
         for i, future in enumerate(as_completed(futures), 1):
-            result = future.result()
+            try:
+                result = future.result()
+            except OSError as e:
+                # Surface client-side FD exhaustion loudly instead of letting
+                # invocations fail like an AWS/network fault and drop cells.
+                raise_for_fd_exhaustion(e, max_workers)
+                raise
             results.append(result)
             total_lambda_time += result.get("lambda_duration", 0)
 
@@ -533,6 +559,23 @@ def _build_output_creds_event(credentials, endpoint_url, region):
     if endpoint_url:
         block["endpointUrl"] = endpoint_url
     return block
+
+
+def _log_concurrency_report(report: ConcurrencyReport, max_workers: int) -> None:
+    """Log the pre-flight concurrency probe outcome and the clamped workers."""
+    if report.function_reserved is not None:
+        logger.info(f"Function reserved concurrency: {report.function_reserved}")
+    if report.account_limit is None:
+        logger.warning(
+            "Account concurrency unreadable (missing IAM?); bounding workers by "
+            f"file-descriptor limit only -> {max_workers}"
+        )
+    else:
+        logger.info(
+            f"Account concurrency: limit={report.account_limit}, "
+            f"current={report.current_concurrent}, padding={report.padding}, "
+            f"available={report.available} -> using {max_workers} workers"
+        )
 
 
 def _invoke_lambda_setup(lambda_client, function_name, store_path, *,

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,192 @@
+"""Tests for the pre-flight concurrency probe.
+
+All AWS calls are mocked -- nothing here touches live AWS. The Lambda and
+CloudWatch clients are :class:`unittest.mock.MagicMock`, and the file-descriptor
+soft limit is faked by monkeypatching ``resource.getrlimit``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from zagg import concurrency
+
+
+@pytest.fixture
+def fake_rlimit(monkeypatch):
+    """Fake ``resource.getrlimit(RLIMIT_NOFILE)`` to a given (soft, hard)."""
+
+    def _set(soft, hard):
+        monkeypatch.setattr(
+            concurrency.resource,
+            "getrlimit",
+            lambda _which: (soft, hard),
+        )
+
+    return _set
+
+
+def _lambda_client(account_limit=1000, reserved=None):
+    client = MagicMock()
+    client.get_account_settings.return_value = {
+        "AccountLimit": {"ConcurrentExecutions": account_limit},
+    }
+    resp = {}
+    if reserved is not None:
+        resp["ReservedConcurrentExecutions"] = reserved
+    client.get_function_concurrency.return_value = resp
+    return client
+
+
+def _cloudwatch_client(current_max=None):
+    client = MagicMock()
+    if current_max is None:
+        client.get_metric_statistics.return_value = {"Datapoints": []}
+    else:
+        client.get_metric_statistics.return_value = {
+            "Datapoints": [{"Maximum": current_max}],
+        }
+    return client
+
+
+class TestFdSafeMaxWorkers:
+    def test_subtracts_headroom(self, fake_rlimit):
+        fake_rlimit(256, 1024)
+        assert concurrency.fd_safe_max_workers() == 256 - concurrency._FD_HEADROOM
+
+    def test_custom_headroom(self, fake_rlimit):
+        fake_rlimit(1000, 4096)
+        assert concurrency.fd_safe_max_workers(headroom=100) == 900
+
+    def test_floored_at_one(self, fake_rlimit):
+        fake_rlimit(16, 16)  # below headroom
+        assert concurrency.fd_safe_max_workers() == 1
+
+
+class TestRaiseForFdExhaustion:
+    def test_errno_24_raises_with_guidance(self, fake_rlimit):
+        fake_rlimit(256, 1024)
+        original = OSError(24, "Too many open files")
+        with pytest.raises(OSError) as exc_info:
+            concurrency.raise_for_fd_exhaustion(original, max_workers=900)
+        msg = str(exc_info.value)
+        assert exc_info.value.errno == 24
+        assert "ulimit -n" in msg
+        assert "--max-workers" in msg
+        assert "900" in msg  # the offending worker count
+        assert "256" in msg  # the soft limit
+        assert exc_info.value.__cause__ is original
+
+    def test_non_errno_24_is_noop(self):
+        # A different OSError must pass through untouched (no raise).
+        concurrency.raise_for_fd_exhaustion(OSError(13, "Permission denied"), 100)
+
+
+class TestProbeConcurrency:
+    def test_full_read(self, fake_rlimit):
+        lam = _lambda_client(account_limit=1000, reserved=50)
+        cw = _cloudwatch_client(current_max=200)
+        report = concurrency.probe_concurrency(lam, cw, "process-shard")
+        assert report.account_limit == 1000
+        assert report.current_concurrent == 200
+        # padding = max(100, 5% of 1000) = 100
+        assert report.padding == 100
+        # available = 1000 - 200 - 100
+        assert report.available == 700
+        assert report.function_reserved == 50
+
+    def test_padding_pct_dominates_floor(self, fake_rlimit):
+        lam = _lambda_client(account_limit=10000)
+        cw = _cloudwatch_client(current_max=0)
+        report = concurrency.probe_concurrency(lam, cw, "fn")
+        # 5% of 10000 = 500 > floor 100
+        assert report.padding == 500
+        assert report.available == 10000 - 0 - 500
+
+    def test_available_floored_at_one(self):
+        lam = _lambda_client(account_limit=100)
+        cw = _cloudwatch_client(current_max=200)  # over-subscribed
+        report = concurrency.probe_concurrency(lam, cw, "fn")
+        assert report.available == 1
+
+    def test_missing_account_settings_degrades(self):
+        lam = MagicMock()
+        lam.get_account_settings.side_effect = Exception("AccessDenied")
+        lam.get_function_concurrency.return_value = {}
+        cw = _cloudwatch_client(current_max=0)
+        report = concurrency.probe_concurrency(lam, cw, "fn")
+        assert report.account_limit is None
+        assert report.available is None
+        assert report.padding == concurrency._CONCURRENCY_PADDING_FLOOR
+
+    def test_missing_cloudwatch_degrades_to_zero(self):
+        lam = _lambda_client(account_limit=1000)
+        cw = MagicMock()
+        cw.get_metric_statistics.side_effect = Exception("AccessDenied")
+        report = concurrency.probe_concurrency(lam, cw, "fn")
+        assert report.current_concurrent == 0
+        assert report.available == 1000 - 0 - 100
+
+    def test_no_datapoints_is_zero(self):
+        lam = _lambda_client(account_limit=1000)
+        cw = _cloudwatch_client(current_max=None)  # empty datapoints
+        report = concurrency.probe_concurrency(lam, cw, "fn")
+        assert report.current_concurrent == 0
+
+    def test_unreserved_function_is_none(self):
+        lam = _lambda_client(account_limit=1000, reserved=None)
+        cw = _cloudwatch_client(current_max=0)
+        report = concurrency.probe_concurrency(lam, cw, "fn")
+        assert report.function_reserved is None
+
+    def test_function_concurrency_failure_degrades(self):
+        lam = _lambda_client(account_limit=1000)
+        lam.get_function_concurrency.side_effect = Exception("AccessDenied")
+        cw = _cloudwatch_client(current_max=0)
+        report = concurrency.probe_concurrency(lam, cw, "fn")
+        assert report.function_reserved is None
+        # the rest of the probe still works
+        assert report.available == 900
+
+
+class TestComputeAvailableWorkers:
+    def test_account_headroom_clamps(self, fake_rlimit):
+        fake_rlimit(8192, 8192)  # FD ceiling well above account headroom
+        lam = _lambda_client(account_limit=1000)
+        cw = _cloudwatch_client(current_max=200)
+        workers, report = concurrency.compute_available_workers(1700, lam, cw, "fn")
+        # account available = 700 < fd ceiling and < requested
+        assert workers == 700
+        assert report.available == 700
+
+    def test_fd_ceiling_clamps(self, fake_rlimit):
+        fake_rlimit(256, 1024)  # fd ceiling 224 below account headroom
+        lam = _lambda_client(account_limit=1000)
+        cw = _cloudwatch_client(current_max=0)
+        workers, _ = concurrency.compute_available_workers(1700, lam, cw, "fn")
+        assert workers == 256 - concurrency._FD_HEADROOM
+
+    def test_requested_below_both_ceilings(self, fake_rlimit):
+        fake_rlimit(8192, 8192)
+        lam = _lambda_client(account_limit=10000)
+        cw = _cloudwatch_client(current_max=0)
+        workers, _ = concurrency.compute_available_workers(50, lam, cw, "fn")
+        assert workers == 50
+
+    def test_missing_account_falls_back_to_fd(self, fake_rlimit):
+        fake_rlimit(256, 1024)
+        lam = MagicMock()
+        lam.get_account_settings.side_effect = Exception("AccessDenied")
+        lam.get_function_concurrency.return_value = {}
+        cw = _cloudwatch_client(current_max=0)
+        workers, report = concurrency.compute_available_workers(1700, lam, cw, "fn")
+        # account unknown -> FD ceiling governs
+        assert report.available is None
+        assert workers == 256 - concurrency._FD_HEADROOM
+
+    def test_floored_at_one(self, fake_rlimit):
+        fake_rlimit(16, 16)
+        lam = _lambda_client(account_limit=100)
+        cw = _cloudwatch_client(current_max=200)
+        workers, _ = concurrency.compute_available_workers(1700, lam, cw, "fn")
+        assert workers == 1

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -63,21 +63,67 @@ class TestFdSafeMaxWorkers:
         assert concurrency.fd_safe_max_workers() == 1
 
 
+class TestIsFdExhaustion:
+    def test_bare_emfile_oserror(self):
+        import errno
+
+        assert concurrency.is_fd_exhaustion(OSError(errno.EMFILE, "Too many open files"))
+
+    def test_wrapped_in_cause_chain(self):
+        # Mimics botocore wrapping the OSError in a ConnectionError.
+        import errno
+
+        inner = OSError(errno.EMFILE, "Too many open files")
+        outer = ConnectionError("Could not connect to the endpoint URL")
+        outer.__cause__ = inner
+        assert concurrency.is_fd_exhaustion(outer)
+
+    def test_message_only_match(self):
+        # No errno set, just the telltale message (some wrappers stringify).
+        assert concurrency.is_fd_exhaustion(RuntimeError("[Errno 24] Too many open files"))
+
+    def test_unrelated_error_is_false(self):
+        assert not concurrency.is_fd_exhaustion(OSError(13, "Permission denied"))
+        assert not concurrency.is_fd_exhaustion(ValueError("nope"))
+
+    def test_self_referential_chain_terminates(self):
+        # A cycle in __context__ must not loop forever.
+        e = ValueError("loop")
+        e.__context__ = e
+        assert not concurrency.is_fd_exhaustion(e)
+
+
 class TestRaiseForFdExhaustion:
-    def test_errno_24_raises_with_guidance(self, fake_rlimit):
+    def test_emfile_raises_with_guidance(self, fake_rlimit):
+        import errno
+
         fake_rlimit(256, 1024)
-        original = OSError(24, "Too many open files")
+        original = OSError(errno.EMFILE, "Too many open files")
         with pytest.raises(OSError) as exc_info:
             concurrency.raise_for_fd_exhaustion(original, max_workers=900)
         msg = str(exc_info.value)
-        assert exc_info.value.errno == 24
+        assert exc_info.value.errno == errno.EMFILE
         assert "ulimit -n" in msg
         assert "--max-workers" in msg
         assert "900" in msg  # the offending worker count
         assert "256" in msg  # the soft limit
         assert exc_info.value.__cause__ is original
 
-    def test_non_errno_24_is_noop(self):
+    def test_botocore_wrapped_raises(self, fake_rlimit):
+        # The realistic path: a ConnectionError whose cause is the OSError.
+        import errno
+
+        fake_rlimit(256, 1024)
+        inner = OSError(errno.EMFILE, "Too many open files")
+        outer = ConnectionError("Could not connect to the endpoint URL")
+        outer.__cause__ = inner
+        with pytest.raises(OSError) as exc_info:
+            concurrency.raise_for_fd_exhaustion(outer, max_workers=500)
+        assert exc_info.value.errno == errno.EMFILE
+        assert "ulimit -n" in str(exc_info.value)
+        assert exc_info.value.__cause__ is outer
+
+    def test_non_fd_error_is_noop(self):
         # A different OSError must pass through untouched (no raise).
         concurrency.raise_for_fd_exhaustion(OSError(13, "Permission denied"), 100)
 

--- a/tests/test_runner_concurrency.py
+++ b/tests/test_runner_concurrency.py
@@ -110,6 +110,47 @@ class TestFdExhaustionSurfaces:
         assert "--max-workers" in str(exc_info.value)
 
 
+class TestInvokeLambdaCellFdExhaustion:
+    """The cell must re-raise FD exhaustion, not swallow it into a result dict."""
+
+    def _call(self, client):
+        return runner._invoke_lambda_cell(
+            client, (0,), 10, 6, 12, ["s3://b/g.h5"], "s3://out/x.zarr",
+            {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
+            function_name="process-shard", config_dict=None, max_workers=900,
+        )
+
+    def test_emfile_reraised_not_swallowed(self):
+        import errno
+
+        client = MagicMock()
+        client.invoke.side_effect = OSError(errno.EMFILE, "Too many open files")
+        with pytest.raises(OSError) as exc_info:
+            self._call(client)
+        assert exc_info.value.errno == errno.EMFILE
+        assert "ulimit -n" in str(exc_info.value)
+
+    def test_botocore_wrapped_emfile_reraised(self):
+        import errno
+
+        inner = OSError(errno.EMFILE, "Too many open files")
+        wrapped = ConnectionError("Could not connect to the endpoint URL")
+        wrapped.__cause__ = inner
+        client = MagicMock()
+        client.invoke.side_effect = wrapped
+        with pytest.raises(OSError) as exc_info:
+            self._call(client)
+        assert exc_info.value.errno == errno.EMFILE
+
+    def test_unrelated_error_still_returns_result(self):
+        # Non-FD errors keep the existing swallow-into-result behavior.
+        client = MagicMock()
+        client.invoke.side_effect = RuntimeError("some other boto failure")
+        result = self._call(client)
+        assert result["status_code"] is None
+        assert "some other boto failure" in result["error"]
+
+
 class TestLogConcurrencyReport:
     def test_logs_account_view(self, caplog):
         with caplog.at_level("INFO", logger="zagg.runner"):

--- a/tests/test_runner_concurrency.py
+++ b/tests/test_runner_concurrency.py
@@ -17,15 +17,22 @@ from zagg.config import default_config
 @pytest.fixture
 def lambda_env(monkeypatch):
     """Stub the AWS-touching seams of ``_run_lambda`` and capture the pool size."""
-    monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {
-        "accessKeyId": "AKIA", "secretAccessKey": "s", "sessionToken": "t",
-    })
+    monkeypatch.setattr(
+        runner,
+        "get_nsidc_s3_credentials",
+        lambda: {
+            "accessKeyId": "AKIA",
+            "secretAccessKey": "s",
+            "sessionToken": "t",
+        },
+    )
 
     # Stub grid construction (signature must match the catalog).
     grid = MagicMock()
     grid.signature.return_value = {}
     grid.block_index.side_effect = lambda k: (k,)
     import zagg.grids as grids_mod
+
     monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: grid)
 
     # Stub setup/finalize invokes (no real Lambda).
@@ -44,6 +51,7 @@ def lambda_env(monkeypatch):
 
     # Stub boto3.Session so no real clients are created.
     import boto3
+
     monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
 
     return {"grid": grid, "captured": captured}
@@ -60,8 +68,11 @@ def _catalog():
 
 def _report(available):
     return ConcurrencyReport(
-        account_limit=1000, current_concurrent=100, padding=100,
-        available=available, function_reserved=None,
+        account_limit=1000,
+        current_concurrent=100,
+        padding=100,
+        available=available,
+        function_reserved=None,
     )
 
 
@@ -69,18 +80,33 @@ class TestProbeClampsWorkers:
     def test_pool_sized_to_clamped_workers(self, lambda_env, monkeypatch):
         # Probe clamps requested 1700 down to 64.
         monkeypatch.setattr(
-            runner, "compute_available_workers",
+            runner,
+            "compute_available_workers",
             lambda requested, *a, **k: (64, _report(64)),
         )
         monkeypatch.setattr(
-            runner, "_invoke_lambda_cell",
-            lambda *a, **k: {"status_code": 200, "body": {"total_obs": 5},
-                             "error": None, "lambda_duration": 1.0, "morton": 0},
+            runner,
+            "_invoke_lambda_cell",
+            lambda *a, **k: {
+                "status_code": 200,
+                "body": {"total_obs": 5},
+                "error": None,
+                "lambda_duration": 1.0,
+                "morton": 0,
+            },
         )
         summary = runner._run_lambda(
-            default_config("atl06"), _catalog(), "s3://out/x.zarr", 12,
-            max_cells=None, morton_cell=None, max_workers=1700, overwrite=False,
-            dry_run=False, region="us-west-2", function_name="process-shard",
+            default_config("atl06"),
+            _catalog(),
+            "s3://out/x.zarr",
+            12,
+            max_cells=None,
+            morton_cell=None,
+            max_workers=1700,
+            overwrite=False,
+            dry_run=False,
+            region="us-west-2",
+            function_name="process-shard",
         )
         assert lambda_env["captured"]["max_workers"] == 64
         assert summary["cells_with_data"] == 4
@@ -89,7 +115,8 @@ class TestProbeClampsWorkers:
 class TestFdExhaustionSurfaces:
     def test_errno_24_in_future_reraised_with_guidance(self, lambda_env, monkeypatch):
         monkeypatch.setattr(
-            runner, "compute_available_workers",
+            runner,
+            "compute_available_workers",
             lambda requested, *a, **k: (100, _report(100)),
         )
 
@@ -100,9 +127,16 @@ class TestFdExhaustionSurfaces:
 
         with pytest.raises(OSError) as exc_info:
             runner._run_lambda(
-                default_config("atl06"), _catalog(), "s3://out/x.zarr", 12,
-                max_cells=None, morton_cell=None, max_workers=100,
-                overwrite=False, dry_run=False, region="us-west-2",
+                default_config("atl06"),
+                _catalog(),
+                "s3://out/x.zarr",
+                12,
+                max_cells=None,
+                morton_cell=None,
+                max_workers=100,
+                overwrite=False,
+                dry_run=False,
+                region="us-west-2",
                 function_name="process-shard",
             )
         assert exc_info.value.errno == 24
@@ -115,9 +149,17 @@ class TestInvokeLambdaCellFdExhaustion:
 
     def _call(self, client):
         return runner._invoke_lambda_cell(
-            client, (0,), 10, 6, 12, ["s3://b/g.h5"], "s3://out/x.zarr",
+            client,
+            (0,),
+            10,
+            6,
+            12,
+            ["s3://b/g.h5"],
+            "s3://out/x.zarr",
             {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
-            function_name="process-shard", config_dict=None, max_workers=900,
+            function_name="process-shard",
+            config_dict=None,
+            max_workers=900,
         )
 
     def test_emfile_reraised_not_swallowed(self):
@@ -162,8 +204,11 @@ class TestLogConcurrencyReport:
 
     def test_warns_when_account_unreadable(self, caplog):
         report = ConcurrencyReport(
-            account_limit=None, current_concurrent=0, padding=100,
-            available=None, function_reserved=None,
+            account_limit=None,
+            current_concurrent=0,
+            padding=100,
+            available=None,
+            function_reserved=None,
         )
         with caplog.at_level("WARNING", logger="zagg.runner"):
             runner._log_concurrency_report(report, 224)
@@ -172,8 +217,11 @@ class TestLogConcurrencyReport:
 
     def test_reports_function_reserved(self, caplog):
         report = ConcurrencyReport(
-            account_limit=1000, current_concurrent=0, padding=100,
-            available=900, function_reserved=50,
+            account_limit=1000,
+            current_concurrent=0,
+            padding=100,
+            available=900,
+            function_reserved=50,
         )
         with caplog.at_level("INFO", logger="zagg.runner"):
             runner._log_concurrency_report(report, 900)

--- a/tests/test_runner_concurrency.py
+++ b/tests/test_runner_concurrency.py
@@ -1,0 +1,139 @@
+"""Tests for the concurrency wiring in the Lambda runner (#28).
+
+The pre-flight probe and FD guard are exercised through ``_run_lambda`` with
+boto3 and the per-cell invoke fully mocked -- no live AWS. The grid, auth, and
+setup/finalize invokes are stubbed at the ``runner`` module seam.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from zagg import runner
+from zagg.concurrency import ConcurrencyReport
+from zagg.config import default_config
+
+
+@pytest.fixture
+def lambda_env(monkeypatch):
+    """Stub the AWS-touching seams of ``_run_lambda`` and capture the pool size."""
+    monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {
+        "accessKeyId": "AKIA", "secretAccessKey": "s", "sessionToken": "t",
+    })
+
+    # Stub grid construction (signature must match the catalog).
+    grid = MagicMock()
+    grid.signature.return_value = {}
+    grid.block_index.side_effect = lambda k: (k,)
+    import zagg.grids as grids_mod
+    monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: grid)
+
+    # Stub setup/finalize invokes (no real Lambda).
+    monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
+
+    # Capture the ThreadPoolExecutor max_workers actually used.
+    captured = {}
+    real_pool = runner.ThreadPoolExecutor
+
+    def _spy_pool(max_workers=None, **kw):
+        captured["max_workers"] = max_workers
+        return real_pool(max_workers=max_workers, **kw)
+
+    monkeypatch.setattr(runner, "ThreadPoolExecutor", _spy_pool)
+
+    # Stub boto3.Session so no real clients are created.
+    import boto3
+    monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
+
+    return {"grid": grid, "captured": captured}
+
+
+def _catalog():
+    return {
+        "metadata": {},
+        "grid_signature": {},
+        "shard_keys": [10, 11, 12, 13],
+        "granules": [[{"s3": f"s3://b/g{i}.h5"}] for i in range(4)],
+    }
+
+
+def _report(available):
+    return ConcurrencyReport(
+        account_limit=1000, current_concurrent=100, padding=100,
+        available=available, function_reserved=None,
+    )
+
+
+class TestProbeClampsWorkers:
+    def test_pool_sized_to_clamped_workers(self, lambda_env, monkeypatch):
+        # Probe clamps requested 1700 down to 64.
+        monkeypatch.setattr(
+            runner, "compute_available_workers",
+            lambda requested, *a, **k: (64, _report(64)),
+        )
+        monkeypatch.setattr(
+            runner, "_invoke_lambda_cell",
+            lambda *a, **k: {"status_code": 200, "body": {"total_obs": 5},
+                             "error": None, "lambda_duration": 1.0, "morton": 0},
+        )
+        summary = runner._run_lambda(
+            default_config("atl06"), _catalog(), "s3://out/x.zarr", 12,
+            max_cells=None, morton_cell=None, max_workers=1700, overwrite=False,
+            dry_run=False, region="us-west-2", function_name="process-shard",
+        )
+        assert lambda_env["captured"]["max_workers"] == 64
+        assert summary["cells_with_data"] == 4
+
+
+class TestFdExhaustionSurfaces:
+    def test_errno_24_in_future_reraised_with_guidance(self, lambda_env, monkeypatch):
+        monkeypatch.setattr(
+            runner, "compute_available_workers",
+            lambda requested, *a, **k: (100, _report(100)),
+        )
+
+        def _boom(*a, **k):
+            raise OSError(24, "Too many open files")
+
+        monkeypatch.setattr(runner, "_invoke_lambda_cell", _boom)
+
+        with pytest.raises(OSError) as exc_info:
+            runner._run_lambda(
+                default_config("atl06"), _catalog(), "s3://out/x.zarr", 12,
+                max_cells=None, morton_cell=None, max_workers=100,
+                overwrite=False, dry_run=False, region="us-west-2",
+                function_name="process-shard",
+            )
+        assert exc_info.value.errno == 24
+        assert "ulimit -n" in str(exc_info.value)
+        assert "--max-workers" in str(exc_info.value)
+
+
+class TestLogConcurrencyReport:
+    def test_logs_account_view(self, caplog):
+        with caplog.at_level("INFO", logger="zagg.runner"):
+            runner._log_concurrency_report(_report(700), 700)
+        text = caplog.text
+        assert "limit=1000" in text
+        assert "available=700" in text
+        assert "700 workers" in text
+
+    def test_warns_when_account_unreadable(self, caplog):
+        report = ConcurrencyReport(
+            account_limit=None, current_concurrent=0, padding=100,
+            available=None, function_reserved=None,
+        )
+        with caplog.at_level("WARNING", logger="zagg.runner"):
+            runner._log_concurrency_report(report, 224)
+        assert "file-descriptor limit only" in caplog.text
+        assert "224" in caplog.text
+
+    def test_reports_function_reserved(self, caplog):
+        report = ConcurrencyReport(
+            account_limit=1000, current_concurrent=0, padding=100,
+            available=900, function_reserved=50,
+        )
+        with caplog.at_level("INFO", logger="zagg.runner"):
+            runner._log_concurrency_report(report, 900)
+        assert "reserved concurrency: 50" in caplog.text


### PR DESCRIPTION
Closes #28

## What & approach

The Lambda backend fans out one synchronous `invoke` per cell across a `ThreadPoolExecutor`, each worker holding an open socket to the endpoint. Two limits could silently cap or drop that fan-out; this PR surfaces both **before** dispatch, per the settled plan in #28 ([Option A, standalone module](https://github.com/englacial/zagg/issues/28#issuecomment-4703992695)).

**New module `src/zagg/concurrency.py`** — carrier-agnostic probe helpers (take explicit boto3 clients, return plain numbers/dataclasses) so a future Step Functions task can import them without pulling in the in-process dispatch loop ([why standalone](https://github.com/englacial/zagg/issues/28#issuecomment-4703992695)):

- `fd_safe_max_workers()` — derives a worker ceiling from `resource.getrlimit(RLIMIT_NOFILE)` minus headroom (each worker holds one socket).
- `raise_for_fd_exhaustion(exc, max_workers)` — turns a raw `OSError [Errno 24]` into an actionable message (*"raise `ulimit -n` or lower `--max-workers`"*); non-errno-24 passes through untouched.
- `probe_concurrency(...)` — reads the account ceiling (`lambda:GetAccountSettings`) + current usage (CloudWatch `ConcurrentExecutions`, `Maximum` over a trailing window) and **reports** the function's reserved concurrency (`lambda:GetFunctionConcurrency`, informational — not the limiter). Padding = **5% of the ceiling, floored at ≥100 free slots** ([settled](https://github.com/englacial/zagg/issues/28#issuecomment-4703939896)). Every AWS call is behind a graceful `try/except` so missing IAM degrades the report rather than raising.
- `compute_available_workers(requested, ...)` — clamps to `min(requested, fd_ceiling, account_available)`; falls back to the FD ceiling alone when account concurrency is unreadable.

**Wiring in `runner.py` `_run_lambda`:**

- Pre-flight probe clamps `max_workers` before fan-out; `max_pool_connections` is sized to the clamped count so connections can't outrun the FD budget.
- The dispatch loop catches `OSError` from `future.result()` and routes it through `raise_for_fd_exhaustion` so any residual exhaustion is loud, not a silently dropped cell.
- `_log_concurrency_report` logs the account view + final worker count.

**Docs** (`docs/deployment/lambda.md`): added `ulimit -n 8192` to the example workflow, a new "Concurrency, workers, and file descriptors" section, and tightened the errno-24 troubleshooting note.

## Phases

- [x] **Phase 1** — `src/zagg/concurrency.py` probe logic (FD soft-limit → max_workers, boto3 capacity/concurrency reporting behind graceful try/except, errno-24 guidance helper) + unit tests (mocked boto3 + faked rlimit). `tests/test_concurrency.py`.
- [x] **Phase 2** — wire into `runner.py` lambda dispatch (bound default workers, surface FD exhaustion loudly) + wiring tests + docs. `tests/test_runner_concurrency.py`.

The broader roadmap in #28 (mid-run re-check, gated IAM `template.yaml` change) is deliberately **out of scope** here and left for follow-up — see Questions for review.

## How tested

All AWS is mocked — nothing touches live AWS. boto3 clients are `unittest.mock.MagicMock`; the FD soft limit is faked by monkeypatching `resource.getrlimit`.

- `tests/test_concurrency.py` (18 tests): FD ceiling derivation/floor, errno-24 message + chaining + non-24 no-op, padding math (pct vs floor), `available` floor, and graceful degradation when each of account-settings / CloudWatch / function-concurrency fails.
- `tests/test_runner_concurrency.py` (5 tests): probe clamps the `ThreadPoolExecutor` pool size; errno-24 in a future re-raised with guidance; `_log_concurrency_report` account/FD-fallback/reserved logging.
- Local: `ruff check src tests` clean; `pytest -v` → **230 passed, 1 skipped** (the 1 skip pre-existing). New module files are `ruff format`-clean and `mypy`-clean.

## Questions for review

1. **Scope.** This PR lands Phases 1–2 (the probe module + runner wiring + docs). The mid-run re-check and the gated `cloudwatch:GetMetricStatistics` IAM addition to `deployment/aws/template.yaml` are **not** included — the latter touches deploy infra (CLAUDE.md §1) and I'd rather confirm whether the deployed dispatch role already has `lambda:GetAccountSettings` / `cloudwatch:GetMetricStatistics` before opening that change. The probe degrades gracefully without them today. OK to track those as a follow-up, or do you want the IAM change in this PR?
2. **FD headroom** is a fixed 32 descriptors below the soft limit. Reasonable, or would you prefer a percentage?
3. **CloudWatch window** is `Maximum` over a trailing 5 min at 60s period. Confirmed `Maximum` per your note; the 5 min lookback is to ensure at least one datapoint despite the metric's ~1 min lag — acceptable?


---
_Generated by [Claude Code](https://claude.ai/code/session_01234nCC9WFf8cxNPM6GUcdc)_