### PR TITLE
fix t-digest δ inversion via k1 scale-function bound (Refs #48)

### DIFF
--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -10,34 +10,41 @@ This module is **pure numpy** — no scipy, no numba, no JAX.  It is the Tier-2
 ragged consumer for issue #48 and the first ``kind: ragged`` reducer wired into
 :func:`zagg.config.resolve_function`.
 
-Algorithm (sequential sort-and-merge variant)
-----------------------------------------------
+Algorithm (scale-function sort-and-merge variant)
+--------------------------------------------------
 ``build_tdigest`` sorts the input, then greedily merges adjacent observations
-into centroids:
+into centroids bounded by Dunning's k1 scale function:
 
 1. Sort all input values.
-2. Walk sorted values; for each value try to merge it into the current centroid.
-3. The merge succeeds if the resulting centroid weight ≤ the local budget
-   ``w_max = δ * (k(q + 1/n) - k(q))``, where k(q) = δ/2 * (1 + sin(π*(q-0.5)))
-   is Dunning's scale function.  A simpler closed-form bound is used here:
-   the budget for a centroid at rank fraction q is proportional to
-   sin(π*q)*(1-sin(π*q)), which peaks at δ/4 at q=0.5 and is 0 at the tails.
-4. When the budget is exhausted, finalize the current centroid and start fresh.
+2. Walk sorted values, accumulating each into the current centroid.
+3. A point joins the current centroid while the centroid still spans ≤ 1 unit
+   of the k1 scale ``k(q) = δ * (arcsin(2q − 1)/π + 1/2)``, which maps the
+   cumulative rank fraction q ∈ [0, 1] onto [0, δ].  ``dk/dq`` is largest at the
+   tails (q → 0 or 1) and smallest at the median, so centroids are narrow and
+   high-resolution in the tails and wide in the middle — the defining t-digest
+   property.
+4. When adding the next point would make the centroid span more than 1 k-unit,
+   finalize it and start a fresh centroid.
+
+Because k maps onto a fixed ``[0, δ]`` range, a digest holds ~δ centroids
+regardless of the observation count (it saturates instead of growing with n),
+and is **loss-free** — one centroid per observation, every weight 1 — while the
+count stays ≤ δ.  Larger δ therefore means more centroids and higher accuracy.
 
 ``merge_tdigests`` concatenates two centroid arrays sorted by mean, then
-re-compresses with the same scale-limited merge so the result respects the
-δ-budget.  The merged sketch matches the one-shot sketch within typical t-digest
-accuracy guarantees.
+re-compresses with the same k1-bounded merge so the result respects the same
+~δ centroid budget.  The merged sketch matches the one-shot sketch within
+typical t-digest accuracy guarantees.
 
 Profiling note (IO vs compute)
 -------------------------------
-At δ=512, ``build_tdigest`` on 10 000 points typically produces ≤200
-centroids; the output is a ``(k, 2)`` float32 array of ≲2 kB, much smaller
+At δ=512, ``build_tdigest`` saturates near ~512 centroids once the observation
+count exceeds δ; the output is a ``(k, 2)`` float32 array of ≲4 kB, much smaller
 than the raw observation array.  Over a 4096-cell shard with ~500 obs per cell,
 the per-cell sort (O(n log n)) and merge loop (O(n)) are the dominant cost at
-~10 μs/cell, giving ~40 ms/shard — well below network IO.  At δ=128 the cost
-is similar but centroid count is 4× smaller; at δ=1024 the loop runs
-4× longer but accuracy improves near the tails.
+~10 μs/cell, giving ~40 ms/shard — well below network IO.  At δ=128 the centroid
+count (and output size) is ~4× smaller; at δ=1024 the digest carries ~2× more
+centroids and is more accurate near the tails.
 
 Usage
 -----
@@ -66,26 +73,18 @@ __all__ = ["build_tdigest", "merge_tdigests", "quantile_from_tdigest"]
 _DEFAULT_DELTA = 512
 
 
-def _k_scale(q: float, delta: float) -> float:
-    """Dunning's k1 scale function: k(q) = delta/2 * (1 + sin(pi*(q - 0.5))).
+def _k1_scale(q: float, delta: float) -> float:
+    """Dunning's k1 scale function: k(q) = delta * (arcsin(2q - 1)/pi + 1/2).
 
-    Maps quantile q ∈ [0,1] to a scale value; the budget for a centroid at
-    cumulative quantile q is proportional to k(q+ε) - k(q).
+    Maps the cumulative rank fraction q ∈ [0, 1] onto [0, delta].  Its
+    derivative is largest at the tails (q → 0 or 1) and smallest at the median,
+    so bounding each centroid to span ≤ 1 unit of k yields narrow, high-
+    resolution centroids in the tails and wide centroids in the middle — the
+    defining t-digest property.  A digest holds ~delta centroids regardless of
+    the observation count, and is loss-free while the count stays ≤ delta.
     """
-    return delta / 2.0 * (1.0 + np.sin(np.pi * (q - 0.5)))
-
-
-def _budget(q: float, delta: float) -> float:
-    """Maximum weight a centroid at fractional rank q can absorb.
-
-    Derived from the derivative of the k1 scale function k(q):
-    the per-centroid budget is proportional to the width Δk at quantile q.
-    For k1: dk/dq = delta * pi/2 * cos(pi*(q-0.5)).
-    Peaks at delta*pi/2 at q=0.5 and approaches 0 at the tails.
-    Bounded below at 1.0 so every value can always form its own centroid.
-    """
-    bud = delta * np.pi / 2.0 * np.cos(np.pi * (q - 0.5))
-    return max(1.0, bud)
+    qc = min(1.0, max(0.0, q))
+    return delta * (float(np.arcsin(2.0 * qc - 1.0)) / np.pi + 0.5)
 
 
 def build_tdigest(
@@ -129,21 +128,18 @@ def build_tdigest(
 
     cur_mean = sorted_vals[0]
     cur_weight = 1.0
-    # cum_w tracks total weight processed so far (finalized + current centroid).
-    # Loop invariant: at the start of each iteration, cum_w == i (total weight
-    # seen up to but not including sorted_vals[i]).  The fractional rank
-    # q = (cum_w - cur_weight/2) / n_total is evaluated *before* attempting to
-    # merge sorted_vals[i], so the budget is assessed one observation behind the
-    # true midpoint — a standard approximation in the sequential sort-and-merge
-    # variant that avoids a second pass.
-    cum_w = 1.0
+    # k1 scale value at the current centroid's left edge — the cumulative rank
+    # fraction *before* its first observation. Observation i extends the
+    # centroid's right edge to rank (i + 1); it joins the centroid while the
+    # centroid still spans ≤ 1 unit of the k1 scale, otherwise it opens a fresh
+    # centroid. This keeps the digest to ~delta centroids and loss-free until
+    # the count exceeds delta.
+    k_left = _k1_scale(0.0, delta_f)
 
     for i in range(1, n):
         v = sorted_vals[i]
-        # Fractional rank of the current centroid's midpoint (one obs behind).
-        q = (cum_w - cur_weight / 2.0) / n_total
-        bud = _budget(q, delta_f)
-        if cur_weight + 1.0 <= bud:
+        k_right = _k1_scale((i + 1) / n_total, delta_f)
+        if k_right - k_left <= 1.0:
             # Merge: update running mean via Welford one-pass update.
             cur_mean += (v - cur_mean) / (cur_weight + 1.0)
             cur_weight += 1.0
@@ -152,7 +148,7 @@ def build_tdigest(
             weights.append(cur_weight)
             cur_mean = v
             cur_weight = 1.0
-        cum_w += 1.0
+            k_left = _k1_scale(i / n_total, delta_f)
 
     means.append(cur_mean)
     weights.append(cur_weight)
@@ -210,14 +206,17 @@ def merge_tdigests(
 
     cur_mean = float(combined[0, 0])
     cur_weight = float(combined[0, 1])
-    cum_w = cur_weight
+    # Cumulative weight before the current centroid's first sub-centroid, and
+    # the k1 scale value at that left edge. A sub-centroid merges in while the
+    # combined centroid still spans ≤ 1 unit of the k1 scale.
+    cum_left = 0.0
+    k_left = _k1_scale(0.0, delta_f)
 
     for i in range(1, len(combined)):
         v_mean = float(combined[i, 0])
         v_weight = float(combined[i, 1])
-        q = (cum_w - cur_weight / 2.0) / n_total
-        bud = _budget(q, delta_f)
-        if cur_weight + v_weight <= bud:
+        k_right = _k1_scale((cum_left + cur_weight + v_weight) / n_total, delta_f)
+        if k_right - k_left <= 1.0:
             # Weighted mean update.
             total = cur_weight + v_weight
             cur_mean = (cur_mean * cur_weight + v_mean * v_weight) / total
@@ -225,9 +224,10 @@ def merge_tdigests(
         else:
             means.append(cur_mean)
             weights.append(cur_weight)
+            cum_left += cur_weight
+            k_left = _k1_scale(cum_left / n_total, delta_f)
             cur_mean = v_mean
             cur_weight = v_weight
-        cum_w += v_weight
 
     means.append(cur_mean)
     weights.append(cur_weight)

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -257,3 +257,89 @@ class TestTDigestDeltaSweep:
         # Centroid count should grow sub-linearly with δ (proportional, not more).
         ratio = len(digest) / delta
         assert ratio <= 4.0, f"delta={delta}: centroid/delta ratio {ratio:.2f} > 4.0"
+
+
+class TestScaleFunctionRegression:
+    """Guards against the k1-budget regression where δ was inverted.
+
+    Before the scale-function fix the per-centroid weight cap was proportional
+    to δ (and independent of n), so larger δ produced *fewer*, coarser centroids
+    and even a handful of points collapsed to a single centroid. These tests pin
+    the correct behavior: δ is a resolution knob, the digest saturates at ~δ
+    centroids, and it is loss-free until the count exceeds δ.
+    """
+
+    @pytest.mark.parametrize("n", [10, 100, 500])
+    def test_loss_free_when_count_at_most_delta(self, n):
+        """With n ≤ δ every observation is kept as its own weight-1 centroid."""
+        rng = np.random.default_rng(n)
+        vals = rng.standard_normal(n)  # distinct values w.p. 1
+        digest = build_tdigest(vals, delta=512)
+        assert digest.shape[0] == n, f"n={n}: expected {n} centroids, got {digest.shape[0]}"
+        np.testing.assert_array_equal(digest[:, 1], np.ones(n, dtype=np.float32))
+
+    def test_compression_begins_past_delta(self):
+        """Once n exceeds δ the digest must actually compress (k < n)."""
+        rng = np.random.default_rng(1)
+        delta = 256
+        vals = rng.standard_normal(4 * delta)
+        digest = build_tdigest(vals, delta=delta)
+        assert digest.shape[0] < len(vals)
+        np.testing.assert_almost_equal(float(digest[:, 1].sum()), len(vals), decimal=4)
+
+    def test_delta_controls_resolution_not_inverted(self):
+        """More δ ⇒ more centroids. The old budget did the opposite."""
+        rng = np.random.default_rng(2)
+        vals = rng.standard_normal(50_000)
+        counts = [build_tdigest(vals, delta=d).shape[0] for d in (128, 256, 512, 1024)]
+        assert counts == sorted(counts), f"centroid count not monotonic in δ: {counts}"
+        assert counts[-1] > 2 * counts[0], f"δ=1024 barely finer than δ=128: {counts}"
+
+    @pytest.mark.parametrize("n", [50_000, 200_000])
+    def test_centroid_count_saturates_near_delta(self, n):
+        """Count stays ~δ regardless of n (≤ 2δ), instead of growing with n."""
+        rng = np.random.default_rng(n)
+        vals = rng.standard_normal(n)
+        k = build_tdigest(vals, delta=256).shape[0]
+        assert k <= 2 * 256, f"n={n}: {k} centroids exceeds 2·δ"
+
+    def test_accuracy_not_degraded_at_high_delta_on_structured_data(self):
+        """On a bimodal mixture, large δ must stay accurate.
+
+        This is the user-visible symptom of the inversion bug: interior-quantile
+        error blew up as δ grew (≈0.33 here at δ=1024 — ~60× the δ=128 error).
+        A correct digest keeps high-δ error small and comparable to low-δ.
+        """
+        rng = np.random.default_rng(3)
+        vals = np.concatenate([rng.normal(-3, 0.3, 5000), rng.normal(3, 0.3, 5000)])
+        qs = [0.1, 0.25, 0.5, 0.75, 0.9]
+        exact = np.quantile(vals, qs)
+
+        def mean_err(delta):
+            d = build_tdigest(vals, delta=delta)
+            est = np.array([quantile_from_tdigest(d, q) for q in qs])
+            return float(np.abs(est - exact).mean())
+
+        err_lo, err_hi = mean_err(128), mean_err(1024)
+        assert err_hi < 0.05, f"δ=1024 interior error {err_hi:.4f} too large"
+        assert err_hi < 5 * err_lo, f"δ=1024 error {err_hi:.4f} >> δ=128 error {err_lo:.4f}"
+
+    @pytest.mark.parametrize("q", [0.02, 0.25, 0.5, 0.75, 0.98])
+    def test_quantiles_track_exact_within_tolerance(self, q):
+        """Estimated quantiles track exact numpy quantiles (independent ground truth)."""
+        rng = np.random.default_rng(4)
+        vals = rng.standard_normal(20_000)
+        digest = build_tdigest(vals, delta=512)
+        est = quantile_from_tdigest(digest, q)
+        exact = float(np.quantile(vals, q))
+        assert abs(est - exact) < 0.05, f"q={q}: est={est:.4f} exact={exact:.4f}"
+
+    def test_merge_saturates_near_delta(self):
+        """Merging two saturated digests stays ~δ, not 2δ-and-growing."""
+        rng = np.random.default_rng(5)
+        delta = 512
+        d1 = build_tdigest(rng.standard_normal(50_000), delta=delta)
+        d2 = build_tdigest(rng.standard_normal(50_000), delta=delta)
+        merged = merge_tdigests(d1, d2, delta=delta)
+        assert merged.shape[0] <= 2 * delta
+        np.testing.assert_almost_equal(float(merged[:, 1].sum()), 100_000, decimal=3)

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -278,14 +278,19 @@ class TestScaleFunctionRegression:
         assert digest.shape[0] == n, f"n={n}: expected {n} centroids, got {digest.shape[0]}"
         np.testing.assert_array_equal(digest[:, 1], np.ones(n, dtype=np.float32))
 
-    def test_loss_free_transition_at_delta_boundary(self):
-        """n == δ is the exact loss-free/compress boundary the fix pins."""
+    def test_loss_free_at_delta_then_compresses(self):
+        """n == δ is guaranteed loss-free; well past δ the digest compresses.
+
+        The k1 bound guarantees loss-free for n ≤ δ (the region actually extends
+        to ~1.27·δ because the left edge lags one observation), so this pins the
+        guaranteed boundary at n == δ and a clearly-compressing case at n == 2δ.
+        """
         delta = 256
         rng = np.random.default_rng(99)
         at = build_tdigest(rng.standard_normal(delta), delta=delta)
-        over = build_tdigest(rng.standard_normal(delta + 1), delta=delta)
+        over = build_tdigest(rng.standard_normal(2 * delta), delta=delta)
         assert at.shape[0] == delta, f"n==δ should be loss-free, got k={at.shape[0]}"
-        assert over.shape[0] < delta + 1, f"n>δ must compress, got k={over.shape[0]}"
+        assert over.shape[0] < 2 * delta, f"n==2δ must compress, got k={over.shape[0]}"
 
     def test_compression_begins_past_delta(self):
         """Once n exceeds δ the digest must actually compress (k < n)."""

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -278,6 +278,15 @@ class TestScaleFunctionRegression:
         assert digest.shape[0] == n, f"n={n}: expected {n} centroids, got {digest.shape[0]}"
         np.testing.assert_array_equal(digest[:, 1], np.ones(n, dtype=np.float32))
 
+    def test_loss_free_transition_at_delta_boundary(self):
+        """n == δ is the exact loss-free/compress boundary the fix pins."""
+        delta = 256
+        rng = np.random.default_rng(99)
+        at = build_tdigest(rng.standard_normal(delta), delta=delta)
+        over = build_tdigest(rng.standard_normal(delta + 1), delta=delta)
+        assert at.shape[0] == delta, f"n==δ should be loss-free, got k={at.shape[0]}"
+        assert over.shape[0] < delta + 1, f"n>δ must compress, got k={over.shape[0]}"
+
     def test_compression_begins_past_delta(self):
         """Once n exceeds δ the digest must actually compress (k < n)."""
         rng = np.random.default_rng(1)


### PR DESCRIPTION
## Summary

Fixes a correctness bug in `zagg.stats.tdigest` (follow-up to #48): the t-digest's `δ` (compression) parameter was **inverted** and compression was independent of the observation count, so the sketch over-merged catastrophically.

### The bug

`_budget()` returned a per-centroid weight cap of `δ·(π/2)·sin(πq)` — proportional to **δ** and **independent of n**. The correct cap is proportional to **n/δ**. Symptoms:

- **δ inverted.** Larger δ gave *fewer*, coarser centroids. On a bimodal mixture, mean interior-quantile error went `0.005 → 0.33` as δ went `64 → 2048` (a resolution knob behaving as a down-sampler).
- **No saturation.** Max centroid weight was pinned at `δ·π/2` (≈804 at δ=512) regardless of n, so a fixed ~142× compression applied at every n — N=100 collapsed to **1** centroid, N=1000 to **3**.
- **Loss-free boundary at n=1.** Any cell with ≥2 observations was already compressed.

Existing tests passed only because they assert a loose `k ≤ 4δ` *upper* bound (trivially true when k is tiny) and quantile tolerances on smooth unimodal normals, where a handful of centroids suffice. Nothing asserted that δ increases resolution or that small-n cells stay loss-free. (`_k_scale()` was defined but unused — the intended scale-function approach had been abandoned for the broken budget shortcut.)

### The fix

Replace the budget shortcut with the standard **k1 scale-function** bound: a point joins the current centroid while the centroid still spans ≤ 1 unit of `k(q) = δ·(arcsin(2q−1)/π + 1/2)` (maps cumulative rank `q ∈ [0,1]` onto `[0, δ]`). `dk/dq` is largest at the tails and smallest at the median → narrow high-resolution tail centroids, wide middle centroids. Applied to both `build_tdigest` and `merge_tdigests`; the dead/incorrect `_k_scale`/`_budget` are removed.

Resulting behavior:

| | before (δ=512) | after (δ=512) |
|---|---|---|
| N=100 | k=1 | k=100 (loss-free) |
| N=1000 | k=3 | k=585 |
| N=50000 | k=354 | k=517 (saturates ~δ) |
| δ scaling (N=50k) | 128→k354, 1024→k191 (inverted) | 128→k129, 1024→k1043 |

Loss-free for n ≤ δ, saturates at ~δ (≤ 2δ) for any n, quantiles track exact `np.quantile` within ~0.05 σ.

## Phases

- [x] **Phase 1** — fix `build_tdigest` + `merge_tdigests` to the k1 scale-function bound; remove dead `_k_scale`/`_budget`; update module docstring.
- [x] **Phase 2** — regression tests guarding each symptom (loss-free ≤ δ, compression past δ, δ-monotonic resolution, saturation ≤ 2δ, no high-δ accuracy degradation, quantiles vs exact, merge saturation).

## How tested

- `pytest tests/test_tdigest.py` — 54 passed (40 pre-existing + 14 new).
- Full suite `pytest` — 536 passed, 1 skipped.
- `ruff check --select=E,F,W,I --ignore=E501` clean on changed files; `ruff format --check` clean.
- mypy clean on the changed files (pre-existing mypy errors in `config.py`/`processing.py`/`rectilinear.py` are unrelated and present on `main` — not touched here).

## Questions for review

- **Quantile interpolation unchanged.** This PR only fixes centroid *construction*; `quantile_from_tdigest` is untouched. Accuracy is good, but interior-quantile error on structured data isn't strictly monotonic in δ (a small interpolation artifact, not the inversion). Worth a follow-up if tighter interior accuracy matters.
- **`merge_tdigests` re-compression** uses the same k1 bound on cumulative weight fractions. It saturates and conserves total weight; if many partial digests are merged hierarchically, accumulated re-compression error could be worth a dedicated test.
