### PR TITLE
Guard plan_read against ATL03 empty-segment sentinel (#68)

### DIFF
--- a/src/zagg/read_plan.py
+++ b/src/zagg/read_plan.py
@@ -150,6 +150,11 @@ def plan_read(
             merged.append((s, e))
 
     # -- Translate to base slices --
+    # ``kept_runs`` stays one-to-one with ``base_slices``/``chunk_lists``: a run
+    # that yields no slice (all-empty, or collapsed) is dropped from all three,
+    # so the returned plan never has phantom ``parent_runs`` without matching
+    # reads (which would crash ``execute_read_plan`` on an empty concatenate).
+    kept_runs: list[tuple[int, int]] = []
     base_slices: list[tuple[int, int]] = []
     chunk_lists: list[list[tuple[int, int]]] = []
     total_base = 0
@@ -162,7 +167,9 @@ def plan_read(
         # spans from photon 0 to the AOI (~half the granule). That balloons
         # total_base past the selectivity threshold -> full-granule read -> OOM
         # (and ruinous compute). Bound each run by its NON-EMPTY segments only;
-        # empty ones carry no photons, so a run with none is skipped.
+        # empty ones carry no photons, so a run with none is skipped. (The single
+        # contiguous [first, last] slice relies on the #43 contiguity assumption:
+        # non-empty segments are monotonic in ph_index_beg and tile the photons.)
         local = np.flatnonzero(cnt[s : e + 1] > 0)
         if local.size == 0:
             continue
@@ -173,6 +180,7 @@ def plan_read(
         base_end = min(n_base, base_end)
         if base_end <= base_start:
             continue
+        kept_runs.append((s, e))
         base_slices.append((base_start, base_end))
         chunk_lists.append([(base_start, base_end)])  # h5coro half-open [start, end)
         total_base += base_end - base_start
@@ -187,7 +195,7 @@ def plan_read(
         )
 
     return ReadPlan(
-        parent_runs=merged,
+        parent_runs=kept_runs,
         base_slices=base_slices,
         chunk_lists=chunk_lists,
     )

--- a/src/zagg/read_plan.py
+++ b/src/zagg/read_plan.py
@@ -153,9 +153,22 @@ def plan_read(
     base_slices: list[tuple[int, int]] = []
     chunk_lists: list[list[tuple[int, int]]] = []
     total_base = 0
+    ibeg = np.asarray(index_beg_arr)
+    cnt = np.asarray(count_arr)
     for s, e in merged:
-        base_start = int(index_beg_arr[s]) - index_base
-        base_end = int(index_beg_arr[e]) - index_base + int(count_arr[e])
+        # ATL03 marks empty segments (no photons) with count == 0 and
+        # ph_index_beg == 0. Using such a segment as a run boundary translates
+        # to a bogus slice: base_start = 0 - index_base clamps to 0, so the read
+        # spans from photon 0 to the AOI (~half the granule). That balloons
+        # total_base past the selectivity threshold -> full-granule read -> OOM
+        # (and ruinous compute). Bound each run by its NON-EMPTY segments only;
+        # empty ones carry no photons, so a run with none is skipped.
+        local = np.flatnonzero(cnt[s : e + 1] > 0)
+        if local.size == 0:
+            continue
+        first, last = s + int(local[0]), s + int(local[-1])
+        base_start = int(ibeg[first]) - index_base
+        base_end = int(ibeg[last]) - index_base + int(cnt[last])
         base_start = max(0, base_start)
         base_end = min(n_base, base_end)
         if base_end <= base_start:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1859,6 +1859,38 @@ class TestPlannedReadGroup:
         assert df_planned["h"].tolist() == [40.0]
         assert df_full["h"].tolist() == [40.0]
 
+    def test_parity_with_empty_segment(self):
+        # ATL03 empty-segment sentinel (#68): seg 1 is empty (ph_index_beg==0,
+        # count==0) and is pulled into the matched run as the pad boundary. Pre-fix
+        # the run collapsed (base_end = 0-1+0 <= base_start) and the planned path
+        # dropped seg 0's real photons -> planned (None) != full. The guard bounds
+        # the run by its non-empty segment, restoring planned == full parity.
+        h5 = _FakeH5({
+            "/seg/lat": np.array([200.0, 300.0, 1000.0, 2000.0]),
+            "/seg/lon": np.zeros(4),
+            "/seg/ph_index_beg": np.array([1, 0, 3, 5], dtype=np.int64),  # seg 1 empty
+            "/seg/segment_ph_cnt": np.array([2, 0, 2, 2], dtype=np.int64),
+            "/heights/lat_ph": np.array([200.0, 210.0, 1000.0, 1010.0, 2000.0, 2010.0]),
+            "/heights/lon_ph": np.zeros(6),
+            "/heights/h": np.arange(6.0, dtype=np.float32) * 10.0,
+            "/heights/qs": np.zeros(6, dtype=np.int8),
+        })
+        grid = _LatBboxGrid((-0.1, 195.0, 0.1, 215.0))  # keeps photons 0,1 (lat 200,210)
+
+        ds_planned = _planned_read_data_source(with_base_filter=True)
+        ds_planned["levels"]["segments"]["link"]["index_base"] = 1  # ATL03 1-based
+        ds_planned["read_plan"]["pad"] = 1  # pull the empty seg 1 into the run
+        ds_full = {
+            "coordinates": {"latitude": "/heights/lat_ph", "longitude": "/heights/lon_ph"},
+            "variables": {"h": "/heights/h"},
+            "filters": [{"dataset": "/heights/qs", "op": "eq", "value": 0}],
+        }
+
+        df_planned = _read_group(h5, "gt1l", ds_planned, 0, grid)
+        df_full = _read_group(h5, "gt1l", ds_full, 0, grid)
+        assert df_planned["h"].tolist() == [0.0, 10.0]
+        assert df_full["h"].tolist() == [0.0, 10.0]
+
     def test_coarse_filter_via_planned_path(self):
         # Cross-level (Phase B) filter ANDs with the planned path: drop
         # segment 1 via podppd; segment 2 (also pulled in by the linestring

--- a/tests/test_read_plan.py
+++ b/tests/test_read_plan.py
@@ -152,6 +152,7 @@ class TestPlanReadEmptySegments:
         plan = plan_read(lats, lons, ibeg, cnt, n_base, bbox, index_base=1, pad=0)
         assert not plan.full_read  # pre-fix this ballooned to [0, 5200] -> selectivity full read
         assert plan.base_slices == [(5000, 5200)]  # non-empty segs 1..2 only
+        assert plan.parent_runs == [(0, 2)]  # parent_runs stays in lockstep
 
     def test_empty_at_run_end_not_dropped(self):
         # Empty segment at the run end must not collapse the slice to nothing.
@@ -163,9 +164,24 @@ class TestPlanReadEmptySegments:
         bbox = (0.0, -0.5, 1.0, 0.5)  # matches segs 0,1,2
         plan = plan_read(lats, lons, ibeg, cnt, n_base, bbox, index_base=1, pad=0)
         assert plan.base_slices == [(5000, 5200)]  # bounded by non-empty seg 1
+        assert plan.parent_runs == [(0, 2)]
 
-    def test_all_empty_run_skipped(self):
-        # A run with only empty segments contributes no photons and is dropped.
+    def test_empty_in_run_middle_stays_contiguous(self):
+        # An empty interior segment consumes no photon indices, so the two
+        # non-empty neighbours are adjacent -- one contiguous slice covers both.
+        lats = np.array([0.00, 0.10, 0.20, 40.0])
+        lons = np.full(4, 0.5)
+        ibeg = np.array([5001, 0, 5101, 5301])  # seg 1 empty (middle)
+        cnt = np.array([100, 0, 100, 100])
+        n_base = 5400
+        bbox = (0.0, -0.5, 1.0, 0.5)  # matches segs 0,1,2
+        plan = plan_read(lats, lons, ibeg, cnt, n_base, bbox, index_base=1, pad=0)
+        assert plan.base_slices == [(5000, 5200)]  # seg0 [5000,5100) + seg2 [5100,5200)
+        assert plan.parent_runs == [(0, 2)]
+
+    def test_all_empty_run_skipped_no_crash(self):
+        # A run with only empty segments contributes no photons. parent_runs MUST
+        # stay empty in lockstep, else execute_read_plan hits np.concatenate([]).
         lats = np.array([0.00, 0.10, 40.0])
         lons = np.full(3, 0.5)
         ibeg = np.array([0, 0, 5301])
@@ -174,7 +190,11 @@ class TestPlanReadEmptySegments:
         bbox = (0.0, -0.5, 1.0, 0.5)  # matches segs 0,1 (both empty)
         plan = plan_read(lats, lons, ibeg, cnt, n_base, bbox, index_base=1, pad=0)
         assert plan.base_slices == []
+        assert plan.parent_runs == []  # lockstep -> consumer short-circuits, no phantom run
         assert not plan.full_read
+        # consumer contract: must return empty, not raise on an empty concatenate.
+        out = execute_read_plan(plan, lambda *a, **k: np.array([]), "any/path", float)
+        assert out.size == 0
 
 
 class TestExecuteReadPlan:

--- a/tests/test_read_plan.py
+++ b/tests/test_read_plan.py
@@ -133,6 +133,50 @@ class TestPlanReadIndexBase:
         assert plan.base_slices[0] == (0, 5)  # 1-1=0, 0+5=5
 
 
+class TestPlanReadEmptySegments:
+    """ATL03 marks empty segments with ph_index_beg == 0 / count == 0. Using one
+    as a run boundary translated to a bogus slice -- balloon to photon 0 (->
+    full-read OOM) or collapse to nothing (-> silent data loss). The run must be
+    bounded by its non-empty segments only.
+    """
+
+    def test_empty_at_run_start_does_not_balloon(self):
+        # Three close rep-points all land in the bbox; the first is empty. The
+        # slice must start at the first NON-EMPTY segment's photons, not at 0.
+        lats = np.array([0.00, 0.10, 0.20, 40.0, 80.0])
+        lons = np.full(5, 0.5)
+        ibeg = np.array([0, 5001, 5101, 5201, 5301])  # seg 0 empty (sentinel 0)
+        cnt = np.array([0, 100, 100, 100, 100])
+        n_base = 5400
+        bbox = (0.0, -0.5, 1.0, 0.5)  # matches segs 0,1,2
+        plan = plan_read(lats, lons, ibeg, cnt, n_base, bbox, index_base=1, pad=0)
+        assert not plan.full_read  # pre-fix this ballooned to [0, 5200] -> selectivity full read
+        assert plan.base_slices == [(5000, 5200)]  # non-empty segs 1..2 only
+
+    def test_empty_at_run_end_not_dropped(self):
+        # Empty segment at the run end must not collapse the slice to nothing.
+        lats = np.array([0.00, 0.10, 0.20, 40.0])
+        lons = np.full(4, 0.5)
+        ibeg = np.array([5001, 5101, 0, 5301])  # seg 2 empty
+        cnt = np.array([100, 100, 0, 100])
+        n_base = 5400
+        bbox = (0.0, -0.5, 1.0, 0.5)  # matches segs 0,1,2
+        plan = plan_read(lats, lons, ibeg, cnt, n_base, bbox, index_base=1, pad=0)
+        assert plan.base_slices == [(5000, 5200)]  # bounded by non-empty seg 1
+
+    def test_all_empty_run_skipped(self):
+        # A run with only empty segments contributes no photons and is dropped.
+        lats = np.array([0.00, 0.10, 40.0])
+        lons = np.full(3, 0.5)
+        ibeg = np.array([0, 0, 5301])
+        cnt = np.array([0, 0, 100])
+        n_base = 5400
+        bbox = (0.0, -0.5, 1.0, 0.5)  # matches segs 0,1 (both empty)
+        plan = plan_read(lats, lons, ibeg, cnt, n_base, bbox, index_base=1, pad=0)
+        assert plan.base_slices == []
+        assert not plan.full_read
+
+
 class TestExecuteReadPlan:
     def _make_plan(self, slices, full_read=False):
         runs = [(s, e - 1) for s, e in slices]


### PR DESCRIPTION
Closes #68.

`plan_read` translated matched coarse segments to base-level photon slices using
the run-boundary segments' `ph_index_beg` directly. ATL03 marks **empty segments**
(no photons) with `ph_index_beg == 0` / `segment_ph_cnt == 0`, so a boundary empty
segment corrupted the slice:

- **start empty** → `base_start = 0 − index_base → clamp(0)` → slice spans photon 0
  to the AOI (~half the granule) → trips the `0.9 × n_base` selectivity threshold →
  `full_read` → `_planned_read_group` reads the whole granule → **Lambda OOM**;
- **end empty** → `base_end ≤ base_start` → run skipped → real photons **dropped**.

## Fix

Bound each run by its **non-empty** segments only (`count > 0`); a run with none is
skipped. One small change in `src/zagg/read_plan.py`'s slice-translation loop.

## How tested

- `pytest tests/test_read_plan.py -q` → **19 passed** (3 new in
  `TestPlanReadEmptySegments`: start-empty no-balloon, end-empty not-dropped,
  all-empty skipped). `ruff check` clean.
- **Real-data validation** (geolocation-only profile, shard 81 of the full-mission
  NEON map, granule `ATL03_20220427190246`):

  | beam | n_base | OLD planned read | OLD full? | NEW planned read | NEW full? | empties |
  |---|---|---|---|---|---|---|
  | gt1l | 59.2M | 106,595,710 | True | **1,160** | False | 3 |
  | gt2l | 49.4M | 133,950,678 | True | **1,407** | False | 5 |
  | gt3r | 22.4M | 20,527,450 | True | **2,858** | False | 1 |

  Full-reads across the shard's beams: **OLD 3 → NEW 0**. Beams that previously
  computed a 0-length read (silent drop) now read their real photons.

## Notes

- **Worker-side** code → needs a Lambda **function redeploy** (`build_function.sh`)
  to take effect on the fleet; nothing changes for existing shardmaps.
- Independent of the h5coro per-granule cache leak (#66); this is the dominant OOM
  driver in the full-mission run (112/256 shards OOM'd pre-fix).
- `_planned_read_group`'s planned-vs-full parity is preserved: empty segments carry
  no photons, so excluding them from the slice bounds changes which bytes are read,
  not which photons land in the AOI.

_Authored by Claude for @espg._
