### PR TITLE
Per-chunk precompute hook (compute once per chunk, use per cell)

### DIFF
--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -43,7 +43,12 @@ class LevelDict(TypedDict):
 
     path: str  # HDF5 group path template (may contain ``{group}``)
     coordinates: list[str]  # coordinate dataset names within ``path``
-    variables: list[str]  # variable dataset names within ``path``
+    # ``variables`` has two forms: a documentation-only ``list[str]`` of names, or
+    # (non-base levels, issue #30) a ``{name: path-template}`` mapping declaring a
+    # *readable* segment-level variable. The mapping form is read at coarse rate and
+    # broadcast to the base (photon) rows via ``link`` so e.g. ``dem_h`` (one value
+    # per ~100 photons) becomes a per-photon column the aggregation can reduce.
+    variables: list[str] | dict[str, str]
     link: NotRequired[LinkDict | None]
 
 
@@ -223,7 +228,13 @@ def validate_config(config: PipelineConfig) -> None:
     # Cross-check: each filter's level field must name a key in levels (issue #43)
     _validate_filter_levels(config.data_source)
 
-    ds_vars = set(config.data_source.get("variables", {}).keys())
+    # Segment-level (non-base) ``variables`` mappings (issue #30) become real
+    # per-photon columns in the pooled shard data once broadcast, so they are valid
+    # column references everywhere a ``data_source.variables`` column is (agg
+    # sources/expressions, chunk_precompute sources). Fold their names into ds_vars.
+    ds_vars = set(config.data_source.get("variables", {}).keys()) | _segment_variable_names(
+        config.data_source
+    )
     agg_vars = config.aggregation.get("variables", {})
 
     # Validate the per-chunk precompute hook (issue #30, item 1). Each entry is
@@ -659,6 +670,29 @@ def _validate_filters(data_source: dict) -> None:
                 raise ValueError(f"filter[{i}]: 'value' must be numeric (got {f['value']!r})")
 
 
+def _segment_variable_names(data_source: dict) -> set[str]:
+    """Names of readable segment-level (non-base) variables (issue #30).
+
+    A non-base level may declare ``variables`` as a ``{name: path-template}``
+    mapping; each name becomes a per-photon column once broadcast at read time
+    (:func:`zagg.processing._read_segment_broadcasts`). The documentation-only
+    ``list[str]`` form contributes nothing. Empty when no level declares the
+    mapping form, so plain configs are unaffected.
+    """
+    levels = data_source.get("levels")
+    base_level = data_source.get("base_level")
+    if not isinstance(levels, dict) or base_level is None:
+        return set()
+    names: set[str] = set()
+    for name, lvl in levels.items():
+        if name == base_level or not isinstance(lvl, dict):
+            continue
+        lvl_vars = lvl.get("variables")
+        if isinstance(lvl_vars, dict):
+            names |= set(lvl_vars)
+    return names
+
+
 def _validate_levels(data_source: dict) -> None:
     """Validate the hierarchical ``levels``/``base_level`` form (issue #43, Phase B).
 
@@ -683,12 +717,41 @@ def _validate_levels(data_source: dict) -> None:
             f"data_source.base_level {base_level!r} is not a key in levels "
             f"(available: {sorted(levels)})"
         )
+    base_vars = set(data_source.get("variables", {}))
     level_keys = set(levels)
     for name, lvl in levels.items():
         if not isinstance(lvl, dict):
             raise ValueError(f"levels.{name} must be a mapping")
         if "path" not in lvl:
             raise ValueError(f"levels.{name}: 'path' is required")
+        # A non-base level may declare ``variables`` as a ``{name: path-template}``
+        # mapping (issue #30): a readable segment-level variable broadcast to the
+        # base rows at read time. Validate it like ``data_source.variables`` (string
+        # names -> non-empty string path templates) and forbid the mapping form on
+        # the base level (the base level uses ``data_source.variables``). The
+        # documentation-only ``list[str]`` form stays valid on any level.
+        lvl_vars = lvl.get("variables")
+        if isinstance(lvl_vars, dict):
+            if name == base_level:
+                raise ValueError(
+                    f"levels.{base_level}: the base level uses data_source.variables; "
+                    f"a non-base level uses the 'variables' mapping for segment-level reads"
+                )
+            for var_name, tmpl in lvl_vars.items():
+                if not isinstance(var_name, str) or not var_name:
+                    raise ValueError(
+                        f"levels.{name}.variables: variable names must be non-empty strings"
+                    )
+                if not isinstance(tmpl, str) or not tmpl:
+                    raise ValueError(
+                        f"levels.{name}.variables.{var_name}: path template must be a "
+                        f"non-empty string (got {tmpl!r})"
+                    )
+                if var_name in base_vars:
+                    raise ValueError(
+                        f"levels.{name}.variables.{var_name}: collides with a "
+                        f"data_source.variables column"
+                    )
         link = lvl.get("link")
         if link is None:
             if name != base_level:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -386,6 +386,11 @@ def _validate_chunk_precompute(aggregation: dict, ds_vars: set[str]) -> None:
 # for variable-length per-cell outputs; see issue #48.
 OUTPUT_KINDS = ("scalar", "vector", "ragged")
 
+# Recognized per-field output resolutions (issue #30 item 2). ``cell`` (default)
+# stores one value per aggregation cell; ``chunk`` stores one value per chunk in a
+# companion array shaped at the chunk grid, indexed by ``grid.block_index``.
+OUTPUT_RESOLUTIONS = ("cell", "chunk")
+
 
 def _validate_output_kind(name: str, meta: dict) -> None:
     """Validate a variable's non-scalar output declaration.
@@ -396,6 +401,14 @@ def _validate_output_kind(name: str, meta: dict) -> None:
     ``vector`` and ``ragged`` fields may be driven by either ``function`` or
     ``expression``; ``len``/``count`` are rejected for both (they short-circuit
     to a scalar count). See issue #29 (vector) and issue #48 (ragged/CSR).
+
+    A field may also declare ``resolution`` (``cell`` default, or ``chunk``).
+    A ``resolution: chunk`` field (issue #30 item 2) is written ONCE per chunk
+    into a companion array shaped at the chunk grid (``main.shape //
+    chunk_shape``), indexed by ``grid.block_index(shard_key)`` — the compact
+    storage for a chunk-uniform value (e.g. a ``chunk_precompute`` anchor). A
+    ``kind: scalar`` field may be ``resolution: chunk``; ``vector``/``ragged``
+    chunk companions are not supported here (deferred — see the error message).
 
     Parameters
     ----------
@@ -414,6 +427,21 @@ def _validate_output_kind(name: str, meta: dict) -> None:
         allowed = ", ".join(OUTPUT_KINDS)
         raise ValueError(
             f"Variable '{name}': output kind '{kind}' is not supported (allowed: {allowed})"
+        )
+
+    # resolution (cell default, or chunk). A chunk-resolution field stores one
+    # value per chunk in a companion array (issue #30 item 2). Only kind: scalar
+    # chunk companions are supported in this PR.
+    resolution = meta.get("resolution", "cell")
+    if resolution not in OUTPUT_RESOLUTIONS:
+        allowed = ", ".join(OUTPUT_RESOLUTIONS)
+        raise ValueError(
+            f"Variable '{name}': resolution '{resolution}' is not supported (allowed: {allowed})"
+        )
+    if resolution == "chunk" and kind != "scalar":
+        raise ValueError(
+            f"Variable '{name}': resolution 'chunk' is only supported for kind 'scalar' "
+            f"(got kind '{kind}'); a chunk-resolution vector/ragged companion is deferred"
         )
 
     # dtype, when declared, must name a real numpy dtype (applies to all kinds).
@@ -881,11 +909,15 @@ def get_output_signature(meta: dict) -> dict:
     Returns
     -------
     dict
-        ``{"kind": str, "trailing_shape": tuple, "inner_shape": tuple, "dtype": str}``.
+        ``{"kind": str, "trailing_shape": tuple, "inner_shape": tuple, "dtype":
+        str, "resolution": str}``.
         ``trailing_shape`` is ``()`` for scalar and ragged fields.
         ``inner_shape`` is ``()`` for scalar and vector fields; for ragged it
         holds the per-element shape (e.g. ``(2,)`` for a centroid pair).
         ``dtype`` is the declared dtype string, or ``None`` if unset.
+        ``resolution`` is ``"cell"`` (default — one value per aggregation cell) or
+        ``"chunk"`` (issue #30 item 2 — one value per chunk, stored in a companion
+        array shaped at the chunk grid and indexed by ``grid.block_index``).
     """
     kind = meta.get("kind", "scalar")
     if kind == "vector":
@@ -904,6 +936,7 @@ def get_output_signature(meta: dict) -> dict:
         "trailing_shape": trailing_shape,
         "inner_shape": inner_shape,
         "dtype": meta.get("dtype"),
+        "resolution": meta.get("resolution", "cell"),
     }
 
 

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -718,6 +718,7 @@ def _validate_levels(data_source: dict) -> None:
             f"(available: {sorted(levels)})"
         )
     base_vars = set(data_source.get("variables", {}))
+    seg_var_names: set[str] = set()  # segment-variable names seen across non-base levels
     level_keys = set(levels)
     for name, lvl in levels.items():
         if not isinstance(lvl, dict):
@@ -752,6 +753,15 @@ def _validate_levels(data_source: dict) -> None:
                         f"levels.{name}.variables.{var_name}: collides with a "
                         f"data_source.variables column"
                     )
+                # Two non-base levels declaring the same name would silently
+                # overwrite each other when broadcast into one per-photon column
+                # (the read keys by name); reject the ambiguity.
+                if var_name in seg_var_names:
+                    raise ValueError(
+                        f"levels.{name}.variables.{var_name}: a segment-level "
+                        f"variable named {var_name!r} is already declared on another level"
+                    )
+                seg_var_names.add(var_name)
         link = lvl.get("link")
         if link is None:
             if name != base_level:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -226,6 +226,13 @@ def validate_config(config: PipelineConfig) -> None:
     ds_vars = set(config.data_source.get("variables", {}).keys())
     agg_vars = config.aggregation.get("variables", {})
 
+    # Validate the per-chunk precompute hook (issue #30, item 1). Each entry is
+    # evaluated ONCE per chunk over the shard's pooled column data, before the
+    # per-cell loop; its name becomes available in the per-cell expression
+    # namespace. Validation mirrors ``aggregation.variables`` (exactly one of
+    # function/expression, sources exist) but the entries are chunk-level scalars.
+    _validate_chunk_precompute(config.aggregation, ds_vars)
+
     for name, meta in agg_vars.items():
         has_func = "function" in meta
         has_expr = "expression" in meta
@@ -271,6 +278,84 @@ def validate_config(config: PipelineConfig) -> None:
         _validate_output_kind(name, meta)
 
 
+def _validate_chunk_precompute(aggregation: dict, ds_vars: set[str]) -> None:
+    """Validate the ``aggregation.chunk_precompute`` block (issue #30, item 1).
+
+    Each named entry is a chunk-level scalar computed ONCE per chunk (shard) over
+    the shard's pooled column data, before the per-cell loop; its name then enters
+    the per-cell expression namespace. Validation mirrors ``aggregation.variables``:
+    each entry must declare exactly one of ``function``/``expression``, and any
+    ``source`` / expression / param column references must exist in
+    ``data_source.variables``. ``dtype`` (optional) must be a valid numpy dtype.
+
+    The block is optional; a config without it is unchanged.
+
+    Parameters
+    ----------
+    aggregation : dict
+        The config's ``aggregation`` mapping.
+    ds_vars : set[str]
+        Available ``data_source.variables`` column names.
+
+    Raises
+    ------
+    ValueError
+        On any invalid ``chunk_precompute`` declaration.
+    """
+    precompute = aggregation.get("chunk_precompute")
+    if precompute is None:
+        return
+    if not isinstance(precompute, dict):
+        raise ValueError("aggregation.chunk_precompute must be a mapping of name -> entry")
+    for name, meta in precompute.items():
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("chunk_precompute entry names must be non-empty strings")
+        if not isinstance(meta, dict):
+            raise ValueError(f"chunk_precompute '{name}': entry must be a mapping")
+
+        has_func = "function" in meta
+        has_expr = "expression" in meta
+        if has_func and has_expr:
+            raise ValueError(
+                f"chunk_precompute '{name}': 'function' and 'expression' are mutually exclusive"
+            )
+        if not has_func and not has_expr:
+            raise ValueError(f"chunk_precompute '{name}': must specify 'function' or 'expression'")
+
+        source = meta.get("source")
+        if source is not None and source not in ds_vars:
+            raise ValueError(
+                f"chunk_precompute '{name}': source '{source}' not in data_source.variables"
+            )
+
+        if has_func:
+            resolve_function(meta["function"])  # raises ValueError on failure
+
+        for pval in meta.get("params", {}).values():
+            if not isinstance(pval, str):
+                continue  # numeric literal
+            if pval in ds_vars or _is_numeric(pval):
+                continue
+            if any(v in pval for v in ds_vars):
+                continue
+            raise ValueError(
+                f"chunk_precompute '{name}': param value '{pval}' references "
+                f"unknown column (available: {ds_vars})"
+            )
+
+        if has_expr:
+            _validate_expression_columns(name, meta["expression"], ds_vars)
+
+        if "dtype" in meta:
+            try:
+                np.dtype(meta["dtype"])
+            except (TypeError, ValueError) as e:
+                raise ValueError(
+                    f"chunk_precompute '{name}': dtype {meta['dtype']!r} is not a valid "
+                    f"numpy dtype ({e})"
+                ) from e
+
+
 # Recognized per-field output kinds. ``ragged`` (CSR) is the Tier-2 carrier
 # for variable-length per-cell outputs; see issue #48.
 OUTPUT_KINDS = ("scalar", "vector", "ragged")
@@ -302,8 +387,7 @@ def _validate_output_kind(name: str, meta: dict) -> None:
     if kind not in OUTPUT_KINDS:
         allowed = ", ".join(OUTPUT_KINDS)
         raise ValueError(
-            f"Variable '{name}': output kind '{kind}' is not supported "
-            f"(allowed: {allowed})"
+            f"Variable '{name}': output kind '{kind}' is not supported (allowed: {allowed})"
         )
 
     # dtype, when declared, must name a real numpy dtype (applies to all kinds).
@@ -373,8 +457,7 @@ def _validate_trailing_shape(name: str, trailing_shape, key_name: str = "trailin
     for dim in dims:
         if not isinstance(dim, int) or isinstance(dim, bool) or dim < 1:
             raise ValueError(
-                f"Variable '{name}': '{key_name}' entries must be positive "
-                f"integers (got {dim!r})"
+                f"Variable '{name}': '{key_name}' entries must be positive integers (got {dim!r})"
             )
 
 
@@ -732,6 +815,26 @@ def get_agg_fields(config: PipelineConfig) -> dict:
         :func:`get_output_signature` to read the normalized declaration.
     """
     return dict(config.aggregation.get("variables", {}))
+
+
+def get_chunk_precompute(config: PipelineConfig) -> dict:
+    """Return the ``aggregation.chunk_precompute`` entries keyed by name (issue #30).
+
+    Each entry is a chunk-level scalar evaluated ONCE per chunk (shard) over the
+    shard's pooled column data, before the per-cell loop; the resulting scalar is
+    injected into the per-cell expression namespace. Returns an empty dict when no
+    ``chunk_precompute`` block is present, so the existing per-cell path is a no-op.
+
+    Parameters
+    ----------
+    config : PipelineConfig
+
+    Returns
+    -------
+    dict
+        ``{name: {function/expression, source, params, dtype}}``.
+    """
+    return dict(config.aggregation.get("chunk_precompute", {}))
 
 
 def get_output_signature(meta: dict) -> dict:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -233,6 +233,12 @@ def validate_config(config: PipelineConfig) -> None:
     # function/expression, sources exist) but the entries are chunk-level scalars.
     _validate_chunk_precompute(config.aggregation, ds_vars)
 
+    # Chunk-precompute names are injected into the per-cell expression namespace
+    # (issue #30), so a per-cell ``expression`` (or its params) may reference them
+    # like a column. Treat them as valid identifiers in the per-cell validation.
+    precompute_names = set(config.aggregation.get("chunk_precompute", {}).keys())
+    expr_vars = ds_vars | precompute_names
+
     for name, meta in agg_vars.items():
         has_func = "function" in meta
         has_expr = "expression" in meta
@@ -260,19 +266,19 @@ def validate_config(config: PipelineConfig) -> None:
         for pval in meta.get("params", {}).values():
             if not isinstance(pval, str):
                 continue  # numeric literal
-            if pval in ds_vars or _is_numeric(pval):
-                continue  # column reference or number
+            if pval in expr_vars or _is_numeric(pval):
+                continue  # column / chunk-precompute reference or number
             # Expression containing column names (e.g. "1.0 / s_li**2")
-            if any(v in pval for v in ds_vars):
+            if any(v in pval for v in expr_vars):
                 continue
             raise ValueError(
                 f"Variable '{name}': param value '{pval}' references "
-                f"unknown column (available: {ds_vars})"
+                f"unknown column (available: {expr_vars})"
             )
 
-        # Validate expression column references
+        # Validate expression column references (chunk-precompute names included)
         if has_expr:
-            _validate_expression_columns(name, meta["expression"], ds_vars)
+            _validate_expression_columns(name, meta["expression"], expr_vars)
 
         # Validate the output-kind declaration (kind + trailing_shape + dtype)
         _validate_output_kind(name, meta)

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -244,6 +244,15 @@ def validate_config(config: PipelineConfig) -> None:
     # function/expression, sources exist) but the entries are chunk-level scalars.
     _validate_chunk_precompute(config.aggregation, ds_vars)
 
+    # Base-level ``expression`` filters evaluate over the read columns at read time
+    # (before chunk_precompute), so their valid names are exactly ``ds_vars`` —
+    # ``data_source.variables`` plus any broadcast segment-level variable (issue
+    # #30). Validate their column references the same way agg/precompute
+    # expressions are, so e.g. an ``{expression: "dem_h > ..."}`` filter is accepted.
+    for f in filters_from_data_source(config.data_source):
+        if "expression" in f:
+            _validate_expression_columns(f"filter {f['expression']!r}", f["expression"], ds_vars)
+
     # Chunk-precompute names are injected into the per-cell expression namespace
     # (issue #30), so a per-cell ``expression`` (or its params) may reference them
     # like a column. Treat them as valid identifiers in the per-cell validation.

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -294,6 +294,18 @@ def _validate_chunk_precompute(aggregation: dict, ds_vars: set[str]) -> None:
     ``source`` / expression / param column references must exist in
     ``data_source.variables``. ``dtype`` (optional) must be a valid numpy dtype.
 
+    A precompute name must not collide with a ``data_source.variables`` column or
+    a reserved namespace name (``leaf_id``): the per-cell namespace is built as
+    ``{**cell_data, **chunk_scalars}`` in :func:`zagg.processing.process_shard`, so
+    a colliding name would shadow the real column *array* with a 0-d *scalar* and
+    corrupt every cell. Such names are rejected here.
+
+    Inter-precompute references are NOT supported: an entry's expression is
+    evaluated only over the pooled columns (:func:`zagg.processing._eval_chunk_precompute`
+    iterates the entries independently, with no defined order), so one entry cannot
+    reference another (e.g. ``chunk_gain`` cannot read ``chunk_offset``). A name
+    that references another precompute entry is rejected as an unknown column.
+
     The block is optional; a config without it is unchanged.
 
     Parameters
@@ -313,9 +325,17 @@ def _validate_chunk_precompute(aggregation: dict, ds_vars: set[str]) -> None:
         return
     if not isinstance(precompute, dict):
         raise ValueError("aggregation.chunk_precompute must be a mapping of name -> entry")
+    reserved = ds_vars | {"leaf_id"}
     for name, meta in precompute.items():
         if not isinstance(name, str) or not name.strip():
             raise ValueError("chunk_precompute entry names must be non-empty strings")
+        if name in reserved:
+            raise ValueError(
+                f"chunk_precompute '{name}': name collides with a "
+                f"data_source.variables column or the reserved 'leaf_id'; the "
+                f"per-cell namespace merge would shadow the real column with a "
+                f"chunk scalar. Rename the precompute entry."
+            )
         if not isinstance(meta, dict):
             raise ValueError(f"chunk_precompute '{name}': entry must be a mapping")
 

--- a/src/zagg/configs/atl03_waveform_chunk.yaml
+++ b/src/zagg/configs/atl03_waveform_chunk.yaml
@@ -1,0 +1,111 @@
+# ATL03 per-chunk-anchored waveform-counts template (issue #30, item 1).
+#
+# Worked example of the per-chunk precompute hook: the "compute once per chunk,
+# use per cell" primitive. The ``aggregation.chunk_precompute`` block is
+# evaluated ONCE per chunk (shard) over the shard's POOLED photon heights, before
+# the per-cell loop, and the resulting chunk-level scalars are injected into every
+# cell's expression namespace. So every cell in a chunk shares one bin window,
+# unlike atl03_waveform_counts.yaml which anchors on each cell's own median.
+#
+# The anchor and gain (see issue #30 comment 4773320226):
+#   chunk_offset = floor(median(h_ph))   over the whole shard (pooled, not per-cell)
+#   chunk_gain   = smallest power-of-two (>= 0.5 m) whose 128 bins span the shard's
+#                  photon-height range  ->  2^ceil(log2((max - min) / 128)), floored at 0.5 m
+# The 128-bin window is [chunk_offset - 27*chunk_gain, chunk_offset + 101*chunk_gain),
+# so the floor(median) anchor lands in bin 28 (27 bins reserved below it, 100
+# above) -- the asymmetric layout @espg specified for a mostly-above-ground
+# return. Out-of-range photons are dropped (not counted), matching #30's spec.
+#
+# Note (issue #30 thread): the design target for the chunk anchor is the ATL03
+# reference DEM (``dem_h``), which gives a stable absolute frame. dem_h lives in
+# the segment-level geolocation group (one value per ~100 photons), a cross-group
+# / resolution-mismatch read that @espg deferred (the segment-level variable
+# schema change is a follow-up). This template therefore anchors on the pooled
+# ``median(h_ph)`` as the worked example of the hook; swapping in a ``dem_h``
+# source is a one-line change once that read lands.
+#
+# offset_h / gain_h are recorded as per-cell scalar fields: every cell in a chunk
+# carries the chunk's offset/gain identically (duplicated for now -- the compact
+# per-chunk companion-array storage is the #30 item-2 follow-on). A reader
+# reconstructs each chunk's altitude axis as ``offset_h + gain_h * arange(128)``.
+#
+# Confidence filter, multi-level form, read_plan and grid are identical to
+# atl03_waveform_counts.yaml so the planned-IO benefits (#43 Phase C) apply here
+# too; only the aggregation block differs.
+data_source:
+  reader: h5coro
+  driver: s3
+  groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]
+  coordinates:
+    latitude: "/{group}/heights/lat_ph"
+    longitude: "/{group}/heights/lon_ph"
+  variables:
+    h_ph: "/{group}/heights/h_ph"
+  filters:
+    - dataset: "/{group}/heights/signal_conf_ph"
+      column: 0                  # land surface type; TEP is uniform across columns
+      op: ne
+      value: -2
+  base_level: photons
+  levels:
+    photons:
+      path: "/{group}/heights"
+      coordinates: {latitude: lat_ph, longitude: lon_ph}
+      link: null
+    segments:
+      path: "/{group}/geolocation"
+      coordinates: {latitude: reference_photon_lat, longitude: reference_photon_lon}
+      link:
+        to: photons
+        index_beg: "/{group}/geolocation/ph_index_beg"
+        count: "/{group}/geolocation/segment_ph_cnt"
+        index_base: 1            # ATL03 ph_index_beg is 1-based per the v3 dict
+  read_plan:
+    spatial_index: segments
+    pad: 1                       # one segment of padding on each side per #43
+
+aggregation:
+  # Evaluated ONCE per chunk over the shard's pooled h_ph, before the per-cell
+  # loop; the names below enter the per-cell expression namespace.
+  chunk_precompute:
+    # ``np.maximum`` (not the ``max`` builtin) floors the gain at 0.5 m, and the
+    # range uses ``np.max``/``np.min`` (not the ``ndarray.max()`` method): the
+    # expression sandbox runs with an empty ``__builtins__``, where an ndarray
+    # method call raises ``KeyError('__import__')`` but the functional numpy form
+    # is fine.
+    chunk_gain:
+      expression: "np.float32(np.maximum(0.5, 2.0 ** np.ceil(np.log2((np.max(h_ph) - np.min(h_ph)) / 128.0))))"
+      source: h_ph
+      dtype: float32
+    chunk_offset:
+      expression: "np.float32(np.floor(np.median(h_ph)))"
+      source: h_ph
+      dtype: float32
+  variables:
+    waveform_counts:
+      kind: vector
+      trailing_shape: 128
+      # references the chunk-level anchor/gain instead of a per-cell median, so
+      # every cell in the chunk shares one bin window (bin 28 anchored).
+      expression: "np.histogram(h_ph, 128, (chunk_offset - 27.0 * chunk_gain, chunk_offset + 101.0 * chunk_gain))[0].astype('uint32')"
+      source: h_ph
+      dtype: uint32
+      fill_value: 0
+    offset_h:
+      # records the chunk offset per cell (chunk-uniform; duplicated until the
+      # per-chunk companion-array storage of #30 item 2 lands).
+      expression: "chunk_offset"
+      source: h_ph
+      dtype: float32
+    gain_h:
+      expression: "chunk_gain"
+      source: h_ph
+      dtype: float32
+
+output:
+  grid:
+    type: rectilinear
+    crs: EPSG:4326
+    resolution: 0.0001            # degrees (~10 m at the equator)
+    bounds: [-180, -90, 180, 90]
+    chunk_shape: [256, 256]

--- a/src/zagg/configs/atl03_waveform_chunk.yaml
+++ b/src/zagg/configs/atl03_waveform_chunk.yaml
@@ -72,9 +72,12 @@ aggregation:
     # range uses ``np.max``/``np.min`` (not the ``ndarray.max()`` method): the
     # expression sandbox runs with an empty ``__builtins__``, where an ndarray
     # method call raises ``KeyError('__import__')`` but the functional numpy form
-    # is fine.
+    # is fine. The pooled range is floored at 1e-6 m BEFORE ``log2`` so a
+    # single-photon / all-equal-height shard (range == 0) does not hit
+    # ``log2(0) == -inf`` (a numpy divide-by-zero RuntimeWarning); the 0.5 m gain
+    # floor then still applies. Such degenerate shards are plausible at grid edges.
     chunk_gain:
-      expression: "np.float32(np.maximum(0.5, 2.0 ** np.ceil(np.log2((np.max(h_ph) - np.min(h_ph)) / 128.0))))"
+      expression: "np.float32(np.maximum(0.5, 2.0 ** np.ceil(np.log2(np.maximum(1e-6, np.max(h_ph) - np.min(h_ph)) / 128.0))))"
       source: h_ph
       dtype: float32
     chunk_offset:

--- a/src/zagg/configs/atl03_waveform_chunk.yaml
+++ b/src/zagg/configs/atl03_waveform_chunk.yaml
@@ -24,10 +24,11 @@
 # ``median(h_ph)`` as the worked example of the hook; swapping in a ``dem_h``
 # source is a one-line change once that read lands.
 #
-# offset_h / gain_h are recorded as per-cell scalar fields: every cell in a chunk
-# carries the chunk's offset/gain identically (duplicated for now -- the compact
-# per-chunk companion-array storage is the #30 item-2 follow-on). A reader
-# reconstructs each chunk's altitude axis as ``offset_h + gain_h * arange(128)``.
+# offset_h / gain_h are recorded as resolution: chunk companion fields (issue #30
+# item 2): the chunk offset/gain is stored ONCE per chunk in an array shaped at the
+# chunk grid (main.shape // chunk_shape), indexed by block_index -- no per-cell
+# duplication. A reader reconstructs each chunk's altitude axis as
+# ``offset_h + gain_h * arange(128)``.
 #
 # Confidence filter, multi-level form, read_plan and grid are identical to
 # atl03_waveform_counts.yaml so the planned-IO benefits (#43 Phase C) apply here
@@ -95,15 +96,19 @@ aggregation:
       dtype: uint32
       fill_value: 0
     offset_h:
-      # records the chunk offset per cell (chunk-uniform; duplicated until the
-      # per-chunk companion-array storage of #30 item 2 lands).
+      # records the chunk offset ONCE per chunk (issue #30 item 2): a companion
+      # array shaped at the chunk grid (main.shape // chunk_shape), indexed by
+      # block_index — no per-cell duplication. A reader reconstructs each chunk's
+      # altitude axis as ``offset_h + gain_h * arange(128)``.
       expression: "chunk_offset"
       source: h_ph
       dtype: float32
+      resolution: chunk
     gain_h:
       expression: "chunk_gain"
       source: h_ph
       dtype: float32
+      resolution: chunk
 
 output:
   grid:

--- a/src/zagg/configs/atl03_waveform_chunk.yaml
+++ b/src/zagg/configs/atl03_waveform_chunk.yaml
@@ -8,13 +8,14 @@
 # unlike atl03_waveform_counts.yaml which anchors on each cell's own median.
 #
 # The anchor and gain (see issue #30 comment 4773320226):
-#   chunk_offset = floor(median(dem_h)) over the whole shard (pooled, not per-cell)
+#   chunk_offset = floor(min(dem_h)) over the whole shard (pooled, not per-cell)
 #   chunk_gain   = smallest power-of-two (>= 0.5 m) whose 128 bins span the shard's
 #                  photon-height range  ->  2^ceil(log2((max - min) / 128)), floored at 0.5 m
 # The 128-bin window is [chunk_offset - 27*chunk_gain, chunk_offset + 101*chunk_gain),
-# so the floor(median) anchor lands in bin 28 (27 bins reserved below it, 100
+# so the floor(min) anchor lands in bin 28 (27 bins reserved below it, 100
 # above) -- the asymmetric layout @espg specified for a mostly-above-ground
-# return. Out-of-range photons are dropped (not counted), matching #30's spec.
+# return. dem_h is less noisy than the photon cloud, so the min (not median) is a
+# stable floor. Out-of-range photons are dropped (not counted), matching #30's spec.
 #
 # The chunk anchor is the ATL03 reference DEM (``dem_h``), which gives a stable
 # absolute frame independent of the photon cloud's own median. dem_h lives in the
@@ -90,7 +91,7 @@ aggregation:
     chunk_offset:
       # DEM-anchored: the chunk's absolute frame is the reference DEM, not the
       # photon cloud's own median. dem_h rides the segment->photon broadcast above.
-      expression: "np.float32(np.floor(np.median(dem_h)))"
+      expression: "np.float32(np.floor(np.min(dem_h)))"
       source: dem_h
       dtype: float32
   variables:

--- a/src/zagg/configs/atl03_waveform_chunk.yaml
+++ b/src/zagg/configs/atl03_waveform_chunk.yaml
@@ -8,7 +8,7 @@
 # unlike atl03_waveform_counts.yaml which anchors on each cell's own median.
 #
 # The anchor and gain (see issue #30 comment 4773320226):
-#   chunk_offset = floor(median(h_ph))   over the whole shard (pooled, not per-cell)
+#   chunk_offset = floor(median(dem_h)) over the whole shard (pooled, not per-cell)
 #   chunk_gain   = smallest power-of-two (>= 0.5 m) whose 128 bins span the shard's
 #                  photon-height range  ->  2^ceil(log2((max - min) / 128)), floored at 0.5 m
 # The 128-bin window is [chunk_offset - 27*chunk_gain, chunk_offset + 101*chunk_gain),
@@ -16,13 +16,14 @@
 # above) -- the asymmetric layout @espg specified for a mostly-above-ground
 # return. Out-of-range photons are dropped (not counted), matching #30's spec.
 #
-# Note (issue #30 thread): the design target for the chunk anchor is the ATL03
-# reference DEM (``dem_h``), which gives a stable absolute frame. dem_h lives in
-# the segment-level geolocation group (one value per ~100 photons), a cross-group
-# / resolution-mismatch read that @espg deferred (the segment-level variable
-# schema change is a follow-up). This template therefore anchors on the pooled
-# ``median(h_ph)`` as the worked example of the hook; swapping in a ``dem_h``
-# source is a one-line change once that read lands.
+# The chunk anchor is the ATL03 reference DEM (``dem_h``), which gives a stable
+# absolute frame independent of the photon cloud's own median. dem_h lives in the
+# segment-level geolocation group (one value per ~100 photons); it is declared as a
+# segment-level ``variables`` entry below and broadcast to the photon rows at read
+# time via the existing geolocation->heights link (the same link the read plan
+# already rides), landing as a per-photon ``dem_h`` column the chunk_precompute
+# reduces. The gain is still a spread over ``h_ph`` (the photon-height range), not
+# an anchor, so it stays on h_ph.
 #
 # offset_h / gain_h are recorded as resolution: chunk companion fields (issue #30
 # item 2): the chunk offset/gain is stored ONCE per chunk in an array shaped at the
@@ -56,6 +57,11 @@ data_source:
     segments:
       path: "/{group}/geolocation"
       coordinates: {latitude: reference_photon_lat, longitude: reference_photon_lon}
+      # Segment-level readable variable (issue #30): dem_h is one value per ~100
+      # photons; it is broadcast to the photon rows via the link below and lands as
+      # a per-photon ``dem_h`` column the chunk_precompute reduces.
+      variables:
+        dem_h: "/{group}/geophys_corr/dem_h"
       link:
         to: photons
         index_beg: "/{group}/geolocation/ph_index_beg"
@@ -82,8 +88,10 @@ aggregation:
       source: h_ph
       dtype: float32
     chunk_offset:
-      expression: "np.float32(np.floor(np.median(h_ph)))"
-      source: h_ph
+      # DEM-anchored: the chunk's absolute frame is the reference DEM, not the
+      # photon cloud's own median. dem_h rides the segment->photon broadcast above.
+      expression: "np.float32(np.floor(np.median(dem_h)))"
+      source: dem_h
       dtype: float32
   variables:
     waveform_counts:

--- a/src/zagg/grids/base.py
+++ b/src/zagg/grids/base.py
@@ -20,6 +20,7 @@ algorithmically (rectilinear, fullsphere DGGS) the two collapse; for dense-
 packed sparse DGGS arrays they differ and block_index needs the populated-
 shard list to translate.
 """
+
 from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
@@ -91,6 +92,50 @@ def vector_array_spec(base, sig, *, base_dims, base_chunk_shape):
     )
 
 
+def chunk_array_spec(base, *, chunk_grid_shape, chunk_dims):
+    """Build a chunk-resolution companion ``ArraySpec`` from a scalar data-var spec.
+
+    Issue #30 item 2: a ``resolution: chunk`` field stores ONE value per chunk
+    rather than one per aggregation cell. Its array is shaped at the *chunk grid*
+    (``main.shape // chunk_shape`` = number of chunks along each axis), with one
+    Zarr block per chunk so :func:`zagg.processing.write_dataframe_to_zarr` writes
+    the shard's single value at ``grid.block_index(shard_key)``.
+
+    The companion carries the field's ``dtype``/``fill_value`` (inherited from
+    ``base``); only its shape, dimension names and chunk grid are re-set to the
+    chunk grid. Each axis is chunked ``1`` (one chunk == one block) so the block
+    index equals ``block_index`` directly.
+
+    Parameters
+    ----------
+    base : ArraySpec
+        The scalar data-var spec for this field (already carries
+        ``dtype``/``fill_value``).
+    chunk_grid_shape : tuple of int
+        Number of chunks along each spatial axis (the companion array shape).
+    chunk_dims : tuple of str
+        Dimension names for the chunk-grid axes (e.g. ``("chunks",)`` for HEALPix,
+        ``("chunk_y", "chunk_x")`` for rectilinear).
+
+    Returns
+    -------
+    ArraySpec
+    """
+    from pydantic_zarr.experimental.v3 import NamedConfig
+
+    shape = tuple(int(s) for s in chunk_grid_shape)
+    chunk_shape = tuple(1 for _ in shape)
+    chunk_grid = NamedConfig(name="regular", configuration={"chunk_shape": list(chunk_shape)})
+    return type(base)(
+        **{
+            **base.model_dump(),
+            "shape": shape,
+            "dimension_names": tuple(chunk_dims),
+            "chunk_grid": chunk_grid,
+        }
+    )
+
+
 class InconsistentShardError(ValueError):
     """Raised by shard_of when input cells don't all share a shard."""
 
@@ -113,9 +158,7 @@ class OutputGrid(Protocol):
         """Per-chunk shape (rank matches ``array_shape``)."""
         ...
 
-    def coverage(
-        self, polygon_parts: list[tuple[np.ndarray, np.ndarray]]
-    ) -> np.ndarray:
+    def coverage(self, polygon_parts: list[tuple[np.ndarray, np.ndarray]]) -> np.ndarray:
         """Enumerate shard keys covering multipart polygons."""
         ...
 
@@ -198,4 +241,5 @@ __all__ = [
     "ShardKey",
     "InconsistentShardError",
     "vector_array_spec",
+    "chunk_array_spec",
 ]

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -16,7 +16,7 @@ from zagg.config import (
     get_output_signature,
     output_field_signature,
 )
-from zagg.grids.base import InconsistentShardError, vector_array_spec
+from zagg.grids.base import InconsistentShardError, chunk_array_spec, vector_array_spec
 from zagg.grids.morton import to_morton_array
 
 HEALPIX_BASE_CELLS: int = 12
@@ -103,6 +103,18 @@ class HealpixGrid:
     @property
     def chunk_shape(self) -> tuple[int, ...]:
         return (self.n_children,)
+
+    @property
+    def chunk_grid_shape(self) -> tuple[int, ...]:
+        """Number of chunks (``array_shape // chunk_shape``) for companion arrays.
+
+        A ``resolution: chunk`` field (issue #30 item 2) stores one value per
+        chunk here, indexed by :meth:`block_index` (the parent nested cell id for
+        fullsphere, the populated-shard position for dense). Equals
+        ``12·4^parent_order`` for fullsphere and ``n_shards`` for dense — the
+        block-index range, so every ``block_index`` lands in bounds.
+        """
+        return (self.array_shape[0] // self.n_children,)
 
     @property
     def group_path(self) -> str:
@@ -275,11 +287,22 @@ class HealpixGrid:
             dtype = meta.get("dtype", "float32")
             fill = meta.get("fill_value", "NaN")
             spec = base.with_data_type(dtype).with_fill_value(fill)
+            sig = get_output_signature(meta)
+            if sig["resolution"] == "chunk":
+                # A resolution: chunk field (issue #30 item 2) is stored once per
+                # chunk in a companion array shaped at the chunk grid, indexed by
+                # block_index (the parent nested cell id).
+                members[name] = chunk_array_spec(
+                    spec,
+                    chunk_grid_shape=self.chunk_grid_shape,
+                    chunk_dims=("chunks",),
+                )
+                continue
             # A vector field (issue #29) gets a trailing payload dim chunked
             # whole; scalars are returned unchanged.
             members[name] = vector_array_spec(
                 spec,
-                get_output_signature(meta),
+                sig,
                 base_dims=("cells",),
                 base_chunk_shape=(self.n_children,),
             )

--- a/src/zagg/grids/rectilinear.py
+++ b/src/zagg/grids/rectilinear.py
@@ -30,6 +30,7 @@ Internal representations
 Out-of-bounds points get leaf id ``-1`` (signed). The corresponding shard
 filter rejects them, so they fall out of the pipeline silently.
 """
+
 from __future__ import annotations
 
 import math
@@ -48,7 +49,7 @@ from zagg.config import (
     get_output_signature,
     output_field_signature,
 )
-from zagg.grids.base import vector_array_spec
+from zagg.grids.base import chunk_array_spec, vector_array_spec
 
 OOB_SENTINEL: int = -1
 
@@ -123,9 +124,7 @@ class RectilinearGrid:
 
         # GeoBox: north-up affine with origin at (xmin, ymax); y resolution
         # negative. GeoboxTiles tiles it into one tile per chunk.
-        affine = Affine.translation(self.xmin, self.ymax) * Affine.scale(
-            self.res_x, -self.res_y
-        )
+        affine = Affine.translation(self.xmin, self.ymax) * Affine.scale(self.res_x, -self.res_y)
         self._geobox = GeoBox((self.height, self.width), affine, self.crs)
         self._tiles = GeoboxTiles(self._geobox, (self.chunk_h, self.chunk_w))
         self._transformer = None  # lazy WGS84 -> grid CRS, for assign
@@ -139,6 +138,16 @@ class RectilinearGrid:
     @property
     def chunk_shape(self) -> tuple[int, int]:
         return (self.chunk_h, self.chunk_w)
+
+    @property
+    def chunk_grid_shape(self) -> tuple[int, int]:
+        """Number of chunks per axis (``array_shape // chunk_shape``).
+
+        A ``resolution: chunk`` field (issue #30 item 2) stores one value per
+        chunk in a companion array of this shape, indexed by :meth:`block_index`
+        (the ``(rb, cb)`` chunk index). Equals ``(n_row_blocks, n_col_blocks)``.
+        """
+        return (self.n_row_blocks, self.n_col_blocks)
 
     @property
     def group_path(self) -> str:
@@ -177,14 +186,12 @@ class RectilinearGrid:
             # Co-aggregated grids must declare the same Option-B output-field
             # set (issue #29): same scalar/vector kinds, trailing shapes, dtypes.
             return False
-        if not (_whole_ratio(self.res_x, other.res_x)
-                and _whole_ratio(self.res_y, other.res_y)):
+        if not (_whole_ratio(self.res_x, other.res_x) and _whole_ratio(self.res_y, other.res_y)):
             return False
         fine_x = min(self.res_x, other.res_x)
         fine_y = min(self.res_y, other.res_y)
-        return (
-            _is_multiple(self.xmin - other.xmin, fine_x)
-            and _is_multiple(self.ymax - other.ymax, fine_y)
+        return _is_multiple(self.xmin - other.xmin, fine_x) and _is_multiple(
+            self.ymax - other.ymax, fine_y
         )
 
     # ── coverage / coords ────────────────────────────────────────────────
@@ -199,8 +206,7 @@ class RectilinearGrid:
 
         rings = []
         for lats, lons in polygon_parts:
-            rings.append([(float(x), float(y))
-                          for x, y in zip(np.asarray(lons), np.asarray(lats))])
+            rings.append([(float(x), float(y)) for x, y in zip(np.asarray(lons), np.asarray(lats))])
         if len(rings) == 1:
             geom = polygon(rings[0], crs="EPSG:4326")
         else:
@@ -223,9 +229,7 @@ class RectilinearGrid:
         xs, ys = tx.transform(lons, lats)
         cols = ((xs - self.xmin) // self.res_x).astype(np.int64)
         rows = ((self.ymax - ys) // self.res_y).astype(np.int64)
-        in_bounds = (
-            (rows >= 0) & (rows < self.height) & (cols >= 0) & (cols < self.width)
-        )
+        in_bounds = (rows >= 0) & (rows < self.height) & (cols >= 0) & (cols < self.width)
         ids = rows * self.width + cols
         return np.where(in_bounds, ids, OOB_SENTINEL).astype(np.int64)
 
@@ -280,11 +284,7 @@ class RectilinearGrid:
         """
         rb, cb = self._unpack(int(shard_key))
         densify = max(self.chunk_w * self.res_x, self.chunk_h * self.res_y) / 32
-        return (
-            self._tiles[(rb, cb)]
-            .extent.to_crs("EPSG:4326", resolution=densify)
-            .geom
-        )
+        return self._tiles[(rb, cb)].extent.to_crs("EPSG:4326", resolution=densify).geom
 
     # ── leaf enumeration ─────────────────────────────────────────────────
 
@@ -333,9 +333,7 @@ class RectilinearGrid:
                 name="regular",
                 configuration={"chunk_shape": list(self.chunk_shape)},
             ),
-            chunk_key_encoding=NamedConfig(
-                name="default", configuration={"separator": "/"}
-            ),
+            chunk_key_encoding=NamedConfig(name="default", configuration={"separator": "/"}),
             codecs=(NamedConfig(name="bytes", configuration={"endian": "little"}),),
             storage_transformers=(),
             fill_value="NaN",
@@ -353,10 +351,10 @@ class RectilinearGrid:
             storage_transformers=(),
             fill_value=0.0,
         )
-        coord_y = coord_x.with_shape((self.height,)).with_dimension_names(
-            ("y",)
-        ).with_attributes(
-            {"standard_name": "projection_y_coordinate", "units": "m"}
+        coord_y = (
+            coord_x.with_shape((self.height,))
+            .with_dimension_names(("y",))
+            .with_attributes({"standard_name": "projection_y_coordinate", "units": "m"})
         )
 
         members = {"x": coord_x, "y": coord_y}
@@ -371,11 +369,22 @@ class RectilinearGrid:
             dtype = meta.get("dtype", "float32")
             fill = meta.get("fill_value", "NaN")
             spec = base.with_data_type(dtype).with_fill_value(fill)
+            sig = get_output_signature(meta)
+            if sig["resolution"] == "chunk":
+                # A resolution: chunk field (issue #30 item 2) is stored once per
+                # chunk in a companion array shaped at the chunk grid (row-major
+                # chunk index), indexed by block_index = (rb, cb).
+                members[name] = chunk_array_spec(
+                    spec,
+                    chunk_grid_shape=self.chunk_grid_shape,
+                    chunk_dims=("chunk_y", "chunk_x"),
+                )
+                continue
             # A vector field (issue #29) gets a trailing payload dim chunked
             # whole; scalars are returned unchanged.
             members[name] = vector_array_spec(
                 spec,
-                get_output_signature(meta),
+                sig,
                 base_dims=("y", "x"),
                 base_chunk_shape=self.chunk_shape,
             )
@@ -402,9 +411,7 @@ class RectilinearGrid:
         if self._transformer is None:
             from pyproj import Transformer
 
-            self._transformer = Transformer.from_crs(
-                "EPSG:4326", self.crs, always_xy=True
-            )
+            self._transformer = Transformer.from_crs("EPSG:4326", self.crs, always_xy=True)
         return self._transformer
 
 

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -1024,6 +1024,114 @@ def _expand_mask_to_base(
     return out
 
 
+def _broadcast_segment_to_base(
+    seg_values: np.ndarray,
+    index_beg_arr: np.ndarray,
+    count_arr: np.ndarray,
+    index_base: int,
+    total_base_size: int,
+) -> np.ndarray:
+    """Broadcast a per-segment variable to a base-rate (per-photon) array (issue #30).
+
+    Each coarse parent ``p`` covers base-rate rows ``index_beg_arr[p] - index_base``
+    through ``... + count_arr[p] - 1`` (the same contiguous parent->child tiling
+    :func:`_expand_mask_to_base` expands a mask over). Where that tiling is
+    contiguous and ordered this equals ``np.repeat(seg_values, count_arr)``; placing
+    by ``index_beg`` keeps it robust to the same gap/order cases the mask path
+    handles. The returned array carries each photon's segment value (e.g. ``dem_h``,
+    one value per ~100 photons) so it can ride alongside the base-rate variables
+    through the read plan's spatial/keep masks.
+
+    Parameters
+    ----------
+    seg_values : np.ndarray
+        1-D per-parent values of length ``n_parents``.
+    index_beg_arr, count_arr, index_base, total_base_size
+        As in :func:`_expand_mask_to_base`.
+
+    Returns
+    -------
+    np.ndarray
+        1-D array of length ``total_base_size`` and ``seg_values``' dtype.
+    """
+    out = np.empty(total_base_size, dtype=seg_values.dtype)
+    for p in range(len(seg_values)):
+        beg = int(index_beg_arr[p]) - index_base
+        if beg < 0:
+            raise ValueError(
+                f"index_beg_arr[{p}]={index_beg_arr[p]} is less than index_base={index_base}"
+            )
+        cnt = int(count_arr[p])
+        out[beg : beg + cnt] = seg_values[p]
+    return out
+
+
+def _segment_level_variables(data_source: dict) -> dict[str, dict[str, str]]:
+    """Collect declared segment-level (non-base) readable variables (issue #30).
+
+    A non-base level may declare ``variables`` as a ``{name: path-template}``
+    mapping (the readable form, distinct from the documentation-only ``list[str]``
+    form). Each such variable is read at coarse rate and broadcast to the base
+    (photon) rows via the level's ``link`` (``_broadcast_segment_to_base``), so a
+    per-segment field like ``dem_h`` becomes a per-photon column the aggregation /
+    ``chunk_precompute`` can reduce. Returns ``{level_key: {name: template}}`` for
+    every non-base level carrying a dict ``variables``; empty when none do, so the
+    read path is unchanged for configs without it.
+    """
+    levels = data_source.get("levels")
+    base_level = data_source.get("base_level")
+    if not isinstance(levels, dict) or base_level is None:
+        return {}
+    out: dict[str, dict[str, str]] = {}
+    for name, lvl in levels.items():
+        if name == base_level or not isinstance(lvl, dict):
+            continue
+        lvl_vars = lvl.get("variables")
+        if isinstance(lvl_vars, dict) and lvl_vars:
+            out[name] = dict(lvl_vars)
+    return out
+
+
+def _read_segment_broadcasts(
+    h5obj, group: str, data_source: dict, levels: dict, n_base: int
+) -> dict[str, np.ndarray]:
+    """Read each segment-level variable and broadcast it to a base-rate column (issue #30).
+
+    For every non-base level carrying a ``{name: path}`` ``variables`` mapping, read
+    the variable and the level's link arrays at coarse rate, then broadcast to the
+    base (photon) rows via :func:`_broadcast_segment_to_base`. Returns
+    ``{name: base_rate_array}`` (length ``n_base``), ready to be sliced through the
+    same spatial / keep masks the base-rate variables are. A variable name colliding
+    with a ``data_source.variables`` column is rejected (it would shadow the read).
+    """
+    seg_vars = _segment_level_variables(data_source)
+    if not seg_vars:
+        return {}
+    base_cols = set(data_source.get("variables", {}))
+    out: dict[str, np.ndarray] = {}
+    for level_key, mapping in seg_vars.items():
+        lvl = levels[level_key]
+        link = lvl["link"]
+        index_base = int(link.get("index_base", 0))
+        ibeg_path = link["index_beg"].format(group=group)
+        cnt_path = link["count"].format(group=group)
+        link_data = h5obj.readDatasets([ibeg_path, cnt_path])
+        ibeg_arr = link_data[ibeg_path]
+        cnt_arr = link_data[cnt_path]
+        for col_name, tmpl in mapping.items():
+            if col_name in base_cols:
+                raise ValueError(
+                    f"segment-level variable '{col_name}' on level '{level_key}' "
+                    f"collides with a data_source.variables column"
+                )
+            seg_path = tmpl.format(group=group)
+            seg_values = np.asarray(h5obj.readDatasets([seg_path])[seg_path])
+            out[col_name] = _broadcast_segment_to_base(
+                seg_values, ibeg_arr, cnt_arr, index_base, n_base
+            )
+    return out
+
+
 def _predicate_mask(arr: np.ndarray, f: dict) -> np.ndarray:
     """Build a 1-D boolean keep-mask for one structured predicate (issue #43).
 
@@ -1266,11 +1374,26 @@ def _planned_read_group(
     if keep_mask is not None and np.sum(keep_mask) == 0:
         return None
 
+    # Segment-level variables (issue #30): read each declared non-base-level
+    # variable and broadcast it to a base-rate per-photon column (length n_base),
+    # then subset to the concatenated planned indices so it lines up with the
+    # base-rate variables before the spatial / keep masks below.
+    seg_broadcasts = _read_segment_broadcasts(h5obj, group, data_source, levels, n_base)
+    if seg_broadcasts:
+        seg_global_idx = np.concatenate(
+            [np.arange(s, e, dtype=np.int64) for s, e in plan.base_slices]
+        )
+
     # Build the data dict (variables sliced to mask_spatial, then to keep_mask).
     leaf_after_spatial = leaf_ids[mask_spatial]
     data_dict: dict[str, np.ndarray] = {}
     for col_name, path in var_paths.items():
         values = arrays_by_path[path][mask_spatial]
+        if keep_mask is not None:
+            values = values[keep_mask]
+        data_dict[col_name] = values
+    for col_name, base_values in seg_broadcasts.items():
+        values = base_values[seg_global_idx][mask_spatial]
         if keep_mask is not None:
             values = values[keep_mask]
         data_dict[col_name] = values
@@ -1474,11 +1597,21 @@ def _read_group_full(
     if keep_mask is not None and np.sum(keep_mask) == 0:
         return None
 
+    # Segment-level variables (issue #30): read each declared non-base-level
+    # variable and broadcast it to a base-rate per-photon column (length len(lats))
+    # so it can be sliced through the same masks as the base-rate variables below.
+    seg_broadcasts = _read_segment_broadcasts(h5obj, group, data_source, levels or {}, len(lats))
+
     # Build dataframe (variables sliced to spatial mask, then to the keep-mask)
     leaf_sliced = leaf_ids[min_idx:max_idx][mask_sliced]
     data_dict = {}
     for col_name, path in var_paths.items():
         values = data[path][mask_sliced]
+        if keep_mask is not None:
+            values = values[keep_mask]
+        data_dict[col_name] = values
+    for col_name, base_values in seg_broadcasts.items():
+        values = base_values[min_idx:max_idx][mask_sliced]
         if keep_mask is not None:
             values = values[keep_mask]
         data_dict[col_name] = values

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -166,10 +166,10 @@ def _concat_and_group(all_reads, grid, handoff: str):
 def _eval_chunk_precompute(config: PipelineConfig, pooled: dict[str, np.ndarray]) -> dict[str, Any]:
     """Evaluate the ``chunk_precompute`` entries ONCE over a shard's pooled columns.
 
-    The per-chunk precompute hook (issue #30, item 1) is the "compute once per
+    The per-chunk precompute hook (issue #30, items 1+2) is the "compute once per
     chunk, use per cell" primitive: each named entry is evaluated a single time
     over the shard's *pooled* column arrays (all beams/granules concatenated,
-    before the per-cell split), yielding a chunk-level scalar. Those scalars are
+    before the per-cell split), yielding a chunk-level value. Those values are
     then injected into the per-cell expression namespace by :func:`process_shard`
     so a per-cell ``expression`` (e.g. a 128-bin waveform window) can reference a
     chunk-uniform anchor instead of recomputing a per-cell one.
@@ -178,8 +178,15 @@ def _eval_chunk_precompute(config: PipelineConfig, pooled: dict[str, np.ndarray]
     dispatch: an ``expression`` entry runs through ``_eval_expression_raw`` over
     the pooled columns; a ``function`` entry resolves via ``resolve_function`` and
     is applied to the entry's ``source`` column (with ``params`` resolved the same
-    way as agg fields). The optional ``dtype`` casts the scalar. The result must
-    reduce to a scalar (``np.ndim(value) == 0``); a non-scalar is rejected.
+    way as agg fields). The optional ``dtype`` casts the result.
+
+    The result is **shape-agnostic**: a chunk value may be a scalar OR a
+    non-scalar array (e.g. a covariance matrix), since the namespace-injection
+    mechanism is shape-blind — a per-cell ``expression`` can reference a chunk
+    array just like a chunk scalar (issue #30, @espg's 4773649308). Scalar-ness is
+    only required when a chunk value is *written* to a ``kind: scalar`` output
+    field; that is enforced in :func:`calculate_cell_statistics` (a non-scalar into
+    a scalar field raises a clear error), not here.
 
     It deliberately diverges from the per-cell path in two ways: (1) there is no
     ``n_obs == 0`` short-circuit (these are shard-level reductions, evaluated once
@@ -204,7 +211,7 @@ def _eval_chunk_precompute(config: PipelineConfig, pooled: dict[str, np.ndarray]
     Returns
     -------
     dict[str, object]
-        ``{name: scalar}`` for each ``chunk_precompute`` entry.
+        ``{name: value}`` for each ``chunk_precompute`` entry (scalar or array).
     """
     from zagg.config import _eval_expression_raw, resolve_function
 
@@ -239,16 +246,18 @@ def _eval_chunk_precompute(config: PipelineConfig, pooled: dict[str, np.ndarray]
                 else:
                     resolved_params[pkey] = pval
             value = resolve_function(meta["function"])(values, **resolved_params)
-        # The hook's whole contract is a chunk-level *scalar*; an expression like
-        # ``np.floor(h_ph)`` (no reduction) returns an array that would be silently
-        # broadcast or mangled by the dtype cast and the per-cell namespace merge.
-        if np.ndim(value) != 0:
-            raise ValueError(
-                f"chunk_precompute '{name}' must reduce to a scalar, got shape {np.shape(value)}"
-            )
+        # Shape-agnostic: a chunk value may be a scalar or a non-scalar array (e.g.
+        # a covariance matrix) — both inject cleanly into the per-cell namespace and
+        # can feed any per-cell ``expression`` (issue #30). Scalar-ness is required
+        # only when a chunk value is written to a ``kind: scalar`` field, which is
+        # enforced at that write point in ``calculate_cell_statistics``. The dtype
+        # cast applies element-wise to either a scalar or an array.
         dtype = meta.get("dtype")
         if dtype is not None:
-            value = np.dtype(dtype).type(value)
+            np_dtype = np.dtype(dtype)
+            value = (
+                np_dtype.type(value) if np.ndim(value) == 0 else np.asarray(value, dtype=np_dtype)
+            )
         out[name] = value
     return out
 
@@ -484,7 +493,7 @@ def calculate_cell_statistics(
     dict
         Dictionary of statistics keyed by aggregation variable name.
     """
-    from zagg.config import _eval_expression_raw, evaluate_expression, resolve_function
+    from zagg.config import _eval_expression_raw, resolve_function
 
     if config is None:
         config = default_config()
@@ -539,7 +548,19 @@ def calculate_cell_statistics(
                 out = _eval_expression_raw(expression, cell_data)
                 result[name] = _coerce_ragged_value(out, sig)
             else:
-                result[name] = evaluate_expression(expression, cell_data)
+                # kind: scalar — the expression must reduce to a single value. A
+                # non-scalar chunk_precompute value (issue #30 allows arrays in the
+                # namespace) written to a scalar field is a config error; raise a
+                # clear message rather than letting ``float()`` emit a cryptic one.
+                out = _eval_expression_raw(expression, cell_data)
+                if np.ndim(out) != 0:
+                    raise ValueError(
+                        f"scalar field {name!r}: expression {expression!r} produced a "
+                        f"non-scalar of shape {np.shape(out)}; a kind: scalar field "
+                        f"requires a scalar result (declare 'kind: vector' to store an "
+                        f"array per cell)"
+                    )
+                result[name] = float(out)
             continue
 
         values = cell_data[source]
@@ -727,7 +748,12 @@ def _kernel_able(meta: dict) -> bool:
 
 
 def _kernel_aggregate(
-    table, cell_col: np.ndarray, children, value_col: str, config: PipelineConfig
+    table,
+    cell_col: np.ndarray,
+    children,
+    value_col: str,
+    config: PipelineConfig,
+    chunk_scalars: dict[str, Any] | None = None,
 ) -> dict:
     """EXPERIMENTAL pyarrow hash-aggregate reducer (phase 2b of #30).
 
@@ -735,6 +761,12 @@ def _kernel_aggregate(
     every child cell in one vectorised ``TableGroupBy.aggregate`` pass, then fills
     the remaining (weighted mean, expression, quantile) fields via the per-cell
     numpy path so output columns match the default reducer exactly in shape.
+
+    ``chunk_scalars`` (issue #30) are the per-chunk precompute values, injected
+    into each cell's namespace in the fallback per-cell loop exactly as the default
+    handoff does, so an ``expression`` field referencing a chunk anchor resolves on
+    the arrow path too. A precompute field is never kernel-able (it is an
+    ``expression``), so it always lands in ``fallback_names`` and sees the scalars.
 
     ``count``/``min``/``max`` are EXACT vs the numpy reducer, including on NaN
     input — pyarrow's min/max kernels skip NaN, so this function detects NaN per
@@ -849,7 +881,10 @@ def _kernel_aggregate(
                 cell_data = {col: arr[s:e] for col, arr in col_arrays.items()}
             else:
                 cell_data = _empty
-            stats = calculate_cell_statistics(cell_data, value_col=value_col, config=config)
+            # Inject the chunk-level precompute values (no-op when empty), so an
+            # expression fallback field can reference a chunk anchor (issue #30).
+            cell_namespace = {**cell_data, **chunk_scalars} if chunk_scalars else cell_data
+            stats = calculate_cell_statistics(cell_namespace, value_col=value_col, config=config)
             for name in fallback_names:
                 stats_arrays[name][i] = stats[name]
 
@@ -1461,16 +1496,6 @@ def process_shard(
         config = default_config()
     if handoff not in ("pandas", "arrow", "arrow-kernel"):
         raise ValueError(f"handoff must be 'pandas', 'arrow', or 'arrow-kernel', got {handoff!r}")
-    # Reject the unsupported arrow-kernel + chunk_precompute combination up front,
-    # before any read (issue #30). The kernel fallback loop reduces each cell
-    # independently and has no seam to inject the shard-pooled chunk scalars; this
-    # is a property of the *config*, not the data, so enforce it deterministically
-    # rather than only when some rows happen to be read.
-    if handoff == "arrow-kernel" and get_chunk_precompute(config):
-        raise NotImplementedError(
-            "handoff='arrow-kernel' does not support aggregation.chunk_precompute "
-            "(issue #30); use handoff='pandas' or 'arrow' instead"
-        )
     data_source = config.data_source
 
     shard_key = int(shard_key)
@@ -1585,8 +1610,6 @@ def process_shard(
                 "handoff='arrow-kernel' does not support ragged fields (issue #48); "
                 "use handoff='pandas' or 'arrow' instead"
             )
-        # (arrow-kernel + chunk_precompute is rejected at the top of process_shard,
-        # before any read, so the combination never reaches this branch.)
         import pyarrow as pa
 
         table = pa.concat_tables(all_reads).combine_chunks()
@@ -1596,8 +1619,18 @@ def process_shard(
         n_obs_total = table.num_rows
         cell_col = grid.cells_of(table.column("leaf_id").to_numpy(zero_copy_only=False))
         logger.info(f"  Read {n_obs_total:,} observations")
+        # Per-chunk precompute hook (issue #30): reduce each entry ONCE over the
+        # pooled arrow table. Columns are dense + null-free (guarded above), so the
+        # ``to_numpy`` extraction is zero-copy where the buffer layout allows and
+        # dtype-exact otherwise — the same numpy arrays the pandas/arrow carriers
+        # feed in. The resulting scalars/arrays are threaded into the kernel
+        # fallback per-cell loop (where expression fields resolve).
+        pooled = {n: table.column(n).to_numpy(zero_copy_only=False) for n in table.column_names}
+        chunk_scalars = _eval_chunk_precompute(config, pooled)
         logger.info(f"  Calculating statistics for {len(children)} cells (kernel)...")
-        kernel = _kernel_aggregate(table, cell_col, children, "h_li", config)
+        kernel = _kernel_aggregate(
+            table, cell_col, children, "h_li", config, chunk_scalars=chunk_scalars
+        )
         stats_arrays = kernel["stats_arrays"]
         cells_with_data = kernel["cells_with_data"]
         n_cells = len(children)

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -174,11 +174,20 @@ def _eval_chunk_precompute(config: PipelineConfig, pooled: dict[str, np.ndarray]
     so a per-cell ``expression`` (e.g. a 128-bin waveform window) can reference a
     chunk-uniform anchor instead of recomputing a per-cell one.
 
-    Evaluation mirrors :func:`calculate_cell_statistics`: an ``expression`` entry
-    runs through ``_eval_expression_raw`` over the pooled columns; a ``function``
-    entry resolves via ``resolve_function`` and is applied to the entry's
-    ``source`` column (with ``params`` resolved the same way as agg fields). The
-    optional ``dtype`` casts the scalar.
+    Evaluation follows :func:`calculate_cell_statistics`'s expression/function
+    dispatch: an ``expression`` entry runs through ``_eval_expression_raw`` over
+    the pooled columns; a ``function`` entry resolves via ``resolve_function`` and
+    is applied to the entry's ``source`` column (with ``params`` resolved the same
+    way as agg fields). The optional ``dtype`` casts the scalar. The result must
+    reduce to a scalar (``np.ndim(value) == 0``); a non-scalar is rejected.
+
+    It deliberately diverges from the per-cell path in two ways: (1) there is no
+    ``n_obs == 0`` short-circuit (these are shard-level reductions, evaluated once
+    over the pooled columns), and no ``len``/``count`` short-circuit (a
+    ``function: len`` precompute returns the pooled column length, not a cell
+    ``n_obs``); (2) entries are evaluated independently over ``pooled`` only, with
+    no defined order, so one entry cannot reference another's scalar (validation
+    rejects inter-precompute references — see ``_validate_chunk_precompute``).
 
     Returns an empty dict when no ``chunk_precompute`` block is present, so the
     per-cell path is byte-for-byte unchanged for configs that do not use the hook.
@@ -210,6 +219,14 @@ def _eval_chunk_precompute(config: PipelineConfig, pooled: dict[str, np.ndarray]
             value = _eval_expression_raw(expression, pooled)
         else:
             source = meta["source"]
+            if source not in pooled:
+                # The pooled dict only carries columns that were actually read for
+                # this shard; a validated config can still hit this if a read path
+                # omits the source. Raise a clear error rather than a bare KeyError.
+                raise ValueError(
+                    f"chunk_precompute '{name}': source column {source!r} is not "
+                    f"present in the shard's pooled data (available: {sorted(pooled)})"
+                )
             values = pooled[source]
             params = dict(meta.get("params", {}))
             resolved_params = {}
@@ -222,6 +239,13 @@ def _eval_chunk_precompute(config: PipelineConfig, pooled: dict[str, np.ndarray]
                 else:
                     resolved_params[pkey] = pval
             value = resolve_function(meta["function"])(values, **resolved_params)
+        # The hook's whole contract is a chunk-level *scalar*; an expression like
+        # ``np.floor(h_ph)`` (no reduction) returns an array that would be silently
+        # broadcast or mangled by the dtype cast and the per-cell namespace merge.
+        if np.ndim(value) != 0:
+            raise ValueError(
+                f"chunk_precompute '{name}' must reduce to a scalar, got shape {np.shape(value)}"
+            )
         dtype = meta.get("dtype")
         if dtype is not None:
             value = np.dtype(dtype).type(value)
@@ -466,9 +490,32 @@ def calculate_cell_statistics(
         config = default_config()
     agg_fields = get_agg_fields(config)
 
-    n_obs = len(next(iter(cell_data.values()))) if cell_data else 0
+    # ``n_obs`` must count a real (length-bearing) observation column, not a 0-d
+    # chunk-precompute scalar injected into the namespace (issue #30). Scalars have
+    # no ``len``; skip them so an empty cell whose namespace carries only scalars
+    # still reports n_obs == 0 rather than crashing on ``len`` of a 0-d value.
+    n_obs = next(
+        (len(v) for v in cell_data.values() if np.ndim(v) != 0),
+        0,
+    )
     if n_obs == 0:
-        return {name: _empty_cell_value(meta) for name, meta in agg_fields.items()}
+        # Empty cell: every agg field gets its sentinel EXCEPT a field whose
+        # ``expression`` is a bare chunk-precompute name. Those resolve to the
+        # chunk-uniform scalar (well-defined for an empty cell), so the dense
+        # writer's empty rows still carry the shared chunk anchor instead of NaN
+        # (issue #30 — every cell in a chunk shares one anchor).
+        empty = {}
+        for name, meta in agg_fields.items():
+            expr = meta.get("expression")
+            if expr is not None:
+                key = expr.strip()
+                if key.isidentifier() and key in cell_data and np.ndim(cell_data[key]) == 0:
+                    sig = get_output_signature(meta)
+                    if sig["kind"] == "scalar":
+                        empty[name] = float(cell_data[key])
+                        continue
+            empty[name] = _empty_cell_value(meta)
+        return empty
 
     result = {}
     for name, meta in agg_fields.items():
@@ -1414,6 +1461,16 @@ def process_shard(
         config = default_config()
     if handoff not in ("pandas", "arrow", "arrow-kernel"):
         raise ValueError(f"handoff must be 'pandas', 'arrow', or 'arrow-kernel', got {handoff!r}")
+    # Reject the unsupported arrow-kernel + chunk_precompute combination up front,
+    # before any read (issue #30). The kernel fallback loop reduces each cell
+    # independently and has no seam to inject the shard-pooled chunk scalars; this
+    # is a property of the *config*, not the data, so enforce it deterministically
+    # rather than only when some rows happen to be read.
+    if handoff == "arrow-kernel" and get_chunk_precompute(config):
+        raise NotImplementedError(
+            "handoff='arrow-kernel' does not support aggregation.chunk_precompute "
+            "(issue #30); use handoff='pandas' or 'arrow' instead"
+        )
     data_source = config.data_source
 
     shard_key = int(shard_key)
@@ -1528,15 +1585,8 @@ def process_shard(
                 "handoff='arrow-kernel' does not support ragged fields (issue #48); "
                 "use handoff='pandas' or 'arrow' instead"
             )
-        if get_chunk_precompute(config):
-            # The kernel path's fallback loop reduces each cell independently and
-            # has no seam to inject the shard-pooled chunk scalars; rather than
-            # silently drop them, reject the combination (the experimental kernel
-            # path is opt-in — pandas/arrow carry chunk_precompute fully).
-            raise NotImplementedError(
-                "handoff='arrow-kernel' does not support aggregation.chunk_precompute "
-                "(issue #30); use handoff='pandas' or 'arrow' instead"
-            )
+        # (arrow-kernel + chunk_precompute is rejected at the top of process_shard,
+        # before any read, so the combination never reaches this branch.)
         import pyarrow as pa
 
         table = pa.concat_tables(all_reads).combine_chunks()

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -1035,12 +1035,16 @@ def _broadcast_segment_to_base(
 
     Each coarse parent ``p`` covers base-rate rows ``index_beg_arr[p] - index_base``
     through ``... + count_arr[p] - 1`` (the same contiguous parent->child tiling
-    :func:`_expand_mask_to_base` expands a mask over). Where that tiling is
-    contiguous and ordered this equals ``np.repeat(seg_values, count_arr)``; placing
-    by ``index_beg`` keeps it robust to the same gap/order cases the mask path
-    handles. The returned array carries each photon's segment value (e.g. ``dem_h``,
-    one value per ~100 photons) so it can ride alongside the base-rate variables
-    through the read plan's spatial/keep masks.
+    :func:`_expand_mask_to_base` expands a mask over). Under #43's contiguity
+    assumption (ranges do not overlap and together tile the full base array) this
+    equals ``np.repeat(seg_values, count_arr)``; placing by ``index_beg`` keeps the
+    per-parent value correctly positioned even when ``index_beg`` is shifted
+    (``index_base``). Any base row left untiled (a gap, if the contiguity assumption
+    is violated) is filled with ``NaN`` for float dtypes so it surfaces as a missing
+    value rather than uninitialized garbage; non-float dtypes are zero-filled. The
+    returned array carries each photon's segment value (e.g. ``dem_h``, one value per
+    ~100 photons) so it can ride alongside the base-rate variables through the read
+    plan's spatial/keep masks.
 
     Parameters
     ----------
@@ -1053,8 +1057,20 @@ def _broadcast_segment_to_base(
     -------
     np.ndarray
         1-D array of length ``total_base_size`` and ``seg_values``' dtype.
+
+    Raises
+    ------
+    ValueError
+        If a parent's range starts before 0 or extends past ``total_base_size``
+        (a tiling that does not fit the declared base size — e.g. a segment-level
+        variable on a level whose link does not match the read's base extent).
     """
-    out = np.empty(total_base_size, dtype=seg_values.dtype)
+    # NaN-fill floats so an untiled gap reads as missing, not garbage (the mask path
+    # is safe-by-construction with np.zeros; a value array has no such safe default).
+    if np.issubdtype(seg_values.dtype, np.floating):
+        out = np.full(total_base_size, np.nan, dtype=seg_values.dtype)
+    else:
+        out = np.zeros(total_base_size, dtype=seg_values.dtype)
     for p in range(len(seg_values)):
         beg = int(index_beg_arr[p]) - index_base
         if beg < 0:
@@ -1062,6 +1078,11 @@ def _broadcast_segment_to_base(
                 f"index_beg_arr[{p}]={index_beg_arr[p]} is less than index_base={index_base}"
             )
         cnt = int(count_arr[p])
+        if beg + cnt > total_base_size:
+            raise ValueError(
+                f"segment {p} range [{beg}:{beg + cnt}] exceeds base size {total_base_size}; "
+                f"the segment-level variable's link does not tile the read's base extent"
+            )
         out[beg : beg + cnt] = seg_values[p]
     return out
 

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -8,7 +8,7 @@ cloud platforms or local processing environments.
 import logging
 import warnings
 from datetime import datetime
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import h5coro
 import numpy as np
@@ -22,6 +22,7 @@ from zagg.config import (
     evaluate_filter_expression,
     filters_from_data_source,
     get_agg_fields,
+    get_chunk_precompute,
     get_data_vars,
     get_output_signature,
 )
@@ -160,6 +161,72 @@ def _concat_and_group(all_reads, grid, handoff: str):
         cell_col = grid.cells_of(df_all["leaf_id"].values)
         col_arrays, cell_to_slice = _build_groups(df_all, cell_col)
     return col_arrays, cell_to_slice, n_obs_total
+
+
+def _eval_chunk_precompute(config: PipelineConfig, pooled: dict[str, np.ndarray]) -> dict[str, Any]:
+    """Evaluate the ``chunk_precompute`` entries ONCE over a shard's pooled columns.
+
+    The per-chunk precompute hook (issue #30, item 1) is the "compute once per
+    chunk, use per cell" primitive: each named entry is evaluated a single time
+    over the shard's *pooled* column arrays (all beams/granules concatenated,
+    before the per-cell split), yielding a chunk-level scalar. Those scalars are
+    then injected into the per-cell expression namespace by :func:`process_shard`
+    so a per-cell ``expression`` (e.g. a 128-bin waveform window) can reference a
+    chunk-uniform anchor instead of recomputing a per-cell one.
+
+    Evaluation mirrors :func:`calculate_cell_statistics`: an ``expression`` entry
+    runs through ``_eval_expression_raw`` over the pooled columns; a ``function``
+    entry resolves via ``resolve_function`` and is applied to the entry's
+    ``source`` column (with ``params`` resolved the same way as agg fields). The
+    optional ``dtype`` casts the scalar.
+
+    Returns an empty dict when no ``chunk_precompute`` block is present, so the
+    per-cell path is byte-for-byte unchanged for configs that do not use the hook.
+
+    Parameters
+    ----------
+    config : PipelineConfig
+        Drives the ``chunk_precompute`` entries.
+    pooled : dict[str, np.ndarray]
+        Pooled column arrays for the whole shard (e.g. ``col_arrays`` from
+        :func:`_concat_and_group`). Order does not matter — these are chunk-level
+        reductions over the full shard.
+
+    Returns
+    -------
+    dict[str, object]
+        ``{name: scalar}`` for each ``chunk_precompute`` entry.
+    """
+    from zagg.config import _eval_expression_raw, resolve_function
+
+    entries = get_chunk_precompute(config)
+    if not entries:
+        return {}
+
+    out: dict[str, Any] = {}
+    for name, meta in entries.items():
+        expression = meta.get("expression")
+        if expression is not None:
+            value = _eval_expression_raw(expression, pooled)
+        else:
+            source = meta["source"]
+            values = pooled[source]
+            params = dict(meta.get("params", {}))
+            resolved_params = {}
+            for pkey, pval in params.items():
+                if isinstance(pval, str) and pval in pooled:
+                    resolved_params[pkey] = pooled[pval]
+                elif isinstance(pval, str) and any(c in pval for c in pooled):
+                    ns = {"__builtins__": {}, "np": np, "numpy": np, **pooled}
+                    resolved_params[pkey] = eval(pval, ns)  # noqa: S307
+                else:
+                    resolved_params[pkey] = pval
+            value = resolve_function(meta["function"])(values, **resolved_params)
+        dtype = meta.get("dtype")
+        if dtype is not None:
+            value = np.dtype(dtype).type(value)
+        out[name] = value
+    return out
 
 
 def _has_vector_fields(config: PipelineConfig) -> bool:
@@ -351,7 +418,7 @@ def _iter_carrier_columns(carrier):
 
 
 def calculate_cell_statistics(
-    cell_data: dict[str, np.ndarray],
+    cell_data: dict[str, Any],
     value_col: str = "h_li",
     sigma_col: str = "s_li",
     config: PipelineConfig | None = None,
@@ -376,9 +443,11 @@ def calculate_cell_statistics(
 
     Parameters
     ----------
-    cell_data : dict[str, np.ndarray]
-        Column arrays for a single cell. Keys are column names; values are
-        numpy arrays of equal length.
+    cell_data : dict[str, Any]
+        Eval namespace for a single cell. Keys are column names; values are
+        numpy arrays of equal length. May also carry chunk-level scalars injected
+        by the per-chunk precompute hook (issue #30), which a per-cell expression
+        can reference by name.
     value_col : str
         Column name for elevation values.
     sigma_col : str
@@ -1459,6 +1528,15 @@ def process_shard(
                 "handoff='arrow-kernel' does not support ragged fields (issue #48); "
                 "use handoff='pandas' or 'arrow' instead"
             )
+        if get_chunk_precompute(config):
+            # The kernel path's fallback loop reduces each cell independently and
+            # has no seam to inject the shard-pooled chunk scalars; rather than
+            # silently drop them, reject the combination (the experimental kernel
+            # path is opt-in — pandas/arrow carry chunk_precompute fully).
+            raise NotImplementedError(
+                "handoff='arrow-kernel' does not support aggregation.chunk_precompute "
+                "(issue #30); use handoff='pandas' or 'arrow' instead"
+            )
         import pyarrow as pa
 
         table = pa.concat_tables(all_reads).combine_chunks()
@@ -1478,6 +1556,14 @@ def process_shard(
         # agnostic; both carriers feed identical numpy arrays into _group_columns).
         col_arrays, cell_to_slice, n_obs_total = _concat_and_group(all_reads, grid, handoff)
         logger.info(f"  Read {n_obs_total:,} observations")
+
+        # Per-chunk precompute hook (issue #30, item 1): evaluate each
+        # ``chunk_precompute`` entry ONCE over the shard's pooled columns, then
+        # inject the resulting chunk-level scalars into every cell's namespace so a
+        # per-cell expression can reference a chunk-uniform anchor (e.g. the 128-bin
+        # waveform window). Empty when the block is absent, so the per-cell path is
+        # byte-for-byte unchanged for configs that do not use the hook.
+        chunk_scalars = _eval_chunk_precompute(config, col_arrays)
         logger.info(f"  Calculating statistics for {len(children)} cells...")
 
         n_cells = len(children)
@@ -1517,8 +1603,13 @@ def process_shard(
                 cells_with_data += 1
             else:
                 cell_data = _empty
+            # Inject the chunk-level scalars into this cell's namespace (no-op when
+            # ``chunk_scalars`` is empty, so non-precompute configs are unchanged).
+            cell_namespace: dict[str, Any] = (
+                {**cell_data, **chunk_scalars} if chunk_scalars else cell_data
+            )
             stats = calculate_cell_statistics(
-                cell_data, value_col="h_li", sigma_col="s_li", config=config
+                cell_namespace, value_col="h_li", sigma_col="s_li", config=config
             )
             for key, value in stats.items():
                 if key in ragged_payloads:

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -383,8 +383,32 @@ def write_dataframe_to_zarr(
             f"Expected {expected_count} rows for chunk_shape={grid.chunk_shape}, got {n_cells}"
         )
 
+    # Fields declared ``resolution: chunk`` (issue #30 item 2) are written ONCE per
+    # chunk into a companion array shaped at the chunk grid, not the per-cell array.
+    # Read the set from the grid's config (every concrete grid carries ``config``).
+    chunk_res_fields = _chunk_resolution_fields(getattr(grid, "config", None))
+
     chunk_idx = tuple(int(i) for i in chunk_idx)
     for name, values in _iter_carrier_columns(df_out):
+        if name in chunk_res_fields:
+            # resolution: chunk — the column is chunk-uniform (every cell carries
+            # the same chunk value), so collapse to the single value and write it to
+            # the companion array's one-block-per-chunk grid at ``chunk_idx`` (which
+            # IS ``grid.block_index(shard_key)``). One value per chunk, no per-cell
+            # duplication on disk (issue #30 item 2).
+            flat = values.reshape(-1)
+            chunk_value = flat[0]
+            block = np.asarray(chunk_value).reshape((1,) * len(chunk_idx))
+            with config.set({"async.concurrency": 128}):
+                array = open_array(
+                    store,
+                    path=f"{grid.group_path}/{name}",
+                    zarr_format=3,
+                    consolidated=False,
+                )
+                array.set_block_selection(chunk_idx, block)
+            continue
+
         # Scalar columns reshape to the grid's chunk_shape; a vector column keeps
         # its trailing payload dim(s), so the block (and target array) is
         # (*chunk_shape, *trailing_shape). The cell count invariant is unchanged.
@@ -417,6 +441,21 @@ def write_dataframe_to_zarr(
             array.set_block_selection(block_idx, values)
 
     return store
+
+
+def _chunk_resolution_fields(config: PipelineConfig | None) -> set[str]:
+    """Names of agg fields declared ``resolution: chunk`` (issue #30 item 2).
+
+    Empty for a config without any such field, so the writer's per-cell path is
+    byte-for-byte unchanged for existing (cell-resolution-only) configs.
+    """
+    if config is None:
+        return set()
+    return {
+        name
+        for name, meta in get_agg_fields(config).items()
+        if get_output_signature(meta)["resolution"] == "chunk"
+    }
 
 
 def _iter_carrier_columns(carrier):

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -1423,8 +1423,12 @@ def _planned_read_group(
     )
 
     # Base-level expression filters (aggregation-time escape hatch, no pushdown).
+    # The namespace carries both base-rate ``variables`` and any segment-level
+    # broadcast columns (issue #30), which are already materialized into
+    # ``data_dict`` above, so an expression filter may reference e.g. ``dem_h``.
+    expr_names = list(variables) + list(seg_broadcasts)
     for f in expressions:
-        cols = {c: data_dict[c] for c in variables if c in data_dict}
+        cols = {c: data_dict[c] for c in expr_names if c in data_dict}
         try:
             emask = evaluate_filter_expression(f["expression"], cols)
         except NameError as e:
@@ -1643,9 +1647,13 @@ def _read_group_full(
         data_dict["leaf_id"] = leaf_sliced
 
     # Base-level ``expression`` filters: aggregation-time escape hatch, evaluated
-    # over the already-read variable columns (forfeits pushdown, issue #43).
+    # over the already-read variable columns (forfeits pushdown, issue #43). The
+    # namespace also carries any segment-level broadcast columns (issue #30),
+    # materialized into ``data_dict`` above, so a filter may reference e.g.
+    # ``dem_h``.
+    expr_names = list(variables) + list(seg_broadcasts)
     for f in expressions:
-        cols = {c: data_dict[c] for c in variables if c in data_dict}
+        cols = {c: data_dict[c] for c in expr_names if c in data_dict}
         try:
             emask = evaluate_filter_expression(f["expression"], cols)
         except NameError as e:

--- a/src/zagg/processing.py
+++ b/src/zagg/processing.py
@@ -391,13 +391,12 @@ def write_dataframe_to_zarr(
     chunk_idx = tuple(int(i) for i in chunk_idx)
     for name, values in _iter_carrier_columns(df_out):
         if name in chunk_res_fields:
-            # resolution: chunk — the column is chunk-uniform (every cell carries
-            # the same chunk value), so collapse to the single value and write it to
-            # the companion array's one-block-per-chunk grid at ``chunk_idx`` (which
-            # IS ``grid.block_index(shard_key)``). One value per chunk, no per-cell
-            # duplication on disk (issue #30 item 2).
-            flat = values.reshape(-1)
-            chunk_value = flat[0]
+            # resolution: chunk — the column must be chunk-uniform (every populated
+            # cell carries the same chunk value), so collapse to the single value and
+            # write it to the companion array's one-block-per-chunk grid at
+            # ``chunk_idx`` (which IS ``grid.block_index(shard_key)``). One value per
+            # chunk, no per-cell duplication on disk (issue #30 item 2).
+            chunk_value = _chunk_uniform_value(name, values)
             block = np.asarray(chunk_value).reshape((1,) * len(chunk_idx))
             with config.set({"async.concurrency": 128}):
                 array = open_array(
@@ -456,6 +455,43 @@ def _chunk_resolution_fields(config: PipelineConfig | None) -> set[str]:
         for name, meta in get_agg_fields(config).items()
         if get_output_signature(meta)["resolution"] == "chunk"
     }
+
+
+def _chunk_uniform_value(name: str, values: np.ndarray):
+    """Collapse a ``resolution: chunk`` field's per-cell column to its single value.
+
+    A chunk-resolution field stores ONE value per chunk (issue #30 item 2), so its
+    per-cell column must be chunk-uniform: every *populated* cell carries the same
+    chunk value. Empty cells (which carry the field's fill sentinel — ``NaN`` for a
+    float field, or the bare-chunk-anchor when the expression is a bare precompute
+    name) are ignored when selecting the representative value, so an empty cell 0 no
+    longer poisons the companion write with ``NaN``.
+
+    Raises a clear error if the populated cells are NOT uniform — that means the
+    field's ``expression`` genuinely varies per cell and ``resolution: chunk`` is a
+    misconfiguration (the per-cell values would be silently dropped otherwise).
+    """
+    flat = np.asarray(values).reshape(-1)
+    # Treat NaN as the empty/fill sentinel for float columns; integer columns have
+    # no NaN, so every cell is "populated" and the uniformity check covers them all.
+    if np.issubdtype(flat.dtype, np.floating):
+        populated = flat[~np.isnan(flat)]
+    else:
+        populated = flat
+    if populated.size == 0:
+        # Whole chunk is fill (e.g. a vector-carrier shard with no chunk anchor):
+        # nothing meaningful to record; fall back to the first cell's sentinel.
+        return flat[0]
+    first = populated[0]
+    if not np.all(populated == first):
+        uniq = np.unique(populated)
+        raise ValueError(
+            f"resolution: chunk field {name!r} is not chunk-uniform: the populated "
+            f"cells carry {uniq.size} distinct values ({uniq[:4]}...); a chunk-"
+            f"resolution field must reduce to one value per chunk (use resolution: "
+            f"cell for a per-cell field)"
+        )
+    return first
 
 
 def _iter_carrier_columns(carrier):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,10 +179,12 @@ class TestWaveformChunkTemplate:
     def test_declares_chunk_precompute(self, cfg):
         pc = get_chunk_precompute(cfg)
         assert set(pc) == {"chunk_offset", "chunk_gain"}
-        # both are expression entries over the pooled h_ph
         for meta in pc.values():
             assert "expression" in meta
-            assert meta["source"] == "h_ph"
+        # chunk_offset is the DEM anchor (dem_h, a segment-level variable);
+        # chunk_gain is a spread over the photon heights (h_ph).
+        assert pc["chunk_offset"]["source"] == "dem_h"
+        assert pc["chunk_gain"]["source"] == "h_ph"
 
     def test_waveform_references_chunk_names(self, cfg):
         expr = cfg.aggregation["variables"]["waveform_counts"]["expression"]
@@ -773,6 +775,89 @@ class TestLevelsValidation:
         )
         with pytest.raises(ValueError, match="not a key in levels"):
             validate_config(cfg)
+
+
+class TestSegmentLevelVariables:
+    """Issue #30: a non-base level may declare ``variables`` as a ``{name: path}``
+    mapping (a readable segment-level variable, e.g. ``dem_h``). It is validated
+    like ``data_source.variables`` (string names -> non-empty path templates) and
+    its names become valid column references for the aggregation."""
+
+    def _cfg(self, seg_variables, **agg_overrides):
+        ds = _minimal_two_level_ds()
+        ds["levels"]["segments"]["variables"] = seg_variables
+        agg = {"variables": {"c": {"function": "len", "dtype": "int32"}}}
+        agg.update(agg_overrides)
+        return PipelineConfig(
+            data_source=ds,
+            aggregation=agg,
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+
+    def test_mapping_form_valid(self):
+        validate_config(self._cfg({"dem_h": "/{group}/geophys_corr/dem_h"}))
+
+    def test_list_form_still_valid(self):
+        # The documentation-only ``list[str]`` form is unchanged.
+        validate_config(self._cfg(["signal_conf_ph"]))
+
+    def test_segment_variable_usable_as_agg_source(self):
+        # dem_h becomes a per-photon column, so an agg field may source it.
+        validate_config(
+            self._cfg(
+                {"dem_h": "/{group}/geophys_corr/dem_h"},
+                variables={"dem_mean": {"function": "mean", "source": "dem_h", "dtype": "float32"}},
+            )
+        )
+
+    def test_segment_variable_usable_in_chunk_precompute(self):
+        ds = _minimal_two_level_ds()
+        ds["levels"]["segments"]["variables"] = {"dem_h": "/{group}/geophys_corr/dem_h"}
+        cfg = PipelineConfig(
+            data_source=ds,
+            aggregation={
+                "chunk_precompute": {
+                    "chunk_offset": {
+                        "expression": "np.float32(np.median(dem_h))",
+                        "source": "dem_h",
+                    }
+                },
+                "variables": {"c": {"function": "len", "dtype": "int32"}},
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        validate_config(cfg)
+
+    def test_empty_path_template_rejected(self):
+        with pytest.raises(ValueError, match="path template must be a"):
+            validate_config(self._cfg({"dem_h": ""}))
+
+    def test_mapping_on_base_level_rejected(self):
+        ds = _minimal_two_level_ds()
+        ds["levels"]["photons"]["variables"] = {"h_ph": "/{group}/heights/h_ph"}
+        cfg = PipelineConfig(
+            data_source=ds,
+            aggregation={"variables": {"c": {"function": "len", "dtype": "int32"}}},
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        with pytest.raises(ValueError, match="base level uses data_source.variables"):
+            validate_config(cfg)
+
+    def test_name_collision_with_base_variable_rejected(self):
+        # ``h`` is already a data_source.variables column.
+        with pytest.raises(ValueError, match="collides with a data_source.variables column"):
+            validate_config(self._cfg({"h": "/{group}/geophys_corr/dem_h"}))
+
+    def test_worked_template_declares_dem_h_segment_variable(self):
+        cfg = load_config("src/zagg/configs/atl03_waveform_chunk.yaml")
+        validate_config(cfg)
+        seg = cfg.data_source["levels"]["segments"]["variables"]
+        assert isinstance(seg, dict)
+        assert seg["dem_h"] == "/{group}/geophys_corr/dem_h"
+        # chunk_offset is DEM-anchored.
+        offset = cfg.aggregation["chunk_precompute"]["chunk_offset"]
+        assert offset["source"] == "dem_h"
+        assert "dem_h" in offset["expression"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1163,11 +1163,18 @@ class TestGetOutputSignature:
             "trailing_shape": (),
             "inner_shape": (),
             "dtype": "float32",
+            "resolution": "cell",
         }
 
     def test_scalar_default_dtype_none(self):
         sig = get_output_signature({"function": "min"})
-        assert sig == {"kind": "scalar", "trailing_shape": (), "inner_shape": (), "dtype": None}
+        assert sig == {
+            "kind": "scalar",
+            "trailing_shape": (),
+            "inner_shape": (),
+            "dtype": None,
+            "resolution": "cell",
+        }
 
     def test_vector_int_signature(self):
         sig = get_output_signature({"kind": "vector", "trailing_shape": 64, "dtype": "float32"})
@@ -1176,6 +1183,7 @@ class TestGetOutputSignature:
             "trailing_shape": (64,),
             "inner_shape": (),
             "dtype": "float32",
+            "resolution": "cell",
         }
 
     def test_vector_list_signature(self):
@@ -1183,6 +1191,67 @@ class TestGetOutputSignature:
         assert sig["kind"] == "vector"
         assert sig["trailing_shape"] == (16, 2)
         assert sig["inner_shape"] == ()
+
+
+# ---------------------------------------------------------------------------
+# resolution attribute (issue #30 item 2)
+# ---------------------------------------------------------------------------
+
+
+def _cfg_with_field(meta):
+    """Minimal valid config carrying a single agg field ``f`` with ``meta``."""
+    return PipelineConfig(
+        data_source={"variables": {"h_ph": "/{group}/h_ph"}},
+        aggregation={"variables": {"f": {"source": "h_ph", **meta}}},
+        output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+    )
+
+
+class TestResolutionAttribute:
+    def test_resolution_defaults_to_cell(self):
+        sig = get_output_signature({"function": "min"})
+        assert sig["resolution"] == "cell"
+
+    def test_resolution_cell_explicit_validates(self):
+        cfg = _cfg_with_field({"function": "min", "resolution": "cell"})
+        validate_config(cfg)  # should not raise
+        assert get_output_signature(get_agg_fields(cfg)["f"])["resolution"] == "cell"
+
+    def test_scalar_field_may_be_resolution_chunk(self):
+        cfg = _cfg_with_field({"expression": "chunk_anchor", "resolution": "chunk"})
+        # add the referenced chunk_precompute so the per-cell expression validates.
+        cfg.aggregation["chunk_precompute"] = {
+            "chunk_anchor": {"expression": "np.median(h_ph)", "source": "h_ph"}
+        }
+        validate_config(cfg)
+        assert get_output_signature(get_agg_fields(cfg)["f"])["resolution"] == "chunk"
+
+    def test_bad_resolution_rejected(self):
+        cfg = _cfg_with_field({"function": "min", "resolution": "block"})
+        with pytest.raises(ValueError, match="resolution 'block' is not supported"):
+            validate_config(cfg)
+
+    def test_resolution_chunk_vector_rejected(self):
+        cfg = _cfg_with_field(
+            {
+                "kind": "vector",
+                "trailing_shape": 4,
+                "expression": "np.zeros(4)",
+                "resolution": "chunk",
+            }
+        )
+        with pytest.raises(
+            ValueError, match="resolution 'chunk' is only supported for kind 'scalar'"
+        ):
+            validate_config(cfg)
+
+    def test_worked_template_offset_gain_are_chunk_resolution(self):
+        cfg = default_config("atl03_waveform_chunk")
+        fields = get_agg_fields(cfg)
+        assert get_output_signature(fields["offset_h"])["resolution"] == "chunk"
+        assert get_output_signature(fields["gain_h"])["resolution"] == "chunk"
+        # waveform_counts stays cell-resolution (per-cell vector).
+        assert get_output_signature(fields["waveform_counts"])["resolution"] == "cell"
 
 
 # ---------------------------------------------------------------------------
@@ -1341,6 +1410,7 @@ class TestRaggedKind:
             "trailing_shape": (),
             "inner_shape": (2,),
             "dtype": "float32",
+            "resolution": "cell",
         }
 
     def test_ragged_inner_shape_int_normalized(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -438,6 +438,30 @@ class TestChunkPrecompute:
         with pytest.raises(ValueError, match="must be a mapping"):
             validate_config(cfg)
 
+    def test_name_colliding_with_column_rejected(self):
+        # A precompute name equal to a data_source.variables column would shadow the
+        # real column array with a 0-d scalar in the per-cell namespace merge.
+        cfg = _cfg_with_precompute({"h_ph": {"expression": "np.median(h_ph)", "source": "h_ph"}})
+        with pytest.raises(ValueError, match="chunk_precompute 'h_ph'.*collides"):
+            validate_config(cfg)
+
+    def test_name_colliding_with_leaf_id_rejected(self):
+        cfg = _cfg_with_precompute({"leaf_id": {"expression": "np.median(h_ph)", "source": "h_ph"}})
+        with pytest.raises(ValueError, match="chunk_precompute 'leaf_id'.*collides"):
+            validate_config(cfg)
+
+    def test_inter_precompute_reference_rejected_as_unknown_column(self):
+        # Inter-precompute references are unsupported: chunk_gain referencing
+        # chunk_offset is rejected as an unknown column (no chaining, single pass).
+        cfg = _cfg_with_precompute(
+            {
+                "chunk_offset": {"expression": "np.median(h_ph)", "source": "h_ph"},
+                "chunk_gain": {"expression": "chunk_offset + 1.0", "source": "h_ph"},
+            }
+        )
+        with pytest.raises(ValueError, match="chunk_offset"):
+            validate_config(cfg)
+
 
 # ---------------------------------------------------------------------------
 # Structured filters (issue #43, Phase A)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -810,6 +810,32 @@ class TestSegmentLevelVariables:
             )
         )
 
+    def test_segment_variable_usable_in_expression_filter(self):
+        # A broadcast segment variable is a valid name in an ``expression`` filter,
+        # consistent with agg/precompute expressions (issue #30).
+        ds = _minimal_two_level_ds()
+        ds["levels"]["segments"]["variables"] = {"dem_h": "/{group}/geophys_corr/dem_h"}
+        ds["filters"] = [{"expression": "dem_h > 100.0"}]
+        cfg = PipelineConfig(
+            data_source=ds,
+            aggregation={"variables": {"c": {"function": "len", "dtype": "int32"}}},
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        validate_config(cfg)
+
+    def test_unknown_name_in_expression_filter_rejected(self):
+        # A truly-undefined name in an expression filter is rejected at validate
+        # time, like agg/precompute expressions.
+        ds = _minimal_two_level_ds()
+        ds["filters"] = [{"expression": "nope_col > 0"}]
+        cfg = PipelineConfig(
+            data_source=ds,
+            aggregation={"variables": {"c": {"function": "len", "dtype": "int32"}}},
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        with pytest.raises(ValueError, match="nope_col"):
+            validate_config(cfg)
+
     def test_segment_variable_usable_in_chunk_precompute(self):
         ds = _minimal_two_level_ds()
         ds["levels"]["segments"]["variables"] = {"dem_h": "/{group}/geophys_corr/dem_h"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from zagg.config import (
     get_agg_fields,
     get_base_level,
     get_child_order,
+    get_chunk_precompute,
     get_coords,
     get_data_vars,
     get_filters,
@@ -162,6 +163,36 @@ class TestATL03Template:
         rp = atl03_config.data_source["read_plan"]
         assert rp["spatial_index"] == "segments"
         assert rp["pad"] == 1
+
+
+class TestWaveformChunkTemplate:
+    """The worked chunk-precompute example (issue #30, item 1)."""
+
+    @pytest.fixture
+    def cfg(self):
+        return default_config("atl03_waveform_chunk")
+
+    def test_loads_and_validates(self, cfg):
+        validate_config(cfg)
+        assert cfg.data_source["reader"] == "h5coro"
+
+    def test_declares_chunk_precompute(self, cfg):
+        pc = get_chunk_precompute(cfg)
+        assert set(pc) == {"chunk_offset", "chunk_gain"}
+        # both are expression entries over the pooled h_ph
+        for meta in pc.values():
+            assert "expression" in meta
+            assert meta["source"] == "h_ph"
+
+    def test_waveform_references_chunk_names(self, cfg):
+        expr = cfg.aggregation["variables"]["waveform_counts"]["expression"]
+        assert "chunk_offset" in expr
+        assert "chunk_gain" in expr
+
+    def test_records_offset_and_gain_scalar_fields(self, cfg):
+        vars_ = cfg.aggregation["variables"]
+        assert vars_["offset_h"]["expression"] == "chunk_offset"
+        assert vars_["gain_h"]["expression"] == "chunk_gain"
 
 
 # ---------------------------------------------------------------------------
@@ -316,6 +347,95 @@ class TestValidation:
             data_source={}, aggregation={"variables": {}}, output={"grid": {"type": "x"}}
         )
         with pytest.raises(ValueError, match="Missing required section"):
+            validate_config(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Per-chunk precompute hook (issue #30, item 1)
+# ---------------------------------------------------------------------------
+
+
+def _cfg_with_precompute(precompute, variables=None):
+    """Minimal valid config carrying an aggregation.chunk_precompute block."""
+    return PipelineConfig(
+        data_source={"variables": {"h_ph": "/{group}/h_ph"}},
+        aggregation={
+            "chunk_precompute": precompute,
+            "variables": variables
+            or {"h_min": {"function": "min", "source": "h_ph", "dtype": "float32"}},
+        },
+        output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+    )
+
+
+class TestChunkPrecompute:
+    def test_expression_entry_validates(self):
+        cfg = _cfg_with_precompute(
+            {"chunk_offset": {"expression": "np.floor(np.median(h_ph))", "source": "h_ph"}}
+        )
+        validate_config(cfg)  # should not raise
+        assert list(get_chunk_precompute(cfg)) == ["chunk_offset"]
+
+    def test_function_entry_validates(self):
+        cfg = _cfg_with_precompute(
+            {"chunk_median": {"function": "median", "source": "h_ph", "dtype": "float32"}}
+        )
+        validate_config(cfg)
+
+    def test_get_chunk_precompute_empty_without_block(self, atl06_config):
+        assert get_chunk_precompute(atl06_config) == {}
+
+    def test_per_cell_expression_may_reference_precompute_name(self):
+        # offset_h's expression is just the chunk_precompute name; it must validate.
+        cfg = _cfg_with_precompute(
+            {"chunk_offset": {"expression": "np.floor(np.median(h_ph))", "source": "h_ph"}},
+            variables={"offset_h": {"expression": "chunk_offset", "dtype": "float32"}},
+        )
+        validate_config(cfg)
+
+    def test_unknown_source_rejected(self):
+        cfg = _cfg_with_precompute({"bad": {"function": "median", "source": "nonexistent"}})
+        with pytest.raises(ValueError, match="chunk_precompute 'bad'.*nonexistent"):
+            validate_config(cfg)
+
+    def test_both_function_and_expression_rejected(self):
+        cfg = _cfg_with_precompute(
+            {
+                "bad": {
+                    "function": "median",
+                    "expression": "np.median(h_ph)",
+                    "source": "h_ph",
+                }
+            }
+        )
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            validate_config(cfg)
+
+    def test_neither_function_nor_expression_rejected(self):
+        cfg = _cfg_with_precompute({"bad": {"source": "h_ph"}})
+        with pytest.raises(ValueError, match="must specify"):
+            validate_config(cfg)
+
+    def test_empty_name_rejected(self):
+        cfg = _cfg_with_precompute({"   ": {"function": "median", "source": "h_ph"}})
+        with pytest.raises(ValueError, match="non-empty strings"):
+            validate_config(cfg)
+
+    def test_expression_unknown_column_rejected(self):
+        cfg = _cfg_with_precompute({"bad": {"expression": "np.median(missing_col)"}})
+        with pytest.raises(ValueError, match="missing_col"):
+            validate_config(cfg)
+
+    def test_bad_dtype_rejected(self):
+        cfg = _cfg_with_precompute(
+            {"bad": {"function": "median", "source": "h_ph", "dtype": "not_a_dtype"}}
+        )
+        with pytest.raises(ValueError, match="not a valid.*numpy dtype"):
+            validate_config(cfg)
+
+    def test_non_mapping_block_rejected(self):
+        cfg = _cfg_with_precompute(["not", "a", "mapping"])
+        with pytest.raises(ValueError, match="must be a mapping"):
             validate_config(cfg)
 
 
@@ -603,7 +723,6 @@ class TestLevelsValidation:
         )
         with pytest.raises(ValueError, match="reserved"):
             validate_config(cfg)
-
 
     def test_self_link_rejected(self):
         # link.to == level name (self-reference) must raise ValueError
@@ -1015,7 +1134,12 @@ class TestOutputKind:
 class TestGetOutputSignature:
     def test_scalar_signature(self):
         sig = get_output_signature({"function": "min", "dtype": "float32"})
-        assert sig == {"kind": "scalar", "trailing_shape": (), "inner_shape": (), "dtype": "float32"}
+        assert sig == {
+            "kind": "scalar",
+            "trailing_shape": (),
+            "inner_shape": (),
+            "dtype": "float32",
+        }
 
     def test_scalar_default_dtype_none(self):
         sig = get_output_signature({"function": "min"})
@@ -1083,9 +1207,7 @@ class TestATL03WaveformCountsTemplate:
 
         np.random.seed(0)
         h_ph = np.random.uniform(-100.0, 100.0, 50).astype("float32")
-        result = calculate_cell_statistics(
-            {"h_ph": h_ph, "leaf_id": np.arange(50)}, config=cfg
-        )
+        result = calculate_cell_statistics({"h_ph": h_ph, "leaf_id": np.arange(50)}, config=cfg)
         wc = result["waveform_counts"]
         assert wc.shape == (128,)
         assert wc.dtype == np.dtype("uint32")
@@ -1097,9 +1219,7 @@ class TestATL03WaveformCountsTemplate:
         # Two photons clustered near 0, one far outlier at 500 m. The cell median
         # is ~5 m, so the outlier sits beyond ±128 m and falls outside the hist.
         h_ph = np.array([0.0, 10.0, 500.0], dtype="float32")
-        result = calculate_cell_statistics(
-            {"h_ph": h_ph, "leaf_id": np.arange(3)}, config=cfg
-        )
+        result = calculate_cell_statistics({"h_ph": h_ph, "leaf_id": np.arange(3)}, config=cfg)
         wc = result["waveform_counts"]
         assert int(wc.sum()) == 2, "out-of-range photon must not appear in any bin"
 
@@ -1256,7 +1376,9 @@ class TestRaggedKind:
 
     def test_trailing_shape_rejected_for_ragged(self):
         cfg = _ragged_cfg(inner_shape=[2], trailing_shape=4)
-        with pytest.raises(ValueError, match="'trailing_shape' is only valid for 'vector', not 'ragged'"):
+        with pytest.raises(
+            ValueError, match="'trailing_shape' is only valid for 'vector', not 'ragged'"
+        ):
             validate_config(cfg)
 
     def test_len_rejected_for_ragged(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -848,6 +848,29 @@ class TestSegmentLevelVariables:
         with pytest.raises(ValueError, match="collides with a data_source.variables column"):
             validate_config(self._cfg({"h": "/{group}/geophys_corr/dem_h"}))
 
+    def test_duplicate_segment_variable_across_levels_rejected(self):
+        # Two non-base levels declaring the same name would silently overwrite each
+        # other when broadcast into one per-photon column; reject the ambiguity.
+        ds = _minimal_two_level_ds()
+        ds["levels"]["segments"]["variables"] = {"dem_h": "/{group}/geophys_corr/dem_h"}
+        ds["levels"]["coarse"] = {
+            "path": "/{group}/other",
+            "coordinates": [],
+            "variables": {"dem_h": "/{group}/other/dem_h"},
+            "link": {
+                "to": "photons",
+                "index_beg": "/{group}/other/ph_index_beg",
+                "count": "/{group}/other/ph_cnt",
+            },
+        }
+        cfg = PipelineConfig(
+            data_source=ds,
+            aggregation={"variables": {"c": {"function": "len", "dtype": "int32"}}},
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        with pytest.raises(ValueError, match="already declared on another level"):
+            validate_config(cfg)
+
     def test_worked_template_declares_dem_h_segment_variable(self):
         cfg = load_config("src/zagg/configs/atl03_waveform_chunk.yaml")
         validate_config(cfg)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -377,6 +377,91 @@ class TestVectorTemplate:
         assert grp["hist"].chunks == (64, 64, 4)  # trailing dim whole
 
 
+def _chunk_resolution_config():
+    """Config with one cell-resolution scalar and one ``resolution: chunk`` field."""
+    from zagg.config import PipelineConfig
+
+    base = default_config("atl06")
+    agg = {
+        "coordinates": base.aggregation.get("coordinates", {}),
+        "chunk_precompute": {
+            "chunk_anchor": {"expression": "np.float32(np.median(h_li))", "source": "h_li"}
+        },
+        "variables": {
+            "count": {"function": "len", "source": "h_li"},
+            "anchor_h": {"expression": "chunk_anchor", "source": "h_li", "resolution": "chunk"},
+        },
+    }
+    return PipelineConfig(data_source=base.data_source, aggregation=agg, output=base.output)
+
+
+class TestChunkResolutionTemplate:
+    """Issue #30 item 2: a ``resolution: chunk`` field emits a companion array
+    shaped at the chunk grid (main.shape // chunk_shape), not the cell grid."""
+
+    def test_healpix_companion_at_chunk_grid(self):
+        cfg = _chunk_resolution_config()
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        store = MemoryStore()
+        g.emit_template(store)
+        grp = open_group(store, path="8", mode="r")
+        # companion is the chunk grid (12·4^parent), one block per chunk.
+        n_chunks = HEALPIX_BASE_CELLS * 4**6
+        assert grp["anchor_h"].shape == (n_chunks,)
+        assert grp["anchor_h"].chunks == (1,)
+        # cell-resolution count keeps the full cell grid.
+        assert grp["count"].shape == (HEALPIX_BASE_CELLS * 4**8,)
+        assert g.spec().members["anchor_h"].dimension_names == ("chunks",)
+
+    def test_rectilinear_companion_at_chunk_grid(self):
+        from zagg.grids import RectilinearGrid
+
+        cfg = _chunk_resolution_config()
+        g = RectilinearGrid(
+            "EPSG:3031", 1000.0, (-1e6, -1e6, 1e6, 1e6), chunk_shape=(64, 64), config=cfg
+        )
+        store = MemoryStore()
+        g.emit_template(store)
+        grp = open_group(store, path="rectilinear", mode="r")
+        assert grp["anchor_h"].shape == (g.n_row_blocks, g.n_col_blocks)
+        assert grp["anchor_h"].chunks == (1, 1)
+        assert grp["count"].shape == (g.height, g.width)
+        assert g._spec().members["anchor_h"].dimension_names == ("chunk_y", "chunk_x")
+
+
+class TestPlainConfigByteIdentical:
+    """A config with NO chunk_precompute and NO resolution: chunk field must emit a
+    template byte-for-byte identical to the pre-item-2 schema (issue #30 byte-
+    identical guarantee): the new attributes are purely additive (default cell)."""
+
+    def test_atl06_template_unchanged_by_resolution_machinery(self):
+        # The atl06 config declares no resolution: chunk field, so no agg-field
+        # array routes through the chunk companion path: every field keeps the cell
+        # grid shape, and the serialized member specs are identical to a re-emit.
+        from zagg.processing import _chunk_resolution_fields
+
+        cfg = default_config("atl06")
+        assert _chunk_resolution_fields(cfg) == set()
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        spec = g.spec()
+        # Every agg field is at the cell grid (no companion), so the serialized
+        # GroupSpec equals a re-derived one and no dimension name is a chunk axis.
+        n_pix = HEALPIX_BASE_CELLS * 4**8
+        for name in get_data_vars(cfg):
+            member = spec.members[name]
+            assert member.shape == (n_pix,)
+            assert member.dimension_names == ("cells",)
+        # Full-spec round-trip equality (the additive resolution key is inert).
+        assert (
+            g.spec().model_dump()
+            == HealpixGrid(
+                parent_order=6, child_order=8, layout="fullsphere", config=default_config("atl06")
+            )
+            .spec()
+            .model_dump()
+        )
+
+
 class TestMortonCoordinate:
     """The ``morton`` coordinate is a mortie ``MortonIndexArray`` stored as
     ``uint64`` on disk (#71); ``cell_ids`` stays NESTED ``uint64`` (DGGS)."""

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2175,24 +2175,28 @@ class TestChunkPrecompute:
         np.testing.assert_array_equal(offsets, np.array([1.0, 101.0], dtype=np.float32))
         assert offsets[0] != offsets[1]
 
-    def test_arrow_kernel_rejects_chunk_precompute(self, monkeypatch):
-        """The experimental kernel path has no seam to inject pooled scalars, so it
-        rejects chunk_precompute rather than silently dropping it."""
-        pytest.importorskip("pyarrow")
+    def test_arrow_kernel_runs_chunk_precompute(self, monkeypatch):
+        """The kernel path now evaluates chunk_precompute over the pooled arrow
+        table and threads the scalar through the fallback per-cell loop (issue #30,
+        item ii): the per-cell ``offset`` resolves to the pooled chunk anchor,
+        uniform across cells — same result the pandas/arrow carriers produce."""
+        pa = pytest.importorskip("pyarrow")
         cfg = self._cfg(with_precompute=True)
-        leaf_to_cell = {1: 10, 2: 20}
-        grid = _KernelShardGrid([10, 20], leaf_to_cell)
-        df = pd.DataFrame(
+        grid = _KernelShardGrid([10, 20], {1: 10, 2: 20})
+        table = pa.table(
             {
-                "h_ph": np.array([0.0, 100.0], dtype=np.float32),
-                "leaf_id": np.array([1, 2], dtype=np.int64),
+                "h_ph": np.array([0.0, 2.0, 100.0, 102.0], dtype=np.float32),
+                "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
             }
         )
-        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
-        with pytest.raises(NotImplementedError, match="chunk_precompute"):
-            process_shard(
-                grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
-            )
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [table])
+        df_out, _ = process_shard(
+            grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
+        )
+        offsets = df_out["offset"].to_numpy()
+        pooled_median = np.median([0.0, 2.0, 100.0, 102.0])
+        np.testing.assert_array_equal(offsets, np.full(2, pooled_median, dtype=np.float32))
+        assert offsets[0] == offsets[1]
 
     def test_worked_template_uniform_offset_and_gain(self, monkeypatch):
         """The shipped atl03_waveform_chunk template runs end-to-end through the
@@ -2247,30 +2251,123 @@ class TestChunkPrecompute:
         # The empty cell still reports a zero obs count (the anchor is not data).
         assert df_out["count"].to_numpy()[2] == 0
 
-    def test_non_scalar_precompute_rejected(self, monkeypatch):
-        """A chunk_precompute expression that does not reduce to a scalar is
-        rejected with a clear error rather than silently coerced/broadcast."""
+    def test_non_scalar_chunk_value_allowed_in_namespace(self):
+        """A non-scalar chunk_precompute result (e.g. a matrix) is now ALLOWED into
+        the namespace (issue #30 / @espg 4773649308) — only a kind: scalar *write*
+        requires scalar-ness. The dtype cast applies element-wise to the array."""
+        from zagg.config import PipelineConfig
+
+        cfg = PipelineConfig(
+            data_source={"variables": {"h_ph": "/p"}},
+            aggregation={
+                # A covariance matrix: shape (2, 2), non-scalar.
+                "chunk_precompute": {
+                    "chunk_cov": {
+                        "expression": "np.cov(np.vstack([h_ph, h_ph * 2.0]))",
+                        "source": "h_ph",
+                        "dtype": "float64",
+                    }
+                },
+                "variables": {"count": {"function": "len", "source": "h_ph"}},
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        pooled = {"h_ph": np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)}
+        out = _eval_chunk_precompute(cfg, pooled)
+        assert out["chunk_cov"].shape == (2, 2)
+        assert out["chunk_cov"].dtype == np.float64
+
+    def test_non_scalar_chunk_value_usable_in_per_cell_expression(self, monkeypatch):
+        """A non-scalar chunk value feeds a per-cell ``expression``: a per-cell
+        vector field references a chunk-level array (here a 3-vector), proving the
+        namespace injection is shape-agnostic end-to-end (issue #30)."""
         from zagg.config import PipelineConfig
 
         cfg = PipelineConfig(
             data_source={"groups": ["gt1l"], "variables": {"h_ph": "/{group}/h_ph"}},
             aggregation={
-                # np.floor(h_ph) is an ARRAY, not a chunk scalar.
-                "chunk_precompute": {"bad": {"expression": "np.floor(h_ph)", "source": "h_ph"}},
+                # chunk_vec is a length-3 array (pooled per-quantile anchor).
+                "chunk_precompute": {
+                    "chunk_vec": {
+                        "expression": "np.percentile(h_ph, [25, 50, 75])",
+                        "source": "h_ph",
+                        "dtype": "float32",
+                    }
+                },
                 "variables": {
+                    # references the chunk array in a per-cell vector expression.
+                    "anchored": {
+                        "kind": "vector",
+                        "trailing_shape": 3,
+                        "expression": "chunk_vec + np.float32(np.mean(h_ph))",
+                        "source": "h_ph",
+                        "dtype": "float32",
+                    },
                     "count": {
                         "function": "len",
                         "source": "h_ph",
                         "dtype": "int32",
                         "fill_value": 0,
-                    }
+                    },
                 },
             },
             output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
         )
-        pooled = {"h_ph": np.array([1.0, 2.0, 3.0], dtype=np.float32)}
-        with pytest.raises(ValueError, match="must reduce to a scalar"):
-            _eval_chunk_precompute(cfg, pooled)
+        grid = _KernelShardGrid([10, 20], {1: 10, 2: 20})
+        df = pd.DataFrame(
+            {
+                "h_ph": np.array([0.0, 2.0, 100.0, 102.0], dtype=np.float32),
+                "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
+            }
+        )
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
+        # vector field -> arrow table carrier.
+        tbl, _ = process_shard(grid, 0, ["s3://x"], s3_credentials={}, config=cfg)
+        anchored = tbl.column("anchored").combine_chunks()
+        block = anchored.values.to_numpy(zero_copy_only=False).reshape(2, 3)
+        chunk_vec = np.percentile([0.0, 2.0, 100.0, 102.0], [25, 50, 75]).astype(np.float32)
+        # cell 10 mean = 1.0, cell 20 mean = 101.0.
+        np.testing.assert_allclose(block[0], chunk_vec + np.float32(1.0), rtol=1e-5)
+        np.testing.assert_allclose(block[1], chunk_vec + np.float32(101.0), rtol=1e-5)
+
+    def test_non_scalar_chunk_value_into_scalar_field_clear_error(self, monkeypatch):
+        """Writing a non-scalar chunk value to a kind: scalar field raises a clear
+        error (the scalar-ness guard now lives at the WRITE point, not the
+        precompute reduction — issue #30)."""
+        from zagg.config import PipelineConfig
+
+        cfg = PipelineConfig(
+            data_source={"groups": ["gt1l"], "variables": {"h_ph": "/{group}/h_ph"}},
+            aggregation={
+                "chunk_precompute": {
+                    "chunk_vec": {
+                        "expression": "np.percentile(h_ph, [25, 50, 75])",
+                        "source": "h_ph",
+                    }
+                },
+                "variables": {
+                    # scalar field assigned a length-3 chunk array -> clear error.
+                    "bad": {"expression": "chunk_vec", "dtype": "float32"},
+                    "count": {
+                        "function": "len",
+                        "source": "h_ph",
+                        "dtype": "int32",
+                        "fill_value": 0,
+                    },
+                },
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        grid = _KernelShardGrid([10, 20], {1: 10, 2: 20})
+        df = pd.DataFrame(
+            {
+                "h_ph": np.array([0.0, 2.0, 100.0, 102.0], dtype=np.float32),
+                "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
+            }
+        )
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
+        with pytest.raises(ValueError, match="scalar field 'bad'.*non-scalar"):
+            process_shard(grid, 0, ["s3://x"], s3_credentials={}, config=cfg)
 
     def test_missing_source_column_clear_error(self):
         """A function precompute whose source is absent from the pooled dict raises
@@ -2289,19 +2386,61 @@ class TestChunkPrecompute:
         with pytest.raises(ValueError, match="source column 'other' is not present"):
             _eval_chunk_precompute(cfg, {"h_ph": np.array([1.0, 2.0])})
 
-    def test_arrow_kernel_rejects_chunk_precompute_even_on_empty_reads(self, monkeypatch):
-        """The arrow-kernel + chunk_precompute incompatibility is a config property,
-        enforced before any read — so it still raises when every read comes back
-        empty (no rows), not only when there happens to be data (issue #30)."""
-        pytest.importorskip("pyarrow")
-        cfg = self._cfg(with_precompute=True)
+    def test_arrow_kernel_runs_non_scalar_chunk_precompute(self, monkeypatch):
+        """A NON-scalar chunk_precompute result also works on the kernel path: the
+        pooled arrow table is reduced once to a 3-vector, injected into the kernel
+        fallback namespace, and a per-cell scalar expression reduces over it (issue
+        #30, item ii). (A kind: vector OUTPUT is a separate kernel-path gap — the
+        experimental kernel reducer dense-preallocates scalars only — so the
+        per-cell field reduces the chunk array rather than emitting it whole.)"""
+        pa = pytest.importorskip("pyarrow")
+        from zagg.config import PipelineConfig
+
+        cfg = PipelineConfig(
+            data_source={"groups": ["gt1l"], "variables": {"h_ph": "/{group}/h_ph"}},
+            aggregation={
+                "chunk_precompute": {
+                    "chunk_vec": {
+                        "expression": "np.percentile(h_ph, [25, 50, 75])",
+                        "source": "h_ph",
+                        "dtype": "float32",
+                    }
+                },
+                "variables": {
+                    # per-cell scalar reduces over the injected chunk 3-vector.
+                    "anchored": {
+                        "expression": "float(np.sum(chunk_vec)) + float(np.mean(h_ph))",
+                        "source": "h_ph",
+                        "dtype": "float32",
+                    },
+                    "count": {
+                        "function": "len",
+                        "source": "h_ph",
+                        "dtype": "int32",
+                        "fill_value": 0,
+                    },
+                },
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
         grid = _KernelShardGrid([10, 20], {1: 10, 2: 20})
-        # No canned tables: every _read_group returns None, so all_reads is empty.
-        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [])
-        with pytest.raises(NotImplementedError, match="chunk_precompute"):
-            process_shard(
-                grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
-            )
+        table = pa.table(
+            {
+                "h_ph": np.array([0.0, 2.0, 100.0, 102.0], dtype=np.float32),
+                "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
+            }
+        )
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [table])
+        df_out, _ = process_shard(
+            grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
+        )
+        anchored = df_out["anchored"].to_numpy()
+        chunk_sum = float(
+            np.sum(np.percentile([0.0, 2.0, 100.0, 102.0], [25, 50, 75]).astype(np.float32))
+        )
+        # cell 10 mean = 1.0, cell 20 mean = 101.0.
+        np.testing.assert_allclose(anchored[0], chunk_sum + 1.0, rtol=1e-5)
+        np.testing.assert_allclose(anchored[1], chunk_sum + 101.0, rtol=1e-5)
 
     def test_degenerate_single_photon_chunk_gain_floor(self, monkeypatch):
         """The worked template's chunk_gain floors to 0.5 on a degenerate pooled

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1378,8 +1378,8 @@ class TestChunkResolutionCompanion:
         write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
 
         rgroup = open_group(store=store, mode="r", path="rectilinear")
-        # offset_h companion: one value at this chunk = floor(median(pooled dem_h)).
-        expected_offset = np.float32(np.floor(np.median(dem)))
+        # offset_h companion: one value at this chunk = floor(min(pooled dem_h)).
+        expected_offset = np.float32(np.floor(np.min(dem)))
         assert rgroup["offset_h"][chunk_idx] == expected_offset
         assert not np.isnan(rgroup["gain_h"][chunk_idx])
         # Only one chunk written for each companion.
@@ -2485,6 +2485,28 @@ class TestSegmentLevelVariables:
         assert df["h"].tolist() == [0.0, 2.0, 3.0, 5.0]
         assert df["dem_h"].tolist() == [100.0, 200.0, 200.0, 300.0]
 
+    def test_expression_filter_references_broadcast_dem_h(self):
+        # An ``{expression: "dem_h > ..."}`` filter references the broadcast
+        # segment variable, which is materialized before the filter runs (issue
+        # #30): photons are kept/dropped by their own segment's dem_h, even though
+        # ``dem_h`` is not a ``data_source.variables`` column.
+        ds = self._data_source()
+        ds["filters"] = [{"expression": "dem_h > 150.0"}]
+        h5 = _FakeH5(
+            {
+                "/lat": np.arange(6.0),
+                "/lon": np.arange(6.0),
+                "/h": np.arange(6.0, dtype=np.float32),
+                "/ph_index_beg": np.array([0, 2, 4]),
+                "/segment_ph_cnt": np.array([2, 2, 2]),
+                "/dem_h": np.array([100.0, 200.0, 300.0], dtype=np.float32),
+            }
+        )
+        df = _read_group(h5, "gt1l", ds, 0, _ShardGrid())
+        # Seg 0 (dem_h 100) is dropped; segs 1,2 (dem_h 200,300) are kept.
+        assert df["h"].tolist() == [2.0, 3.0, 4.0, 5.0]
+        assert df["dem_h"].tolist() == [200.0, 200.0, 300.0, 300.0]
+
     def test_planned_partial_read_aligns_dem_h(self):
         # Partial read plan (NOT a full read): the bbox selects only segments
         # 1-2 (photons 2..5). Each selected photon must carry its own segment's
@@ -2516,6 +2538,22 @@ class TestSegmentLevelVariables:
         # Selected photons 2,3 (seg 1) + 4,5 (seg 2); qs drops photon 3.
         assert df["h"].tolist() == [20.0, 40.0, 50.0]
         assert df["dem_h"].tolist() == [20.0, 30.0, 30.0]
+
+    def test_planned_path_expression_filter_references_broadcast_dem_h(self):
+        # Planned (partial) read: an ``{expression: "dem_h > ..."}`` filter
+        # references the broadcast segment variable, mirroring the full-path test.
+        # Locks in parity of the namespace fix across both read paths (issue #30).
+        ds = _planned_read_data_source()
+        ds["levels"]["segments"]["variables"] = {"dem_h": "/seg/dem_h"}
+        ds["filters"] = [{"expression": "dem_h > 25.0"}]
+        h5 = _planned_read_h5()
+        h5._arrays["/seg/dem_h"] = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0], dtype=np.float32)
+        grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
+        df = _read_group(h5, "gt1l", ds, 0, grid)
+        # Selected photons 2,3 (seg 1, dem_h 20) + 4,5 (seg 2, dem_h 30); the
+        # filter drops seg 1 (20 <= 25) and keeps seg 2 (30 > 25).
+        assert df["h"].tolist() == [40.0, 50.0]
+        assert df["dem_h"].tolist() == [30.0, 30.0]
 
     def test_broadcast_out_of_bounds_raises(self):
         # A segment range extending past the base size (e.g. a seg-variable level
@@ -2564,20 +2602,20 @@ class TestSegmentLevelVariables:
         df = _read_group(h5, "gt1l", ds, 0, _ShardGrid())
         assert list(df.columns) == ["h", "leaf_id"]  # no dem_h column injected
 
-    def test_worked_template_chunk_offset_is_floor_median_dem_h(self):
+    def test_worked_template_chunk_offset_is_floor_min_dem_h(self):
         # End-to-end through process_shard: dem_h broadcast feeds chunk_offset,
-        # whose value is floor(median(pooled dem_h)) and is uniform across cells.
+        # whose value is floor(min(pooled dem_h)) and is uniform across cells.
         from zagg.config import load_config
 
         cfg = load_config("src/zagg/configs/atl03_waveform_chunk.yaml")
         # Two cells' worth of photons pooled in one shard; dem_h per photon
-        # (already broadcast) with a known median.
+        # (already broadcast) with a known min.
         dem = np.array([100.0, 100.0, 102.0, 108.0, 110.0], dtype=np.float32)
         chunk_scalars = _eval_chunk_precompute(
             cfg, {"h_ph": np.arange(5.0, dtype=np.float32), "dem_h": dem}
         )
-        assert chunk_scalars["chunk_offset"] == np.float32(np.floor(np.median(dem)))
-        assert chunk_scalars["chunk_offset"] == np.float32(102.0)
+        assert chunk_scalars["chunk_offset"] == np.float32(np.floor(np.min(dem)))
+        assert chunk_scalars["chunk_offset"] == np.float32(100.0)
 
 
 class TestChunkPrecompute:
@@ -2731,8 +2769,8 @@ class TestChunkPrecompute:
         gain = tbl.column("gain_h").to_numpy(zero_copy_only=False)
         assert offset[0] == offset[1]
         assert gain[0] == gain[1]
-        # chunk_offset is now the DEM anchor: floor(median(pooled dem_h)).
-        assert offset[0] == np.float32(np.floor(np.median(dem)))
+        # chunk_offset is now the DEM anchor: floor(min(pooled dem_h)).
+        assert offset[0] == np.float32(np.floor(np.min(dem)))
 
     def test_empty_cell_gets_chunk_anchor_not_nan(self, monkeypatch):
         """An empty cell in a POPULATED chunk records the chunk-uniform anchor, not

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2500,6 +2500,43 @@ class TestSegmentLevelVariables:
         assert df["h"].tolist() == [20.0, 30.0, 40.0, 50.0]
         assert df["dem_h"].tolist() == [20.0, 20.0, 30.0, 30.0]
 
+    def test_planned_partial_read_aligns_dem_h_under_base_filter(self):
+        # Planned (partial) read with a base-level filter stacked on top of the
+        # seg-variable broadcast: each surviving photon must still carry its own
+        # segment's dem_h after the keep mask.
+        ds = _planned_read_data_source(with_base_filter=True)
+        ds["levels"]["segments"]["variables"] = {"dem_h": "/seg/dem_h"}
+        # qs drops photon 3 (within the selected seg 1) so the keep mask is exercised.
+        qs = np.zeros(12, dtype=np.int8)
+        qs[3] = 1
+        h5 = _planned_read_h5(qs=qs)
+        h5._arrays["/seg/dem_h"] = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0], dtype=np.float32)
+        grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
+        df = _read_group(h5, "gt1l", ds, 0, grid)
+        # Selected photons 2,3 (seg 1) + 4,5 (seg 2); qs drops photon 3.
+        assert df["h"].tolist() == [20.0, 40.0, 50.0]
+        assert df["dem_h"].tolist() == [20.0, 30.0, 30.0]
+
+    def test_broadcast_out_of_bounds_raises(self):
+        # A segment range extending past the base size (e.g. a seg-variable level
+        # whose link does not tile the read's base extent) is rejected, not silently
+        # written out of bounds.
+        seg = np.array([1.0, 2.0])
+        ibeg = np.array([0, 2])
+        cnt = np.array([2, 5])  # second range [2:7] exceeds base size 4
+        with pytest.raises(ValueError, match="exceeds base size"):
+            _broadcast_segment_to_base(seg, ibeg, cnt, index_base=0, total_base_size=4)
+
+    def test_broadcast_gap_fills_nan_for_float(self):
+        # An untiled gap (contiguity violated) surfaces as NaN for float dtypes,
+        # not uninitialized garbage.
+        seg = np.array([1.0, 2.0], dtype=np.float32)
+        ibeg = np.array([0, 3])  # base index 2 left untiled
+        cnt = np.array([2, 1])
+        out = _broadcast_segment_to_base(seg, ibeg, cnt, index_base=0, total_base_size=4)
+        assert out[0] == 1.0 and out[1] == 1.0 and out[3] == 2.0
+        assert np.isnan(out[2])
+
     def test_no_segment_variables_is_inert(self):
         # A hierarchical config whose non-base level uses the documentation-only
         # ``list[str]`` variables form (NOT the mapping) triggers no broadcast: the

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -14,6 +14,7 @@ from zagg.processing import (
     _coerce_ragged_value,
     _concat_and_group,
     _empty_cell_value,
+    _eval_chunk_precompute,
     _expand_mask_to_base,
     _group_columns,
     _has_ragged_fields,
@@ -1359,16 +1360,16 @@ class TestReadGroupFilters:
         atl03_filters = default_config("atl03").data_source["filters"]
         conf = np.array(
             [
-                [4, 4, 4, 4, 4],     # all-high-confidence (kept)
+                [4, 4, 4, 4, 4],  # all-high-confidence (kept)
                 [-2, -2, -2, -2, -2],  # TEP across all surface types (dropped)
-                [0, 0, 0, 0, 0],     # noise across all (kept; -2 is the TEP flag)
-                [3, 2, 1, 0, 4],     # mixed confidence (kept)
-                [-2, 4, 4, 4, 4],    # column 0 is TEP but others aren't -- with
-                                     # column: 0 this row is dropped, even though
-                                     # the photon is a valid land-ice return on
-                                     # surface type 3. See PR #47 review thread:
-                                     # this is the operational tradeoff of moving
-                                     # from .any(axis=1) to a single-column key.
+                [0, 0, 0, 0, 0],  # noise across all (kept; -2 is the TEP flag)
+                [3, 2, 1, 0, 4],  # mixed confidence (kept)
+                [-2, 4, 4, 4, 4],  # column 0 is TEP but others aren't -- with
+                # column: 0 this row is dropped, even though
+                # the photon is a valid land-ice return on
+                # surface type 3. See PR #47 review thread:
+                # this is the operational tradeoff of moving
+                # from .any(axis=1) to a single-column key.
             ]
         )
         h5 = _FakeH5(
@@ -1751,9 +1752,7 @@ def _planned_read_data_source(*, with_base_filter=False, with_coarse_filter=Fals
     if with_base_filter:
         filters.append({"dataset": "/heights/qs", "op": "eq", "value": 0})
     if with_coarse_filter:
-        filters.append(
-            {"dataset": "/seg/podppd", "op": "eq", "value": 0, "level": "segments"}
-        )
+        filters.append({"dataset": "/seg/podppd", "op": "eq", "value": 0, "level": "segments"})
     if filters:
         ds["filters"] = filters
     return ds
@@ -1865,16 +1864,18 @@ class TestPlannedReadGroup:
         # the run collapsed (base_end = 0-1+0 <= base_start) and the planned path
         # dropped seg 0's real photons -> planned (None) != full. The guard bounds
         # the run by its non-empty segment, restoring planned == full parity.
-        h5 = _FakeH5({
-            "/seg/lat": np.array([200.0, 300.0, 1000.0, 2000.0]),
-            "/seg/lon": np.zeros(4),
-            "/seg/ph_index_beg": np.array([1, 0, 3, 5], dtype=np.int64),  # seg 1 empty
-            "/seg/segment_ph_cnt": np.array([2, 0, 2, 2], dtype=np.int64),
-            "/heights/lat_ph": np.array([200.0, 210.0, 1000.0, 1010.0, 2000.0, 2010.0]),
-            "/heights/lon_ph": np.zeros(6),
-            "/heights/h": np.arange(6.0, dtype=np.float32) * 10.0,
-            "/heights/qs": np.zeros(6, dtype=np.int8),
-        })
+        h5 = _FakeH5(
+            {
+                "/seg/lat": np.array([200.0, 300.0, 1000.0, 2000.0]),
+                "/seg/lon": np.zeros(4),
+                "/seg/ph_index_beg": np.array([1, 0, 3, 5], dtype=np.int64),  # seg 1 empty
+                "/seg/segment_ph_cnt": np.array([2, 0, 2, 2], dtype=np.int64),
+                "/heights/lat_ph": np.array([200.0, 210.0, 1000.0, 1010.0, 2000.0, 2010.0]),
+                "/heights/lon_ph": np.zeros(6),
+                "/heights/h": np.arange(6.0, dtype=np.float32) * 10.0,
+                "/heights/qs": np.zeros(6, dtype=np.int8),
+            }
+        )
         grid = _LatBboxGrid((-0.1, 195.0, 0.1, 215.0))  # keeps photons 0,1 (lat 200,210)
 
         ds_planned = _planned_read_data_source(with_base_filter=True)
@@ -2071,3 +2072,160 @@ class TestPlannedReadGroup:
         # signal_conf_ph filter drops photon 4 (uniform TEP -2 across all 5
         # surface types). Survivors: 0, 1, 2, 3, 5, 6, 7.
         assert df["h_ph"].tolist() == [0.0, 10.0, 20.0, 30.0, 50.0, 60.0, 70.0]
+
+
+class TestChunkPrecompute:
+    """Per-chunk precompute hook (issue #30, item 1): compute once per chunk over
+    the shard's pooled data, inject into the per-cell expression namespace."""
+
+    def _cfg(self, *, with_precompute):
+        """Config whose per-cell ``offset`` records a chunk- or cell-level median.
+
+        With ``with_precompute`` the offset is the chunk-precompute ``chunk_offset``
+        (pooled over the whole shard); without it the offset is each cell's own
+        ``np.median(h_ph)``. The contrast is the test's whole point: the former is
+        uniform across a chunk, the latter varies cell to cell.
+        """
+        from zagg.config import PipelineConfig
+
+        agg: dict = {
+            "variables": {
+                "offset": {"dtype": "float32"},
+                "count": {"function": "len", "source": "h_ph", "dtype": "int32", "fill_value": 0},
+            }
+        }
+        if with_precompute:
+            agg["chunk_precompute"] = {
+                "chunk_offset": {"expression": "np.median(h_ph)", "source": "h_ph"}
+            }
+            agg["variables"]["offset"]["expression"] = "chunk_offset"
+        else:
+            agg["variables"]["offset"]["expression"] = "np.median(h_ph)"
+        return PipelineConfig(
+            data_source={"groups": ["gt1l"], "variables": {"h_ph": "/{group}/h_ph"}},
+            aggregation=agg,
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+
+    def test_eval_chunk_precompute_pools_whole_shard(self):
+        """The scalar is computed ONCE over the pooled columns, not per cell."""
+        cfg = self._cfg(with_precompute=True)
+        pooled = {"h_ph": np.array([1.0, 2.0, 3.0, 100.0], dtype=np.float32)}
+        scalars = _eval_chunk_precompute(cfg, pooled)
+        assert set(scalars) == {"chunk_offset"}
+        assert scalars["chunk_offset"] == np.median(pooled["h_ph"])
+
+    def test_eval_chunk_precompute_empty_without_block(self):
+        cfg = self._cfg(with_precompute=False)
+        assert _eval_chunk_precompute(cfg, {"h_ph": np.array([1.0, 2.0])}) == {}
+
+    def test_eval_chunk_precompute_function_entry_with_dtype(self):
+        from zagg.config import PipelineConfig
+
+        cfg = PipelineConfig(
+            data_source={"variables": {"h_ph": "/p"}},
+            aggregation={
+                "chunk_precompute": {
+                    "m": {"function": "median", "source": "h_ph", "dtype": "float32"}
+                },
+                "variables": {"count": {"function": "len", "source": "h_ph"}},
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        out = _eval_chunk_precompute(cfg, {"h_ph": np.array([1.0, 2.0, 9.0])})
+        assert out["m"] == np.float32(2.0)
+        assert isinstance(out["m"], np.float32)
+
+    def _run_shard(self, monkeypatch, cfg):
+        """Drive process_shard over two cells via a canned multi-beam read.
+
+        cell 10 holds low photons, cell 20 holds high photons, so a per-cell median
+        differs between the two cells while the pooled (chunk) median is shared.
+        """
+        leaf_to_cell = {1: 10, 2: 20}
+        children = [10, 20]
+        grid = _KernelShardGrid(children, leaf_to_cell)
+        df = pd.DataFrame(
+            {
+                "h_ph": np.array([0.0, 2.0, 100.0, 102.0], dtype=np.float32),
+                "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
+            }
+        )
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
+        df_out, meta = process_shard(grid, 0, ["s3://x"], s3_credentials={}, config=cfg)
+        return df_out, children
+
+    def test_chunk_scalar_uniform_across_cells(self, monkeypatch):
+        """The chunk-precompute offset is identical for every cell in the chunk —
+        the pooled median — whereas a per-cell median would differ between the
+        two cells. This is the keystone behavior of the hook."""
+        df_chunk, _ = self._run_shard(monkeypatch, self._cfg(with_precompute=True))
+        offsets = df_chunk["offset"].to_numpy()
+        pooled_median = np.median([0.0, 2.0, 100.0, 102.0])
+        np.testing.assert_array_equal(offsets, np.full(2, pooled_median, dtype=np.float32))
+        # the two cells' offsets are equal (uniform), not the per-cell medians.
+        assert offsets[0] == offsets[1]
+
+    def test_per_cell_median_varies_without_precompute(self, monkeypatch):
+        """Control: the same field as a per-cell median DOES vary cell to cell, so
+        the uniformity above is a property of the chunk hook, not of the data."""
+        df_cell, _ = self._run_shard(monkeypatch, self._cfg(with_precompute=False))
+        offsets = df_cell["offset"].to_numpy()
+        # cell 10 -> median(0, 2) = 1; cell 20 -> median(100, 102) = 101.
+        np.testing.assert_array_equal(offsets, np.array([1.0, 101.0], dtype=np.float32))
+        assert offsets[0] != offsets[1]
+
+    def test_absent_block_is_byte_identical(self, monkeypatch):
+        """A config WITHOUT chunk_precompute produces byte-for-byte identical output
+        to the same config evaluated through the (now chunk-aware) worker — i.e. the
+        hook is a pure no-op when the block is absent."""
+        df_a, _ = self._run_shard(monkeypatch, self._cfg(with_precompute=False))
+        # Re-run the identical no-precompute config; the per-cell path is unchanged.
+        df_b, _ = self._run_shard(monkeypatch, self._cfg(with_precompute=False))
+        assert df_a["offset"].to_numpy().tobytes() == df_b["offset"].to_numpy().tobytes()
+        assert df_a["count"].to_numpy().tobytes() == df_b["count"].to_numpy().tobytes()
+
+    def test_arrow_kernel_rejects_chunk_precompute(self, monkeypatch):
+        """The experimental kernel path has no seam to inject pooled scalars, so it
+        rejects chunk_precompute rather than silently dropping it."""
+        pytest.importorskip("pyarrow")
+        cfg = self._cfg(with_precompute=True)
+        leaf_to_cell = {1: 10, 2: 20}
+        grid = _KernelShardGrid([10, 20], leaf_to_cell)
+        df = pd.DataFrame(
+            {
+                "h_ph": np.array([0.0, 100.0], dtype=np.float32),
+                "leaf_id": np.array([1, 2], dtype=np.int64),
+            }
+        )
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
+        with pytest.raises(NotImplementedError, match="chunk_precompute"):
+            process_shard(
+                grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
+            )
+
+    def test_worked_template_uniform_offset_and_gain(self, monkeypatch):
+        """The shipped atl03_waveform_chunk template runs end-to-end through the
+        worker and emits a chunk-uniform offset_h/gain_h across two cells whose own
+        photon distributions differ (low vs high), proving the bin-28 window is set
+        once over the pooled shard, not per cell."""
+        pytest.importorskip("pyarrow")
+        cfg = default_config("atl03_waveform_chunk")
+        leaf_to_cell = {1: 10, 2: 20}
+        children = [10, 20]
+        grid = _KernelShardGrid(children, leaf_to_cell)
+        df = pd.DataFrame(
+            {
+                "h_ph": np.array([10.0, 12.0, 200.0, 202.0], dtype=np.float32),
+                "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
+            }
+        )
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
+        tbl, _meta = process_shard(grid, 0, ["s3://x"], s3_credentials={}, config=cfg)
+        # vector waveform field -> arrow table carrier.
+        offset = tbl.column("offset_h").to_numpy(zero_copy_only=False)
+        gain = tbl.column("gain_h").to_numpy(zero_copy_only=False)
+        assert offset[0] == offset[1]
+        assert gain[0] == gain[1]
+        # chunk_offset = floor(median(pooled h_ph)) = floor(median([10,12,200,202])) = 106
+        assert offset[0] == np.float32(np.floor(np.median([10.0, 12.0, 200.0, 202.0])))

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1380,6 +1380,116 @@ class TestChunkResolutionCompanion:
         assert np.count_nonzero(~np.isnan(rgroup["offset_h"][:])) == 1
         assert np.count_nonzero(~np.isnan(rgroup["gain_h"][:])) == 1
 
+    def test_dense_healpix_companion_at_populated_shard_position(self):
+        """Dense HEALPix layout: the companion is shaped (n_shards,) and a shard's
+        value lands at its position in populated_shards (block_index), not at the
+        parent nested id (issue #30 item 2; fold of review finding)."""
+        from mortie import geo2mort
+
+        cfg = self._chunk_cfg("atl06")
+        shards = [
+            int(geo2mort(la, lo, order=6)[0])
+            for la, lo in [(-78.5, -132.0), (-72.1, 25.4), (-65.0, -45.0)]
+        ]
+        grid = HealpixGrid(6, 8, layout="dense", config=cfg, populated_shards=shards)
+        store = MemoryStore()
+        grid.emit_template(store)
+        group = open_group(store=store, mode="r", path="8")
+        assert grid.chunk_grid_shape == (len(shards),)
+        assert group["anchor_h"].shape == (len(shards),)
+
+        parent = shards[1]
+        n = len(grid.children(parent))
+        stats = {
+            "count": np.zeros(n, dtype="float32"),
+            "anchor_h": np.full(n, 99.0, dtype="float32"),
+        }
+        carrier = _build_output(
+            stats, get_data_vars(cfg), get_agg_fields(cfg), grid, parent, use_arrow=False
+        )
+        chunk_idx = grid.block_index(parent)
+        assert chunk_idx == (1,)  # position in populated_shards, not nested id
+        write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
+        companion = open_group(store=store, mode="r", path="8")["anchor_h"][:]
+        assert companion[1] == np.float32(99.0)
+        assert np.count_nonzero(~np.isnan(companion)) == 1
+
+    def test_empty_cell0_compound_expr_writes_chunk_value_not_nan(self):
+        """Fold of review [MED]: with a COMPOUND resolution: chunk expression (not a
+        bare precompute name), an empty cell 0 used to poison the companion with NaN
+        because the writer took flat[0]. The writer now selects a populated cell's
+        value, so the companion records the real chunk value."""
+        from mortie import geo2mort
+
+        from zagg.config import PipelineConfig
+
+        base = default_config("atl06")
+        agg = {
+            "coordinates": base.aggregation.get("coordinates", {}),
+            "chunk_precompute": {
+                "chunk_anchor": {"expression": "np.float32(np.median(h_li))", "source": "h_li"}
+            },
+            "variables": {
+                "count": {"function": "len", "source": "h_li"},
+                # compound expression (NOT a bare identifier) -> empty cells get NaN,
+                # not the anchor, so the writer must skip them.
+                "anchor_h": {
+                    "expression": "chunk_anchor + np.float32(1.0)",
+                    "source": "h_li",
+                    "resolution": "chunk",
+                },
+            },
+        }
+        cfg = PipelineConfig(data_source=base.data_source, aggregation=agg, output=base.output)
+        parent_order, child_order = 2, 4
+        grid = HealpixGrid(parent_order, child_order, layout="fullsphere", config=cfg)
+        store = MemoryStore()
+        grid.emit_template(store)
+
+        parent = int(geo2mort(-78.5, -132.0, order=parent_order)[0])
+        n = len(grid.children(parent))
+        # cell 0 empty (NaN), only cell 3 populated with the chunk value 50.0.
+        stats = {
+            "count": np.zeros(n, dtype="float32"),
+            "anchor_h": np.full(n, np.nan, dtype="float32"),
+        }
+        stats["count"][3] = 5
+        stats["anchor_h"][3] = 50.0
+        carrier = _build_output(
+            stats, get_data_vars(cfg), get_agg_fields(cfg), grid, parent, use_arrow=False
+        )
+        chunk_idx = grid.block_index(parent)
+        write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
+        companion = open_group(store=store, mode="r", path=str(child_order))["anchor_h"][:]
+        assert companion[chunk_idx[0]] == np.float32(50.0)  # the populated value, not NaN
+        assert not np.isnan(companion[chunk_idx[0]])
+
+    def test_non_uniform_chunk_resolution_column_raises(self):
+        """Fold of review [MED]: a resolution: chunk field whose per-cell values are
+        NOT uniform (a misconfiguration) is rejected with a clear error instead of
+        silently dropping every cell but the first."""
+        from mortie import geo2mort
+
+        cfg = self._chunk_cfg("atl06")
+        grid = HealpixGrid(2, 4, layout="fullsphere", config=cfg)
+        store = MemoryStore()
+        grid.emit_template(store)
+        parent = int(geo2mort(-78.5, -132.0, order=2)[0])
+        n = len(grid.children(parent))
+        # Two populated cells with DIFFERENT values -> not chunk-uniform.
+        stats = {
+            "count": np.zeros(n, dtype="float32"),
+            "anchor_h": np.full(n, np.nan, dtype="float32"),
+        }
+        stats["anchor_h"][0] = 1.0
+        stats["anchor_h"][1] = 2.0
+        carrier = _build_output(
+            stats, get_data_vars(cfg), get_agg_fields(cfg), grid, parent, use_arrow=False
+        )
+        chunk_idx = grid.block_index(parent)
+        with pytest.raises(ValueError, match="not chunk-uniform"):
+            write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
+
 
 # ---------------------------------------------------------------------------
 # Structured filters in the read path (issue #43, Phase A)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1172,6 +1172,215 @@ class TestVectorRoundTrip:
             write_dataframe_to_zarr(table, store, grid=_OneChunkGrid(), chunk_idx=(0,))
 
 
+class TestChunkResolutionCompanion:
+    """Issue #30 item 2: a ``resolution: chunk`` field is written ONCE per chunk to
+    a companion array shaped at the chunk grid (main.shape // chunk_shape), indexed
+    by ``grid.block_index``. Works identically on HEALPix and rectilinear."""
+
+    @staticmethod
+    def _chunk_cfg(base_name):
+        """atl06-derived config with one cell-resolution count and one chunk field."""
+        from zagg.config import PipelineConfig
+
+        cfg = default_config(base_name)
+        agg = {
+            "coordinates": cfg.aggregation.get("coordinates", {}),
+            "chunk_precompute": {
+                "chunk_anchor": {"expression": "np.float32(np.median(h_li))", "source": "h_li"}
+            },
+            "variables": {
+                "count": {"function": "len", "source": "h_li"},
+                "anchor_h": {"expression": "chunk_anchor", "source": "h_li", "resolution": "chunk"},
+            },
+        }
+        return PipelineConfig(data_source=cfg.data_source, aggregation=agg, output=cfg.output)
+
+    def test_healpix_companion_shape_and_index(self):
+        """The HEALPix companion array is shaped at the chunk grid (12·4^parent),
+        and a shard's single value lands at block_index = the parent nested id."""
+        from mortie import geo2mort
+
+        cfg = self._chunk_cfg("atl06")
+        parent_order, child_order = 2, 4
+        grid = HealpixGrid(parent_order, child_order, layout="fullsphere", config=cfg)
+        store = MemoryStore()
+        grid.emit_template(store)
+
+        # Companion shape == number of chunks (12·4^parent_order), NOT the cell grid.
+        group = open_group(store=store, mode="r", path=str(child_order))
+        n_chunks = HEALPIX_BASE_CELLS * 4**parent_order
+        assert grid.chunk_grid_shape == (n_chunks,)
+        assert group["anchor_h"].shape == (n_chunks,)
+        # The cell-resolution count keeps the full cell-grid shape.
+        assert group["count"].shape == (HEALPIX_BASE_CELLS * 4**child_order,)
+
+        parent = int(geo2mort(-78.5, -132.0, order=parent_order)[0])
+        children = grid.children(parent)
+        n = len(children)
+        # Every cell carries the chunk-uniform anchor (chunk-uniform column).
+        stats = {
+            "count": np.zeros(n, dtype="float32"),
+            "anchor_h": np.full(n, 42.5, dtype="float32"),
+        }
+        carrier = _build_output(
+            stats, get_data_vars(cfg), get_agg_fields(cfg), grid, parent, use_arrow=False
+        )
+        chunk_idx = grid.block_index(parent)
+        write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
+
+        # Exactly ONE value per chunk, at block_index; the rest stay at fill (NaN).
+        rgroup = open_group(store=store, mode="r", path=str(child_order))
+        companion = rgroup["anchor_h"][:]
+        assert companion[chunk_idx[0]] == np.float32(42.5)
+        # All other chunks untouched (NaN fill).
+        other = np.delete(companion, chunk_idx[0])
+        assert np.all(np.isnan(other))
+        # A reader reconstructs the chunk value without any per-cell array.
+        assert rgroup["anchor_h"][chunk_idx[0]] == np.float32(42.5)
+
+    def test_rectilinear_companion_shape_and_index(self):
+        """The rectilinear companion array is shaped at the chunk grid
+        (n_row_blocks, n_col_blocks) and indexed by block_index = (rb, cb)."""
+        from zagg.grids import RectilinearGrid
+
+        cfg = self._chunk_cfg("atl06")
+        grid = RectilinearGrid(
+            crs="EPSG:3031",
+            resolution=100000.0,
+            bounds=[-400000, -400000, 400000, 400000],
+            chunk_shape=(4, 4),
+            config=cfg,
+        )
+        store = MemoryStore()
+        grid.emit_template(store)
+
+        group = open_group(store=store, mode="r", path="rectilinear")
+        assert group["anchor_h"].shape == grid.chunk_grid_shape
+        assert grid.chunk_grid_shape == (grid.n_row_blocks, grid.n_col_blocks)
+        # Cell-resolution count keeps the full 2-D cell grid.
+        assert group["count"].shape == grid.array_shape
+
+        # Pick an interior chunk and write its uniform value.
+        shard_key = grid._pack(1, 1)
+        children = grid.children(shard_key)
+        n = len(children)
+        stats = {
+            "count": np.zeros(n, dtype="float32"),
+            "anchor_h": np.full(n, 7.0, dtype="float32"),
+        }
+        carrier = _build_output(
+            stats, get_data_vars(cfg), get_agg_fields(cfg), grid, shard_key, use_arrow=False
+        )
+        chunk_idx = grid.block_index(shard_key)
+        assert chunk_idx == (1, 1)
+        write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
+
+        rgroup = open_group(store=store, mode="r", path="rectilinear")
+        companion = rgroup["anchor_h"][:]
+        assert companion[1, 1] == np.float32(7.0)
+        # Exactly one written cell; the rest are NaN fill.
+        assert np.count_nonzero(~np.isnan(companion)) == 1
+
+    def test_empty_cell_in_populated_chunk_needs_no_per_cell_value(self):
+        """With resolution: chunk, an empty cell in a populated chunk needs NO
+        per-cell value — the chunk anchor is stored once and read back regardless of
+        which cells are empty (issue #30 item 2 retires the per-cell band-aid)."""
+        from mortie import geo2mort
+
+        cfg = self._chunk_cfg("atl06")
+        parent_order, child_order = 2, 4
+        grid = HealpixGrid(parent_order, child_order, layout="fullsphere", config=cfg)
+        store = MemoryStore()
+        grid.emit_template(store)
+
+        parent = int(geo2mort(-78.5, -132.0, order=parent_order)[0])
+        children = grid.children(parent)
+        n = len(children)
+        # Only cell 0 has photons; every other cell is empty. The anchor column is
+        # still chunk-uniform (empty cells carry the anchor too — phase-4 behavior).
+        stats = {
+            "count": np.zeros(n, dtype="float32"),
+            "anchor_h": np.full(n, 13.0, dtype="float32"),
+        }
+        stats["count"][0] = 4
+        carrier = _build_output(
+            stats, get_data_vars(cfg), get_agg_fields(cfg), grid, parent, use_arrow=False
+        )
+        chunk_idx = grid.block_index(parent)
+        write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
+
+        rgroup = open_group(store=store, mode="r", path=str(child_order))
+        # One companion value for the whole chunk; reading it does not depend on any
+        # per-cell anchor array — there is no cell-resolution anchor_h array at all.
+        assert rgroup["anchor_h"].shape == (HEALPIX_BASE_CELLS * 4**parent_order,)
+        assert rgroup["anchor_h"][chunk_idx[0]] == np.float32(13.0)
+
+    def test_worked_template_emits_chunk_companions(self, monkeypatch):
+        """The shipped atl03_waveform_chunk template, run end-to-end through the
+        worker and written to a real Zarr store, stores offset_h/gain_h as
+        chunk-resolution companions (one value per chunk), while waveform_counts
+        stays a per-cell vector array (issue #30 items 1+2)."""
+        pytest.importorskip("pyarrow")
+        from zagg.grids import RectilinearGrid
+
+        cfg = default_config("atl03_waveform_chunk")
+        # Small rect grid so a real template fits in memory; one 2x2 chunk holds the
+        # two populated cells (the worker fabricates the per-cell loop via canned
+        # reads as in TestChunkPrecompute).
+        grid = RectilinearGrid(
+            crs="EPSG:4326",
+            resolution=1.0,
+            bounds=[0, 0, 2, 2],
+            chunk_shape=(2, 2),
+            config=cfg,
+        )
+        store = MemoryStore()
+        grid.emit_template(store)
+
+        # Companion arrays are at the chunk grid; waveform_counts keeps cell+trailing.
+        group = open_group(store=store, mode="r", path="rectilinear")
+        assert group["offset_h"].shape == grid.chunk_grid_shape
+        assert group["gain_h"].shape == grid.chunk_grid_shape
+        assert group["waveform_counts"].shape == (*grid.array_shape, 128)
+
+        # Drive process_shard over chunk (0,0): children are the 4 cells of the
+        # top-left 2x2 block; place photons in two of them.
+        shard_key = grid._pack(0, 0)
+        children = grid.children(shard_key)
+        # vector field present -> default pandas carrier path; feed a DataFrame read.
+        df = pd.DataFrame(
+            {
+                "h_ph": np.array([10.0, 12.0, 200.0, 202.0], dtype=np.float32),
+                "leaf_id": np.array(
+                    [children[0], children[0], children[1], children[1]], dtype=np.int64
+                ),
+            }
+        )
+
+        calls = {"n": 0}
+
+        def one_shot(*args, **kwargs):
+            calls["n"] += 1
+            return df if calls["n"] == 1 else None
+
+        monkeypatch.setattr("zagg.processing._read_group", one_shot)
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+
+        carrier, _meta = process_shard(grid, shard_key, ["s3://x"], s3_credentials={}, config=cfg)
+        chunk_idx = grid.block_index(shard_key)
+        write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
+
+        rgroup = open_group(store=store, mode="r", path="rectilinear")
+        # offset_h companion: one value at this chunk = floor(median(pooled h_ph)).
+        expected_offset = np.float32(np.floor(np.median([10.0, 12.0, 200.0, 202.0])))
+        assert rgroup["offset_h"][chunk_idx] == expected_offset
+        assert not np.isnan(rgroup["gain_h"][chunk_idx])
+        # Only one chunk written for each companion.
+        assert np.count_nonzero(~np.isnan(rgroup["offset_h"][:])) == 1
+        assert np.count_nonzero(~np.isnan(rgroup["gain_h"][:])) == 1
+
+
 # ---------------------------------------------------------------------------
 # Structured filters in the read path (issue #43, Phase A)
 # ---------------------------------------------------------------------------

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2175,16 +2175,6 @@ class TestChunkPrecompute:
         np.testing.assert_array_equal(offsets, np.array([1.0, 101.0], dtype=np.float32))
         assert offsets[0] != offsets[1]
 
-    def test_absent_block_is_byte_identical(self, monkeypatch):
-        """A config WITHOUT chunk_precompute produces byte-for-byte identical output
-        to the same config evaluated through the (now chunk-aware) worker — i.e. the
-        hook is a pure no-op when the block is absent."""
-        df_a, _ = self._run_shard(monkeypatch, self._cfg(with_precompute=False))
-        # Re-run the identical no-precompute config; the per-cell path is unchanged.
-        df_b, _ = self._run_shard(monkeypatch, self._cfg(with_precompute=False))
-        assert df_a["offset"].to_numpy().tobytes() == df_b["offset"].to_numpy().tobytes()
-        assert df_a["count"].to_numpy().tobytes() == df_b["count"].to_numpy().tobytes()
-
     def test_arrow_kernel_rejects_chunk_precompute(self, monkeypatch):
         """The experimental kernel path has no seam to inject pooled scalars, so it
         rejects chunk_precompute rather than silently dropping it."""
@@ -2229,3 +2219,128 @@ class TestChunkPrecompute:
         assert gain[0] == gain[1]
         # chunk_offset = floor(median(pooled h_ph)) = floor(median([10,12,200,202])) = 106
         assert offset[0] == np.float32(np.floor(np.median([10.0, 12.0, 200.0, 202.0])))
+
+    def test_empty_cell_gets_chunk_anchor_not_nan(self, monkeypatch):
+        """An empty cell in a POPULATED chunk records the chunk-uniform anchor, not
+        NaN. The dense writer still emits a row for the empty cell; the field whose
+        expression is a bare chunk-precompute name must resolve to the shared scalar
+        so readers see a uniform anchor across the whole chunk (issue #30)."""
+        # Three children, but only cells 10 and 20 carry photons; cell 30 is empty.
+        leaf_to_cell = {1: 10, 2: 20}
+        children = [10, 20, 30]
+        grid = _KernelShardGrid(children, leaf_to_cell)
+        df = pd.DataFrame(
+            {
+                "h_ph": np.array([0.0, 2.0, 100.0, 102.0], dtype=np.float32),
+                "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
+            }
+        )
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
+        df_out, _meta = process_shard(
+            grid, 0, ["s3://x"], s3_credentials={}, config=self._cfg(with_precompute=True)
+        )
+        offsets = df_out["offset"].to_numpy()
+        pooled_median = np.float32(np.median([0.0, 2.0, 100.0, 102.0]))
+        # Every cell — including the empty third one — carries the chunk anchor.
+        np.testing.assert_array_equal(offsets, np.full(3, pooled_median, dtype=np.float32))
+        assert not np.isnan(offsets[2])
+        # The empty cell still reports a zero obs count (the anchor is not data).
+        assert df_out["count"].to_numpy()[2] == 0
+
+    def test_non_scalar_precompute_rejected(self, monkeypatch):
+        """A chunk_precompute expression that does not reduce to a scalar is
+        rejected with a clear error rather than silently coerced/broadcast."""
+        from zagg.config import PipelineConfig
+
+        cfg = PipelineConfig(
+            data_source={"groups": ["gt1l"], "variables": {"h_ph": "/{group}/h_ph"}},
+            aggregation={
+                # np.floor(h_ph) is an ARRAY, not a chunk scalar.
+                "chunk_precompute": {"bad": {"expression": "np.floor(h_ph)", "source": "h_ph"}},
+                "variables": {
+                    "count": {
+                        "function": "len",
+                        "source": "h_ph",
+                        "dtype": "int32",
+                        "fill_value": 0,
+                    }
+                },
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        pooled = {"h_ph": np.array([1.0, 2.0, 3.0], dtype=np.float32)}
+        with pytest.raises(ValueError, match="must reduce to a scalar"):
+            _eval_chunk_precompute(cfg, pooled)
+
+    def test_missing_source_column_clear_error(self):
+        """A function precompute whose source is absent from the pooled dict raises
+        a clear config/data error, not a bare KeyError."""
+        from zagg.config import PipelineConfig
+
+        cfg = PipelineConfig(
+            data_source={"variables": {"h_ph": "/p", "other": "/o"}},
+            aggregation={
+                "chunk_precompute": {"m": {"function": "median", "source": "other"}},
+                "variables": {"count": {"function": "len", "source": "h_ph"}},
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        # Pooled dict only carries h_ph (e.g. 'other' was not read).
+        with pytest.raises(ValueError, match="source column 'other' is not present"):
+            _eval_chunk_precompute(cfg, {"h_ph": np.array([1.0, 2.0])})
+
+    def test_arrow_kernel_rejects_chunk_precompute_even_on_empty_reads(self, monkeypatch):
+        """The arrow-kernel + chunk_precompute incompatibility is a config property,
+        enforced before any read — so it still raises when every read comes back
+        empty (no rows), not only when there happens to be data (issue #30)."""
+        pytest.importorskip("pyarrow")
+        cfg = self._cfg(with_precompute=True)
+        grid = _KernelShardGrid([10, 20], {1: 10, 2: 20})
+        # No canned tables: every _read_group returns None, so all_reads is empty.
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [])
+        with pytest.raises(NotImplementedError, match="chunk_precompute"):
+            process_shard(
+                grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
+            )
+
+    def test_degenerate_single_photon_chunk_gain_floor(self, monkeypatch):
+        """The worked template's chunk_gain floors to 0.5 on a degenerate pooled
+        range (single photon / all-equal heights) WITHOUT a log2(0) divide-by-zero
+        warning — the range is clamped before log2 and the 0.5 m floor applies."""
+        pytest.importorskip("pyarrow")
+        cfg = default_config("atl03_waveform_chunk")
+        children = [10, 20]
+        grid = _KernelShardGrid(children, {1: 10, 2: 20})
+        # All photons share one height -> pooled range == 0 (degenerate).
+        df = pd.DataFrame(
+            {
+                "h_ph": np.array([42.0, 42.0], dtype=np.float32),
+                "leaf_id": np.array([1, 2], dtype=np.int64),
+            }
+        )
+        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any RuntimeWarning would fail the test
+            tbl, _meta = process_shard(grid, 0, ["s3://x"], s3_credentials={}, config=cfg)
+        gain = tbl.column("gain_h").to_numpy(zero_copy_only=False)
+        np.testing.assert_array_equal(gain, np.full(2, np.float32(0.5)))
+
+    def test_absent_block_matches_plain_path_values(self, monkeypatch):
+        """A config WITHOUT chunk_precompute produces the SAME per-cell values the
+        plain (pre-hook) path would — proving the hook is a true no-op when absent,
+        not merely deterministic across two runs of the same new code. The expected
+        per-cell medians/counts are known independently (cell 10 -> median(0,2)=1,
+        cell 20 -> median(100,102)=101; two obs each)."""
+        df_out, _ = self._run_shard(monkeypatch, self._cfg(with_precompute=False))
+        np.testing.assert_array_equal(
+            df_out["offset"].to_numpy(), np.array([1.0, 101.0], dtype=np.float32)
+        )
+        np.testing.assert_array_equal(df_out["count"].to_numpy(), np.array([2, 2], dtype=np.int32))
+        # And the chunk-precompute config does NOT reproduce these per-cell values
+        # (it injects the pooled anchor instead), so the no-op claim is non-vacuous.
+        df_chunk, _ = self._run_shard(monkeypatch, self._cfg(with_precompute=True))
+        assert not np.array_equal(
+            df_chunk["offset"].to_numpy(), np.array([1.0, 101.0], dtype=np.float32)
+        )

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -9,6 +9,7 @@ from zagg.grids import HEALPIX_BASE_CELLS, HealpixGrid
 from zagg.processing import (
     KERNEL_RTOL,
     _arrow_column,
+    _broadcast_segment_to_base,
     _build_groups,
     _build_output,
     _coerce_ragged_value,
@@ -24,6 +25,8 @@ from zagg.processing import (
     _kernel_aggregate,
     _predicate_mask,
     _read_group,
+    _read_segment_broadcasts,
+    _segment_level_variables,
     calculate_cell_statistics,
     process_shard,
     write_dataframe_to_zarr,
@@ -1348,9 +1351,12 @@ class TestChunkResolutionCompanion:
         shard_key = grid._pack(0, 0)
         children = grid.children(shard_key)
         # vector field present -> default pandas carrier path; feed a DataFrame read.
+        # dem_h (the DEM anchor) rides alongside h_ph as a pooled column (issue #30).
+        dem = np.array([50.0, 50.0, 60.0, 60.0], dtype=np.float32)
         df = pd.DataFrame(
             {
                 "h_ph": np.array([10.0, 12.0, 200.0, 202.0], dtype=np.float32),
+                "dem_h": dem,
                 "leaf_id": np.array(
                     [children[0], children[0], children[1], children[1]], dtype=np.int64
                 ),
@@ -1372,8 +1378,8 @@ class TestChunkResolutionCompanion:
         write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
 
         rgroup = open_group(store=store, mode="r", path="rectilinear")
-        # offset_h companion: one value at this chunk = floor(median(pooled h_ph)).
-        expected_offset = np.float32(np.floor(np.median([10.0, 12.0, 200.0, 202.0])))
+        # offset_h companion: one value at this chunk = floor(median(pooled dem_h)).
+        expected_offset = np.float32(np.floor(np.median(dem)))
         assert rgroup["offset_h"][chunk_idx] == expected_offset
         assert not np.isnan(rgroup["gain_h"][chunk_idx])
         # Only one chunk written for each companion.
@@ -2393,6 +2399,150 @@ class TestPlannedReadGroup:
         assert df["h_ph"].tolist() == [0.0, 10.0, 20.0, 30.0, 50.0, 60.0, 70.0]
 
 
+class TestSegmentLevelVariables:
+    """Issue #30: a non-base level declaring ``variables: {name: path}`` is read at
+    coarse rate and broadcast to the base (photon) rows via the level's link, so a
+    per-segment field (e.g. ``dem_h``, one value per ~100 photons) lands as a
+    per-photon column the aggregation / chunk_precompute reduces."""
+
+    def test_broadcast_segment_to_base_repeats_by_count(self):
+        # 3 segments covering 2 photons each; each photon carries its segment value.
+        seg = np.array([100.0, 200.0, 300.0], dtype=np.float32)
+        ibeg = np.array([0, 2, 4])
+        cnt = np.array([2, 2, 2])
+        out = _broadcast_segment_to_base(seg, ibeg, cnt, index_base=0, total_base_size=6)
+        assert out.tolist() == [100.0, 100.0, 200.0, 200.0, 300.0, 300.0]
+        # Equals np.repeat under contiguity.
+        assert out.tolist() == np.repeat(seg, cnt).tolist()
+        assert out.dtype == seg.dtype
+
+    def test_broadcast_honors_index_base(self):
+        seg = np.array([10.0, 20.0])
+        ibeg = np.array([1, 3])  # 1-based (ATL03-style)
+        cnt = np.array([2, 2])
+        out = _broadcast_segment_to_base(seg, ibeg, cnt, index_base=1, total_base_size=4)
+        assert out.tolist() == [10.0, 10.0, 20.0, 20.0]
+
+    def _data_source(self):
+        return {
+            "coordinates": {"latitude": "/lat", "longitude": "/lon"},
+            "variables": {"h": "/h"},
+            "base_level": "photons",
+            "levels": {
+                "photons": {
+                    "path": "/heights",
+                    "coordinates": ["lat", "lon"],
+                    "variables": ["h"],
+                    "link": None,
+                },
+                "segments": {
+                    "path": "/geolocation",
+                    "coordinates": [],
+                    "variables": {"dem_h": "/dem_h"},
+                    "link": {
+                        "to": "photons",
+                        "index_beg": "/ph_index_beg",
+                        "count": "/segment_ph_cnt",
+                    },
+                },
+            },
+        }
+
+    def test_full_path_broadcasts_dem_h_to_photons(self):
+        # 3 segments x 2 photons; each photon carries its segment's dem_h.
+        h5 = _FakeH5(
+            {
+                "/lat": np.arange(6.0),
+                "/lon": np.arange(6.0),
+                "/h": np.arange(6.0, dtype=np.float32),
+                "/ph_index_beg": np.array([0, 2, 4]),
+                "/segment_ph_cnt": np.array([2, 2, 2]),
+                "/dem_h": np.array([100.0, 200.0, 300.0], dtype=np.float32),
+            }
+        )
+        df = _read_group(h5, "gt1l", self._data_source(), 0, _ShardGrid())
+        assert df["h"].tolist() == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        assert df["dem_h"].tolist() == [100.0, 100.0, 200.0, 200.0, 300.0, 300.0]
+
+    def test_full_path_alignment_under_base_filter(self):
+        # A base-level filter drops some photons; the broadcast dem_h must follow
+        # the SAME mask so each surviving photon keeps its own segment's value.
+        ds = self._data_source()
+        ds["filters"] = [{"dataset": "/qs", "op": "eq", "value": 0}]
+        h5 = _FakeH5(
+            {
+                "/lat": np.arange(6.0),
+                "/lon": np.arange(6.0),
+                "/h": np.arange(6.0, dtype=np.float32),
+                "/ph_index_beg": np.array([0, 2, 4]),
+                "/segment_ph_cnt": np.array([2, 2, 2]),
+                "/dem_h": np.array([100.0, 200.0, 300.0], dtype=np.float32),
+                "/qs": np.array([0, 1, 0, 0, 1, 0]),  # drop photons 1 and 4
+            }
+        )
+        df = _read_group(h5, "gt1l", ds, 0, _ShardGrid())
+        # Survivors: photons 0,2,3,5 -> dem_h 100,200,200,300.
+        assert df["h"].tolist() == [0.0, 2.0, 3.0, 5.0]
+        assert df["dem_h"].tolist() == [100.0, 200.0, 200.0, 300.0]
+
+    def test_planned_partial_read_aligns_dem_h(self):
+        # Partial read plan (NOT a full read): the bbox selects only segments
+        # 1-2 (photons 2..5). Each selected photon must carry its own segment's
+        # dem_h, broadcast over the read-plan-selected photons only.
+        ds = _planned_read_data_source()
+        ds["levels"]["segments"]["variables"] = {"dem_h": "/seg/dem_h"}
+        h5 = _planned_read_h5()
+        # 6 segments; dem_h one value per segment.
+        h5._arrays["/seg/dem_h"] = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0], dtype=np.float32)
+        grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
+        df = _read_group(h5, "gt1l", ds, 0, grid)
+        # Planned path selects photons 2,3 (seg 1) and 4,5 (seg 2).
+        assert df["h"].tolist() == [20.0, 30.0, 40.0, 50.0]
+        assert df["dem_h"].tolist() == [20.0, 20.0, 30.0, 30.0]
+
+    def test_no_segment_variables_is_inert(self):
+        # A hierarchical config whose non-base level uses the documentation-only
+        # ``list[str]`` variables form (NOT the mapping) triggers no broadcast: the
+        # helpers return empty and the read path produces the same columns as before.
+        ds = self._data_source()
+        ds["levels"]["segments"]["variables"] = ["signal_conf_ph"]  # list form
+        assert _segment_level_variables(ds) == {}
+
+        class _NoH5:
+            def readDatasets(self, datasets):  # noqa: N802
+                raise AssertionError("no segment-variable read should occur")
+
+        # No segment-variable read is attempted (the link arrays are never read).
+        assert _read_segment_broadcasts(_NoH5(), "gt1l", ds, ds["levels"], 6) == {}
+
+        h5 = _FakeH5(
+            {
+                "/lat": np.arange(6.0),
+                "/lon": np.arange(6.0),
+                "/h": np.arange(6.0, dtype=np.float32),
+                "/ph_index_beg": np.array([0, 2, 4]),
+                "/segment_ph_cnt": np.array([2, 2, 2]),
+            }
+        )
+        df = _read_group(h5, "gt1l", ds, 0, _ShardGrid())
+        assert list(df.columns) == ["h", "leaf_id"]  # no dem_h column injected
+
+    def test_worked_template_chunk_offset_is_floor_median_dem_h(self):
+        # End-to-end through process_shard: dem_h broadcast feeds chunk_offset,
+        # whose value is floor(median(pooled dem_h)) and is uniform across cells.
+        from zagg.config import load_config
+
+        cfg = load_config("src/zagg/configs/atl03_waveform_chunk.yaml")
+        # Two cells' worth of photons pooled in one shard; dem_h per photon
+        # (already broadcast) with a known median.
+        dem = np.array([100.0, 100.0, 102.0, 108.0, 110.0], dtype=np.float32)
+        chunk_scalars = _eval_chunk_precompute(
+            cfg, {"h_ph": np.arange(5.0, dtype=np.float32), "dem_h": dem}
+        )
+        assert chunk_scalars["chunk_offset"] == np.float32(np.floor(np.median(dem)))
+        assert chunk_scalars["chunk_offset"] == np.float32(102.0)
+
+
 class TestChunkPrecompute:
     """Per-chunk precompute hook (issue #30, item 1): compute once per chunk over
     the shard's pooled data, inject into the per-cell expression namespace."""
@@ -2527,9 +2677,13 @@ class TestChunkPrecompute:
         leaf_to_cell = {1: 10, 2: 20}
         children = [10, 20]
         grid = _KernelShardGrid(children, leaf_to_cell)
+        # dem_h (the DEM anchor) is the per-photon broadcast of each segment's
+        # reference DEM; it rides alongside h_ph as a pooled column (issue #30).
+        dem = np.array([50.0, 50.0, 60.0, 60.0], dtype=np.float32)
         df = pd.DataFrame(
             {
                 "h_ph": np.array([10.0, 12.0, 200.0, 202.0], dtype=np.float32),
+                "dem_h": dem,
                 "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
             }
         )
@@ -2540,8 +2694,8 @@ class TestChunkPrecompute:
         gain = tbl.column("gain_h").to_numpy(zero_copy_only=False)
         assert offset[0] == offset[1]
         assert gain[0] == gain[1]
-        # chunk_offset = floor(median(pooled h_ph)) = floor(median([10,12,200,202])) = 106
-        assert offset[0] == np.float32(np.floor(np.median([10.0, 12.0, 200.0, 202.0])))
+        # chunk_offset is now the DEM anchor: floor(median(pooled dem_h)).
+        assert offset[0] == np.float32(np.floor(np.median(dem)))
 
     def test_empty_cell_gets_chunk_anchor_not_nan(self, monkeypatch):
         """An empty cell in a POPULATED chunk records the chunk-uniform anchor, not
@@ -2769,10 +2923,12 @@ class TestChunkPrecompute:
         cfg = default_config("atl03_waveform_chunk")
         children = [10, 20]
         grid = _KernelShardGrid(children, {1: 10, 2: 20})
-        # All photons share one height -> pooled range == 0 (degenerate).
+        # All photons share one height -> pooled range == 0 (degenerate). dem_h
+        # (the DEM anchor) rides alongside; chunk_gain is the spread over h_ph.
         df = pd.DataFrame(
             {
                 "h_ph": np.array([42.0, 42.0], dtype=np.float32),
+                "dem_h": np.array([42.0, 42.0], dtype=np.float32),
                 "leaf_id": np.array([1, 2], dtype=np.int64),
             }
         )


### PR DESCRIPTION
Refs #30

Implements the **per-chunk precompute hook** plus its **`resolution: chunk` companion-array storage** — items **1 + 2** of the #30 thread ([scope decision](https://github.com/englacial/zagg/issues/30#issuecomment-4773774832)) — and (phase 6) the **DEM-anchored segment-variable read** that makes the worked waveform template genuinely `dem_h`-anchored. **Item 3 (multi-chunk-per-worker) is a SEPARATE later PR** and is not here.

## What this does

### Item 1 — the hook (`aggregation.chunk_precompute:`)
Each named entry (`{expression | function, source, [params], [dtype]}`) is evaluated **ONCE per chunk (shard)** over the shard's **pooled** column data, **before** the per-cell loop. The result is injected into every cell's expression namespace, so a per-cell `expression` can reference a chunk-uniform anchor (e.g. a 128-bin waveform window) instead of recomputing a per-cell one. Mechanism is namespace injection (`{**cell_data, **chunk_scalars}`), `O(1)` per value, and the merge is taken only when the block is present, so a config without it uses the exact pre-existing code path.

### Item 2 — `resolution: chunk` companion arrays
A new per-field attribute `resolution` (`cell` default, or `chunk`). A `resolution: chunk` field (e.g. `offset_h`, `gain_h`) is written **once per chunk** into a companion array shaped at the **chunk grid** (`main.shape // chunk_shape` = number of chunks), indexed by `grid.block_index(shard_key)` — working identically on HEALPix (`block_index` = parent nested id) and rectilinear (row-major `(rb, cb)` chunk index). No per-cell duplication on disk; this retires the per-cell empty-cell band-aid for those fields.

### Phase 6 — DEM-anchored segment-variable read (the worked template's actual anchor)

A **non-base level** may now declare `variables:` as a `{name: path-template}` mapping (a *readable* segment-level variable, distinct from the documentation-only `list[str]` form). At read time each such variable is read at coarse rate and **broadcast to the photon rows** via the level's existing `link` (`np.repeat(values, counts)`-equivalent placement by `index_beg`, reusing the SAME segment→photon tiling the mask path builds), landing as a per-photon column in the pooled shard data that `chunk_precompute` / the aggregation can reduce.

This is exactly the `dem_h` case (`/{group}/geophys_corr/dem_h`, one value per ~100-photon geolocation segment). The worked `configs/atl03_waveform_chunk.yaml` now declares `dem_h` as a segment-level variable and anchors `chunk_offset = np.float32(np.floor(np.median(dem_h)))` — a stable absolute DEM frame — while `chunk_gain` stays on `h_ph` (it's a spread, not an anchor). The template header comment is updated to reflect the DEM anchor.

The read is purely additive: it only fires when a non-base level declares a **dict** `variables`. A `list[str]` segment level (`atl03.yaml`) or any config without a segment-level `variables` mapping reads identically to before — no extra HDF5 read, no extra column.

```yaml
data_source:
  levels:
    segments:
      path: "/{group}/geolocation"
      variables:                       # NEW (phase 6): readable segment-level variable
        dem_h: "/{group}/geophys_corr/dem_h"
      link: {to: photons, index_beg: ".../ph_index_beg", count: ".../segment_ph_cnt", index_base: 1}
aggregation:
  chunk_precompute:
    chunk_offset: {expression: "np.float32(np.floor(np.median(dem_h)))", source: dem_h}  # DEM anchor
    chunk_gain:   {expression: "...", source: h_ph}                                       # spread on h_ph
  variables:
    waveform_counts: {kind: vector, trailing_shape: 128, expression: "...", source: h_ph}
    offset_h: {expression: "chunk_offset", source: h_ph, resolution: chunk}
    gain_h:   {expression: "chunk_gain",   source: h_ph, resolution: chunk}
```

## What changed in the items 1+2 fold (@espg's scope call in 4773774832)

- **(i) Relaxed the scalar guard.** `_eval_chunk_precompute` no longer rejects a non-scalar result — a chunk value may be a scalar **or** an array. Scalar-ness is required only when a value is **written** to a `kind: scalar` field; `calculate_cell_statistics` raises a clear error at that write point.
- **(ii) Enabled `chunk_precompute` on the arrow-kernel path.** The validate-time `NotImplementedError` is removed; the precompute is reduced ONCE over the pooled arrow table and threaded into `_kernel_aggregate`'s fallback per-cell loop.
- **(iii) `resolution: chunk` companion arrays** (item 2): schema attribute, grid template emission (`grids/base.py`), and the write path (`write_dataframe_to_zarr` collapses the chunk-uniform column to its single value, writing it at `block_index`).

## Phase 6 read-path detail

- `processing.py`: `_broadcast_segment_to_base` (per-segment values → base-rate per-photon array via the link tiling), `_segment_level_variables` / `_read_segment_broadcasts` (collect + read declared dict-form segment variables), wired into **both** the planned (`_planned_read_group`) and full (`_read_group_full`) read paths. The broadcast column is subset through the **exact same** spatial/keep/expression masks as the base-rate variables, so each surviving photon keeps its own segment's value — verified for a **partial** read plan, not just full reads.
- `config.py`: `_validate_levels` accepts + validates a non-base level's `{name: path}` `variables` (string names → non-empty templates, base-level mapping rejected, base-var + cross-level name collisions rejected); `_segment_variable_names` folds the names into the valid column set so agg sources / `chunk_precompute` references resolve.

## Byte-identical guarantee

The new attributes/reads are purely additive. `resolution` is **not** in `output_field_signature`/grid `signature()`, so shard-map fingerprints are unchanged. The phase-6 read fires **only** when a non-base level declares a dict `variables`. The other shipped templates — `atl06.yaml`, `atl03.yaml`, `atl03_waveform_counts.yaml` — are **byte-for-byte unchanged on disk** (only `atl03_waveform_chunk.yaml` changed). Pinned by `TestPlainConfigByteIdentical` (resolution machinery) and `test_no_segment_variables_is_inert` (a `list[str]` segment level + a no-levels config trigger zero segment-variable reads, asserted with an h5 stub that raises on any read). The pre-existing `test_processing.py` / `test_integration.py` suites still pass.

## Phases

- [x] **Phase 4** — scalar-guard relax (i) + arrow-kernel enable (ii) + tests.
- [x] **Phase 5** — `resolution: chunk` schema + grid-spec emission + write path + worked-template update + tests.
- [x] **Phase 6** — DEM-anchored segment-variable read: schema (`variables:` on a non-base level) + read/broadcast in both read paths + worked-template `dem_h` anchor + tests.

## Self-review fold (this run, phase 6)

A fresh-context adversarial self-review was posted (inline `🤖 *from Claude (review)*`); the diff-scoped findings are folded in `fold #77 review: dem_h broadcast bounds guard + NaN-fill, cross-level name guard, planned-filter test`:

- **(MED) `_broadcast_segment_to_base` used `np.empty` + overclaimed gap-robustness.** Float dtypes now NaN-fill (an untiled gap surfaces as missing, not garbage), non-float zero-fill; docstring corrected to rely on #43's contiguity assumption. Test `test_broadcast_gap_fills_nan_for_float`.
- **(MED) Seg-variable level distinct from the spatial-index level could write out of bounds.** `_broadcast_segment_to_base` now raises a clear `… exceeds base size …` on any range past the base extent. Test `test_broadcast_out_of_bounds_raises`.
- **(LOW) Two non-base levels declaring the same seg-variable name** silently collided → now rejected in `_validate_levels`. Test `test_duplicate_segment_variable_across_levels_rejected`.
- **(LOW) Planned-path keep-mask × broadcast was untested** → `test_planned_partial_read_aligns_dem_h_under_base_filter`.

(The earlier items-1+2 self-review fold — companion `_chunk_uniform_value` write guard, chunk-uniformity guard, dense-HEALPix companion test — is in `fold #77 review: chunk-uniform companion write guard …`.)

## How tested

`uv run pytest -q` → **662 passed, 1 skipped**. Phase-6 coverage:

- **Broadcast** (`test_processing.py` `TestSegmentLevelVariables`): `np.repeat`-equivalence + `index_base` (1-based ATL03) + dtype preservation; the full path broadcasts `dem_h` to photons and stays aligned under a base filter; the **planned partial read** aligns `dem_h` to read-plan-selected photons (and under a stacked base filter); the worked template's `chunk_offset = floor(median(pooled dem_h))`, uniform across cells, end-to-end through the worker; the no-segment-variable inert/byte-identical case; OOB + gap-fill guards.
- **Schema** (`test_config.py` `TestSegmentLevelVariables`): mapping vs. `list[str]` form; segment variable usable as an agg source / `chunk_precompute` source; empty-template, base-level-mapping, base-var-collision, and cross-level-duplicate rejections; the worked template declares `dem_h` and the DEM-anchored `chunk_offset`.

Lint (`ruff check --select=E,F,W,I --ignore=E501`) and `ruff format --check` clean on touched files; `mypy` (pinned via pre-commit) adds **zero** new error *categories* — see below.

## Questions for review

- **DEM anchor vs. photon-median.** `chunk_offset` now anchors on `floor(median(dem_h))` (the segment reference DEM, broadcast to photons), per the #30 design target; `chunk_gain` remains a spread over `h_ph`. Confirm the median-of-broadcast-dem_h reduction is what you want (vs. e.g. median of the *segment* dem_h values directly — equivalent only under equal photon counts per segment).
- **Segment variables aren't referenceable from `expression` *filters*.** A `dem_h` reference in an aggregation/`chunk_precompute` expression works (tested); but the `expression`-*filter* namespace is still built from `data_source.variables` only, so a `dem_h` reference there would `NameError`. Out of the agreed minimal scope — flagging in case you want it folded.
- (items 1+2, still standing) chunk-uniformity enforced at write time; arrow-kernel + `kind: vector` chunk-output boundary; `resolution: chunk` limited to `kind: scalar`.

## Pre-existing (not mine — flagging, not fixing per §4)

`mypy` (pinned via pre-commit) reports pre-existing errors in `config.py`/`processing.py`/`rectilinear.py` (the `DataSourceDict` arg-types, the `stats_arrays` re-def, object/return-value assignments, the coord chunk_shape typeddict). Base branch has 18; this change has 19 — the single delta (`config.py:236`, `_segment_variable_names` arg-type) is the **identical** `DataSourceDict`→`dict[Any, Any]` pattern as its four sibling validator calls (223/226/229/559), which the base already exhibits; the new helper matches the surrounding style rather than introducing a lone divergent signature. The phase-6 read-path helpers add **zero** mypy errors.