### PR TITLE
Capability registry — shared name→object vocabulary (#64)

### DIFF
--- a/src/zagg/registry.py
+++ b/src/zagg/registry.py
@@ -1,0 +1,450 @@
+"""Capability registry — the shared name→object vocabulary (issue #64).
+
+zagg resolves *capabilities* — spatial functions, reducers, mask providers,
+etc. — by **name** rather than by passing callables through a config. Names
+round-trip through YAML, Lambda JSON payloads, and the MCP `describe_products`
+tool (#59); callables do not. This module owns the eight capability namespaces
+named in the June 2026 plan
+(https://github.com/englacial/zagg/issues/12#issuecomment-4635480666):
+
+==================  ===================================================
+Registry            What it holds
+==================  ===================================================
+spatial_func        Per-timestep reductions over a 2-D field (``max``)
+reducer             Streaming accumulators across timesteps (``Max``)
+mask_provider       Producers of boolean masks (``ais``, ``ocean``)
+field_transform     Per-timestep transforms (``monthly_anomaly``)
+event_trigger       Predicates that fire on a specific timestep
+reader              Multi-collection data readers
+catalog_source      Catalog adapters (CMR, earthaccess, …)
+credential_provider Credential adapters (NSIDC, GES-DISC, EDL, …)
+==================  ===================================================
+
+Design (issue #64, locked with @espg):
+
+- **Strings, never callables.** The registry maps a public *name* to a private
+  *object*; configs/payloads carry the name and re-resolve the object at the
+  execution site. The name is the stable identifier, the object is versioned.
+- **`Registry[T]` class core** with `register` / `get` / `list` / `describe`.
+- **Optional per-entry schema.** Each registration may carry a one-line
+  ``description`` and an optional ``schema`` (a pydantic model / JSON schema for
+  the entry's YAML args). Entries without a schema pay nothing; ``describe``
+  surfaces it when present. This is the additive "(B) now, (C) where it earns
+  its keep" path to the full MCP parameter surface.
+- **Lazy entry-point discovery.** External packages contribute by declaring a
+  ``zagg.plugins`` entry point pointing at a zero-arg ``register()`` callable;
+  the first ``get`` / ``list`` triggers discovery once.
+- **`UnknownCapability`** carries the kind + the sorted ``available`` names so a
+  miss is a clean, propagatable error (good "did you mean…" surface for MCP).
+
+Built-in capabilities register when the later phases land their owning modules;
+this module ships the seam alone — every registry starts empty.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from importlib import metadata
+from typing import Any, Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Entry-point group external plugins declare in their ``pyproject.toml``::
+#
+#     [project.entry-points."zagg.plugins"]
+#     antarctic_ar = "zagg_ar:register"
+_ENTRY_POINT_GROUP = "zagg.plugins"
+
+
+class UnknownCapability(KeyError):
+    """Raised when a capability name is not registered for its kind.
+
+    Subclasses ``KeyError`` so existing ``except KeyError`` paths still catch
+    it, while carrying ``kind`` and the sorted ``available`` names for a
+    diagnosable message (and a clean error type for the MCP server to relay).
+    """
+
+    def __init__(self, name: str, kind: str, available: Iterable[str]):
+        self.name = name
+        self.kind = kind
+        self.available = list(available)
+        super().__init__(f"Unknown {kind} {name!r}; registered: {self.available}")
+
+    def __str__(self) -> str:  # KeyError stringifies via repr(); override for readability
+        return f"Unknown {self.kind} {self.name!r}; registered: {self.available}"
+
+
+@dataclass(frozen=True)
+class Entry(Generic[T]):
+    """One registered capability: its name, object, and optional metadata."""
+
+    name: str
+    obj: T
+    description: str = ""
+    schema: Any | None = None
+
+
+class Registry(Generic[T]):
+    """A single named capability namespace (one of the eight ``kind``\\ s).
+
+    Use as a decorator (``@SPATIAL_FUNCS.register("max")``) or a direct call
+    (``SPATIAL_FUNCS.register("max", my_func)``). ``get`` / ``list`` /
+    ``describe`` trigger lazy entry-point discovery on first use.
+    """
+
+    def __init__(self, kind: str):
+        self.kind = kind
+        self._entries: dict[str, Entry[T]] = {}
+
+    def register(
+        self,
+        name: str,
+        obj: T | None = None,
+        *,
+        description: str = "",
+        schema: Any | None = None,
+        replace: bool = False,
+    ):
+        """Register ``obj`` under ``name`` (or return a decorator if omitted)."""
+        if obj is None:
+            def _decorate(target: T) -> T:
+                self._set(name, target, description, schema, replace)
+                return target
+
+            return _decorate
+        self._set(name, obj, description, schema, replace)
+        return obj
+
+    def _set(self, name: str, obj: T, description: str, schema: Any | None, replace: bool) -> None:
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"{self.kind} name must be a non-empty string, got {name!r}")
+        if not replace and name in self._entries:
+            raise ValueError(
+                f"{self.kind} {name!r} is already registered; pass replace=True to override"
+            )
+        self._entries[name] = Entry(name, obj, description, schema)
+
+    def get(self, name: str) -> T:
+        _ensure_discovered()
+        try:
+            return self._entries[name].obj
+        except KeyError:
+            raise UnknownCapability(name, self.kind, sorted(self._entries)) from None
+
+    def list(self) -> list[str]:
+        _ensure_discovered()
+        return sorted(self._entries)
+
+    def describe(self, name: str) -> dict[str, Any]:
+        """Return ``{name, kind, description, schema?}`` for one entry."""
+        _ensure_discovered()
+        try:
+            entry = self._entries[name]
+        except KeyError:
+            raise UnknownCapability(name, self.kind, sorted(self._entries)) from None
+        return _entry_dict(entry, self.kind)
+
+    def describe_all(self) -> list[dict[str, Any]]:
+        """Return one ``describe`` dict per entry, name-sorted."""
+        _ensure_discovered()
+        return [_entry_dict(self._entries[name], self.kind) for name in sorted(self._entries)]
+
+    def __contains__(self, name: object) -> bool:
+        _ensure_discovered()
+        return name in self._entries
+
+
+def _entry_dict(entry: Entry, kind: str) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": entry.name, "kind": kind, "description": entry.description}
+    if entry.schema is not None:
+        out["schema"] = entry.schema
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The eight registries
+# ---------------------------------------------------------------------------
+
+SPATIAL_FUNCS: Registry[Callable] = Registry("spatial_func")
+REDUCERS: Registry[Any] = Registry("reducer")
+MASK_PROVIDERS: Registry[Any] = Registry("mask_provider")
+FIELD_TRANSFORMS: Registry[Callable] = Registry("field_transform")
+EVENT_TRIGGERS: Registry[Callable] = Registry("event_trigger")
+READERS: Registry[Any] = Registry("reader")
+CATALOG_SOURCES: Registry[Any] = Registry("catalog_source")
+CREDENTIAL_PROVIDERS: Registry[Any] = Registry("credential_provider")
+
+_REGISTRIES: dict[str, Registry] = {
+    reg.kind: reg
+    for reg in (
+        SPATIAL_FUNCS,
+        REDUCERS,
+        MASK_PROVIDERS,
+        FIELD_TRANSFORMS,
+        EVENT_TRIGGERS,
+        READERS,
+        CATALOG_SOURCES,
+        CREDENTIAL_PROVIDERS,
+    )
+}
+
+
+# ---------------------------------------------------------------------------
+# Lazy entry-point discovery
+# ---------------------------------------------------------------------------
+
+# ``_DISCOVERED`` flips True after a successful entry-point sweep so repeated
+# ``get`` / ``list`` calls don't re-iterate ``entry_points`` every time.
+# ``_DISCOVERING`` is a re-entrancy guard: if a plugin's ``register()`` reaches
+# a ``get`` during loading, we return early without re-running the sweep.
+_DISCOVERED = False
+_DISCOVERING = False
+
+
+def _ensure_discovered() -> None:
+    """Discover ``zagg.plugins`` entry points exactly once per interpreter.
+
+    Each entry point must resolve to a zero-arg callable that registers its
+    capabilities. A failure in one plugin's ``ep.load()`` / ``register()`` is
+    logged at ERROR and skipped — the rest still load. If
+    ``entry_points()`` itself raises, ``_DISCOVERED`` stays False so the next
+    ``get`` / ``list`` retries (transient backport failures don't degrade the
+    seam permanently).
+    """
+    global _DISCOVERED, _DISCOVERING
+    if _DISCOVERED or _DISCOVERING:
+        return
+    _DISCOVERING = True
+    try:
+        try:
+            eps: Iterable[metadata.EntryPoint] = metadata.entry_points(group=_ENTRY_POINT_GROUP)
+        except Exception:
+            logger.exception(
+                "zagg.plugins entry-point lookup failed; will retry on next get/list"
+            )
+            return  # Leave _DISCOVERED=False so subsequent calls retry.
+        # Flip the persistent flag before invoking plugins so a plugin's
+        # ``register()`` calling back through ``get`` short-circuits on
+        # ``_DISCOVERED`` and never re-enters the sweep.
+        _DISCOVERED = True
+        for ep in eps:
+            try:
+                register_fn = ep.load()
+            except Exception:
+                logger.exception("Failed to load zagg.plugins entry point %r", ep.name)
+                continue
+            try:
+                register_fn()
+            except Exception:
+                logger.exception("zagg.plugins entry point %r raised on register()", ep.name)
+    finally:
+        _DISCOVERING = False
+
+
+def discover_plugins(*, force: bool = False) -> None:
+    """Trigger entry-point discovery explicitly.
+
+    Discovery is normally lazy (deferred to the first ``get`` / ``list``). The
+    Lambda handler calls this at import so plugin-load failures surface in
+    cold-start logs rather than mid-invocation. ``force=True`` re-runs the
+    sweep (intended for tests that patch ``entry_points`` before first
+    discovery); re-running against already-registered plugins trips the
+    duplicate-name guard — use ``register(..., replace=True)`` to overwrite.
+    """
+    global _DISCOVERED
+    if force:
+        _DISCOVERED = False
+    _ensure_discovered()
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics + MCP surface
+# ---------------------------------------------------------------------------
+
+
+def registry_snapshot() -> dict[str, list[str]]:
+    """Name-only snapshot of every registry (diagnostics; coarse MCP view)."""
+    _ensure_discovered()
+    return {kind: reg.list() for kind, reg in _REGISTRIES.items()}
+
+
+def describe_all() -> dict[str, list[dict[str, Any]]]:
+    """Structured snapshot the MCP ``describe_products`` tool (#59) consumes.
+
+    ``{kind: [{name, kind, description, schema?}, …]}`` — a superset of
+    ``registry_snapshot`` that carries each entry's description and, where the
+    registrant supplied one, its argument ``schema``.
+    """
+    _ensure_discovered()
+    return {kind: reg.describe_all() for kind, reg in _REGISTRIES.items()}
+
+
+# ---------------------------------------------------------------------------
+# Per-kind functional wrappers
+#
+# Thin sugar over the ``Registry`` instances so call sites read as
+# ``register_spatial_func("max")`` and miss messages name the kind. Each pair
+# threads ``description`` / ``schema`` straight through to ``Registry.register``.
+# ---------------------------------------------------------------------------
+
+
+def register_spatial_func(name, func=None, *, description="", schema=None, replace=False):
+    """Register/decorate a spatial function (per-timestep 2-D reduction)."""
+    return SPATIAL_FUNCS.register(
+        name, func, description=description, schema=schema, replace=replace
+    )
+
+
+def get_spatial_func(name: str) -> Callable:
+    return SPATIAL_FUNCS.get(name)
+
+
+def list_spatial_funcs() -> list[str]:
+    return SPATIAL_FUNCS.list()
+
+
+def register_reducer(name, factory=None, *, description="", schema=None, replace=False):
+    """Register a streaming reducer/accumulator (class or zero-arg factory)."""
+    return REDUCERS.register(name, factory, description=description, schema=schema, replace=replace)
+
+
+def get_reducer(name: str) -> Any:
+    return REDUCERS.get(name)
+
+
+def list_reducers() -> list[str]:
+    return REDUCERS.list()
+
+
+def register_mask_provider(name, provider=None, *, description="", schema=None, replace=False):
+    """Register a mask provider (``ais``, ``ocean``, ``full``)."""
+    return MASK_PROVIDERS.register(
+        name, provider, description=description, schema=schema, replace=replace
+    )
+
+
+def get_mask_provider(name: str) -> Any:
+    return MASK_PROVIDERS.get(name)
+
+
+def list_mask_providers() -> list[str]:
+    return MASK_PROVIDERS.list()
+
+
+def register_field_transform(name, transform=None, *, description="", schema=None, replace=False):
+    """Register a per-timestep field transform (``monthly_anomaly``)."""
+    return FIELD_TRANSFORMS.register(
+        name, transform, description=description, schema=schema, replace=replace
+    )
+
+
+def get_field_transform(name: str) -> Callable:
+    return FIELD_TRANSFORMS.get(name)
+
+
+def list_field_transforms() -> list[str]:
+    return FIELD_TRANSFORMS.list()
+
+
+def register_event_trigger(name, predicate=None, *, description="", schema=None, replace=False):
+    """Register an event-trigger predicate (``first_landfall``)."""
+    return EVENT_TRIGGERS.register(
+        name, predicate, description=description, schema=schema, replace=replace
+    )
+
+
+def get_event_trigger(name: str) -> Callable:
+    return EVENT_TRIGGERS.get(name)
+
+
+def list_event_triggers() -> list[str]:
+    return EVENT_TRIGGERS.list()
+
+
+def register_reader(name, reader=None, *, description="", schema=None, replace=False):
+    """Register a data reader (multi-collection xarray loader)."""
+    return READERS.register(name, reader, description=description, schema=schema, replace=replace)
+
+
+def get_reader(name: str) -> Any:
+    return READERS.get(name)
+
+
+def list_readers() -> list[str]:
+    return READERS.list()
+
+
+def register_catalog_source(name, source=None, *, description="", schema=None, replace=False):
+    """Register a catalog source (``cmr``, ``earthaccess``)."""
+    return CATALOG_SOURCES.register(
+        name, source, description=description, schema=schema, replace=replace
+    )
+
+
+def get_catalog_source(name: str) -> Any:
+    return CATALOG_SOURCES.get(name)
+
+
+def list_catalog_sources() -> list[str]:
+    return CATALOG_SOURCES.list()
+
+
+def register_credential_provider(name, provider=None, *, description="", schema=None, replace=False):
+    """Register a credential provider (``nsidc``, ``gesdisc``, ``edl``)."""
+    return CREDENTIAL_PROVIDERS.register(
+        name, provider, description=description, schema=schema, replace=replace
+    )
+
+
+def get_credential_provider(name: str) -> Any:
+    return CREDENTIAL_PROVIDERS.get(name)
+
+
+def list_credential_providers() -> list[str]:
+    return CREDENTIAL_PROVIDERS.list()
+
+
+__all__ = [
+    "Entry",
+    "Registry",
+    "UnknownCapability",
+    "SPATIAL_FUNCS",
+    "REDUCERS",
+    "MASK_PROVIDERS",
+    "FIELD_TRANSFORMS",
+    "EVENT_TRIGGERS",
+    "READERS",
+    "CATALOG_SOURCES",
+    "CREDENTIAL_PROVIDERS",
+    "describe_all",
+    "registry_snapshot",
+    "discover_plugins",
+    "register_spatial_func",
+    "get_spatial_func",
+    "list_spatial_funcs",
+    "register_reducer",
+    "get_reducer",
+    "list_reducers",
+    "register_mask_provider",
+    "get_mask_provider",
+    "list_mask_providers",
+    "register_field_transform",
+    "get_field_transform",
+    "list_field_transforms",
+    "register_event_trigger",
+    "get_event_trigger",
+    "list_event_triggers",
+    "register_reader",
+    "get_reader",
+    "list_readers",
+    "register_catalog_source",
+    "get_catalog_source",
+    "list_catalog_sources",
+    "register_credential_provider",
+    "get_credential_provider",
+    "list_credential_providers",
+]

--- a/src/zagg/registry.py
+++ b/src/zagg/registry.py
@@ -44,6 +44,7 @@ this module ships the seam alone — every registry starts empty.
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from importlib import metadata
@@ -109,8 +110,13 @@ class Registry(Generic[T]):
         schema: Any | None = None,
         replace: bool = False,
     ):
-        """Register ``obj`` under ``name`` (or return a decorator if omitted)."""
+        """Register ``obj`` under ``name`` (or return a decorator if omitted).
+
+        ``schema`` is stored by reference and surfaced as-is by ``describe`` —
+        pass an immutable / owned object; the registry does not copy it.
+        """
         if obj is None:
+
             def _decorate(target: T) -> T:
                 self._set(name, target, description, schema, replace)
                 return target
@@ -135,7 +141,7 @@ class Registry(Generic[T]):
         except KeyError:
             raise UnknownCapability(name, self.kind, sorted(self._entries)) from None
 
-    def list(self) -> list[str]:
+    def names(self) -> list[str]:
         _ensure_discovered()
         return sorted(self._entries)
 
@@ -203,6 +209,12 @@ _REGISTRIES: dict[str, Registry] = {
 # a ``get`` during loading, we return early without re-running the sweep.
 _DISCOVERED = False
 _DISCOVERING = False
+# Guards the first-time sweep so concurrent ``get`` / ``names`` from worker
+# threads (the Lambda ThreadPoolExecutor) can't double-run discovery. Reentrant
+# so a plugin's ``register()`` calling back through ``get`` on the same thread
+# doesn't deadlock — though it short-circuits on ``_DISCOVERED`` before the lock
+# anyway, since that flag flips before the plugin loop runs.
+_DISCOVERY_LOCK = threading.RLock()
 
 
 def _ensure_discovered() -> None:
@@ -216,33 +228,36 @@ def _ensure_discovered() -> None:
     seam permanently).
     """
     global _DISCOVERED, _DISCOVERING
-    if _DISCOVERED or _DISCOVERING:
+    if _DISCOVERED:
         return
-    _DISCOVERING = True
-    try:
+    with _DISCOVERY_LOCK:
+        if _DISCOVERED or _DISCOVERING:
+            return
+        _DISCOVERING = True
         try:
-            eps: Iterable[metadata.EntryPoint] = metadata.entry_points(group=_ENTRY_POINT_GROUP)
-        except Exception:
-            logger.exception(
-                "zagg.plugins entry-point lookup failed; will retry on next get/list"
-            )
-            return  # Leave _DISCOVERED=False so subsequent calls retry.
-        # Flip the persistent flag before invoking plugins so a plugin's
-        # ``register()`` calling back through ``get`` short-circuits on
-        # ``_DISCOVERED`` and never re-enters the sweep.
-        _DISCOVERED = True
-        for ep in eps:
             try:
-                register_fn = ep.load()
+                eps: Iterable[metadata.EntryPoint] = metadata.entry_points(group=_ENTRY_POINT_GROUP)
             except Exception:
-                logger.exception("Failed to load zagg.plugins entry point %r", ep.name)
-                continue
-            try:
-                register_fn()
-            except Exception:
-                logger.exception("zagg.plugins entry point %r raised on register()", ep.name)
-    finally:
-        _DISCOVERING = False
+                logger.exception(
+                    "zagg.plugins entry-point lookup failed; will retry on next get/names"
+                )
+                return  # Leave _DISCOVERED=False so subsequent calls retry.
+            # Flip the persistent flag before invoking plugins so a plugin's
+            # ``register()`` calling back through ``get`` short-circuits on
+            # ``_DISCOVERED`` and never re-enters the sweep.
+            _DISCOVERED = True
+            for ep in eps:
+                try:
+                    register_fn = ep.load()
+                except Exception:
+                    logger.exception("Failed to load zagg.plugins entry point %r", ep.name)
+                    continue
+                try:
+                    register_fn()
+                except Exception:
+                    logger.exception("zagg.plugins entry point %r raised on register()", ep.name)
+        finally:
+            _DISCOVERING = False
 
 
 def discover_plugins(*, force: bool = False) -> None:
@@ -269,7 +284,7 @@ def discover_plugins(*, force: bool = False) -> None:
 def registry_snapshot() -> dict[str, list[str]]:
     """Name-only snapshot of every registry (diagnostics; coarse MCP view)."""
     _ensure_discovered()
-    return {kind: reg.list() for kind, reg in _REGISTRIES.items()}
+    return {kind: reg.names() for kind, reg in _REGISTRIES.items()}
 
 
 def describe_all() -> dict[str, list[dict[str, Any]]]:
@@ -304,7 +319,7 @@ def get_spatial_func(name: str) -> Callable:
 
 
 def list_spatial_funcs() -> list[str]:
-    return SPATIAL_FUNCS.list()
+    return SPATIAL_FUNCS.names()
 
 
 def register_reducer(name, factory=None, *, description="", schema=None, replace=False):
@@ -317,7 +332,7 @@ def get_reducer(name: str) -> Any:
 
 
 def list_reducers() -> list[str]:
-    return REDUCERS.list()
+    return REDUCERS.names()
 
 
 def register_mask_provider(name, provider=None, *, description="", schema=None, replace=False):
@@ -332,7 +347,7 @@ def get_mask_provider(name: str) -> Any:
 
 
 def list_mask_providers() -> list[str]:
-    return MASK_PROVIDERS.list()
+    return MASK_PROVIDERS.names()
 
 
 def register_field_transform(name, transform=None, *, description="", schema=None, replace=False):
@@ -347,7 +362,7 @@ def get_field_transform(name: str) -> Callable:
 
 
 def list_field_transforms() -> list[str]:
-    return FIELD_TRANSFORMS.list()
+    return FIELD_TRANSFORMS.names()
 
 
 def register_event_trigger(name, predicate=None, *, description="", schema=None, replace=False):
@@ -362,7 +377,7 @@ def get_event_trigger(name: str) -> Callable:
 
 
 def list_event_triggers() -> list[str]:
-    return EVENT_TRIGGERS.list()
+    return EVENT_TRIGGERS.names()
 
 
 def register_reader(name, reader=None, *, description="", schema=None, replace=False):
@@ -375,7 +390,7 @@ def get_reader(name: str) -> Any:
 
 
 def list_readers() -> list[str]:
-    return READERS.list()
+    return READERS.names()
 
 
 def register_catalog_source(name, source=None, *, description="", schema=None, replace=False):
@@ -390,10 +405,12 @@ def get_catalog_source(name: str) -> Any:
 
 
 def list_catalog_sources() -> list[str]:
-    return CATALOG_SOURCES.list()
+    return CATALOG_SOURCES.names()
 
 
-def register_credential_provider(name, provider=None, *, description="", schema=None, replace=False):
+def register_credential_provider(
+    name, provider=None, *, description="", schema=None, replace=False
+):
     """Register a credential provider (``nsidc``, ``gesdisc``, ``edl``)."""
     return CREDENTIAL_PROVIDERS.register(
         name, provider, description=description, schema=schema, replace=replace
@@ -405,7 +422,7 @@ def get_credential_provider(name: str) -> Any:
 
 
 def list_credential_providers() -> list[str]:
-    return CREDENTIAL_PROVIDERS.list()
+    return CREDENTIAL_PROVIDERS.names()
 
 
 __all__ = [

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -94,7 +94,7 @@ class TestSurface:
         assert ret is sentinel  # direct call returns the object
         reg = registry._REGISTRIES[kind]
         assert reg.get("demo") is sentinel
-        assert "demo" in reg.list()
+        assert "demo" in reg.names()
         assert "demo" in reg
 
     def test_register_decorator_form(self, kind, register_fn):
@@ -224,7 +224,7 @@ class TestDiscovery:
             _FakeEntryPoint("good", good_register),
         ]
         _patch_entry_points(monkeypatch, eps)
-        assert "good" in registry.REDUCERS.list()  # the broken one didn't abort discovery
+        assert "good" in registry.REDUCERS.names()  # the broken one didn't abort discovery
 
     def test_broken_register_is_skipped(self, monkeypatch):
         def bad_register():
@@ -235,7 +235,7 @@ class TestDiscovery:
 
         eps = [_FakeEntryPoint("bad", bad_register), _FakeEntryPoint("ok", good_register)]
         _patch_entry_points(monkeypatch, eps)
-        assert "ok" in registry.READERS.list()
+        assert "ok" in registry.READERS.names()
 
     def test_entry_points_lookup_failure_retries(self, monkeypatch):
         calls = {"n": 0}
@@ -261,12 +261,15 @@ class TestDiscovery:
         # A plugin whose register() itself calls get_* must not re-enter the sweep.
         def plugin_register():
             register_field_transform("a", object())
-            # Touch a get during discovery — should short-circuit, not recurse.
-            assert "a" in registry.FIELD_TRANSFORMS._entries
+            # Touch get/list during discovery — must short-circuit via the
+            # re-entrancy guard, not recurse into another sweep. These calls go
+            # through _ensure_discovered(); they hang/recurse if the guard breaks.
+            assert "a" in registry.FIELD_TRANSFORMS  # __contains__ -> _ensure_discovered
+            assert registry.FIELD_TRANSFORMS.names() == ["a"]
 
         _patch_entry_points(monkeypatch, [_FakeEntryPoint("p", plugin_register)])
         discover_plugins()
-        assert "a" in registry.FIELD_TRANSFORMS.list()
+        assert "a" in registry.FIELD_TRANSFORMS.names()
 
     def test_discover_plugins_force_reruns(self, monkeypatch):
         seen = {"n": 0}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,297 @@
+"""Tests for the capability registry (issue #64)."""
+
+from __future__ import annotations
+
+import pytest
+
+import zagg.registry as registry
+from zagg.registry import (
+    UnknownCapability,
+    describe_all,
+    discover_plugins,
+    get_spatial_func,
+    list_spatial_funcs,
+    register_catalog_source,
+    register_credential_provider,
+    register_event_trigger,
+    register_field_transform,
+    register_mask_provider,
+    register_reader,
+    register_reducer,
+    register_spatial_func,
+    registry_snapshot,
+)
+
+# The June plan names exactly these eight registries; treated as an invariant.
+_EXPECTED_REGISTRIES = {
+    "spatial_func",
+    "reducer",
+    "mask_provider",
+    "field_transform",
+    "event_trigger",
+    "reader",
+    "catalog_source",
+    "credential_provider",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries():
+    """Snapshot every registry + the discovery flags; restore on teardown."""
+    saved = {kind: dict(reg._entries) for kind, reg in registry._REGISTRIES.items()}
+    saved_discovered = registry._DISCOVERED
+    saved_discovering = registry._DISCOVERING
+    yield
+    for kind, reg in registry._REGISTRIES.items():
+        reg._entries.clear()
+        reg._entries.update(saved[kind])
+    registry._DISCOVERED = saved_discovered
+    registry._DISCOVERING = saved_discovering
+
+
+# ---------------------------------------------------------------------------
+# Registry set
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrySet:
+    def test_exactly_eight_registries(self):
+        assert set(registry._REGISTRIES) == _EXPECTED_REGISTRIES
+
+    def test_each_registry_knows_its_kind(self):
+        for kind, reg in registry._REGISTRIES.items():
+            assert reg.kind == kind
+
+    def test_snapshot_lists_every_registry_name_sorted(self):
+        snap = registry_snapshot()
+        assert set(snap) == _EXPECTED_REGISTRIES
+        for names in snap.values():
+            assert isinstance(names, list)
+            assert names == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# Register / get / list round-trip across all eight, both call forms
+# ---------------------------------------------------------------------------
+
+_REGISTER = [
+    ("spatial_func", register_spatial_func),
+    ("reducer", register_reducer),
+    ("mask_provider", register_mask_provider),
+    ("field_transform", register_field_transform),
+    ("event_trigger", register_event_trigger),
+    ("reader", register_reader),
+    ("catalog_source", register_catalog_source),
+    ("credential_provider", register_credential_provider),
+]
+
+
+@pytest.mark.parametrize("kind,register_fn", _REGISTER)
+class TestSurface:
+    def test_register_direct_then_get(self, kind, register_fn):
+        sentinel = object()
+        ret = register_fn("demo", sentinel)
+        assert ret is sentinel  # direct call returns the object
+        reg = registry._REGISTRIES[kind]
+        assert reg.get("demo") is sentinel
+        assert "demo" in reg.list()
+        assert "demo" in reg
+
+    def test_register_decorator_form(self, kind, register_fn):
+        @register_fn("decorated")
+        def capability():  # pragma: no cover - never called
+            return 1
+
+        assert registry._REGISTRIES[kind].get("decorated") is capability
+
+    def test_duplicate_raises_unless_replace(self, kind, register_fn):
+        register_fn("dup", object())
+        with pytest.raises(ValueError, match="already registered"):
+            register_fn("dup", object())
+        replacement = object()
+        register_fn("dup", replacement, replace=True)
+        assert registry._REGISTRIES[kind].get("dup") is replacement
+
+    def test_empty_or_nonstring_name_raises(self, kind, register_fn):
+        with pytest.raises(ValueError, match="non-empty string"):
+            register_fn("", object())
+        with pytest.raises(ValueError, match="non-empty string"):
+            register_fn(None, object())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Unknown-name error
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownCapability:
+    def test_get_unknown_raises_with_kind_and_available(self):
+        register_spatial_func("alpha", object())
+        register_spatial_func("beta", object())
+        with pytest.raises(UnknownCapability) as exc:
+            get_spatial_func("gamma")
+        err = exc.value
+        assert err.kind == "spatial_func"
+        assert err.name == "gamma"
+        assert err.available == ["alpha", "beta"]
+        assert "spatial_func" in str(err)
+        assert "alpha" in str(err)
+
+    def test_is_a_keyerror_subclass(self):
+        # Existing ``except KeyError`` paths keep catching it.
+        with pytest.raises(KeyError):
+            get_spatial_func("missing")
+
+    def test_describe_unknown_raises(self):
+        with pytest.raises(UnknownCapability):
+            registry.SPATIAL_FUNCS.describe("nope")
+
+
+# ---------------------------------------------------------------------------
+# Optional description + schema
+# ---------------------------------------------------------------------------
+
+
+class TestDescribeAndSchema:
+    def test_describe_without_schema_omits_key(self):
+        register_spatial_func("plain", object(), description="a plain one")
+        d = registry.SPATIAL_FUNCS.describe("plain")
+        assert d == {"name": "plain", "kind": "spatial_func", "description": "a plain one"}
+        assert "schema" not in d
+
+    def test_describe_with_schema_includes_it(self):
+        schema = {"type": "object", "properties": {"window": {"type": "integer"}}}
+        register_spatial_func("with_schema", object(), description="d", schema=schema)
+        d = registry.SPATIAL_FUNCS.describe("with_schema")
+        assert d["schema"] is schema
+        assert d["description"] == "d"
+
+    def test_describe_all_is_structured_and_sorted(self):
+        register_reducer("zeta", object())
+        register_reducer("alpha", object(), description="first")
+        out = describe_all()
+        assert set(out) == _EXPECTED_REGISTRIES
+        reducers = out["reducer"]
+        assert [e["name"] for e in reducers] == ["alpha", "zeta"]
+        assert reducers[0] == {"name": "alpha", "kind": "reducer", "description": "first"}
+
+    def test_schema_default_none_pays_nothing(self):
+        register_mask_provider("m", object())
+        entry = registry.MASK_PROVIDERS._entries["m"]
+        assert entry.schema is None
+        assert entry.description == ""
+
+
+# ---------------------------------------------------------------------------
+# Lazy entry-point discovery
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntryPoint:
+    def __init__(self, name, register_fn, *, load_error=None):
+        self.name = name
+        self._register_fn = register_fn
+        self._load_error = load_error
+
+    def load(self):
+        if self._load_error is not None:
+            raise self._load_error
+        return self._register_fn
+
+
+def _patch_entry_points(monkeypatch, eps):
+    monkeypatch.setattr(registry.metadata, "entry_points", lambda group: list(eps))
+    registry._DISCOVERED = False
+    registry._DISCOVERING = False
+
+
+class TestDiscovery:
+    def test_entry_point_register_runs_on_first_get(self, monkeypatch):
+        def plugin_register():
+            register_spatial_func("from_plugin", object())
+
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("p", plugin_register)])
+        # Not discovered yet until a get/list touches the registry.
+        assert "from_plugin" not in registry.SPATIAL_FUNCS._entries
+        assert "from_plugin" in list_spatial_funcs()
+
+    def test_broken_load_is_skipped(self, monkeypatch):
+        def good_register():
+            register_reducer("good", object())
+
+        eps = [
+            _FakeEntryPoint("broken", None, load_error=ImportError("boom")),
+            _FakeEntryPoint("good", good_register),
+        ]
+        _patch_entry_points(monkeypatch, eps)
+        assert "good" in registry.REDUCERS.list()  # the broken one didn't abort discovery
+
+    def test_broken_register_is_skipped(self, monkeypatch):
+        def bad_register():
+            raise RuntimeError("plugin blew up")
+
+        def good_register():
+            register_reader("ok", object())
+
+        eps = [_FakeEntryPoint("bad", bad_register), _FakeEntryPoint("ok", good_register)]
+        _patch_entry_points(monkeypatch, eps)
+        assert "ok" in registry.READERS.list()
+
+    def test_entry_points_lookup_failure_retries(self, monkeypatch):
+        calls = {"n": 0}
+
+        def flaky(group):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("transient metadata failure")
+            return []
+
+        monkeypatch.setattr(registry.metadata, "entry_points", flaky)
+        registry._DISCOVERED = False
+        registry._DISCOVERING = False
+        # First call swallows the failure and leaves the seam retryable.
+        assert list_spatial_funcs() == []
+        assert registry._DISCOVERED is False
+        # Second call succeeds and flips the flag.
+        assert list_spatial_funcs() == []
+        assert registry._DISCOVERED is True
+        assert calls["n"] == 2
+
+    def test_register_reentrancy_during_discovery(self, monkeypatch):
+        # A plugin whose register() itself calls get_* must not re-enter the sweep.
+        def plugin_register():
+            register_field_transform("a", object())
+            # Touch a get during discovery — should short-circuit, not recurse.
+            assert "a" in registry.FIELD_TRANSFORMS._entries
+
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("p", plugin_register)])
+        discover_plugins()
+        assert "a" in registry.FIELD_TRANSFORMS.list()
+
+    def test_discover_plugins_force_reruns(self, monkeypatch):
+        seen = {"n": 0}
+
+        def plugin_register():
+            seen["n"] += 1
+            # replace=True so the second (forced) sweep doesn't trip the dup guard.
+            register_credential_provider("edl", object(), replace=True)
+
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("p", plugin_register)])
+        discover_plugins()
+        assert seen["n"] == 1
+        discover_plugins(force=True)
+        assert seen["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Strings-not-callables invariant
+# ---------------------------------------------------------------------------
+
+
+def test_name_resolves_back_to_same_object():
+    def my_max(arr):  # pragma: no cover - never called
+        return arr
+
+    register_spatial_func("max", my_max)
+    # A config would carry the string "max"; resolution returns the callable.
+    assert get_spatial_func("max") is my_max


### PR DESCRIPTION
Closes #64.

Implements the plugin/capability registry as the shared **name→object** vocabulary for configs, Lambda payloads, and the MCP `describe_products` tool (#59), per the design locked with @espg on the issue thread (https://github.com/englacial/zagg/issues/64#issuecomment-4771358325).

## What / approach

New `src/zagg/registry.py` — a `Registry[T]` class core with thin per-kind functional wrappers:

- **`Registry[T]`** with `register` / `get` / `list` / `describe` / `describe_all` over the **eight** capability kinds from the [June plan](https://github.com/englacial/zagg/issues/12#issuecomment-4635480666) (`spatial_func`, `reducer`, `mask_provider`, `field_transform`, `event_trigger`, `reader`, `catalog_source`, `credential_provider`). `register` doubles as a decorator (`@SPATIAL_FUNCS.register("max")`) or a direct call.
- **Strings, never callables** — the registry maps a public *name* to a private *object*; configs/payloads carry the name and re-resolve at the execution site.
- **Optional per-entry `description` + `schema`** — the locked "(B) now, (C) where it earns its keep" path: entries without a schema pay nothing; `describe` surfaces a pydantic/JSON arg schema when a registrant supplies one. This is the additive route to the full MCP parameter surface without forcing every capability author to write a schema up front.
- **`UnknownCapability(name, kind, available=[...])`** — subclasses `KeyError` (so existing `except KeyError` paths still catch it) while carrying the kind + sorted available names for a clean "did you mean…" / MCP-relayable error.
- **Lazy `zagg.plugins` entry-point discovery** — first `get`/`list` triggers a one-time sweep; a broken plugin's `load()`/`register()` is logged-and-skipped, and a failure in `entry_points()` itself leaves the seam retryable. Includes the re-entrancy guard for a plugin whose `register()` calls back through `get`.
- **`describe_all()`** returns the structured `{kind: [{name, kind, description, schema?}, …]}` shape #59 consumes; `registry_snapshot()` keeps the name-only view for diagnostics.
- **Per-kind functional wrappers** (`register_spatial_func` / `get_spatial_func` / `list_spatial_funcs`, ×8) so call sites read clearly and miss-messages name the kind — names match #70's existing surface so its rebase (below) is minimal.

Built-ins register nothing yet — this ships the seam alone; the temporal engine's mask providers / field transforms / etc. register into it as their owning modules land.

## Relationship to #70

#70's Phase 2 shipped a *functional* registry; this PR lands the **canonical `Registry[T]` class core** per #64's locked design. As agreed (rebase, not restart — https://github.com/englacial/zagg/issues/63#issuecomment-4771921400), #70 rebases its registry onto this one and drops its copy; the functional wrapper names are kept identical here so that rebase is near-mechanical.

## Phases

- [x] `Registry[T]` core + the eight registries + `UnknownCapability` + optional `description`/`schema`
- [x] Lazy `zagg.plugins` entry-point discovery (re-entrancy guard + retry-on-lookup-failure)
- [x] `describe_all()` structured MCP surface + `registry_snapshot()` + per-kind functional wrappers
- [x] Tests (`tests/test_registry.py`)

## How tested

- `uv run pytest tests/test_registry.py -q` → **49 passed**. Covers: the eight-registry invariant; direct + decorator registration round-trips across all eight; duplicate→`ValueError` unless `replace=True`; empty/non-string name→`ValueError`; `UnknownCapability` carries kind + `available` and is a `KeyError`; optional `description`/`schema` surfaced by `describe`/`describe_all` (and omitted when absent); structured + sorted `describe_all`; lazy discovery (entry-point `register` runs on first `get`, broken `load()`/`register()` skipped, `entry_points()` failure retries, re-entrancy, `discover_plugins(force=True)`); and the name→same-object invariant.
- `uv run ruff check --select=E,F,W,I --ignore=E501 src/zagg/registry.py tests/test_registry.py` → clean.

## Questions for review

- **Functional wrapper naming:** kept `list_spatial_funcs` (etc.) to match #70's existing surface for a minimal rebase; the issue body wrote `list_spatial_functions()` illustratively. Flag if you'd prefer the longer form as the canonical name.
- **`schema` field type** is left as `Any` (a pydantic model *or* a JSON-schema dict) until #59 pins the MCP parameter encoding. Confirm that's the right level of looseness for now.

_Authored by Claude for @espg under the #64 routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EN7X53ZAyaCca9rjwv9qZw)_