### PR TITLE
use h5coro 1.0.4 in lambda layer + lockstep tests

### DIFF
--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -66,7 +66,7 @@ $PIP install \
     --no-cache-dir
 
 echo "Installing h5coro and mortie (--no-deps)..."
-$PIP install "h5coro==1.0.3" mortie --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
+$PIP install "h5coro==1.0.4" mortie --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
 
 # Verify numpy stayed < 2.3
 NUMPY_VERSION=$(ls "$OUTPUT_DIR/python" | grep -E "^numpy-" | head -1)

--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -66,7 +66,7 @@ $PIP install \
     --no-cache-dir
 
 echo "Installing h5coro and mortie (--no-deps)..."
-$PIP install "h5coro==0.0.8" mortie --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
+$PIP install "h5coro==1.0.3" mortie --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
 
 # Verify numpy stayed < 2.3
 NUMPY_VERSION=$(ls "$OUTPUT_DIR/python" | grep -E "^numpy-" | head -1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 lambda = [
     "numpy==2.2.6",
     "pandas==2.2.3",
-    "h5coro==1.0.3",
+    "h5coro==1.0.4",
     "cramjam",
     "astropy",
 ]

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -160,9 +160,20 @@ class TestPackageConsistency:
         import tomllib
 
         config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
-        dep = next(d for d in config["project"]["optional-dependencies"]["lambda"]
-                   if d.startswith(f"{pkg}=="))
+        dep = next(
+            d
+            for d in config["project"]["optional-dependencies"]["lambda"]
+            if d.startswith(f"{pkg}==")
+        )
         return dep.split("==", 1)[1]
+
+    @staticmethod
+    def _core_floor(pkg):
+        import tomllib
+
+        config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        dep = next(d for d in config["project"]["dependencies"] if d.startswith(f"{pkg}>="))
+        return dep.split(">=", 1)[1]
 
     @staticmethod
     def _pinned_in_script(pkg, script_path):
@@ -190,3 +201,13 @@ class TestPackageConsistency:
     def test_h5coro_version_consistent(self):
         """Lambda [extra] and the build script must pin the same h5coro version."""
         self._assert_lockstep("h5coro", "build_layer.sh")
+
+    def test_h5coro_lambda_pin_satisfies_core_floor(self):
+        """The [lambda] exact pin must not fall below the core h5coro floor."""
+        from packaging.version import Version
+
+        lambda_pin = Version(self._lambda_extra_pin("h5coro"))
+        core_floor = Version(self._core_floor("h5coro"))
+        assert lambda_pin >= core_floor, (
+            f"[lambda] pins h5coro=={lambda_pin} but core requires h5coro>={core_floor}"
+        )


### PR DESCRIPTION
## What

Makes the Lambda layer build and the h5coro version-consistency tests green, and reconciles the `[lambda]` extra with a version that actually installs on the supported Python matrix.

## The problem (and why 1.0.4, not 1.0.3)

On `main`, the core dep was bumped to `h5coro>=1.0.3` and the `[lambda]` extra to `h5coro==1.0.3`, but `deployment/aws/build_layer.sh` was left at `h5coro==0.0.8` — so `test_h5coro_version_consistent` (a real two-source lockstep check, not a hardcoded assert) was red.

Pinning the build script to `1.0.3` to match turned out to **break the actual layer build**:

```
ERROR: Ignored the following versions that require a different python version:
       1.0.3 Requires-Python >=3.10,<=3.12.0
ERROR: Could not find a version that satisfies the requirement h5coro==1.0.3
       (from versions: 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.0.8, 1.0.4)
```

h5coro **1.0.3** declares `requires_python = >=3.10,<=3.12.0`, so it cannot install on the Lambda cp312 image (a 3.12.x newer than 3.12.0) **or on Python 3.13** — i.e. nowhere in zagg's `requires-python = ">=3.12"` / 3.12+3.13 CI matrix. The unit-test jobs only went green because a fresh resolve of the core `>=1.0.3` floor already skips 1.0.3 and lands on **1.0.4** (`requires_python = >=3.10`, the latest release and the version used in the #4 profiling work). The lockstep test passed on strings while the real build failed.

So the only version that makes the whole matrix coherent — core floor, `[lambda]` exact pin, build script, and a raw `pip install` in the manylinux image — is **1.0.4**.

## Changes

- `deployment/aws/build_layer.sh`: `h5coro==0.0.8` → `h5coro==1.0.4` (the `--no-deps` layer install). Build-script edit explicitly authorized; no script is run against live AWS.
- `pyproject.toml` `[lambda]` extra: `h5coro==1.0.3` → `h5coro==1.0.4` so the layer pin matches the build script and is installable on 3.12+/3.13. (Core floor stays `h5coro>=1.0.3`; 1.0.4 satisfies it. `uv.lock` is gitignored, so CI resolves fresh — no lock to commit.)
- `tests/test_lambda_build.py`: add `test_h5coro_lambda_pin_satisfies_core_floor`, asserting the `[lambda]` exact pin is `>=` the core `h5coro>=` floor (via `packaging.version.Version`) — catches a second drift class the existing lockstep test doesn't (core floor advancing past the lambda pin).

## Testing

- `uv run pytest tests/test_lambda_build.py::TestPackageConsistency -q` → 4 passed.
- `uv run pytest -q` → 646 passed, 1 skipped (full suite green with h5coro 1.0.4 installed; was 0.0.8 before).
- `ruff check` clean on the touched test file.

## Note for review

- I bumped the target to **1.0.4 rather than the 1.0.3 originally pinned on `main`**, because 1.0.3 is uninstallable on the entire supported Python matrix (`<=3.12.0` cap) — the 1.0.3 `[lambda]` pin was a phantom the lockstep test couldn't catch. If you specifically need 1.0.3 for some reason, it would also require capping `requires-python` to `==3.12.0`, which I don't think is intended — flagging so you can confirm 1.0.4 is the right call.
- The new core-floor test uses `packaging` (already present transitively); flag if you'd rather it stay stdlib-only.