### PR TITLE
Lift HEALPix assign reference order to 29 + order-19 t-digest / gain-bias templates

### DIFF
--- a/src/zagg/configs/atl03_gain_bias_healpix.yaml
+++ b/src/zagg/configs/atl03_gain_bias_healpix.yaml
@@ -1,0 +1,125 @@
+# ATL03 per-chunk gain/bias waveform template (HEALPix, multi-chunk-per-worker).
+#
+# Per-CHUNK-anchored waveform counts with a stored gain + bias (offset) per Zarr
+# chunk -- the remote-sensing scale+offset paradigm. The ``chunk_precompute``
+# hook (issue #30 item 1) is evaluated ONCE per inner chunk over that chunk's
+# pooled photons, BEFORE the per-cell loop, and the resulting chunk-level scalars
+# are injected into every cell's expression namespace, so every cell in a chunk
+# shares one 128-bin altitude window:
+#
+#   chunk_offset = floor(min(dem_h))        # absolute DEM-anchored bin-0 floor
+#   chunk_gain   = smallest power-of-two (>= 0.5 m) whose 128 bins span the
+#                  chunk's photon-height range: 2^ceil(log2((max-min)/128)) >= 0.5
+#
+# The 128-bin window is [chunk_offset - 27*chunk_gain, chunk_offset + 101*chunk_gain),
+# so the floor(min) DEM anchor lands in bin 28 (27 bins below, 100 above) -- the
+# asymmetric layout for a mostly-above-ground return. dem_h (the segment-level
+# reference DEM, less noisy than the photon cloud) gives a stable absolute frame;
+# it is declared as a segment-level readable variable and broadcast to the photon
+# rows via the geolocation->heights link, landing as a per-photon ``dem_h`` column
+# the chunk_precompute reduces. Out-of-range photons are dropped.
+#
+# offset_h / gain_h are ``resolution: chunk`` companion fields (issue #30 item 2):
+# stored ONCE per Zarr chunk in an array shaped at the chunk grid, indexed by
+# block_index -- no per-cell duplication. A reader reconstructs each chunk's
+# altitude axis as ``offset_h + gain_h * arange(128)``.
+#
+# Because chunk_precompute is reduced PER inner chunk (not pooled over the whole
+# shard), every one of the K finer chunks gets its own gain/offset -- the
+# multi-chunk-per-worker path (issue #30 item 3). Grid is HEALPix nested at
+# child_order 19: parent_order 11 shards (256x256 cells) each own K = 16 inner
+# chunks (chunk_inner 13 = 64x64 cells). The worker reads the shard once and
+# writes 16 chunk regions + 16 offset_h/gain_h companion slices.
+data_source:
+  reader: h5coro
+  driver: s3
+  groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]
+  coordinates:
+    latitude: "/{group}/heights/lat_ph"
+    longitude: "/{group}/heights/lon_ph"
+  variables:
+    h_ph: "/{group}/heights/h_ph"
+  filters:
+    - dataset: "/{group}/heights/signal_conf_ph"
+      column: 0                  # land surface type; TEP is uniform across columns
+      op: ne
+      value: -2
+  base_level: photons
+  levels:
+    photons:
+      path: "/{group}/heights"
+      coordinates: {latitude: lat_ph, longitude: lon_ph}
+      link: null
+    segments:
+      path: "/{group}/geolocation"
+      coordinates: {latitude: reference_photon_lat, longitude: reference_photon_lon}
+      # Segment-level readable variable (issue #30): dem_h is one value per ~100
+      # photons; broadcast to the photon rows via the link below as a per-photon
+      # ``dem_h`` column the chunk_precompute reduces.
+      variables:
+        dem_h: "/{group}/geophys_corr/dem_h"
+      link:
+        to: photons
+        index_beg: "/{group}/geolocation/ph_index_beg"
+        count: "/{group}/geolocation/segment_ph_cnt"
+        index_base: 1            # ATL03 ph_index_beg is 1-based per the v3 dict
+  read_plan:
+    spatial_index: segments
+    pad: 1                       # one segment of padding on each side per #43
+
+aggregation:
+  coordinates:
+    cell_ids:
+      dtype: uint64
+      fill_value: 0
+    morton:
+      dtype: uint64
+      fill_value: 0
+  # Evaluated ONCE per inner chunk over that chunk's pooled photons, before the
+  # per-cell loop; the names below enter the per-cell expression namespace.
+  chunk_precompute:
+    # ``np.maximum`` (not the ``max`` builtin) floors the gain at 0.5 m, and the
+    # range uses ``np.max``/``np.min`` (not ndarray methods): the expression
+    # sandbox runs with an empty ``__builtins__`` where an ndarray method call
+    # raises but the functional numpy form is fine. The range is floored at 1e-6 m
+    # BEFORE log2 so an all-equal-height chunk (range == 0) does not hit log2(0).
+    chunk_gain:
+      expression: "np.float32(np.maximum(0.5, 2.0 ** np.ceil(np.log2(np.maximum(1e-6, np.max(h_ph) - np.min(h_ph)) / 128.0))))"
+      source: h_ph
+      dtype: float32
+    chunk_offset:
+      # DEM-anchored: the chunk's absolute frame is the reference DEM, not the
+      # photon cloud's own median. dem_h rides the segment->photon broadcast above.
+      expression: "np.float32(np.floor(np.min(dem_h)))"
+      source: dem_h
+      dtype: float32
+  variables:
+    waveform_counts:
+      kind: vector
+      trailing_shape: 128
+      # references the chunk-level anchor/gain, so every cell in the chunk shares
+      # one bin window (the floor(min(dem_h)) anchor at bin 28).
+      expression: "np.histogram(h_ph, 128, (chunk_offset - 27.0 * chunk_gain, chunk_offset + 101.0 * chunk_gain))[0].astype('uint32')"
+      source: h_ph
+      dtype: uint32
+      fill_value: 0
+    offset_h:
+      # the chunk bin-0 absolute elevation, recorded ONCE per chunk.
+      expression: "chunk_offset"
+      source: h_ph
+      dtype: float32
+      resolution: chunk
+    gain_h:
+      # the chunk vertical bin width (m), recorded ONCE per chunk.
+      expression: "chunk_gain"
+      source: h_ph
+      dtype: float32
+      resolution: chunk
+
+output:
+  grid:
+    type: healpix
+    indexing_scheme: nested
+    parent_order: 11             # shard / dispatch unit: 4^(19-11) = 256x256 cells
+    chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=16 per shard)
+    child_order: 19              # leaf cell resolution (~10 m)

--- a/src/zagg/configs/atl03_tdigest_healpix.yaml
+++ b/src/zagg/configs/atl03_tdigest_healpix.yaml
@@ -1,0 +1,91 @@
+# ATL03 photon-height t-digest template (HEALPix, multi-chunk-per-worker).
+#
+# Per-cell approximate-quantile sketch: each grid cell stores a t-digest of its
+# photon heights (h_ph) as a ``kind: ragged`` CSR field. A t-digest is a small,
+# mergeable set of (mean, weight) centroids from which any quantile (median,
+# p5/p95, IQR, ...) is recovered at read time -- far cheaper than storing every
+# photon, and exact-enough in the tails. The reducer is the pure-numpy
+# ``zagg.stats.tdigest.build_tdigest`` (issue #48), resolved as the field's
+# ``function`` via ``zagg.config.resolve_function`` (dotted path). ``delta`` is
+# the centroid budget (accuracy knob): ~delta centroids per cell regardless of
+# photon count. Read the digests back with ``zagg.readers.tdigest_tensor``.
+#
+# Grid is HEALPix nested at child_order 19 (the ~10 m cell, now that mortie 0.8.1
+# resolves past the old order-18 reference cap). Multi-chunk-per-worker (issue
+# #30 item 3) is on: one shard (the dispatch unit, parent_order 11 = 256x256
+# cells) owns K = 16 finer Zarr chunks (chunk_inner 13 = 64x64 cells each). The
+# worker reads the shard's granules once and writes 16 chunk regions + 16 CSR
+# groups, one per inner chunk. chunk_inner unset would collapse to K=1 (shard ==
+# chunk), byte-identical to the single-chunk path.
+#
+# Confidence filter, multi-level form and read_plan match atl03.yaml (the planned
+# segment->photon IO of issue #43 applies here too); only the aggregation differs.
+data_source:
+  reader: h5coro
+  driver: s3
+  groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]
+  coordinates:
+    latitude: "/{group}/heights/lat_ph"
+    longitude: "/{group}/heights/lon_ph"
+  variables:
+    h_ph: "/{group}/heights/h_ph"
+  filters:
+    - dataset: "/{group}/heights/signal_conf_ph"
+      column: 0                  # land surface type; TEP is uniform across columns
+      op: ne
+      value: -2
+  base_level: photons
+  levels:
+    photons:
+      path: "/{group}/heights"
+      coordinates: {latitude: lat_ph, longitude: lon_ph}
+      link: null
+    segments:
+      path: "/{group}/geolocation"
+      coordinates: {latitude: reference_photon_lat, longitude: reference_photon_lon}
+      link:
+        to: photons
+        index_beg: "/{group}/geolocation/ph_index_beg"
+        count: "/{group}/geolocation/segment_ph_cnt"
+        index_base: 1            # ATL03 ph_index_beg is 1-based per the v3 dict
+  read_plan:
+    spatial_index: segments
+    pad: 1                       # one segment of padding on each side per #43
+
+aggregation:
+  coordinates:
+    cell_ids:
+      dtype: uint64
+      fill_value: 0
+    morton:
+      dtype: uint64
+      fill_value: 0
+  variables:
+    count:
+      function: len
+      source: h_ph
+      dtype: int32
+      fill_value: 0
+    h_tdigest:
+      # Per-cell t-digest of photon heights: a ragged (CSR) field whose payload
+      # is an (n_centroids, 2) array of (mean, weight) centroids. ``build_tdigest``
+      # is called as build_tdigest(h_ph_values, delta=256); ``inner_shape: [2]``
+      # declares the per-element centroid width. To store ONE digest per chunk
+      # instead of per cell, add ``resolution: chunk`` (one CSR payload per inner
+      # chunk under the chunk-uniform contract).
+      kind: ragged
+      function: "zagg.stats.tdigest.build_tdigest"
+      source: h_ph
+      inner_shape: [2]
+      params:
+        delta: 256
+      dtype: float32
+      fill_value: 0
+
+output:
+  grid:
+    type: healpix
+    indexing_scheme: nested
+    parent_order: 11             # shard / dispatch unit: 4^(19-11) = 256x256 cells
+    chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=16 per shard)
+    child_order: 19              # leaf cell resolution (~10 m)

--- a/src/zagg/grids/base.py
+++ b/src/zagg/grids/base.py
@@ -7,8 +7,8 @@ storage-block mapping, footprint geometry, and Zarr template emission.
 Terminology
 -----------
 - **leaf id** — the high-precision spatial identifier returned by ``assign``.
-  Grid-specific (HEALPix: order-18 morton; rectilinear: flat row-major cell
-  index). Pipeline code treats it as an opaque integer.
+  Grid-specific (HEALPix: morton at the grid's reference order; rectilinear:
+  flat row-major cell index). Pipeline code treats it as an opaque integer.
 - **cell id** — the aggregation-grid identifier returned by ``cells_of`` and
   ``children``. For some grids (rectilinear) leaf id and cell id coincide.
 - **shard key** — the write-partition identifier returned by ``shard_of``.

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -20,7 +20,14 @@ from zagg.grids.base import InconsistentShardError, chunk_array_spec, vector_arr
 from zagg.grids.morton import to_morton_array
 
 HEALPIX_BASE_CELLS: int = 12
-HEALPIX_REF_ORDER: int = 18  # mortie's clip2order reference order; do not change
+# Reference order at which ``assign`` resolves points before ``cells_of`` /
+# ``shards_of`` coarsen down to ``child_order`` / ``parent_order``. It must be
+# >= the finest ``child_order`` any grid uses, or that resolution is silently
+# lost (``clip2order`` cannot refine past its input order). mortie 0.8.1 supports
+# orders up to 29, so this is the cap. Coarsening from a deeper reference is
+# byte-identical for any order <= the old value, so raising it leaves existing
+# grids' cell/shard assignments unchanged (verified for the shipped configs).
+HEALPIX_REF_ORDER: int = 29
 
 
 class HealpixGrid:
@@ -207,15 +214,17 @@ class HealpixGrid:
     def assign(self, lats, lons) -> np.ndarray:
         """Map (lat, lon) points to morton IDs at the HEALPix reference order.
 
-        Returns morton at order 18 — mortie's ``clip2order`` requires its
-        input at that fixed reference order to clip correctly.
+        Returns morton at :data:`HEALPIX_REF_ORDER` — the finest order zagg
+        resolves to. ``cells_of`` / ``shards_of`` then coarsen this down to
+        ``child_order`` / ``parent_order`` via ``clip2order``, so the reference
+        must be at least as fine as the grid's ``child_order``.
         """
         from mortie import geo2mort
 
         return geo2mort(lats, lons, order=HEALPIX_REF_ORDER)
 
     def shards_of(self, leaf_ids) -> np.ndarray:
-        """Vectorized parent-morton lookup. ``leaf_ids`` must be at order 18."""
+        """Vectorized parent-morton lookup. ``leaf_ids`` at :data:`HEALPIX_REF_ORDER`."""
         from mortie import clip2order
 
         return clip2order(self.parent_order, np.asarray(leaf_ids))

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -230,7 +230,7 @@ class HealpixGrid:
         return clip2order(self.parent_order, np.asarray(leaf_ids))
 
     def cells_of(self, leaf_ids) -> np.ndarray:
-        """Coarsen order-18 leaf morton IDs to ``child_order`` cell IDs."""
+        """Coarsen reference-order leaf morton IDs to ``child_order`` cell IDs."""
         from mortie import clip2order
 
         return clip2order(self.child_order, np.asarray(leaf_ids))

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -203,6 +203,52 @@ class TestRoundTrip:
         assert cell_ids.shape == children.shape
 
 
+class TestReferenceOrder:
+    """Regression: the HEALPix assign reference order must reach mortie 0.8.1's
+    max (29), not the old hardcoded 18 -- otherwise a fine ``child_order`` is
+    silently collapsed onto order 18 (no added resolution)."""
+
+    def test_ref_order_supports_fine_child_orders(self):
+        from zagg.grids.healpix import HEALPIX_REF_ORDER
+
+        assert HEALPIX_REF_ORDER >= 19  # mortie 0.8.1 resolves up to 29
+
+    def test_child_order_19_refines_order_18(self):
+        # The bug: ``assign`` pinned points at order 18, so ``child_order=19``
+        # produced the SAME cells as ``child_order=18``. They must now differ.
+        rng = np.random.default_rng(0)
+        lats = rng.uniform(-89, 89, 2000)
+        lons = rng.uniform(-179, 179, 2000)
+        g18 = HealpixGrid(parent_order=10, child_order=18, layout="fullsphere")
+        g19 = HealpixGrid(parent_order=11, child_order=19, layout="fullsphere")
+        c18 = g18.cells_of(g18.assign(lats, lons))
+        c19 = g19.cells_of(g19.assign(lats, lons))
+        assert not np.array_equal(c19, c18)
+
+    def test_existing_order_assignment_unchanged(self):
+        # Raising the reference order must NOT move existing (<= 18) assignments:
+        # coarsening order-12 cells from a deeper reference is byte-identical to
+        # the pre-fix order-18 reference, so shipped configs' outputs don't drift.
+        from mortie import clip2order, geo2mort
+
+        rng = np.random.default_rng(3)
+        lats = rng.uniform(-89, 89, 2000)
+        lons = rng.uniform(-179, 179, 2000)
+        g = HealpixGrid(parent_order=6, child_order=12, layout="fullsphere")
+        cells = g.cells_of(g.assign(lats, lons))
+        cells_via18 = clip2order(12, geo2mort(lats, lons, order=18))
+        assert np.array_equal(cells, cells_via18)
+
+    def test_order_19_nesting_holds(self):
+        # An order-19 child cell coarsens back to its order-11 parent shard.
+        g = HealpixGrid(parent_order=11, chunk_inner=13, child_order=19, layout="fullsphere")
+        leaves = g.assign(np.array([38.89, -45.0]), np.array([-76.5, 30.0]))
+        for shard in np.unique(g.shards_of(leaves)):
+            children = g.children(int(shard))
+            assert len(children) == 4 ** (19 - 11)
+            assert np.all(g.shards_of(children) == int(shard))
+
+
 class TestFromConfig:
     def test_healpix_default_fullsphere(self, cfg):
         # No layout in YAML → fullsphere (default since dense was deprecated).

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -248,6 +248,29 @@ class TestReferenceOrder:
             assert len(children) == 4 ** (19 - 11)
             assert np.all(g.shards_of(children) == int(shard))
 
+    def test_assign_morton_exceeds_int64(self):
+        # Order-29 ``assign`` produces morton values past int64's max (bit 63
+        # set) -- they must be carried unsigned, never silently truncated/signed.
+        g = HealpixGrid(parent_order=11, child_order=19, layout="fullsphere")
+        rng = np.random.default_rng(11)
+        leaves = np.asarray(g.assign(rng.uniform(-89, 89, 50000), rng.uniform(-179, 179, 50000)))
+        mx = int(leaves.max())
+        assert mx > np.iinfo(np.int64).max  # would be negative if stored signed
+        assert mx <= np.iinfo(np.uint64).max
+
+    def test_order_19_template_emits(self):
+        # The order-19 + chunk_inner template emits sanely: cell-resolution arrays
+        # at the full 12*4^19 grid, ``resolution: chunk`` companions at the chunk
+        # grid (12*4^13). The nominal 3.3e12 cell array is metadata-only.
+        cfg = default_config("atl03_gain_bias_healpix")
+        g = from_config(cfg)
+        store = MemoryStore()
+        g.emit_template(store)
+        group = open_group(store, path=str(g.child_order), mode="r")
+        assert group["waveform_counts"].shape == (HEALPIX_BASE_CELLS * 4**19, 128)
+        assert group["offset_h"].shape == (HEALPIX_BASE_CELLS * 4**13,)
+        assert group["gain_h"].shape == (HEALPIX_BASE_CELLS * 4**13,)
+
 
 class TestFromConfig:
     def test_healpix_default_fullsphere(self, cfg):


### PR DESCRIPTION
## What

1. **Fix: lift the HEALPix assign reference order so `child_order` > 18 actually resolves.** `HealpixGrid.assign()` pinned point resolution at `HEALPIX_REF_ORDER = 18` (commented *"do not change"*), then `cells_of`/`shards_of` coarsen down. mortie 0.8.1 resolves up to order 29, but with the reference pinned at 18 any `child_order > 18` was **silently collapsed to order 18** (verified: order-19 cells were byte-identical to order-18 for 5000 random points). This raises the constant to **29** (mortie's max). #75 fixed the morton *dtype* but never lifted this pin.

2. **Two HEALPix order-19 test templates** (multi-chunk-per-worker), for exercising the #82/#30/#48 work end-to-end:
   - `configs/atl03_tdigest_healpix.yaml` — per-cell **t-digest** of photon heights (`kind: ragged`, `function: zagg.stats.tdigest.build_tdigest`, `inner_shape: [2]`, `delta: 256`), stored as CSR.
   - `configs/atl03_gain_bias_healpix.yaml` — **per-chunk gain/bias**: `chunk_precompute` DEM-anchored `chunk_offset` + power-of-two `chunk_gain`, with `offset_h`/`gain_h` as `resolution: chunk` companions.

Both grids: `parent_order: 11` (shard = 256×256 cells), `chunk_inner: 13` (inner Zarr chunk = 64×64 cells), `child_order: 19` (~10 m leaf) ⇒ **K = 16** inner chunks per shard.

## Safety of the reference-order bump

Coarsening from a *deeper* reference is byte-identical for any order ≤ the old value, so existing configs are unaffected. Verified for the shipped configs: atl06 (order 12) and atl03 (order 18) produce **identical cells _and_ shards** at reference 18 vs 29. The constant has a single usage (`assign`, healpix.py:215).

## What stays at `child_order` (not 29)

The bump only changes the *intermediate* resolution in `assign`; the stored `morton`/`cell_ids` coordinates (and the DGGS `refinement_level`) remain at the grid's `child_order` (19 here), since they come from `children() = generate_morton_children(shard_key, child_order)`. (See the thread for the more general per-observation high-resolution location-morton case, which this bump now makes computable — tracked separately.)

## Deploy note

The fix lives in the **function** code (`src/zagg/grids/healpix.py`, shipped by `build_function.sh`), and `assign`/`cells_of` run inside `process_shard` on the **worker** — so Lambda runs need a **function redeploy** (and the deployed **layer** must carry `mortie ≥ 0.8.1` for `geo2mort(order=29)`). The catalog/shardmap (orchestrator) is unaffected. Local runs pick it up directly. If deploying via `stand_up.sh` (which reads zips from source.coop), that means a fresh Lambda Build → `publish_mirror.sh` → `stand_up.sh`.

## Testing

- `tests/test_grids.py::TestReferenceOrder` (new): reference order ≥ 19; order-19 genuinely refines order-18 (the regression); existing order-12 assignment byte-identical from the deeper reference; order-19 children (65536 = 256×256) nest back to their order-11 shard.
- `uv run pytest tests/test_grids.py tests/test_config.py -q` → 225 passed. Both templates `load_config` + `validate_config` + `from_config` clean (K=16, 4096 cells/chunk). `ruff check`/`format --check` clean on touched files.

## Questions for review

- Reference order set to **29** (mortie's max) rather than a per-grid `max(child_order, …)`. Keeps a single fixed reference and is forward-compatible with high-resolution morton location encoding (order 26/27); flag if you'd prefer it derived from `child_order`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EN7X53ZAyaCca9rjwv9qZw)_