### PR TITLE
normalize output_credentials key conventions (#45)

### DIFF
--- a/src/zagg/__main__.py
+++ b/src/zagg/__main__.py
@@ -13,7 +13,7 @@ import logging
 import os
 
 from zagg.config import load_config
-from zagg.runner import agg
+from zagg.runner import agg, normalize_output_credentials
 
 
 def main():
@@ -45,7 +45,8 @@ examples:
         "--output-creds", default=None, metavar="PATH",
         help="Path to a JSON file with credentials for writing the output store "
              "(keys: accessKeyId, secretAccessKey, optional sessionToken/"
-             "endpointUrl/region). Omit to use the ambient/execution-role creds.",
+             "endpointUrl/region; camelCase, snake_case, or STS PascalCase "
+             "spellings accepted). Omit to use the ambient/execution-role creds.",
     )
     parser.add_argument(
         "--function-name",
@@ -64,6 +65,8 @@ examples:
     if args.output_creds:
         with open(args.output_creds) as f:
             output_credentials = json.load(f)
+        # Accept camelCase, snake_case, or STS PascalCase key spellings.
+        output_credentials = normalize_output_credentials(output_credentials)
         output_endpoint_url = output_credentials.get("endpointUrl")
 
     results = agg(

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -565,15 +565,17 @@ def normalize_output_credentials(credentials):
     Accepts camelCase (``accessKeyId``), boto snake_case
     (``aws_access_key_id``), and STS PascalCase (``AccessKeyId``) spellings,
     returning a dict keyed only by the canonical camelCase names. Keys that are
-    absent under every spelling are simply omitted. ``None``/empty passes
-    through unchanged so callers can keep using execution-role writes.
+    absent (or falsy under every spelling) are simply omitted -- the first
+    truthy spelling wins, mirroring the ``or``-chain read-path leniency in
+    ``processing.process_shard``. ``None``/empty passes through unchanged so
+    callers can keep using execution-role writes.
     """
     if not credentials:
         return credentials
     normalized = {}
     for canonical, aliases in _OUTPUT_CRED_ALIASES.items():
         for alias in aliases:
-            if alias in credentials:
+            if credentials.get(alias):
                 normalized[canonical] = credentials[alias]
                 break
     return normalized
@@ -605,8 +607,9 @@ def _build_output_creds_event(credentials, endpoint_url, region):
     }
     if credentials.get("sessionToken"):
         block["sessionToken"] = credentials["sessionToken"]
-    if endpoint_url:
-        block["endpointUrl"] = endpoint_url
+    endpoint = endpoint_url or credentials.get("endpointUrl")
+    if endpoint:
+        block["endpointUrl"] = endpoint
     return block
 
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -547,15 +547,57 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
     return summary
 
 
+# Maps each canonical camelCase key to the alternate spellings we accept on
+# input: boto/``~/.aws/credentials`` snake_case and STS PascalCase. Mirrors the
+# read-path leniency in ``processing.process_shard``.
+_OUTPUT_CRED_ALIASES = {
+    "accessKeyId": ("accessKeyId", "aws_access_key_id", "AccessKeyId"),
+    "secretAccessKey": ("secretAccessKey", "aws_secret_access_key", "SecretAccessKey"),
+    "sessionToken": ("sessionToken", "aws_session_token", "SessionToken"),
+    "region": ("region", "region_name", "Region"),
+    "endpointUrl": ("endpointUrl", "endpoint_url"),
+}
+
+
+def normalize_output_credentials(credentials):
+    """Normalize an output-credentials dict to the canonical camelCase shape.
+
+    Accepts camelCase (``accessKeyId``), boto snake_case
+    (``aws_access_key_id``), and STS PascalCase (``AccessKeyId``) spellings,
+    returning a dict keyed only by the canonical camelCase names. Keys that are
+    absent under every spelling are simply omitted. ``None``/empty passes
+    through unchanged so callers can keep using execution-role writes.
+    """
+    if not credentials:
+        return credentials
+    normalized = {}
+    for canonical, aliases in _OUTPUT_CRED_ALIASES.items():
+        for alias in aliases:
+            if alias in credentials:
+                normalized[canonical] = credentials[alias]
+                break
+    return normalized
+
+
 def _build_output_creds_event(credentials, endpoint_url, region):
     """Build the optional ``output_credentials`` event block, or None.
 
     Normalizes runtime credentials + non-secret endpoint/region into the
-    camelCase event shape the handler expects. Returns ``None`` when no
-    explicit credentials are supplied (execution-role writes, unchanged).
+    camelCase event shape the handler expects. Accepts camelCase, snake_case,
+    and STS PascalCase key conventions (see ``normalize_output_credentials``).
+    Returns ``None`` when no explicit credentials are supplied (execution-role
+    writes, unchanged).
     """
     if not credentials:
         return None
+    credentials = normalize_output_credentials(credentials)
+    missing = [k for k in ("accessKeyId", "secretAccessKey") if k not in credentials]
+    if missing:
+        raise ValueError(
+            "output_credentials is missing required field(s): "
+            f"{', '.join(missing)} (accepts camelCase, snake_case, or STS "
+            "PascalCase spellings)"
+        )
     block = {
         "accessKeyId": credentials["accessKeyId"],
         "secretAccessKey": credentials["secretAccessKey"],

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -175,6 +175,47 @@ class TestOutputCredsEvent:
         assert block["region"] == "eu-west-1"
         assert "sessionToken" not in block
 
+    def test_snake_case_input(self):
+        """boto / ``~/.aws/credentials`` spellings normalize to camelCase (#45)."""
+        from zagg.runner import _build_output_creds_event
+        creds = {
+            "aws_access_key_id": "AKIA",
+            "aws_secret_access_key": "s",
+            "aws_session_token": "t",
+            "region_name": "eu-west-1",
+        }
+        block = _build_output_creds_event(creds, None, "us-west-2")
+        assert block == {"accessKeyId": "AKIA", "secretAccessKey": "s",
+                         "region": "eu-west-1", "sessionToken": "t"}
+
+    def test_sts_pascalcase_input(self):
+        """STS ``Credentials`` spellings normalize to camelCase (#45)."""
+        from zagg.runner import _build_output_creds_event
+        creds = {
+            "AccessKeyId": "AKIA",
+            "SecretAccessKey": "s",
+            "SessionToken": "t",
+            "Region": "eu-west-1",
+        }
+        block = _build_output_creds_event(creds, None, "us-west-2")
+        assert block == {"accessKeyId": "AKIA", "secretAccessKey": "s",
+                         "region": "eu-west-1", "sessionToken": "t"}
+
+    def test_missing_required_field_raises_clear_error(self):
+        """A missing access key gives an actionable message, not a raw KeyError (#45)."""
+        from zagg.runner import _build_output_creds_event
+        creds = {"secretAccessKey": "s"}
+        with pytest.raises(ValueError, match="accessKeyId"):
+            _build_output_creds_event(creds, None, "us-west-2")
+
+    def test_endpoint_url_snake_case_normalizes(self):
+        """``endpoint_url`` in the creds dict normalizes to ``endpointUrl`` (#45)."""
+        from zagg.runner import normalize_output_credentials
+        creds = {"aws_access_key_id": "AKIA", "aws_secret_access_key": "s",
+                 "endpoint_url": "https://r2.example"}
+        normalized = normalize_output_credentials(creds)
+        assert normalized["endpointUrl"] == "https://r2.example"
+
 
 class TestInvokeLambdaCellEvent:
     """The per-cell Lambda event uses the grid-neutral ``shard_key`` field, and

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -208,13 +208,40 @@ class TestOutputCredsEvent:
         with pytest.raises(ValueError, match="accessKeyId"):
             _build_output_creds_event(creds, None, "us-west-2")
 
-    def test_endpoint_url_snake_case_normalizes(self):
-        """``endpoint_url`` in the creds dict normalizes to ``endpointUrl`` (#45)."""
-        from zagg.runner import normalize_output_credentials
+    def test_missing_both_required_fields_names_both(self):
+        """Both missing fields are named in the error (#45)."""
+        from zagg.runner import _build_output_creds_event
+        with pytest.raises(ValueError, match="accessKeyId.*secretAccessKey"):
+            _build_output_creds_event({"region": "us-west-2"}, None, "us-west-2")
+
+    def test_empty_creds_returns_none(self):
+        """An empty dict is treated as "no explicit creds", like None (#45)."""
+        from zagg.runner import _build_output_creds_event
+        assert _build_output_creds_event({}, None, "us-west-2") is None
+
+    def test_endpoint_url_from_creds_flows_into_event(self):
+        """``endpoint_url`` in the creds dict reaches the event block (#45)."""
+        from zagg.runner import _build_output_creds_event
         creds = {"aws_access_key_id": "AKIA", "aws_secret_access_key": "s",
                  "endpoint_url": "https://r2.example"}
+        block = _build_output_creds_event(creds, None, "us-west-2")
+        assert block["endpointUrl"] == "https://r2.example"
+
+    def test_endpoint_param_takes_precedence_over_creds(self):
+        """The explicit endpoint_url parameter wins over the creds dict (#45)."""
+        from zagg.runner import _build_output_creds_event
+        creds = {"accessKeyId": "AKIA", "secretAccessKey": "s",
+                 "endpointUrl": "https://from-creds"}
+        block = _build_output_creds_event(creds, "https://from-param", "us-west-2")
+        assert block["endpointUrl"] == "https://from-param"
+
+    def test_first_truthy_spelling_wins(self):
+        """A falsy spelling falls through to the next, mirroring the read path (#45)."""
+        from zagg.runner import normalize_output_credentials
+        creds = {"accessKeyId": "", "aws_access_key_id": "AKIA",
+                 "secretAccessKey": "s"}
         normalized = normalize_output_credentials(creds)
-        assert normalized["endpointUrl"] == "https://r2.example"
+        assert normalized["accessKeyId"] == "AKIA"
 
 
 class TestInvokeLambdaCellEvent:


### PR DESCRIPTION
Closes #45

## What

The write path for output credentials (`_build_output_creds_event` in `src/zagg/runner.py`) hard-subscripted `credentials["accessKeyId"]` / `["secretAccessKey"]`, so only camelCase keys worked. A creds JSON written in boto / `~/.aws/credentials` snake_case (`aws_access_key_id`, …) or STS PascalCase (`AccessKeyId`, …) failed with a confusing raw `KeyError`. The read path (`process_shard` in `src/zagg/processing.py`, ~L674-680) is already lenient — this makes the write path symmetric.

## Approach

Added a single normalization helper, `normalize_output_credentials`, in `runner.py`, driven by an `_OUTPUT_CRED_ALIASES` table that maps each canonical camelCase key to its accepted spellings:

- `accessKeyId` ← `aws_access_key_id` / `AccessKeyId`
- `secretAccessKey` ← `aws_secret_access_key` / `SecretAccessKey`
- `sessionToken` ← `aws_session_token` / `SessionToken`
- `region` ← `region_name` / `Region`
- `endpointUrl` ← `endpoint_url`

camelCase remains the canonical internal/event shape. The helper is applied at both touch points:

- the `--output-creds` loader in `src/zagg/__main__.py`, so the `endpointUrl` extraction is convention-agnostic;
- inside `_build_output_creds_event`, which now normalizes first and then raises a clear `ValueError` naming the missing field(s) instead of a bare `KeyError`:

```python
missing = [k for k in ("accessKeyId", "secretAccessKey") if k not in credentials]
if missing:
    raise ValueError(
        "output_credentials is missing required field(s): "
        f"{', '.join(missing)} (accepts camelCase, snake_case, or STS "
        "PascalCase spellings)"
    )
```

The `--output-creds` help text now notes that all three spellings are accepted.

## Phases

- [x] Add `normalize_output_credentials` helper + alias table; normalize in loader and event builder; replace bare KeyError with an actionable ValueError; cover camelCase / snake_case / STS PascalCase / missing-key with tests.

## Testing

- `uv run pytest -v` → 276 passed, 1 skipped (pre-existing spherely fork skip).
- `uv run ruff check src tests` → clean.
- New tests in `tests/test_runner.py::TestOutputCredsEvent`: `test_snake_case_input`, `test_sts_pascalcase_input`, `test_missing_required_field_raises_clear_error`, `test_endpoint_url_snake_case_normalizes` (plus the existing camelCase passthrough still green).

## Questions for review

- `ruff format --check` flags pre-existing drift across ~22 files repo-wide (unrelated to this change; the touched files add no new drift). Left as-is per the "don't fix unrelated CI failures" rule — flagging in case a separate format sweep is wanted.


---
_Generated by [Claude Code](https://claude.ai/code/session_014j6c1Xom5WATgtNSbCVBpZ)_