### PR TITLE
publish_mirror: --creds flag for source.coop JSON credentials

### DIFF
--- a/deployment/aws/publish_mirror.sh
+++ b/deployment/aws/publish_mirror.sh
@@ -13,12 +13,21 @@
 #   ./publish_mirror.sh 0.2                  # latest successful Lambda Build run
 #   ./publish_mirror.sh 0.2 --run 27312613736
 #   ./publish_mirror.sh 0.2 --dir ./zips     # local dir holding the 4 zips
+#   ./publish_mirror.sh 0.2 --creds sc.json  # source.coop write creds from JSON
 #
-# Requires: aws CLI (write creds to MIRROR_BUCKET); gh (unless --dir).
+# --creds points at a JSON file of source.coop write credentials (so they don't
+# have to be exported by hand). It accepts the same AWS key spellings the rest of
+# zagg does — camelCase (accessKeyId), boto snake_case (aws_access_key_id), and
+# STS PascalCase (AccessKeyId) — and exports them for the aws CLI. Without it the
+# aws CLI falls back to the ambient environment / profile as before. Flags may be
+# combined, e.g. `--dir ./zips --creds sc.json`.
+#
+# Requires: aws CLI (write creds to MIRROR_BUCKET); gh (unless --dir); python3
+# (only when --creds is used).
 
 set -euo pipefail
 
-MINOR="${1:?usage: publish_mirror.sh <minor> [--run <id> | --dir <dir>]}"; shift || true
+MINOR="${1:?usage: publish_mirror.sh <minor> [--run <id> | --dir <dir>] [--creds <json>]}"; shift || true
 
 REPO="${MIRROR_SRC_REPO:-englacial/zagg}"
 MIRROR_BUCKET="${MIRROR_BUCKET:-us-west-2.opendata.source.coop}"
@@ -30,13 +39,55 @@ MIRROR_REGION="${MIRROR_REGION:-us-west-2}"
 MIRROR_REPO_PREFIX="${MIRROR_REPO_PREFIX:-${MIRROR_PREFIX%/lambda}}"
 REPO_TOP="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
 
-RUN_ID=""; ZIP_DIR=""
-case "${1:-}" in
-    --run) RUN_ID="${2:?--run needs a run id}" ;;
-    --dir) ZIP_DIR="${2:?--dir needs a directory}" ;;
-    "") ;;
-    *) echo "ERROR: unknown argument '$1'"; exit 1 ;;
-esac
+RUN_ID=""; ZIP_DIR=""; CREDS_FILE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --run) RUN_ID="${2:?--run needs a run id}"; shift 2 ;;
+        --dir) ZIP_DIR="${2:?--dir needs a directory}"; shift 2 ;;
+        --creds) CREDS_FILE="${2:?--creds needs a json file}"; shift 2 ;;
+        *) echo "ERROR: unknown argument '$1'"; exit 1 ;;
+    esac
+done
+
+# Optional: load source.coop write credentials from a JSON file so they don't
+# have to be exported by hand. Accepts the common AWS key spellings (camelCase,
+# boto snake_case, STS PascalCase), matching zagg's own credential handling, and
+# exports them for the aws CLI calls below. sessionToken is optional.
+if [ -n "$CREDS_FILE" ]; then
+    [ -f "$CREDS_FILE" ] || { echo "ERROR: --creds file not found: $CREDS_FILE" >&2; exit 1; }
+    CREDS_EXPORTS="$(python3 - "$CREDS_FILE" <<'PY'
+import json, shlex, sys
+
+with open(sys.argv[1]) as fh:
+    data = json.load(fh)
+
+ALIASES = {
+    "AWS_ACCESS_KEY_ID":     ("accessKeyId", "aws_access_key_id", "AccessKeyId"),
+    "AWS_SECRET_ACCESS_KEY": ("secretAccessKey", "aws_secret_access_key", "SecretAccessKey"),
+    "AWS_SESSION_TOKEN":     ("sessionToken", "aws_session_token", "SessionToken"),
+}
+
+def pick(keys):
+    for k in keys:
+        v = data.get(k)
+        if v:
+            return str(v)
+    return None
+
+resolved = {env: pick(keys) for env, keys in ALIASES.items()}
+missing = [e for e in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY") if not resolved[e]]
+if missing:
+    sys.stderr.write("ERROR: --creds JSON missing %s\n" % ", ".join(missing))
+    sys.exit(1)
+
+for env, val in resolved.items():
+    if val:
+        print("export %s=%s" % (env, shlex.quote(val)))
+PY
+    )" || { echo "ERROR: could not load credentials from $CREDS_FILE" >&2; exit 1; }
+    eval "$CREDS_EXPORTS"
+    echo "Loaded source.coop credentials from $CREDS_FILE"
+fi
 
 WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
 STAGE="$WORK/$MINOR"; mkdir -p "$STAGE"


### PR DESCRIPTION
## What

Adds an optional `--creds <json>` flag to `deployment/aws/publish_mirror.sh` so a maintainer can point at a source.coop credentials JSON file when running the mirror by hand, instead of exporting `AWS_*` environment variables each time.

```
./publish_mirror.sh 0.2 --creds sc.json
./publish_mirror.sh 0.2 --dir ./zips --creds sc.json   # flags combine
```

## How

- Reworked the single-shot arg `case` into a `while` loop so `--creds` composes with the existing `--run` / `--dir` flags (previously only one optional flag was parsed).
- When `--creds` is given, a small `python3` block reads the JSON and exports `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` for the `aws s3` calls. It accepts the **same AWS key spellings the rest of zagg does** — camelCase (`accessKeyId`), boto snake_case (`aws_access_key_id`), and STS PascalCase (`AccessKeyId`) — mirroring `_CRED_ALIASES` in `src/zagg/runner.py:634`. `sessionToken` is optional; a missing access key or secret errors out with a clear message. Values are `shlex.quote`d before `eval`.
- Without `--creds`, behavior is unchanged: the `aws` CLI falls back to the ambient environment / profile exactly as before.
- Header usage + `Requires` note updated (`python3` is only needed when `--creds` is used).

## Scope / authorization

`deployment/aws/publish_mirror.sh` is a mirror script under §1's "don't modify `deployment/aws/`" rule; this change was **explicitly requested by @espg by name** (the §1 exception). No mirror publish / live-AWS action was run from this PR — the script was only edited and statically validated.

## Testing

- `bash -n` clean.
- Verified the credential parser on all three accepted spellings (camelCase / boto / STS), confirmed `sessionToken` is optional (omitted when absent), and that a JSON missing the secret exits non-zero with `ERROR: --creds JSON missing AWS_SECRET_ACCESS_KEY`.
- Not executed end-to-end (would require source.coop write creds + a real mirror upload, which is out of scope to run here).

## Questions for review

- The flag reads access key / secret / session token only. If your source.coop JSON also carries a region or endpoint you'd like honored, say so and I'll thread those through too (today it keeps the existing `MIRROR_REGION` default and standard S3 endpoint).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EN7X53ZAyaCca9rjwv9qZw)_