### PR TITLE
Adopt mortie MortonIndexDtype for the `morton` coordinate (keep NESTED `cell_ids`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy>=2.0",
     "pandas>=2.2",
     "h5coro>=0.0.8",
-    "mortie>=0.8.0",
+    "mortie>=0.8.1",
     "earthaccess",
     "boto3",
     "fastparquet",

--- a/src/zagg/configs/atl06.yaml
+++ b/src/zagg/configs/atl06.yaml
@@ -18,7 +18,7 @@ aggregation:
       dtype: uint64
       fill_value: 0
     morton:
-      dtype: int64
+      dtype: uint64
       fill_value: 0
   variables:
     count:

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -1,4 +1,5 @@
 """HEALPix DGGS output grid via mortie."""
+
 from __future__ import annotations
 
 from typing import Literal
@@ -16,6 +17,7 @@ from zagg.config import (
     output_field_signature,
 )
 from zagg.grids.base import InconsistentShardError, vector_array_spec
+from zagg.grids.morton import to_morton_array
 
 HEALPIX_BASE_CELLS: int = 12
 HEALPIX_REF_ORDER: int = 18  # mortie's clip2order reference order; do not change
@@ -163,9 +165,7 @@ class HealpixGrid:
             healpix, _ = mort2healpix(np.asarray([int(shard_key)]))
             return (int(healpix[0]),)
         if self._position_map is None:
-            raise RuntimeError(
-                "block_index requires set_populated_shards() for dense layout"
-            )
+            raise RuntimeError("block_index requires set_populated_shards() for dense layout")
         return (self._position_map[int(shard_key)],)
 
     def shard_footprint(self, shard_key):
@@ -192,9 +192,17 @@ class HealpixGrid:
         return cell_ids
 
     def chunk_coords(self, shard_key) -> dict:
-        """Per-cell coord columns for HEALPix: ``morton`` and ``cell_ids``."""
+        """Per-cell coord columns for HEALPix: ``morton`` and ``cell_ids``.
+
+        ``morton`` is a mortie ``MortonIndexArray`` (the typed coordinate; #71);
+        it is stored as ``uint64`` on disk via :mod:`zagg.grids.morton`. ``cell_ids``
+        stays NESTED ``uint64`` (the DGGS coordinate, unchanged).
+        """
         children = self.children(shard_key)
-        return {"morton": children, "cell_ids": self.encode_cell_ids(children)}
+        return {
+            "morton": to_morton_array(children),
+            "cell_ids": self.encode_cell_ids(children),
+        }
 
     # ── identity / nesting ───────────────────────────────────────────────
 
@@ -223,9 +231,7 @@ class HealpixGrid:
         """
         if not isinstance(other, HealpixGrid):
             return False
-        return output_field_signature(self.config) == output_field_signature(
-            other.config
-        )
+        return output_field_signature(self.config) == output_field_signature(other.config)
 
     def emit_template(self, store: Store, *, overwrite: bool = False) -> Store:
         """Write the Zarr template (group + arrays) to ``store``."""
@@ -254,9 +260,7 @@ class HealpixGrid:
             chunk_grid=NamedConfig(
                 name="regular", configuration={"chunk_shape": (self.n_children,)}
             ),
-            chunk_key_encoding=NamedConfig(
-                name="default", configuration={"separator": "/"}
-            ),
+            chunk_key_encoding=NamedConfig(name="default", configuration={"separator": "/"}),
             codecs=(NamedConfig(name="bytes", configuration={"endian": "little"}),),
             storage_transformers=(),
             fill_value="NaN",

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -1,0 +1,59 @@
+"""Boundary adapter for mortie's ``morton_index`` extension type.
+
+The ``morton`` output coordinate is carried in memory as a mortie
+:class:`~mortie.morton_index.MortonIndexArray` (a pandas ExtensionArray over the
+packed ``uint64`` Morton words). On disk it is stored as plain ``uint64`` — Zarr
+stores numpy dtypes, not pandas extension dtypes — and reconstructed as a
+``MortonIndexArray`` on read.
+
+This is the contained #71 migration: only the ``morton`` coordinate adopts the
+type. ``cell_ids`` stays NESTED ``uint64`` (the DGGS coordinate, unchanged), and
+the internal leaf/cell/shard morton arithmetic (``cells_of`` / ``shards_of`` /
+``children``) stays on plain ``uint64`` ndarrays.
+
+Storing the raw ``uint64`` words (rather than a reinterpreted ``int64``) is what
+removes the sign hazard: the packed word's prefix is ``base+1``, so base cells
+7–11 set bit 63 and read back negative under an ``int64`` coordinate. ``uint64``
+keeps them non-negative and the Z-order intact (espg/zagg#71).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def morton_words(values) -> np.ndarray:
+    """Return the packed ``uint64`` Morton words for ``values``.
+
+    Accepts a :class:`~mortie.morton_index.MortonIndexArray` (its ``uint64``
+    storage is returned) or any ``uint64``-coercible array-like (returned as a
+    ``uint64`` ndarray). This is the on-disk / wire form of the ``morton``
+    coordinate.
+    """
+    data = getattr(values, "_data", None)
+    if data is not None:
+        return np.asarray(data, dtype=np.uint64)
+    return np.asarray(values, dtype=np.uint64)
+
+
+def to_morton_array(words):
+    """Reconstruct a ``MortonIndexArray`` from packed ``uint64`` words.
+
+    The inverse of :func:`morton_words` for the storage round-trip: read the
+    ``uint64`` coordinate back from Zarr and wrap it as the extension array.
+    """
+    from mortie import MortonIndexArray
+
+    return MortonIndexArray.from_words(np.asarray(words, dtype=np.uint64))
+
+
+def is_morton_array(values) -> bool:
+    """True if ``values`` is a mortie ``MortonIndexArray``."""
+    try:
+        from mortie import MortonIndexArray
+    except ImportError:  # pragma: no cover - mortie is a hard dependency
+        return False
+    return isinstance(values, MortonIndexArray)
+
+
+__all__ = ["morton_words", "to_morton_array", "is_morton_array"]

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -22,6 +22,15 @@ from __future__ import annotations
 import numpy as np
 
 
+def is_morton_array(values) -> bool:
+    """True if ``values`` is a mortie ``MortonIndexArray``."""
+    try:
+        from mortie import MortonIndexArray
+    except ImportError:  # pragma: no cover - mortie is a hard dependency
+        return False
+    return isinstance(values, MortonIndexArray)
+
+
 def morton_words(values) -> np.ndarray:
     """Return the packed ``uint64`` Morton words for ``values``.
 
@@ -30,9 +39,8 @@ def morton_words(values) -> np.ndarray:
     ``uint64`` ndarray). This is the on-disk / wire form of the ``morton``
     coordinate.
     """
-    data = getattr(values, "_data", None)
-    if data is not None:
-        return np.asarray(data, dtype=np.uint64)
+    if is_morton_array(values):
+        return np.asarray(values._data, dtype=np.uint64)
     return np.asarray(values, dtype=np.uint64)
 
 
@@ -47,13 +55,4 @@ def to_morton_array(words):
     return MortonIndexArray.from_words(np.asarray(words, dtype=np.uint64))
 
 
-def is_morton_array(values) -> bool:
-    """True if ``values`` is a mortie ``MortonIndexArray``."""
-    try:
-        from mortie import MortonIndexArray
-    except ImportError:  # pragma: no cover - mortie is a hard dependency
-        return False
-    return isinstance(values, MortonIndexArray)
-
-
-__all__ = ["morton_words", "to_morton_array", "is_morton_array"]
+__all__ = ["is_morton_array", "morton_words", "to_morton_array"]

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -25,6 +25,7 @@ from zagg.config import (
     get_data_vars,
     get_output_signature,
 )
+from zagg.grids.morton import is_morton_array, morton_words
 from zagg.read_plan import execute_read_plan, plan_read
 from zagg.schema import ProcessingMetadata
 
@@ -323,7 +324,13 @@ def _iter_carrier_columns(carrier):
     """
     if isinstance(carrier, pd.DataFrame):
         for name, series in carrier.items():
-            yield name, series.values
+            values = series.values
+            # The ``morton`` coordinate is carried as a mortie ``MortonIndexArray``
+            # (#71); Zarr stores numpy dtypes, so extract its packed ``uint64``
+            # words for the on-disk write (no .reshape on the extension array).
+            if is_morton_array(values):
+                values = morton_words(values)
+            yield name, values
         return
 
     import pyarrow as pa
@@ -876,9 +883,7 @@ def _planned_read_group(
     si_lvl = levels[spatial_index_level]
     link = si_lvl.get("link")
     if not isinstance(link, dict):
-        raise ValueError(
-            f"read_plan.spatial_index level {spatial_index_level!r} requires a 'link'"
-        )
+        raise ValueError(f"read_plan.spatial_index level {spatial_index_level!r} requires a 'link'")
     if link["to"] != base_level_key:
         raise ValueError(
             f"read_plan.spatial_index level {spatial_index_level!r} must link "
@@ -962,9 +967,7 @@ def _planned_read_group(
     coarse_structured = [
         f
         for f in filters
-        if "expression" not in f
-        and f.get("level") is not None
-        and f.get("level") != base_level_key
+        if "expression" not in f and f.get("level") is not None and f.get("level") != base_level_key
     ]
     expressions = [f for f in filters if "expression" in f]
 
@@ -1008,9 +1011,7 @@ def _planned_read_group(
     if coarse_structured:
         # Build the global base-index array once: which original-base positions
         # are present in the concatenated planned read.
-        global_idx = np.concatenate(
-            [np.arange(s, e, dtype=np.int64) for s, e in plan.base_slices]
-        )
+        global_idx = np.concatenate([np.arange(s, e, dtype=np.int64) for s, e in plan.base_slices])
         cross_full: np.ndarray | None = None
         for f in coarse_structured:
             level_key = f["level"]
@@ -1043,7 +1044,9 @@ def _planned_read_group(
         if keep_mask is not None:
             values = values[keep_mask]
         data_dict[col_name] = values
-    data_dict["leaf_id"] = leaf_after_spatial[keep_mask] if keep_mask is not None else leaf_after_spatial
+    data_dict["leaf_id"] = (
+        leaf_after_spatial[keep_mask] if keep_mask is not None else leaf_after_spatial
+    )
 
     # Base-level expression filters (aggregation-time escape hatch, no pushdown).
     for f in expressions:
@@ -1108,13 +1111,10 @@ def _read_group(h5obj, group: str, data_source: dict, shard_key: int, grid, arro
     if isinstance(rp, dict) and rp.get("spatial_index"):
         if not isinstance(levels, dict) or not levels:
             raise ValueError(
-                "data_source.read_plan.spatial_index requires a non-empty "
-                "'levels' mapping"
+                "data_source.read_plan.spatial_index requires a non-empty 'levels' mapping"
             )
         if not base_level:
-            raise ValueError(
-                "data_source.read_plan.spatial_index requires 'base_level'"
-            )
+            raise ValueError("data_source.read_plan.spatial_index requires 'base_level'")
         return _planned_read_group(h5obj, group, data_source, shard_key, grid, arrow=arrow)
     return _read_group_full(h5obj, group, data_source, shard_key, grid, arrow=arrow)
 

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -226,7 +226,11 @@ def _build_output(stats_arrays, data_vars, agg_fields, grid, shard_key, use_arro
         for var in data_vars
     }
     for col_name, vals in grid.chunk_coords(shard_key).items():
-        columns[col_name] = pa.array(np.asarray(vals))
+        # Route the morton coordinate through the same uint64 boundary as the
+        # pandas carrier (#71), so both carriers share one on-disk dtype guarantee
+        # rather than relying on MortonIndexArray.__array__ returning uint64.
+        arr = morton_words(vals) if is_morton_array(vals) else np.asarray(vals)
+        columns[col_name] = pa.array(arr)
     return pa.table(columns)
 
 

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -418,6 +418,9 @@ class TestMortonCoordinate:
         words = morton_words(coord)
         np.testing.assert_array_equal(words, np.asarray(cells, dtype=np.uint64))
         assert words.dtype == np.uint64
+        # The southern children set bit 63: non-negative as uint64, but at least
+        # one would have read back negative under the old int64 coordinate.
+        assert (words.view(np.int64) < 0).any()
         # Round-trips losslessly back through the uint64 storage form.
         np.testing.assert_array_equal(morton_words(to_morton_array(words)), words)
 
@@ -451,6 +454,9 @@ class TestMortonCoordinate:
         stored = grp["morton"][lo : hi + 1]
         expected = morton_words(coords["morton"])
         np.testing.assert_array_equal(stored, expected)
-        assert (stored >= 0).all()
+        # The southern parent's order-8 children set bit 63: under the old int64
+        # coordinate at least one word would have read back negative. As uint64
+        # they are stored intact (this is the sign hazard #71 removes).
+        assert stored.view(np.int64).min() < 0
         # Reconstructs to the same MortonIndexArray on read.
         np.testing.assert_array_equal(morton_words(to_morton_array(stored)), expected)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -5,7 +5,7 @@ import pytest
 from zarr import open_group
 from zarr.storage import MemoryStore
 
-from zagg.config import default_config
+from zagg.config import default_config, get_data_vars
 from zagg.grids import HEALPIX_BASE_CELLS, HealpixGrid, InconsistentShardError, from_config
 
 
@@ -107,9 +107,7 @@ class TestBlockIndex:
 
     def test_dense_uses_position_map(self):
         shards = _valid_parents(3)
-        g = HealpixGrid(
-            parent_order=6, child_order=8, layout="dense", populated_shards=shards
-        )
+        g = HealpixGrid(parent_order=6, child_order=8, layout="dense", populated_shards=shards)
         for i, s in enumerate(shards):
             assert g.block_index(s) == (i,)
 
@@ -123,7 +121,9 @@ class TestBlockIndex:
         shards = _valid_parents(3)
         shards_reordered = [shards[2], shards[0], shards[1]]
         g = HealpixGrid(
-            parent_order=6, child_order=8, layout="dense",
+            parent_order=6,
+            child_order=8,
+            layout="dense",
             populated_shards=shards_reordered,
         )
         assert g.block_index(shards_reordered[0]) == (0,)
@@ -136,8 +136,11 @@ class TestEmitTemplate:
         n_shards = 3
         shards = list(range(n_shards))
         g = HealpixGrid(
-            parent_order=6, child_order=8, layout="dense",
-            config=cfg, populated_shards=shards,
+            parent_order=6,
+            child_order=8,
+            layout="dense",
+            config=cfg,
+            populated_shards=shards,
         )
         store = MemoryStore()
         g.emit_template(store)
@@ -147,9 +150,7 @@ class TestEmitTemplate:
             assert group[name].shape == expected
 
     def test_fullsphere_shape(self, cfg):
-        g = HealpixGrid(
-            parent_order=6, child_order=8, layout="fullsphere", config=cfg
-        )
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
         store = MemoryStore()
         g.emit_template(store)
         group = open_group(store, path="8", mode="r")
@@ -161,7 +162,10 @@ class TestEmitTemplate:
         """Chunk-alignment invariant: chunks == 4^(child - parent)."""
         for layout in ("dense", "fullsphere"):
             g = HealpixGrid(
-                parent_order=6, child_order=8, layout=layout, config=cfg,
+                parent_order=6,
+                child_order=8,
+                layout=layout,
+                config=cfg,
                 populated_shards=[1, 2, 3] if layout == "dense" else None,
             )
             store = MemoryStore()
@@ -169,9 +173,7 @@ class TestEmitTemplate:
             group = open_group(store, path="8", mode="r")
             expected_chunks = (4 ** (8 - 6),)
             for name in group:
-                assert group[name].chunks == expected_chunks, (
-                    f"layout={layout} var={name}"
-                )
+                assert group[name].chunks == expected_chunks, f"layout={layout} var={name}"
 
 
 class TestRoundTrip:
@@ -181,7 +183,9 @@ class TestRoundTrip:
 
         g = HealpixGrid(parent_order=6, child_order=12, config=cfg)
         lat, lon = -78.5, -132.0
-        expected_parent = int(clip2order(6, geo2mort(np.array([lat]), np.array([lon]), order=18))[0])
+        expected_parent = int(
+            clip2order(6, geo2mort(np.array([lat]), np.array([lon]), order=18))[0]
+        )
         leaves = g.assign(np.array([lat]), np.array([lon]))
         assert g.shard_of(leaves) == expected_parent
 
@@ -240,9 +244,7 @@ class TestBackcompatWrapper:
         from zagg.schema import xdggs_zarr_template
 
         store = MemoryStore()
-        xdggs_zarr_template(
-            store, parent_order=6, child_order=8, n_parent_cells=3, config=cfg
-        )
+        xdggs_zarr_template(store, parent_order=6, child_order=8, n_parent_cells=3, config=cfg)
         group = open_group(store, path="8", mode="r")
         assert group["count"].shape == (4 ** (8 - 6) * 3,)
 
@@ -266,9 +268,7 @@ def _vector_config(bins=4, dtype="int64"):
             },
         },
     }
-    return PipelineConfig(
-        data_source=base.data_source, aggregation=agg, output=base.output
-    )
+    return PipelineConfig(data_source=base.data_source, aggregation=agg, output=base.output)
 
 
 class TestOutputFieldSignature:
@@ -286,9 +286,7 @@ class TestOutputFieldSignature:
             assert set(f) == {"name", "kind", "trailing_shape", "inner_shape", "dtype"}
 
     def test_signature_marks_vector_field(self):
-        g = HealpixGrid(
-            parent_order=6, child_order=8, layout="fullsphere", config=_vector_config()
-        )
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=_vector_config())
         by_name = {f["name"]: f for f in g.signature()["output_fields"]}
         assert by_name["hist"]["kind"] == "vector"
         assert by_name["hist"]["trailing_shape"] == [4]
@@ -298,9 +296,7 @@ class TestOutputFieldSignature:
     def test_signature_is_json_serializable(self):
         import json
 
-        g = HealpixGrid(
-            parent_order=6, child_order=8, layout="fullsphere", config=_vector_config()
-        )
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=_vector_config())
         fields = g.signature()["output_fields"]
         # Round-trips through JSON unchanged (recorded in a ShardMap as JSON).
         assert json.loads(json.dumps(fields)) == fields
@@ -311,9 +307,7 @@ class TestOutputFieldSignature:
         assert a.nests_with(b) and b.nests_with(a)
 
     def test_nests_with_differing_field_kind_rejected(self, cfg):
-        scalar = HealpixGrid(
-            parent_order=6, child_order=8, layout="fullsphere", config=cfg
-        )
+        scalar = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
         vector = HealpixGrid(
             parent_order=6, child_order=8, layout="fullsphere", config=_vector_config()
         )
@@ -381,3 +375,82 @@ class TestVectorTemplate:
         assert grp["count"].shape == (g.height, g.width)
         assert grp["hist"].shape == (g.height, g.width, 4)
         assert grp["hist"].chunks == (64, 64, 4)  # trailing dim whole
+
+
+class TestMortonCoordinate:
+    """The ``morton`` coordinate is a mortie ``MortonIndexArray`` stored as
+    ``uint64`` on disk (#71); ``cell_ids`` stays NESTED ``uint64`` (DGGS)."""
+
+    def test_chunk_coords_morton_is_extension_array(self, cfg):
+        from mortie import MortonIndexArray
+
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        parent = _valid_parents(1)[0]
+        coords = g.chunk_coords(parent)
+        assert isinstance(coords["morton"], MortonIndexArray)
+        # cell_ids stays a plain NESTED integer array, unchanged.
+        assert not isinstance(coords["cell_ids"], MortonIndexArray)
+
+    def test_morton_words_match_generate_children(self, cfg):
+        """The typed coordinate carries the same packed words generate_morton_children
+        returns — the type is a skin, not a re-encoding."""
+        from mortie import generate_morton_children
+
+        from zagg.grids.morton import morton_words
+
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        parent = _valid_parents(1)[0]
+        children = generate_morton_children(int(parent), 8)
+        coords = g.chunk_coords(parent)
+        np.testing.assert_array_equal(morton_words(coords["morton"]), children)
+
+    def test_geo2mort_clip2order_coord_roundtrip(self, cfg):
+        """geo2mort → clip2order → coord → reload reconstructs the same words and
+        is non-negative for southern (base 7-11) cells where int64 went negative."""
+        from mortie import clip2order, geo2mort
+
+        from zagg.grids.morton import morton_words, to_morton_array
+
+        # A southern point lands in a high base cell whose packed word sets bit 63.
+        leaf = geo2mort(np.array([-78.5]), np.array([-132.0]), order=18)
+        cells = clip2order(8, leaf)
+        coord = to_morton_array(cells)
+        words = morton_words(coord)
+        np.testing.assert_array_equal(words, np.asarray(cells, dtype=np.uint64))
+        assert words.dtype == np.uint64
+        # Round-trips losslessly back through the uint64 storage form.
+        np.testing.assert_array_equal(morton_words(to_morton_array(words)), words)
+
+    def test_morton_stored_uint64_roundtrips_through_zarr(self, cfg):
+        """Write a fullsphere chunk and read morton back as the same non-negative
+        uint64 words — the int64 sign hazard is gone (#71)."""
+        import pandas as pd
+
+        from zagg.grids.morton import morton_words, to_morton_array
+        from zagg.processing import write_dataframe_to_zarr
+
+        parent_order, child_order = 6, 8
+        g = HealpixGrid(parent_order, child_order, layout="fullsphere", config=cfg)
+        store = MemoryStore()
+        g.emit_template(store)
+
+        parent = _valid_parents(1)[0]
+        coords = g.chunk_coords(parent)
+        n = len(coords["cell_ids"])
+        df = pd.DataFrame({"cell_ids": coords["cell_ids"]})
+        df["morton"] = coords["morton"]
+        for var in get_data_vars(cfg):
+            df[var] = np.zeros(n, dtype=np.int32 if var == "count" else np.float32)
+
+        write_dataframe_to_zarr(df, store, grid=g, chunk_idx=g.block_index(parent))
+
+        grp = open_group(store, path=str(child_order), mode="r")
+        assert grp["morton"].dtype == np.uint64
+        lo = int(np.asarray(coords["cell_ids"]).min())
+        hi = int(np.asarray(coords["cell_ids"]).max())
+        stored = grp["morton"][lo : hi + 1]
+        expected = morton_words(coords["morton"])
+        np.testing.assert_array_equal(stored, expected)
+        assert (stored >= 0).all()
+        # Reconstructs to the same MortonIndexArray on read.
+        np.testing.assert_array_equal(morton_words(to_morton_array(stored)), expected)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -87,7 +87,10 @@ class TestCreateZarrTemplate:
 
         group = open_group(store, path="8", mode="r")
         assert group["cell_ids"].dtype == np.uint64
-        assert group["morton"].dtype == np.int64
+        # morton is stored as uint64 (#71): the mortie MortonIndexArray's packed
+        # words are unsigned, so base cells 7-11 (bit 63 set) no longer read back
+        # negative as they did under the old int64 coordinate.
+        assert group["morton"].dtype == np.uint64
 
     def test_count_dtype(self):
         store = MemoryStore()

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -27,11 +27,15 @@ from zagg.grids import HealpixGrid, RectilinearGrid
 def _item(gid, lon0, lon1, lat0=38.85, lat1=38.93):
     ring = [[lon0, lat0], [lon1, lat0], [lon1, lat1], [lon0, lat1], [lon0, lat0]]
     return {
-        "type": "Feature", "stac_version": "1.0.0", "id": gid,
+        "type": "Feature",
+        "stac_version": "1.0.0",
+        "id": gid,
         "geometry": {"type": "Polygon", "coordinates": [ring]},
         "bbox": [lon0, lat0, lon1, lat1],
         "properties": {"datetime": "2025-06-01T00:00:00Z"},
-        "collection": "TEST", "stac_extensions": [], "links": [],
+        "collection": "TEST",
+        "stac_extensions": [],
+        "links": [],
         "assets": {
             "data": {"href": f"https://h/{gid}.h5", "roles": ["data"]},
             "data_s3": {"href": f"s3://b/{gid}.h5", "roles": ["data"]},
@@ -49,7 +53,10 @@ def _catalog(items):
 @pytest.fixture
 def grid():
     return RectilinearGrid(
-        "EPSG:32618", 10, [359400, 4300740, 369400, 4310740], [250, 250],
+        "EPSG:32618",
+        10,
+        [359400, 4300740, 369400, 4310740],
+        [250, 250],
         config=default_config("atl06_polar"),
     )
 
@@ -57,11 +64,13 @@ def grid():
 @pytest.fixture
 def catalog():
     # West-half, east-half, and a small NE granule over SERC.
-    return _catalog([
-        _item("Gwest", -76.62, -76.57),
-        _item("Geast", -76.55, -76.50),
-        _item("GneSmall", -76.55, -76.52, 38.91, 38.93),
-    ])
+    return _catalog(
+        [
+            _item("Gwest", -76.62, -76.57),
+            _item("Geast", -76.55, -76.50),
+            _item("GneSmall", -76.55, -76.52, 38.91, 38.93),
+        ]
+    )
 
 
 def _granule_shards(sm):
@@ -81,14 +90,19 @@ def _granule_shards(sm):
 # the real ``_intersect_spherely`` brute branch run end-to-end. It deliberately
 # omits ``SpatialIndex`` to force ``hasattr(spherely, "SpatialIndex")`` False.
 
+
 class _FakePoly:
     def __init__(self, lons, lats):
         self.x0, self.x1 = float(min(lons)), float(max(lons))
         self.y0, self.y1 = float(min(lats)), float(max(lats))
 
     def _overlaps(self, other):
-        return (self.x0 <= other.x1 and other.x0 <= self.x1
-                and self.y0 <= other.y1 and other.y0 <= self.y1)
+        return (
+            self.x0 <= other.x1
+            and other.x0 <= self.x1
+            and self.y0 <= other.y1
+            and other.y0 <= self.y1
+        )
 
 
 def _fake_create_polygon(*, shell, oriented):  # noqa: ARG001 (mirror real sig)
@@ -147,6 +161,7 @@ class TestBuildSpherelyBrute:
     def test_brute_empty_records_early_out(self, grid, fake_spherely):
         # No records -> no polygons -> {} early-out, no intersect call (#36 brute path).
         from zagg.catalog.shardmap import _intersect_spherely
+
         assert _intersect_spherely([], grid, {}) == {}
 
 
@@ -178,8 +193,9 @@ def _has_spatial_index():
         return False
 
 
-@pytest.mark.skipif(not _has_spatial_index(),
-                    reason="spherely SpatialIndex (fork build) not installed")
+@pytest.mark.skipif(
+    not _has_spatial_index(), reason="spherely SpatialIndex (fork build) not installed"
+)
 class TestBuildSpherely:
     def test_spatial_split(self, catalog, grid):
         # Exact S2 with SpatialIndex gives the expected local split.
@@ -219,10 +235,11 @@ class TestResolveBackend:
     def test_cli_rejects_shapely_backend(self, monkeypatch):
         # shapely was dropped as a backend (#36); the CLI must not accept it.
         from zagg.catalog import main
+
         monkeypatch.setattr(
-            sys, "argv",
-            ["zagg-catalog", "--config", "x.yaml", "--short-name", "ATL03",
-             "--backend", "shapely"],
+            sys,
+            "argv",
+            ["zagg-catalog", "--config", "x.yaml", "--short-name", "ATL03", "--backend", "shapely"],
         )
         with pytest.raises(SystemExit):
             main()
@@ -244,3 +261,25 @@ class TestIO:
             path = f.name
         with pytest.raises(ValueError, match="missing required key"):
             ShardMap.from_json(path)
+
+    def test_high_base_cell_morton_keys_roundtrip(self):
+        """Parent-morton shard keys from southern (base 7-11) cells are large
+        unsigned words; JSON (de)serialization preserves them exactly (#71).
+
+        These are the keys that, as a signed int64, would read back negative —
+        here we assert the manifest carries the unsigned value byte-for-byte.
+        """
+        from mortie import clip2order, geo2mort
+
+        # Southern points → high base cells whose packed parent word sets bit 63.
+        pts = [(-78.5, -132.0), (-72.1, 25.4), (-65.0, -45.0)]
+        keys = sorted(
+            int(clip2order(6, geo2mort(np.array([lat]), np.array([lon]), order=18))[0])
+            for lat, lon in pts
+        )
+        assert any(k > 2**63 for k in keys)  # at least one bit-63-set key
+        sm = ShardMap({"type": "healpix"}, keys, [[] for _ in keys], {})
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            sm.to_json(f.name)
+            sm2 = ShardMap.from_json(f.name)
+        assert sm2.shard_keys == keys


### PR DESCRIPTION
Closes #71. Refs #57.

## What

Migrates the `morton` output coordinate to mortie's typed `morton_index` (a `MortonIndexArray` over packed `uint64` words), stored as `uint64` on disk and reconstructed as a `MortonIndexArray` on read. `cell_ids` stays NESTED `uint64` (the DGGS coordinate, byte-identical, unchanged) — exactly the contained slice locked in https://github.com/englacial/zagg/issues/57#issuecomment-4771871445.

This removes the int64 sign hazard that caused the three pre-existing `morton int64/uint64` failures on `main`. The packed Morton word's prefix is `base+1`, so base cells 7–11 set bit 63; pinned as the old `morton: int64` coordinate they read back **negative** (~5/12 of the sphere). Stored as `uint64` they stay non-negative with the Z-order intact.

## Approach

- **Boundary adapter** `src/zagg/grids/morton.py`: `morton_words()` (MortonIndexArray → packed `uint64` for storage/wire), `to_morton_array()` (the inverse, reconstruct on read), `is_morton_array()`. Zarr stores numpy dtypes, not pandas extension dtypes, so this is the seam where the type meets disk. (mortie's `to_morton_index`/`from_morton_index` are pyarrow/IPC bridges; the zarr coordinate is a plain numpy buffer, so the adapter goes through the array's `uint64` words directly — same bytes, no pyarrow dependency on the write path.)
- **`HealpixGrid.chunk_coords`** now returns `morton` as a `MortonIndexArray`; `cell_ids` untouched.
- **Storage boundary** in `processing._iter_carrier_columns` (pandas carrier) **and** `_build_output` (arrow carrier): a `MortonIndexArray` morton column is written as its `uint64` words via `morton_words`, so both carriers share one on-disk dtype guarantee.
- **Type scope (contained):** the internal leaf/cell/shard morton **arithmetic** (`cells_of`/`shards_of`/`children`, and the `cell_to_slice` dict keys in `processing.py`) stays on plain `uint64` ndarrays. Those are grouping/coarsening math (`np.argsort`/`np.diff`/`==`), not the stored coordinate; wrapping them would change grouping semantics with no benefit to this slice. The typed array lives at the **coordinate/storage** surface, which is what #71 specifies ("Make the `morton` coordinate a `MortonIndexDtype`-backed array").
- **Config:** `configs/atl06.yaml` `morton: int64 → uint64`. `atl06_polar.yaml` is rectilinear (no morton coord).
- **Dep pin:** `mortie>=0.8.0 → >=0.8.1` (0.8.x is the 1.0 RC with the core in place, per https://github.com/englacial/zagg/issues/57#issuecomment-4771968670).

## Hashability / ordering probe (the two items flagged verify-during-impl)

Both confirmed present against the installed mortie 0.8.1 (`mortie/morton_index.py`):

1. **Element-wise hashable (dict keys)** — **YES.** Scalar access `arr[i]` returns a plain `np.uint64` (`__getitem__` boxes scalars as `np.uint64(result)`), which is hashable; `{arr[i]: i ...}` and `arr[j] in d` both work. *(Note: zagg's `cell_to_slice` keys come from `cells_of` `uint64` ndarrays, not the extension array, so this isn't even on the hot path — but it's confirmed for any future use.)*
2. **Ordering (hyperslice min/max)** — **YES.** `MortonIndexArray` defines element-wise `__lt__/__le__/__gt__/__ge__` over the raw `uint64` (the Z-order; unsigned, so bit-63 cells sort correctly with no special-casing) and `_values_for_argsort()` returns the `uint64` words, so `np.argsort`/`np.unique`/`min`/`max` all work. `np.asarray(arr)` yields a plain `uint64` ndarray.

Nothing missing upstream — no blocker, no issue-#71 comment needed.

## Phases

- [x] **Phase 1** — Boundary adapter (`grids/morton.py`), `mortie>=0.8.1` pin, `morton: uint64` config.
- [x] **Phase 2** — `morton` coordinate as `MortonIndexArray` through `chunk_coords` + `uint64` storage round-trip at the write boundary (both carriers); tests. The three sign-bug tests pass.
- [x] **Review fold** — Folded the fresh-context self-review's four diff-scoped findings: route the arrow carrier morton column through `morton_words`; replace the vacuous `(stored >= 0).all()` with `stored.view(np.int64).min() < 0` (proves the sign bug is actually fixed); add the missing non-negativity assertion to the geo2mort→clip2order round-trip test; gate `morton_words` on the public `is_morton_array` instead of the private `_data`.

## How tested

- `uv run pytest -q`: **527 passed, 1 skipped** (was 519 passed / **3 failed** on `main`). The three previously-failing sign-bug tests now pass: `test_processing.TestWriteDataframeToZarr::test_write_dataframe_to_zarr`, `test_integration::test_full_integration`, `test_integration::test_multiple_parent_cells`.
- New tests (`tests/test_grids.py::TestMortonCoordinate`): `chunk_coords` yields a `MortonIndexArray`; words equal `generate_morton_children`; `geo2mort → clip2order → coord → reload` round-trip (asserts at least one bit-63 word); full zarr write/read round-trip asserting `uint64` dtype, lossless words, and that `stored.view(int64).min() < 0` (the bit that would have read negative under the old coordinate).
- `tests/test_shardmap.py::TestIO::test_high_base_cell_morton_keys_roundtrip`: parent-morton shard keys from base-7–11 cells (words > 2^63) survive JSON (de)serialization byte-for-byte.
- `tests/test_schema.py::test_coordinate_dtypes` updated to assert `morton` is now `uint64`.
- `ruff check --select=E,F,W,I --ignore=E501 src tests`, pinned `pre-commit` `ruff-format`/`ruff-check`/`codespell` — clean on touched files. CI `test (3.12)`/`test (3.13)`/`ruff`/`build`/`build-x86_64`/`build-arm64` green.

## Questions for review

1. **`lambda` extra mortie pin.** The locked design said "move the `lambda` extra's mortie pin in lockstep," but the `lambda` extra in `pyproject.toml` doesn't pin `mortie` (the core `mortie>=0.8.1` dep governs it), and the deployment layer build (`deployment/aws/build_layer.sh`) installs `mortie` unpinned. So there is no separate lambda pin to move — the core bump covers it. I left the deploy scripts untouched per the infra rule. Flag if you'd rather pin mortie explicitly in the `lambda` extra and/or the layer script (a deploy-script change I won't make without you naming it).
2. **Pre-existing `mypy` errors** in untouched files (`config.py`, `rectilinear.py`, `grids/__init__.py:51`, and pre-existing `processing.py` lines 422/429/459/1033/1353/1418/1481) are unrelated to this change; left as-is per §4. None are in the code this PR touches.
3. **Out-of-scope review observation (left standing).** The self-review noted that the existing `use_arrow=True` `_build_output` test in `tests/test_processing.py` exercises the arrow morton write but asserts only on `edges`/`count`, not the morton column's `uint64` round-trip. The arrow-path fix in this PR plus the new `test_morton_stored_uint64_roundtrips_through_zarr` cover the round-trip; adding a morton assertion to that pre-existing arrow test would be a belt-and-suspenders guard against a future `__array__` dtype regression. Left for you rather than expand scope into an unrelated test — say the word and I'll add it.
