### PR TITLE
t-digest → tensor read helpers (Refs #79)

### DIFF
--- a/src/zagg/readers/__init__.py
+++ b/src/zagg/readers/__init__.py
@@ -1,0 +1,17 @@
+"""Client-side read helpers for zagg products (issue #79).
+
+These sit just outside the core write path: they reconstruct dense, fixed-size
+arrays a downstream client can consume from the gridded Zarr products zagg
+writes.  Pure-numpy + zarr (both already core deps); no new dependency.
+"""
+
+from __future__ import annotations
+
+from zagg.readers.tdigest_tensor import (
+    chunk_z_range,
+    rasterize_cell,
+    read_raw_values,
+    read_tensors,
+)
+
+__all__ = ["chunk_z_range", "rasterize_cell", "read_raw_values", "read_tensors"]

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -171,15 +171,17 @@ def chunk_z_range(
     window = n_bins * resolution
 
     if fit == "collapse_bins":
-        # Shrink n_bins to the smallest power of two whose window still covers
-        # the trimmed range. Only ever reduces the bin count, so it cannot help
-        # a range that already exceeds the full n_bins window.
+        # Shrink to the smallest power-of-two bin count (≤ the largest power of
+        # two that fits within n_bins) whose window still covers the trimmed
+        # range. Only ever reduces the bin count, so it cannot help a range that
+        # already exceeds the full n_bins window.
         if needed > window:
             raise ValueError(
                 f'fit="collapse_bins" cannot grow the window: trimmed span {needed} '
                 f"exceeds {n_bins} bins × {resolution} = {window}"
             )
-        n = n_bins
+        # Largest power of two ≤ n_bins (the collapsed count is always pow2).
+        n = 1 << (int(n_bins).bit_length() - 1)
         while n // 2 >= 1 and (n // 2) * resolution >= needed:
             n //= 2
         return float(z_lo), n, resolution
@@ -209,6 +211,11 @@ def _resolve_chunk_morton(
     Prefers a sibling ``{field}/morton`` ``uint64`` coordinate array (chunk
     order → morton id); falls back to parsing the subgroup name as the parent
     morton id (the shard key is the parent morton — see :func:`process_shard`).
+
+    The coordinate array is aligned against the subgroup names sorted
+    **numerically** (the canonical ascending-morton chunk order), not
+    lexicographically — string sorting would mis-align names of differing digit
+    counts (e.g. ``"1000"`` before ``"99"``).
     """
     try:
         arr = zarr.open_array(store, path=f"{field}/morton", mode="r", zarr_format=zarr_format)
@@ -218,7 +225,7 @@ def _resolve_chunk_morton(
     if len(morton) != len(shard_keys):
         # Coordinate present but not 1:1 with subgroups — fall back to the names.
         return {k: int(k) for k in shard_keys}
-    return {k: int(m) for k, m in zip(sorted(shard_keys), morton)}
+    return {k: int(m) for k, m in zip(sorted(shard_keys, key=int), morton)}
 
 
 def read_tensors(
@@ -259,7 +266,9 @@ def read_tensors(
         (default ``"raise"``).
     dtype : {"uint16", "uint32", "float32"}, optional
         Output tensor dtype (default ``"uint32"``).  ``uint16``/``uint32`` round
-        counts to the nearest integer; ``float32`` keeps fractional counts.
+        counts to the nearest integer; ``float32`` keeps fractional counts.  A
+        per-bin count exceeding the dtype's max (65535 for ``uint16``) wraps on
+        cast — keep ``uint32`` for dense cells with many observations per bin.
     zarr_format : int, optional
         Zarr format version (default 3).
 

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -1,0 +1,366 @@
+"""Client-side reader: per-cell t-digests → fixed ``(64, 64, n_bins)`` tensors.
+
+These are *read helpers* (issue #79) that live in-repo but sit just outside
+zagg's core write path: a client consuming a gridded Zarr product wants a dense,
+fixed-size tensor per coverage chunk, reconstructed from the per-cell t-digest
+ragged field that zagg writes (issue #48).
+
+Store layout consumed
+---------------------
+The t-digest field is stored per shard as a CSR ragged group (see
+:mod:`zagg.csr`): under the field prefix, one subgroup per shard, named by the
+shard's **parent morton id** (the coverage cell), each holding the three CSR
+arrays ``values`` / ``offsets`` / ``cell_ids``::
+
+    {field}/{parent_morton}/values
+    {field}/{parent_morton}/offsets
+    {field}/{parent_morton}/cell_ids
+
+``cell_ids[k]`` is a cell's position in the chunk's row-major ``(64, 64)``
+children block, and ``values[offsets[k]:offsets[k+1]]`` is that cell's
+``(k_centroids, 2)`` ``(mean, weight)`` digest.  The subgroup name is the
+chunk's morton index, recovered directly from the store (issue #79 design
+decision (3)); when a sibling ``{field}/morton`` ``uint64`` coordinate array is
+present it is used in preference, mapping chunk order → morton id.
+
+The reader (generator)
+----------------------
+:func:`read_tensors` opens the store and yields ``(tensor, morton_index)`` one
+chunk at a time.  Per chunk it derives a tail-trimmed z-range from the cells'
+``bottom``/``top`` quantiles, anchors a fixed ``n_bins * resolution`` window at
+the floor of that range, and rasterizes each cell's digest into per-bin counts
+via :func:`zagg.stats.tdigest.cdf_from_tdigest`.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+from typing import Literal
+
+import numpy as np
+import zarr
+from zarr.abc.store import Store
+
+from zagg.csr import iter_csr_cells, read_csr
+from zagg.stats.tdigest import cdf_from_tdigest, quantile_from_tdigest
+
+__all__ = ["rasterize_cell", "chunk_z_range", "read_tensors", "read_raw_values"]
+
+# Coverage chunk is a 64×64 block of child cells (issue #79).
+_CHUNK_SIDE = 64
+_CHUNK_CELLS = _CHUNK_SIDE * _CHUNK_SIDE
+
+FitMode = Literal["raise", "degrade_resolution", "collapse_bins"]
+TensorDtype = Literal["uint16", "uint32", "float32"]
+
+_TENSOR_DTYPES: dict[str, np.dtype] = {
+    "uint16": np.dtype(np.uint16),
+    "uint32": np.dtype(np.uint32),
+    "float32": np.dtype(np.float32),
+}
+
+
+def rasterize_cell(
+    digest: np.ndarray,
+    z_lo: float,
+    resolution: float,
+    n_bins: int,
+) -> np.ndarray:
+    """Rasterize one cell's t-digest into ``n_bins`` per-bin counts.
+
+    The bins are evenly spaced in value-space: bin ``i`` covers
+    ``[z_lo + i*resolution, z_lo + (i+1)*resolution)``.  The count in a bin is
+    the digest's reconstructed weight in that value interval, using the digest
+    CDF::
+
+        count[i] = cdf(edge_{i+1}) - cdf(edge_i)
+
+    where ``cdf = cdf_from_tdigest`` (issue #79).  Weight below the first edge
+    or above the last is dropped (the window is fixed; see :func:`chunk_z_range`
+    for the fit policy that guards against truncation).
+
+    Parameters
+    ----------
+    digest : ndarray, shape (k, 2)
+        Centroid array ``(mean, weight)`` for one cell.  An empty digest yields
+        an all-zero vector.
+    z_lo : float
+        Left edge of the first bin (meter-aligned chunk floor).
+    resolution : float
+        Bin width in value units.
+    n_bins : int
+        Number of bins.
+
+    Returns
+    -------
+    ndarray, shape (n_bins,), dtype float64
+        Per-bin reconstructed counts (not yet cast to the output dtype).
+    """
+    if len(digest) == 0:
+        return np.zeros(n_bins, dtype=np.float64)
+    edges = z_lo + resolution * np.arange(n_bins + 1, dtype=np.float64)
+    cdf = np.asarray(cdf_from_tdigest(digest, edges), dtype=np.float64)
+    counts = np.diff(cdf)
+    # CDF is monotonic non-decreasing, so counts are ≥ 0 up to float noise.
+    np.clip(counts, 0.0, None, out=counts)
+    return counts
+
+
+def _cell_tail_bounds(digest: np.ndarray, bottom: float, top: float) -> tuple[float, float] | None:
+    """Return ``(lo, hi)`` = (``bottom``, ``top``) quantiles, or None if empty."""
+    if len(digest) == 0:
+        return None
+    lo = quantile_from_tdigest(digest, bottom)
+    hi = quantile_from_tdigest(digest, top)
+    if not (math.isfinite(lo) and math.isfinite(hi)):
+        return None
+    return lo, hi
+
+
+def chunk_z_range(
+    digests: list[np.ndarray],
+    *,
+    n_bins: int,
+    resolution: float,
+    bottom: float,
+    top: float,
+    fit: FitMode,
+) -> tuple[float, int, float]:
+    """Derive the chunk's z-window and apply the fit policy.
+
+    Per cell, ``lo_c = quantile_from_tdigest(d, bottom)`` and
+    ``hi_c = quantile_from_tdigest(d, top)`` trim the tails.  The window floor is
+    ``z_lo = floor(min lo_c)``; the fixed window spans ``n_bins * resolution``
+    anchored at ``z_lo``.  If ``ceil(max hi_c) > z_lo + n_bins*resolution`` the
+    trimmed data does not fit, and ``fit`` decides what happens:
+
+    - ``"raise"`` (default) — raise :class:`ValueError`.
+    - ``"degrade_resolution"`` — double ``resolution`` (powers of two) until the
+      window covers the range, keeping ``n_bins`` fixed.
+    - ``"collapse_bins"`` — shrink ``n_bins`` to the smallest power of two whose
+      window (at the original ``resolution``) covers the range.
+
+    Parameters
+    ----------
+    digests : list of ndarray
+        Per-populated-cell digests for the chunk.
+    n_bins, resolution, bottom, top, fit
+        See :func:`read_tensors`.
+
+    Returns
+    -------
+    (z_lo, n_bins, resolution) : tuple
+        The window floor and the (possibly adjusted) bin count and resolution.
+
+    Raises
+    ------
+    ValueError
+        If the chunk has no populated cells, or ``fit="raise"`` and the trimmed
+        range exceeds the fixed window.
+    """
+    bounds = [b for b in (_cell_tail_bounds(d, bottom, top) for d in digests) if b is not None]
+    if not bounds:
+        raise ValueError("chunk has no populated cells with a finite quantile range")
+
+    lo_min = min(b[0] for b in bounds)
+    hi_max = max(b[1] for b in bounds)
+    z_lo = math.floor(lo_min)
+    z_hi = math.ceil(hi_max)
+    needed = z_hi - z_lo
+    window = n_bins * resolution
+
+    if fit == "collapse_bins":
+        # Shrink n_bins to the smallest power of two whose window still covers
+        # the trimmed range. Only ever reduces the bin count, so it cannot help
+        # a range that already exceeds the full n_bins window.
+        if needed > window:
+            raise ValueError(
+                f'fit="collapse_bins" cannot grow the window: trimmed span {needed} '
+                f"exceeds {n_bins} bins × {resolution} = {window}"
+            )
+        n = n_bins
+        while n // 2 >= 1 and (n // 2) * resolution >= needed:
+            n //= 2
+        return float(z_lo), n, resolution
+
+    if needed <= window:
+        return float(z_lo), n_bins, resolution
+
+    if fit == "raise":
+        raise ValueError(
+            f"trimmed z-range [{z_lo}, {z_hi}] (span {needed}) exceeds the fixed "
+            f"window {n_bins} bins × {resolution} = {window}; pass "
+            f'fit="degrade_resolution" or fit="collapse_bins" to adapt'
+        )
+    if fit == "degrade_resolution":
+        res = resolution
+        while needed > n_bins * res:
+            res *= 2.0
+        return float(z_lo), n_bins, res
+    raise ValueError(f"unknown fit mode {fit!r}")
+
+
+def _resolve_chunk_morton(
+    store: Store, field: str, shard_keys: list[str], zarr_format: Literal[2, 3]
+) -> dict[str, int]:
+    """Map each shard subgroup name → its morton id.
+
+    Prefers a sibling ``{field}/morton`` ``uint64`` coordinate array (chunk
+    order → morton id); falls back to parsing the subgroup name as the parent
+    morton id (the shard key is the parent morton — see :func:`process_shard`).
+    """
+    try:
+        arr = zarr.open_array(store, path=f"{field}/morton", mode="r", zarr_format=zarr_format)
+        morton = np.asarray(arr[...])
+    except (FileNotFoundError, KeyError, ValueError):
+        return {k: int(k) for k in shard_keys}
+    if len(morton) != len(shard_keys):
+        # Coordinate present but not 1:1 with subgroups — fall back to the names.
+        return {k: int(k) for k in shard_keys}
+    return {k: int(m) for k, m in zip(sorted(shard_keys), morton)}
+
+
+def read_tensors(
+    store: Store,
+    field: str,
+    *,
+    n_bins: int = 128,
+    resolution: float = 0.5,
+    bottom: float = 0.05,
+    top: float = 0.95,
+    fit: FitMode = "raise",
+    dtype: TensorDtype = "uint32",
+    zarr_format: Literal[2, 3] = 3,
+) -> Iterator[tuple[np.ndarray, int]]:
+    """Yield ``(tensor, morton_index)`` per coverage chunk of a t-digest field.
+
+    Opens the CSR ragged store for ``field`` and iterates one Zarr chunk (one
+    64×64 parent block) at a time.  For each chunk it trims the per-cell tails,
+    derives a fixed z-window (see :func:`chunk_z_range`), rasterizes every
+    populated cell's digest into ``n_bins`` counts (see :func:`rasterize_cell`),
+    and emits the ``(64, 64, n_bins)`` tensor with the chunk's morton id.
+
+    Parameters
+    ----------
+    store : Store
+        Zarr store holding the per-shard CSR groups under ``field``.
+    field : str
+        Field prefix (e.g. ``"h_tdigest"``).
+    n_bins : int, optional
+        Number of z-bins (default 128).
+    resolution : float, optional
+        Bin width in value units (default 0.5).
+    bottom, top : float, optional
+        Lower/upper density-trim quantiles (default 0.05 / 0.95) — the window
+        spans the cells' ``bottom``→``top`` quantile range.
+    fit : {"raise", "degrade_resolution", "collapse_bins"}, optional
+        Behaviour when the trimmed range exceeds ``n_bins * resolution``
+        (default ``"raise"``).
+    dtype : {"uint16", "uint32", "float32"}, optional
+        Output tensor dtype (default ``"uint32"``).  ``uint16``/``uint32`` round
+        counts to the nearest integer; ``float32`` keeps fractional counts.
+    zarr_format : int, optional
+        Zarr format version (default 3).
+
+    Yields
+    ------
+    (tensor, morton_index) : (ndarray, int)
+        ``tensor`` has shape ``(64, 64, n_bins_out)`` and the requested dtype;
+        ``morton_index`` is the chunk's coverage-cell morton id.
+
+    Raises
+    ------
+    ValueError
+        On an unknown ``dtype``/``fit``, or (with ``fit="raise"``) a chunk whose
+        trimmed range overflows the fixed window.
+    """
+    if dtype not in _TENSOR_DTYPES:
+        raise ValueError(f"unknown dtype {dtype!r}; expected one of {sorted(_TENSOR_DTYPES)}")
+    out_dtype = _TENSOR_DTYPES[dtype]
+    is_float = np.issubdtype(out_dtype, np.floating)
+
+    group = zarr.open_group(store, path=field, mode="r", zarr_format=zarr_format)
+    shard_keys = sorted(k for k in group.group_keys() if k != "morton")
+    morton_of = _resolve_chunk_morton(store, field, shard_keys, zarr_format)
+
+    for key in shard_keys:
+        cells = iter_csr_cells(read_csr(store, f"{field}/{key}", zarr_format=zarr_format))
+        digests = [payload for _, payload in cells]
+        z_lo, n_bins_c, resolution_c = chunk_z_range(
+            digests,
+            n_bins=n_bins,
+            resolution=resolution,
+            bottom=bottom,
+            top=top,
+            fit=fit,
+        )
+
+        tensor = np.zeros((_CHUNK_SIDE, _CHUNK_SIDE, n_bins_c), dtype=out_dtype)
+        for cell_id, digest in cells:
+            if not (0 <= cell_id < _CHUNK_CELLS):
+                raise ValueError(
+                    f"cell_id {cell_id} out of range for a {_CHUNK_SIDE}×{_CHUNK_SIDE} chunk"
+                )
+            counts = rasterize_cell(digest, z_lo, resolution_c, n_bins_c)
+            if not is_float:
+                counts = np.rint(counts)
+            row, col = divmod(cell_id, _CHUNK_SIDE)
+            tensor[row, col, :] = counts.astype(out_dtype)
+
+        yield tensor, morton_of[key]
+
+
+def read_raw_values(
+    store: Store,
+    field: str,
+    *,
+    zarr_format: Literal[2, 3] = 3,
+) -> Iterator[tuple[int, int, np.ndarray]]:
+    """Yield ``(morton_index, cell_id, values)`` raw samples per populated cell.
+
+    The companion lossless reader (issue #79 follow-up): when a digest was built
+    with no merges (every centroid weight 1) its centroid means *are* the
+    original observations, so the raw value vector can be recovered exactly.  A
+    cell whose digest contains any merged centroid (weight > 1) is **not**
+    losslessly recoverable and raises :class:`ValueError`.
+
+    Parameters
+    ----------
+    store : Store
+        Zarr store holding the per-shard CSR groups under ``field``.
+    field : str
+        Field prefix.
+    zarr_format : int, optional
+        Zarr format version (default 3).
+
+    Yields
+    ------
+    (morton_index, cell_id, values) : (int, int, ndarray)
+        ``values`` is the cell's recovered 1-D sample vector (sorted ascending,
+        as the digest stores centroids by mean).
+
+    Raises
+    ------
+    ValueError
+        If any cell's digest carries a merged centroid (weight > 1), so the raw
+        values cannot be recovered without loss.
+    """
+    group = zarr.open_group(store, path=field, mode="r", zarr_format=zarr_format)
+    shard_keys = sorted(k for k in group.group_keys() if k != "morton")
+    morton_of = _resolve_chunk_morton(store, field, shard_keys, zarr_format)
+
+    for key in shard_keys:
+        morton = morton_of[key]
+        for cell_id, digest in iter_csr_cells(
+            read_csr(store, f"{field}/{key}", zarr_format=zarr_format)
+        ):
+            if len(digest) == 0:
+                continue
+            weights = np.asarray(digest[:, 1], dtype=np.float64)
+            if np.any(weights > 1.0):
+                raise ValueError(
+                    f"cell {cell_id} (chunk {morton}) has merged centroids "
+                    "(weight > 1); raw values are not losslessly recoverable"
+                )
+            yield int(morton), int(cell_id), np.asarray(digest[:, 0], dtype=np.float64)

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -68,7 +68,12 @@ from __future__ import annotations
 
 import numpy as np
 
-__all__ = ["build_tdigest", "merge_tdigests", "quantile_from_tdigest"]
+__all__ = [
+    "build_tdigest",
+    "cdf_from_tdigest",
+    "merge_tdigests",
+    "quantile_from_tdigest",
+]
 
 _DEFAULT_DELTA = 512
 
@@ -284,3 +289,64 @@ def quantile_from_tdigest(digest: np.ndarray, q: float) -> float:
                 hi_val = means[k] if k == len(means) - 1 else (means[k] + means[k + 1]) / 2.0
             return float(lo_val + frac * (hi_val - lo_val))
     return float(means[-1])
+
+
+def cdf_from_tdigest(digest: np.ndarray, x: float | np.ndarray) -> float | np.ndarray:
+    """Estimate cumulative weight at value ``x`` from a t-digest.
+
+    The value→cumulative-weight inverse of :func:`quantile_from_tdigest`: where
+    that maps a rank fraction to a value, this maps a value to the cumulative
+    *weight* (number of observations) at or below ``x``.  It is the primitive
+    needed to fill evenly-spaced *value* bins from a digest (issue #79).
+
+    Each centroid ``k`` (mean ``m_k``, weight ``w_k``) is placed at the centre
+    of its cumulative-weight span, i.e. at cumulative weight
+    ``cum_before + w_k / 2``.  The CDF interpolates cumulative weight linearly
+    in value-space between adjacent centroid means and is clamped flat outside
+    ``[m_0, m_{k-1}]``, so it is monotonic non-decreasing in ``x`` with
+    endpoints ``0`` (below the first mean) and the total weight (above the
+    last).
+
+    Parameters
+    ----------
+    digest : ndarray, shape (k, 2)
+        Centroid array (mean, weight) as returned by :func:`build_tdigest`.
+    x : float or ndarray
+        Value(s) at which to evaluate the cumulative weight.
+
+    Returns
+    -------
+    float or ndarray
+        Cumulative weight at ``x``, in ``[0, total_weight]``.  Returns NaN
+        (matching the shape of ``x``) for an empty digest.
+
+    Notes
+    -----
+    Returns a scalar ``float`` for scalar ``x`` and an ``ndarray`` (float64)
+    for array ``x``.
+    """
+    x_arr = np.asarray(x, dtype=np.float64)
+    scalar = x_arr.ndim == 0
+
+    if len(digest) == 0:
+        out = np.full(x_arr.shape, np.nan, dtype=np.float64)
+        return float(out) if scalar else out
+
+    means = np.asarray(digest[:, 0], dtype=np.float64)
+    weights = np.asarray(digest[:, 1], dtype=np.float64)
+    total = float(weights.sum())
+
+    # Cumulative weight at each centroid's centre: cum_before + w/2.
+    cum_upper = np.cumsum(weights)
+    cum_center = cum_upper - weights / 2.0
+
+    # Single centroid (or all-equal means): step from 0 to total at the mean.
+    if len(means) == 1:
+        out = np.where(x_arr >= means[0], total, 0.0)
+        return float(out) if scalar else out.astype(np.float64)
+
+    # Piecewise-linear interpolation of cumulative weight over centroid means.
+    # np.interp clamps to the endpoint values outside [means[0], means[-1]],
+    # giving the flat 0 / total tails.
+    out = np.interp(x_arr, means, cum_center, left=0.0, right=total)
+    return float(out) if scalar else out

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,0 +1,270 @@
+"""Tests for the t-digest → tensor read helpers — issue #79."""
+
+import math
+
+import numpy as np
+import pytest
+import zarr
+from zarr.storage import MemoryStore
+
+from zagg.csr import write_csr
+from zagg.readers.tdigest_tensor import (
+    chunk_z_range,
+    rasterize_cell,
+    read_raw_values,
+    read_tensors,
+)
+from zagg.stats.tdigest import build_tdigest
+
+
+def _write_chunk(store, field, morton_key, cell_to_values, *, delta=512):
+    """Write one shard subgroup of per-cell t-digests under {field}/{morton_key}."""
+    cell_ids = sorted(cell_to_values)
+    payloads = [build_tdigest(np.asarray(cell_to_values[c]), delta=delta) for c in cell_ids]
+    write_csr(store, f"{field}/{morton_key}", payloads, cell_ids)
+
+
+class TestRasterizeCell:
+    def test_empty_digest_all_zero(self):
+        out = rasterize_cell(np.empty((0, 2), dtype=np.float32), 0.0, 0.5, 16)
+        assert out.shape == (16,)
+        assert np.all(out == 0.0)
+
+    def test_counts_sum_to_in_window_weight(self):
+        rng = np.random.default_rng(0)
+        vals = rng.uniform(10.0, 20.0, size=5_000)
+        digest = build_tdigest(vals, delta=512)
+        # Window comfortably brackets all data.
+        out = rasterize_cell(digest, 9.0, 0.5, 24)  # [9, 21)
+        # Total reconstructed weight ≈ N.
+        assert out.sum() == pytest.approx(len(vals), rel=0.01)
+
+    def test_counts_non_negative(self):
+        rng = np.random.default_rng(1)
+        digest = build_tdigest(rng.standard_normal(2_000), delta=256)
+        out = rasterize_cell(digest, -4.0, 0.25, 32)
+        assert np.all(out >= 0.0)
+
+    def test_matches_histogram_within_tolerance(self):
+        """Rasterized counts track np.histogram of the original samples."""
+        rng = np.random.default_rng(2)
+        vals = rng.normal(50.0, 5.0, size=40_000)
+        digest = build_tdigest(vals, delta=512)
+        z_lo, resolution, n_bins = 30.0, 1.0, 40  # [30, 70)
+        out = rasterize_cell(digest, z_lo, resolution, n_bins)
+        edges = z_lo + resolution * np.arange(n_bins + 1)
+        hist, _ = np.histogram(vals, bins=edges)
+        # Compare as fractions of total; t-digest bin counts track the empirical
+        # histogram within a few percent of N over the bulk of the distribution.
+        frac_err = np.abs(out - hist) / len(vals)
+        assert np.max(frac_err) < 0.02
+
+
+class TestChunkZRange:
+    def _digest(self, lo, hi, n=4_000, seed=0):
+        rng = np.random.default_rng(seed)
+        return build_tdigest(rng.uniform(lo, hi, size=n), delta=512)
+
+    def test_no_cells_raises(self):
+        with pytest.raises(ValueError, match="no populated cells"):
+            chunk_z_range([], n_bins=128, resolution=0.5, bottom=0.05, top=0.95, fit="raise")
+
+    def test_all_empty_digests_raises(self):
+        empty = [np.empty((0, 2), dtype=np.float32)]
+        with pytest.raises(ValueError, match="no populated cells"):
+            chunk_z_range(empty, n_bins=128, resolution=0.5, bottom=0.05, top=0.95, fit="raise")
+
+    def test_window_floor_and_fit(self):
+        # Data spans ~[100, 120]; trimmed range fits in 128 × 0.5 = 64 m.
+        digests = [self._digest(100.0, 120.0, seed=3)]
+        z_lo, n_bins, res = chunk_z_range(
+            digests, n_bins=128, resolution=0.5, bottom=0.05, top=0.95, fit="raise"
+        )
+        assert n_bins == 128
+        assert res == 0.5
+        assert z_lo == math.floor(z_lo)
+        # Floor should be at/just below the 5th-percentile minimum (~101).
+        assert 99.0 <= z_lo <= 102.0
+
+    def test_raise_when_too_wide(self):
+        # Span ~200 m ≫ 64 m window → raise.
+        digests = [self._digest(0.0, 200.0, seed=4)]
+        with pytest.raises(ValueError, match="exceeds the fixed window"):
+            chunk_z_range(digests, n_bins=128, resolution=0.5, bottom=0.0, top=1.0, fit="raise")
+
+    def test_degrade_resolution_doubles_in_pow2(self):
+        digests = [self._digest(0.0, 200.0, seed=5)]
+        z_lo, n_bins, res = chunk_z_range(
+            digests,
+            n_bins=128,
+            resolution=0.5,
+            bottom=0.0,
+            top=1.0,
+            fit="degrade_resolution",
+        )
+        assert n_bins == 128
+        # resolution must be 0.5 * 2**k and the window must now cover the range.
+        ratio = res / 0.5
+        assert ratio == pytest.approx(2 ** round(math.log2(ratio)))
+        span = math.ceil(max(0.0, 200.0)) - z_lo
+        assert span <= n_bins * res
+
+    def test_collapse_bins_shrinks_to_smallest_pow2(self):
+        # Span ~10 m fits in far fewer than 128 × 0.5 = 64 m. Smallest pow2
+        # window ≥ 10 m at 0.5 m is 32 bins (16 m); 16 bins (8 m) is too small.
+        digests = [self._digest(100.0, 110.0, seed=6)]
+        z_lo, n_bins, res = chunk_z_range(
+            digests,
+            n_bins=128,
+            resolution=0.5,
+            bottom=0.0,
+            top=1.0,
+            fit="collapse_bins",
+        )
+        assert res == 0.5
+        # n_bins is a power of two ≤ 128 and the window covers the span.
+        assert n_bins in (1, 2, 4, 8, 16, 32, 64, 128)
+        span = math.ceil(110.0) - z_lo
+        assert n_bins * res >= span
+        # And halving once more would no longer cover it (smallest that fits).
+        assert (n_bins // 2) * res < span
+
+    def test_collapse_bins_cannot_grow_raises(self):
+        digests = [self._digest(0.0, 200.0, seed=66)]
+        with pytest.raises(ValueError, match="cannot grow"):
+            chunk_z_range(
+                digests,
+                n_bins=128,
+                resolution=0.5,
+                bottom=0.0,
+                top=1.0,
+                fit="collapse_bins",
+            )
+
+    def test_unknown_fit_raises(self):
+        digests = [self._digest(0.0, 300.0, seed=7)]
+        with pytest.raises(ValueError, match="unknown fit"):
+            chunk_z_range(digests, n_bins=128, resolution=0.5, bottom=0.0, top=1.0, fit="nope")
+
+
+class TestReadTensors:
+    def _store(self):
+        store = MemoryStore()
+        rng = np.random.default_rng(10)
+        # Two chunks (parent mortons 100 and 250), a few populated cells each.
+        _write_chunk(
+            store,
+            "h_tdigest",
+            100,
+            {
+                0: rng.uniform(10.0, 30.0, 3_000),
+                5: rng.uniform(12.0, 28.0, 2_000),
+                4095: rng.uniform(11.0, 29.0, 1_500),
+            },
+        )
+        _write_chunk(
+            store,
+            "h_tdigest",
+            250,
+            {7: rng.uniform(40.0, 60.0, 2_500), 63: rng.uniform(42.0, 58.0, 2_000)},
+        )
+        return store
+
+    def test_shape_and_dtype_default(self):
+        out = dict((m, t) for t, m in read_tensors(self._store(), "h_tdigest"))
+        assert set(out) == {100, 250}
+        for t in out.values():
+            assert t.shape == (64, 64, 128)
+            assert t.dtype == np.uint32
+
+    def test_morton_recovered_from_subgroup_name(self):
+        mortons = sorted(m for _, m in read_tensors(self._store(), "h_tdigest"))
+        assert mortons == [100, 250]
+
+    def test_populated_cell_placement_rowmajor(self):
+        out = dict((m, t) for t, m in read_tensors(self._store(), "h_tdigest"))
+        t = out[100]
+        # cell 5 → row 0, col 5; cell 4095 → row 63, col 63.
+        assert t[0, 5].sum() > 0
+        assert t[63, 63].sum() > 0
+        # An unpopulated cell stays zero.
+        assert t[10, 10].sum() == 0
+
+    def test_counts_match_population(self):
+        store = MemoryStore()
+        rng = np.random.default_rng(11)
+        n = 5_000
+        _write_chunk(store, "f", 1, {0: rng.uniform(0.0, 40.0, n)})
+        t, m = next(read_tensors(store, "f", n_bins=128, resolution=0.5))
+        assert m == 1
+        # Most of the population should land in-window (uniform [0,40] in a 64 m
+        # window anchored at floor of the 5th pct).
+        assert 0.8 * n <= t[0, 0].sum() <= n
+
+    @pytest.mark.parametrize(
+        "dtype,np_dtype",
+        [("uint16", np.uint16), ("uint32", np.uint32), ("float32", np.float32)],
+    )
+    def test_dtype_flag(self, dtype, np_dtype):
+        store = MemoryStore()
+        rng = np.random.default_rng(12)
+        _write_chunk(store, "f", 1, {0: rng.uniform(0.0, 30.0, 2_000)})
+        t, _ = next(read_tensors(store, "f", dtype=dtype))
+        assert t.dtype == np_dtype
+
+    def test_morton_coord_array_preferred(self):
+        store = MemoryStore()
+        rng = np.random.default_rng(13)
+        _write_chunk(store, "f", 100, {0: rng.uniform(0.0, 30.0, 2_000)})
+        _write_chunk(store, "f", 250, {0: rng.uniform(0.0, 30.0, 2_000)})
+        # Sibling coord maps sorted chunk order [100, 250] → custom mortons.
+        arr = zarr.open_array(
+            store, path="f/morton", mode="w", shape=(2,), chunks=(2,), dtype="uint64"
+        )
+        arr[...] = np.array([900, 901], dtype=np.uint64)
+        mortons = sorted(m for _, m in read_tensors(store, "f"))
+        assert mortons == [900, 901]
+
+    def test_raise_when_chunk_too_wide(self):
+        store = MemoryStore()
+        rng = np.random.default_rng(14)
+        _write_chunk(store, "f", 1, {0: rng.uniform(0.0, 400.0, 5_000)})
+        with pytest.raises(ValueError, match="exceeds the fixed window"):
+            next(read_tensors(store, "f", bottom=0.0, top=1.0))
+
+    def test_degrade_resolution_fits(self):
+        store = MemoryStore()
+        rng = np.random.default_rng(15)
+        _write_chunk(store, "f", 1, {0: rng.uniform(0.0, 400.0, 5_000)})
+        t, _ = next(read_tensors(store, "f", bottom=0.0, top=1.0, fit="degrade_resolution"))
+        assert t.shape == (64, 64, 128)
+
+    def test_unknown_dtype_raises(self):
+        store = MemoryStore()
+        rng = np.random.default_rng(16)
+        _write_chunk(store, "f", 1, {0: rng.uniform(0.0, 30.0, 1_000)})
+        with pytest.raises(ValueError, match="unknown dtype"):
+            next(read_tensors(store, "f", dtype="float64"))
+
+
+class TestReadRawValues:
+    def test_recovers_unmerged_samples_exactly(self):
+        store = MemoryStore()
+        # Few enough values (< delta) that build_tdigest performs no merges.
+        vals = np.array([3.0, 1.0, 2.0, 5.0, 4.0])
+        _write_chunk(store, "f", 42, {7: vals}, delta=512)
+        out = list(read_raw_values(store, "f"))
+        assert len(out) == 1
+        morton, cell_id, recovered = out[0]
+        assert morton == 42
+        assert cell_id == 7
+        # Digest stores centroids sorted by mean → sorted samples.
+        np.testing.assert_allclose(recovered, np.sort(vals))
+
+    def test_merged_digest_raises(self):
+        store = MemoryStore()
+        rng = np.random.default_rng(20)
+        # Many values at small delta → merges (weight > 1) somewhere.
+        _write_chunk(store, "f", 1, {0: rng.standard_normal(5_000)}, delta=64)
+        with pytest.raises(ValueError, match="not losslessly recoverable"):
+            list(read_raw_values(store, "f"))

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -9,6 +9,7 @@ from zarr.storage import MemoryStore
 
 from zagg.csr import write_csr
 from zagg.readers.tdigest_tensor import (
+    _resolve_chunk_morton,
     chunk_z_range,
     rasterize_cell,
     read_raw_values,
@@ -129,6 +130,20 @@ class TestChunkZRange:
         # And halving once more would no longer cover it (smallest that fits).
         assert (n_bins // 2) * res < span
 
+    def test_collapse_bins_pow2_for_non_pow2_n_bins(self):
+        # Non-power-of-two n_bins must still collapse to a power of two.
+        digests = [self._digest(100.0, 110.0, seed=8)]
+        _, n_bins, res = chunk_z_range(
+            digests,
+            n_bins=100,
+            resolution=0.5,
+            bottom=0.0,
+            top=1.0,
+            fit="collapse_bins",
+        )
+        assert n_bins in (1, 2, 4, 8, 16, 32, 64)  # ≤ largest pow2 ≤ 100 (=64)
+        assert res == 0.5
+
     def test_collapse_bins_cannot_grow_raises(self):
         digests = [self._digest(0.0, 200.0, seed=66)]
         with pytest.raises(ValueError, match="cannot grow"):
@@ -224,6 +239,22 @@ class TestReadTensors:
         arr[...] = np.array([900, 901], dtype=np.uint64)
         mortons = sorted(m for _, m in read_tensors(store, "f"))
         assert mortons == [900, 901]
+
+    def test_morton_coord_array_mixed_digit_keys(self):
+        # Regression: subgroup names of differing digit counts must align with
+        # the coord array in numeric (not lexicographic) order — a lexicographic
+        # zip would pair "1000" before "99" and mis-assign mortons.
+        store = MemoryStore()
+        rng = np.random.default_rng(33)
+        for key in (99, 100, 1000):
+            _write_chunk(store, "f", key, {0: rng.uniform(0.0, 30.0, 1_000)})
+        arr = zarr.open_array(
+            store, path="f/morton", mode="w", shape=(3,), chunks=(3,), dtype="uint64"
+        )
+        # Coord in ascending-morton chunk order (99, 100, 1000).
+        arr[...] = np.array([900, 901, 902], dtype=np.uint64)
+        mapping = _resolve_chunk_morton(store, "f", ["99", "100", "1000"], 3)
+        assert mapping == {"99": 900, "100": 901, "1000": 902}
 
     def test_raise_when_chunk_too_wide(self):
         store = MemoryStore()

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -3,7 +3,12 @@
 import numpy as np
 import pytest
 
-from zagg.stats.tdigest import build_tdigest, merge_tdigests, quantile_from_tdigest
+from zagg.stats.tdigest import (
+    build_tdigest,
+    cdf_from_tdigest,
+    merge_tdigests,
+    quantile_from_tdigest,
+)
 
 
 class TestBuildTDigest:
@@ -357,3 +362,75 @@ class TestScaleFunctionRegression:
         merged = merge_tdigests(d1, d2, delta=delta)
         assert merged.shape[0] <= 2 * delta
         np.testing.assert_almost_equal(float(merged[:, 1].sum()), 100_000, decimal=3)
+
+
+class TestCdfFromTDigest:
+    def test_empty_returns_nan_scalar(self):
+        out = cdf_from_tdigest(np.empty((0, 2), dtype=np.float32), 3.0)
+        assert isinstance(out, float)
+        assert np.isnan(out)
+
+    def test_empty_returns_nan_array(self):
+        out = cdf_from_tdigest(np.empty((0, 2), dtype=np.float32), np.array([1.0, 2.0]))
+        assert isinstance(out, np.ndarray)
+        assert out.shape == (2,)
+        assert np.all(np.isnan(out))
+
+    def test_single_centroid_step(self):
+        digest = build_tdigest(np.array([5.0]))
+        assert cdf_from_tdigest(digest, 4.0) == pytest.approx(0.0)
+        assert cdf_from_tdigest(digest, 5.0) == pytest.approx(1.0)
+        assert cdf_from_tdigest(digest, 9.0) == pytest.approx(1.0)
+
+    def test_endpoints_zero_and_total(self):
+        rng = np.random.default_rng(1)
+        vals = rng.standard_normal(5_000)
+        digest = build_tdigest(vals, delta=256)
+        total = float(digest[:, 1].sum())
+        # Far below the minimum mean → 0; far above the maximum mean → total.
+        lo = float(digest[:, 0].min()) - 100.0
+        hi = float(digest[:, 0].max()) + 100.0
+        assert cdf_from_tdigest(digest, lo) == pytest.approx(0.0)
+        assert cdf_from_tdigest(digest, hi) == pytest.approx(total)
+
+    def test_monotonic_non_decreasing(self):
+        rng = np.random.default_rng(2)
+        vals = rng.standard_normal(8_000)
+        digest = build_tdigest(vals, delta=256)
+        xs = np.linspace(vals.min() - 1.0, vals.max() + 1.0, 500)
+        cdf = cdf_from_tdigest(digest, xs)
+        assert np.all(np.diff(cdf) >= -1e-9)
+
+    def test_scalar_in_scalar_out(self):
+        digest = build_tdigest(np.arange(100.0))
+        out = cdf_from_tdigest(digest, 50.0)
+        assert isinstance(out, float)
+
+    def test_array_in_array_out(self):
+        digest = build_tdigest(np.arange(100.0))
+        out = cdf_from_tdigest(digest, np.array([10.0, 50.0, 90.0]))
+        assert isinstance(out, np.ndarray)
+        assert out.shape == (3,)
+
+    def test_matches_empirical_cdf_within_tolerance(self):
+        """cdf_from_tdigest tracks the empirical CDF of the samples (as a fraction)."""
+        rng = np.random.default_rng(3)
+        vals = rng.standard_normal(20_000)
+        digest = build_tdigest(vals, delta=512)
+        total = float(digest[:, 1].sum())
+        xs = np.linspace(np.quantile(vals, 0.02), np.quantile(vals, 0.98), 50)
+        est_frac = np.asarray(cdf_from_tdigest(digest, xs)) / total
+        emp_frac = np.searchsorted(np.sort(vals), xs, side="right") / len(vals)
+        # t-digest CDF tracks the empirical CDF within a few percent.
+        assert np.max(np.abs(est_frac - emp_frac)) < 0.03
+
+    def test_inverse_consistency_with_quantile(self):
+        """cdf(quantile(q)) ≈ q*total over the interior (round-trip within tolerance)."""
+        rng = np.random.default_rng(7)
+        vals = rng.standard_normal(20_000)
+        digest = build_tdigest(vals, delta=512)
+        total = float(digest[:, 1].sum())
+        for q in (0.1, 0.25, 0.5, 0.75, 0.9):
+            x = quantile_from_tdigest(digest, q)
+            frac = cdf_from_tdigest(digest, x) / total
+            assert abs(frac - q) < 0.03, f"q={q}: round-trip frac={frac:.4f}"


### PR DESCRIPTION
Refs #79

## What

Client-side read helpers (issue #79) that reconstruct fixed-size tensors from the per-cell t-digest CSR ragged store zagg writes (issue #48). New `zagg.readers` package (core, no new dependency — pure numpy + zarr).

- **`cdf_from_tdigest(digest, x)`** (`src/zagg/stats/tdigest.py`) — the value→cumulative-weight inverse of `quantile_from_tdigest`, the one primitive needed to fill evenly-spaced *value* bins. Each centroid `(m_k, w_k)` is placed at the centre of its cumulative-weight span (`cum_before + w_k/2`); the CDF interpolates cumulative weight linearly in value-space between centroid means (`np.interp`) and is clamped flat outside `[m_0, m_last]`. Monotonic non-decreasing; endpoints 0 and total weight; empty digest → NaN; scalar-in/scalar-out, array-in/array-out. **Purely additive — does not touch `build_tdigest`/`merge_tdigests` (PR #80 is vectorizing those).**
- **`rasterize_cell(digest, z_lo, resolution, n_bins)`** — `count[i] = cdf(edge_{i+1}) - cdf(edge_i)`, clipped to ≥0.
- **`chunk_z_range(...)`** — per cell `lo_c = quantile(d, bottom)`, `hi_c = quantile(d, top)`; `z_lo = floor(min lo_c)`; fixed window `n_bins*resolution` anchored at `z_lo`. `fit="raise"` (default) raises when `ceil(max hi_c) > z_lo + window`; `fit="degrade_resolution"` doubles `resolution` (powers of two) until it fits; `fit="collapse_bins"` shrinks `n_bins` to the smallest power-of-two bin count whose window still covers the range (raises if even the full window can't).
- **`read_tensors(store, field, *, n_bins=128, resolution=0.5, bottom=0.05, top=0.95, fit="raise", dtype="uint32")`** — generator yielding `(tensor[64,64,n_bins], morton_index)` per coverage chunk. Reuses `csr.read_csr`/`iter_csr_cells`, places cells row-major via `divmod(cell_id, 64)`, recovers the chunk morton from the store.
- **`read_raw_values(store, field)`** — companion lossless reader (per the issue-thread follow-up): when a digest has no merges (all weights 1) the centroid means *are* the original samples, so it yields the raw sorted vector per cell; raises on any merged centroid.

### Store layout consumed

Per shard, a CSR ragged group named by its **parent morton id** (the coverage cell): `{field}/{parent_morton}/{values,offsets,cell_ids}`. `cell_ids[k]` is the cell's position in the chunk's row-major 64×64 children block; `values[offsets[k]:offsets[k+1]]` is that cell's `(k,2)` digest. The chunk morton is recovered from the store — a sibling `{field}/morton` uint64 coord array (aligned against subgroup names sorted **numerically**) if present, else the subgroup name.

## Phases

- [x] Phase 1 — `cdf_from_tdigest` + tests (monotonic, endpoints, empirical-CDF parity, quantile round-trip).
- [x] Phase 2 — `rasterize_cell`; parity test vs `np.histogram` of the original samples within t-digest tolerance.
- [x] Phase 3 — `chunk_z_range` + the three fit modes.
- [x] Phase 4 — `read_tensors` generator + `read_raw_values`; end-to-end against a synthetic CSR store built with `build_tdigest` + `write_csr`.

A fresh-context adversarial self-review ran after the implementation; its two diff-scoped findings are folded: (a) the `{field}/morton` coord array is now aligned against numerically-sorted subgroup names (lexicographic sort mis-aligned mixed-digit mortons), and (b) `collapse_bins` now returns a true power-of-two bin count for non-power-of-two `n_bins`. Both have regression tests.

## How tested

`uv run pytest -q` — 644 passed, 1 pre-existing skip; 91 of those are the new `test_readers.py` + `test_tdigest.py` cases. `ruff check --select=E,F,W,I --ignore=E501 src tests` clean; `ruff format --check` clean on touched files; `pre-commit run mypy` clean on the new modules (pre-existing mypy errors elsewhere in the tree are not introduced by this PR). The reader is exercised end-to-end offline via a synthetic per-shard t-digest CSR store built with `build_tdigest` + `write_csr`.

Note: `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` is flaky under the full-suite run (fails intermittently, passes in isolation) — it is the Lambda build-script test, unrelated to this pure-Python change, and is left untouched.

## Questions for review

The plan's 4 open questions were implemented with these defaults — please confirm:

1. **Tensor values** — per-bin **counts** reconstructed from the digest CDF. dtype is a **flag** (`uint16` | `uint32` | `float32`), defaulting to `uint32`; per the thread note that the client currently consumes `uint16`, should the **default** be `uint16` instead?
2. **Window positioning** — fixed-width window **anchored at `z_lo = floor(min bottom-quantile)`**, span `n_bins*resolution`, `fit="raise"` default (vs a window centred on the trimmed range).
3. **Per-chunk morton id** — recovered from the store: sibling `{field}/morton` uint64 coord array if present, else the shard subgroup name (= parent morton id). Confirm the store-layout assumption (one CSR subgroup per shard, keyed by parent morton) matches the writer once #48's store integration lands — if the real layout differs the iteration will need adapting.
4. **Module home** — `zagg.readers` in core (no extra), per "readers in core is fine."

Also flagging two follow-ups from the thread: (a) the non-synthetic t-digest store check is not yet wired (needs a real product fixture); (b) `read_raw_values` is the raw-vector reader requested, with a `raise` on merged centroids — confirm the lossless-only semantics.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EN7X53ZAyaCca9rjwv9qZw)_