### PR TITLE
spatial-signature shardmap reuse (#89)

### DIFF
--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -9,7 +9,9 @@ The ``ShardMap`` is a small, self-contained JSON plan (option C): each granule
 is recorded with **both** its S3 and HTTPS hrefs so the runner can pick the
 endpoint at dispatch time via ``data_source.driver`` -- the map itself stays
 endpoint-neutral and never needs the Catalog at run time. It also records the
-grid ``signature()`` so a run can refuse a map built for a different grid.
+grid ``spatial_signature()`` (the spatial layout only, no aggregation fields;
+#89) so a run can refuse a map built for a different *spatial* grid while still
+reusing one map across configs that differ only in what they aggregate.
 
 Geometry backends (all sphere-correct):
 
@@ -229,8 +231,12 @@ class ShardMap:
     Parameters
     ----------
     grid_signature : dict
-        ``grid.signature()`` at build time. The runner checks it against the
-        run grid so a map can't be silently paired with a mismatched grid.
+        ``grid.spatial_signature()`` at build time -- the spatial layout only
+        (#89). The runner checks it against the run grid's spatial signature so
+        a map can't be paired with a mismatched *spatial* grid, while staying
+        reusable across configs that differ only in aggregation fields. (Kept as
+        ``grid_signature`` for back-compat; old maps carry the full signature
+        and still validate via a spatial-subset projection.)
     shard_keys : list of int
         Sorted shard keys with at least one granule.
     granules : list of list of dict
@@ -263,7 +269,7 @@ class ShardMap:
             Fetched granule metadata (provides ``granule_records()``).
         grid : OutputGrid
             Output grid (provides ``coverage``, ``shard_footprint``,
-            ``signature``).
+            ``spatial_signature``).
         region : list of (lats, lons), optional
             Coverage mask in WGS84. Defaults to the catalog bbox rectangle.
         backend : {"auto", "spherely", "mortie"}
@@ -310,7 +316,7 @@ class ShardMap:
         }
         if chosen == "mortie":
             meta["mortie_order"] = mortie_order
-        return cls(grid.signature(), shard_keys, granules, meta)
+        return cls(grid.spatial_signature(), shard_keys, granules, meta)
 
     def to_json(self, path: str) -> None:
         """Write the manifest as JSON."""

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -310,11 +310,13 @@ class HealpixGrid:
 
     # ── identity / nesting ───────────────────────────────────────────────
 
-    def signature(self) -> dict:
-        """Canonical fingerprint of the grid's defining parameters.
+    def spatial_signature(self) -> dict:
+        """Structural (spatial-only) fingerprint of the grid.
 
-        Recorded in a ShardMap at build time and re-checked at run time so a
-        shard map can never be silently paired with a different grid.
+        The shard-map reuse guard (``runner._check_signature``, #89) compares
+        this — it is purely the spatial layout (no ``output_fields``), so one
+        ShardMap is reusable across configs that share the spatial grid but
+        declare different aggregation fields.
         """
         return {
             "type": "healpix",
@@ -322,6 +324,17 @@ class HealpixGrid:
             "parent_order": self.parent_order,
             "child_order": self.child_order,
             "layout": self.layout,
+        }
+
+    def signature(self) -> dict:
+        """Canonical fingerprint of the grid's defining parameters.
+
+        The full fingerprint: the spatial layout (:meth:`spatial_signature`)
+        plus the Option-B output-field set. ``nests_with`` (#29) keys on the
+        latter; the shard-map reuse guard keys on the former (#89).
+        """
+        return {
+            **self.spatial_signature(),
             "output_fields": output_field_signature(self.config),
         }
 

--- a/src/zagg/grids/rectilinear.py
+++ b/src/zagg/grids/rectilinear.py
@@ -238,11 +238,13 @@ class RectilinearGrid:
 
     # ── identity / nesting ───────────────────────────────────────────────
 
-    def signature(self) -> dict:
-        """Canonical fingerprint of the grid's defining parameters.
+    def spatial_signature(self) -> dict:
+        """Structural (spatial-only) fingerprint of the grid.
 
-        Recorded in a ShardMap at build time and re-checked at run time so a
-        shard map can never be silently paired with a different grid.
+        The shard-map reuse guard (``runner._check_signature``, #89) compares
+        this — it is purely the spatial layout (no ``output_fields``), so one
+        ShardMap is reusable across configs that share the spatial grid but
+        declare different aggregation fields.
         """
         a = self._geobox.affine
         return {
@@ -251,6 +253,17 @@ class RectilinearGrid:
             "affine": [a.a, a.b, a.c, a.d, a.e, a.f],
             "shape": [self.height, self.width],
             "chunk_shape": [self.chunk_h, self.chunk_w],
+        }
+
+    def signature(self) -> dict:
+        """Canonical fingerprint of the grid's defining parameters.
+
+        The full fingerprint: the spatial layout (:meth:`spatial_signature`)
+        plus the Option-B output-field set. ``nests_with`` (#29) keys on the
+        latter; the shard-map reuse guard keys on the former (#89).
+        """
+        return {
+            **self.spatial_signature(),
             "output_fields": output_field_signature(self.config),
         }
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -163,19 +163,30 @@ def agg(
 
     # Load catalog and determine cell count for worker capping
     catalog_data = _load_catalog(catalog_path)
-    n_cells = len(_select_cells(
-        catalog_data, morton_cell=morton_cell, max_cells=max_cells,
-    ))
+    n_cells = len(
+        _select_cells(
+            catalog_data,
+            morton_cell=morton_cell,
+            max_cells=max_cells,
+        )
+    )
 
     if backend == "local":
         if max_workers is None:
             max_workers = 4
         max_workers = min(max_workers, n_cells)
         return _run_local(
-            config, catalog_data, store_path, child_order,
-            max_cells=max_cells, morton_cell=morton_cell,
-            max_workers=max_workers, overwrite=overwrite,
-            dry_run=dry_run, region=region, driver=resolved_driver,
+            config,
+            catalog_data,
+            store_path,
+            child_order,
+            max_cells=max_cells,
+            morton_cell=morton_cell,
+            max_workers=max_workers,
+            overwrite=overwrite,
+            dry_run=dry_run,
+            region=region,
+            driver=resolved_driver,
             output_credentials=output_credentials,
             output_endpoint_url=resolved_endpoint,
             handoff=handoff,
@@ -189,10 +200,16 @@ def agg(
         if function_name is None:
             function_name = os.environ.get("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard")
         return _run_lambda(
-            config, catalog_data, store_path, child_order,
-            max_cells=max_cells, morton_cell=morton_cell,
-            max_workers=max_workers, overwrite=overwrite,
-            dry_run=dry_run, region=region,
+            config,
+            catalog_data,
+            store_path,
+            child_order,
+            max_cells=max_cells,
+            morton_cell=morton_cell,
+            max_workers=max_workers,
+            overwrite=overwrite,
+            dry_run=dry_run,
+            region=region,
             function_name=function_name,
             output_credentials=output_credentials,
             output_endpoint_url=resolved_endpoint,
@@ -227,8 +244,9 @@ def _load_catalog(catalog_path: str) -> dict:
     )
 
 
-def _select_cells(catalog_data: dict, *, morton_cell: str | None = None,
-                   max_cells: int | None = None) -> list[tuple]:
+def _select_cells(
+    catalog_data: dict, *, morton_cell: str | None = None, max_cells: int | None = None
+) -> list[tuple]:
     """Select (shard_key, granule_urls) pairs from a loaded catalog.
 
     Parameters
@@ -302,14 +320,15 @@ def _check_signature(grid, catalog_data: dict) -> None:
     if stored_spatial != actual:
         raise ValueError(
             "ShardMap was built for a different grid than this run config.\n"
-            f"  shard map : {stored_spatial}\n"
-            f"  run config: {actual}"
+            f"  shard map (spatial): {stored_spatial}\n"
+            f"  run config (spatial): {actual}\n"
+            f"  shard map (raw stored signature): {expected}"
         )
 
 
-def _process_and_write(shard_key, chunk_idx, records, grid,
-                       s3_creds, zarr_store, config, driver=None,
-                       handoff="pandas"):
+def _process_and_write(
+    shard_key, chunk_idx, records, grid, s3_creds, zarr_store, config, driver=None, handoff="pandas"
+):
     """Process a single shard and write its K finer chunks to the store.
 
     Multi-chunk-per-worker (issue #30 item 3): one shard owns
@@ -337,7 +356,8 @@ def _process_and_write(shard_key, chunk_idx, records, grid,
         # write_dataframe_to_zarr no-ops on an empty carrier (DataFrame or Arrow
         # table), so no carrier-specific emptiness check is needed here.
         write_dataframe_to_zarr(
-            carrier, zarr_store,
+            carrier,
+            zarr_store,
             grid=grid,
             chunk_idx=block_index,
         )
@@ -348,17 +368,31 @@ def _process_and_write(shard_key, chunk_idx, records, grid,
         # distinct. No-ops when ``ragged`` is empty.
         ragged_key = int(shard_key) if single_chunk else _block_index_key(block_index, grid)
         write_ragged_to_zarr(
-            ragged, zarr_store,
+            ragged,
+            zarr_store,
             grid=grid,
             shard_key=ragged_key,
         )
     return metadata
 
 
-def _run_local(config, catalog_data, store_path, child_order, *,
-               max_cells, morton_cell, max_workers, overwrite, dry_run, region,
-               driver="s3", output_credentials=None, output_endpoint_url=None,
-               handoff="pandas"):
+def _run_local(
+    config,
+    catalog_data,
+    store_path,
+    child_order,
+    *,
+    max_cells,
+    morton_cell,
+    max_workers,
+    overwrite,
+    dry_run,
+    region,
+    driver="s3",
+    output_credentials=None,
+    output_endpoint_url=None,
+    handoff="pandas",
+):
     """Run processing locally via the generic dispatch loop on a thread pool.
 
     This is the trivial backend: a :class:`~zagg.dispatch.LocalExecutor` over a
@@ -371,7 +405,9 @@ def _run_local(config, catalog_data, store_path, child_order, *,
     all_shards = list(catalog_data["shard_keys"])
 
     cells = _select_cells(catalog_data, morton_cell=morton_cell, max_cells=max_cells)
-    logger.info(f"Processing {len(cells)} of {len(all_shards)} cells (local, {max_workers} workers, driver={driver})")
+    logger.info(
+        f"Processing {len(cells)} of {len(all_shards)} cells (local, {max_workers} workers, driver={driver})"
+    )
 
     if dry_run:
         return _dry_run_summary(cells, store_path)
@@ -386,6 +422,7 @@ def _run_local(config, catalog_data, store_path, child_order, *,
     # shard map built for a different grid. For HEALPix-dense, populated_shards
     # order matches the catalog's shard_keys list (sorted at build time).
     from zagg.grids import from_config
+
     layout = get_layout(config)
     grid_type = config.output.get("grid", {}).get("type", "healpix")
     if grid_type == "healpix" and layout == "dense":
@@ -394,8 +431,10 @@ def _run_local(config, catalog_data, store_path, child_order, *,
         grid = from_config(config)
     _check_signature(grid, catalog_data)
     zarr_store = open_store(
-        store_path, region=region,
-        credentials=output_credentials, endpoint_url=output_endpoint_url,
+        store_path,
+        region=region,
+        credentials=output_credentials,
+        endpoint_url=output_endpoint_url,
     )
     zarr_store = grid.emit_template(zarr_store, overwrite=overwrite)
 
@@ -407,17 +446,24 @@ def _run_local(config, catalog_data, store_path, child_order, *,
         shard_key, records = payload
         try:
             meta = _process_and_write(
-                shard_key, grid.block_index(int(shard_key)), records,
+                shard_key,
+                grid.block_index(int(shard_key)),
+                records,
                 grid,
-                s3_creds, zarr_store, config,
-                driver=driver, handoff=handoff,
+                s3_creds,
+                zarr_store,
+                config,
+                driver=driver,
+                handoff=handoff,
             )
             return {"shard_key": shard_key, "ok": True, "meta": meta}
         except Exception as e:
             return {"shard_key": shard_key, "ok": False, "error": e}
 
     executor = LocalExecutor(
-        _cell_work, max_workers=max_workers, pool_factory=ThreadPoolExecutor,
+        _cell_work,
+        max_workers=max_workers,
+        pool_factory=ThreadPoolExecutor,
     )
     executor.preflight(len(cells))
 
@@ -443,7 +489,10 @@ def _run_local(config, catalog_data, store_path, child_order, *,
     start_time = time.time()
     try:
         report = dispatch(
-            executor, cells, retry=LOCAL_RETRY, accumulate=_accumulate,
+            executor,
+            cells,
+            retry=LOCAL_RETRY,
+            accumulate=_accumulate,
         )
     finally:
         executor.shutdown()
@@ -461,14 +510,28 @@ def _run_local(config, catalog_data, store_path, child_order, *,
         "backend": "local",
         "results": report.results,
     }
-    logger.info(f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s")
+    logger.info(
+        f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"
+    )
     return summary
 
 
-def _run_lambda(config, catalog_data, store_path, child_order, *,
-                max_cells, morton_cell, max_workers, overwrite, dry_run,
-                region, function_name,
-                output_credentials=None, output_endpoint_url=None):
+def _run_lambda(
+    config,
+    catalog_data,
+    store_path,
+    child_order,
+    *,
+    max_cells,
+    morton_cell,
+    max_workers,
+    overwrite,
+    dry_run,
+    region,
+    function_name,
+    output_credentials=None,
+    output_endpoint_url=None,
+):
     """Run processing via AWS Lambda invocation.
 
     The fan-out -> retry -> measured-cost loop is the generic
@@ -507,6 +570,7 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
     # Build grid from the run config (single source of truth); enforce the
     # shard map was built for the same grid.
     from zagg.grids import from_config
+
     layout = get_layout(config)
     if grid_type == "healpix" and layout == "dense":
         grid = from_config(config, populated_shards=[int(s) for s in all_shards])
@@ -518,7 +582,9 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
     # Build the optional output_credentials event block (write side, symmetric
     # to s3_credentials on the read side). None -> execution-role writes.
     output_creds_event = _build_output_creds_event(
-        output_credentials, output_endpoint_url, region,
+        output_credentials,
+        output_endpoint_url,
+        region,
     )
 
     # The dispatch lambda_client is built inside preflight() (once the probe
@@ -538,7 +604,10 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
         probe_lambda = session.client("lambda", region_name=region)
         cloudwatch_client = session.client("cloudwatch", region_name=region)
         clamped, concurrency_report = compute_available_workers(
-            max_workers, probe_lambda, cloudwatch_client, function_name,
+            max_workers,
+            probe_lambda,
+            cloudwatch_client,
+            function_name,
         )
         _log_concurrency_report(concurrency_report, clamped)
 
@@ -554,7 +623,9 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
         )
         state["workers"] = clamped
         state["lambda_client"] = session.client(
-            "lambda", region_name=region, config=boto_config,
+            "lambda",
+            region_name=region,
+            config=boto_config,
         )
         return PreflightReport(workers=clamped, detail=concurrency_report)
 
@@ -564,9 +635,14 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
     def _cell_work(payload):
         shard_key, records = payload
         return _invoke_lambda_cell(
-            state["lambda_client"], grid.block_index(int(shard_key)), int(shard_key),
-            parent_order, child_order,
-            _resolve_urls(records, "s3"), store_path, s3_creds,
+            state["lambda_client"],
+            grid.block_index(int(shard_key)),
+            int(shard_key),
+            parent_order,
+            child_order,
+            _resolve_urls(records, "s3"),
+            store_path,
+            s3_creds,
             function_name=function_name,
             config_dict=config_dict,
             output_creds_event=output_creds_event,
@@ -578,7 +654,9 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
         preflight_fn=_preflight,
         pool_factory=ThreadPoolExecutor,
         finalize_fn=lambda: _invoke_lambda_finalize(
-            state["lambda_client"], function_name, store_path,
+            state["lambda_client"],
+            function_name,
+            store_path,
             output_creds_event=output_creds_event,
         ),
     )
@@ -591,10 +669,14 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
     # direct S3 access to the output bucket is required (works cleanly
     # for cross-account callers like CryoCloud).
     _invoke_lambda_setup(
-        state["lambda_client"], function_name, store_path,
-        parent_order=parent_order, child_order=child_order,
+        state["lambda_client"],
+        function_name,
+        store_path,
+        parent_order=parent_order,
+        child_order=child_order,
         n_parent_cells=len(all_shards) if grid_type == "healpix" and layout == "dense" else None,
-        overwrite=overwrite, config_dict=config_dict,
+        overwrite=overwrite,
+        config_dict=config_dict,
         output_creds_event=output_creds_event,
     )
 
@@ -663,8 +745,12 @@ def _run_lambda(config, catalog_data, store_path, child_order, *,
         "function_name": function_name,
         "results": report.results,
     }
-    logger.info(f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s")
-    logger.info(f"Lambda compute: {total_lambda_time:.0f}s total, {gb_seconds:.0f} GB-s, ~${estimated_cost:.2f}")
+    logger.info(
+        f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"
+    )
+    logger.info(
+        f"Lambda compute: {total_lambda_time:.0f}s total, {gb_seconds:.0f} GB-s, ~${estimated_cost:.2f}"
+    )
     return summary
 
 
@@ -751,9 +837,18 @@ def _log_concurrency_report(report: ConcurrencyReport, max_workers: int) -> None
         )
 
 
-def _invoke_lambda_setup(lambda_client, function_name, store_path, *,
-                         parent_order, child_order, n_parent_cells,
-                         overwrite, config_dict, output_creds_event=None):
+def _invoke_lambda_setup(
+    lambda_client,
+    function_name,
+    store_path,
+    *,
+    parent_order,
+    child_order,
+    n_parent_cells,
+    overwrite,
+    config_dict,
+    output_creds_event=None,
+):
     """Invoke Lambda in setup mode to create the zarr template."""
     event = {
         "mode": "setup",
@@ -779,8 +874,7 @@ def _invoke_lambda_setup(lambda_client, function_name, store_path, *,
         raise RuntimeError(f"Lambda setup error: {result.get('body')}")
 
 
-def _invoke_lambda_finalize(lambda_client, function_name, store_path,
-                            output_creds_event=None):
+def _invoke_lambda_finalize(lambda_client, function_name, store_path, output_creds_event=None):
     """Invoke Lambda in finalize mode to consolidate zarr metadata."""
     event = {"mode": "finalize", "store_path": store_path}
     if output_creds_event is not None:
@@ -799,9 +893,19 @@ def _invoke_lambda_finalize(lambda_client, function_name, store_path,
 
 
 def _invoke_lambda_cell(
-    lambda_client, chunk_idx, shard_key, parent_order, child_order,
-    granule_urls, store_path, s3_credentials, *,
-    function_name, config_dict, output_creds_event=None, max_retries=3,
+    lambda_client,
+    chunk_idx,
+    shard_key,
+    parent_order,
+    child_order,
+    granule_urls,
+    store_path,
+    s3_credentials,
+    *,
+    function_name,
+    config_dict,
+    output_creds_event=None,
+    max_retries=3,
     max_workers=None,
 ):
     """Invoke Lambda for a single cell with retry logic.
@@ -880,10 +984,15 @@ def _invoke_lambda_cell(
             # loudly with ulimit guidance instead (#28).
             raise_for_fd_exhaustion(e, max_workers)
             last_error = str(e)
-            retryable = ["TooManyRequestsException", "Rate exceeded",
-                         "Read timeout", "timed out", "UNEXPECTED_EOF"]
+            retryable = [
+                "TooManyRequestsException",
+                "Rate exceeded",
+                "Read timeout",
+                "timed out",
+                "UNEXPECTED_EOF",
+            ]
             if any(x in last_error for x in retryable):
-                time.sleep((2 ** attempt) + (time.time() % 1))
+                time.sleep((2**attempt) + (time.time() % 1))
             else:
                 break
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -285,13 +285,24 @@ def _resolve_urls(records: list, driver: str | None) -> list[str]:
 
 
 def _check_signature(grid, catalog_data: dict) -> None:
-    """Refuse a ShardMap built for a different grid than the run config."""
+    """Refuse a ShardMap built for a different *spatial* grid than the run config.
+
+    A ShardMap is a spatial artifact (shard keys + granule→shard assignment), so
+    the guard compares only the spatial signature (#89) — one map is reusable
+    across configs that share the spatial grid but declare different aggregation
+    fields. The stored ``grid_signature`` is projected onto the spatial keys, so
+    both new spatial-only maps and old full-signature maps (which also carry
+    ``output_fields``) validate.
+    """
     expected = catalog_data.get("grid_signature")
-    actual = grid.signature()
-    if expected is not None and expected != actual:
+    if expected is None:
+        return
+    actual = grid.spatial_signature()
+    stored_spatial = {k: expected.get(k) for k in actual}
+    if stored_spatial != actual:
         raise ValueError(
             "ShardMap was built for a different grid than this run config.\n"
-            f"  shard map : {expected}\n"
+            f"  shard map : {stored_spatial}\n"
             f"  run config: {actual}"
         )
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -5,7 +5,8 @@ import json
 import pytest
 
 from zagg.config import default_config
-from zagg.runner import _load_catalog, _select_cells, agg
+from zagg.grids import HealpixGrid, RectilinearGrid, from_config
+from zagg.runner import _check_signature, _load_catalog, _select_cells, agg
 
 
 @pytest.fixture
@@ -119,6 +120,82 @@ class TestLoadCatalog:
         p.write_text(json.dumps(old))
         with pytest.raises(ValueError, match="not a Phase-5 ShardMap"):
             _load_catalog(str(p))
+
+
+class TestCheckSignature:
+    """The shard-map reuse guard compares the *spatial* signature only (#89).
+
+    A ShardMap is a spatial artifact, so it must validate any config that shares
+    the spatial grid while declaring different aggregation fields, and still
+    reject a genuinely different spatial grid. Old (full-signature) maps keep
+    validating via a spatial-subset projection.
+    """
+
+    @staticmethod
+    def _grid(name):
+        return from_config(default_config(name))
+
+    @staticmethod
+    def _catalog(grid_signature):
+        return {"metadata": {}, "grid_signature": grid_signature,
+                "shard_keys": [0], "granules": [[_rec(1)]]}
+
+    def test_cross_aggregator_reuse_healpix(self):
+        # Headline: a map built for tdigest validates a gain_bias run (same
+        # parent11/chunk_inner13/child19 spatial grid, different agg fields).
+        tdigest = self._grid("atl03_tdigest_healpix")
+        gain_bias = self._grid("atl03_gain_bias_healpix")
+        assert tdigest.signature() != gain_bias.signature()  # full sigs differ
+        built = self._catalog(tdigest.spatial_signature())
+        _check_signature(gain_bias, built)  # no raise
+        # ... and the reverse.
+        _check_signature(tdigest, self._catalog(gain_bias.spatial_signature()))
+
+    def test_different_spatial_grid_raises_healpix(self):
+        a = HealpixGrid(6, 12, layout="fullsphere")
+        built = self._catalog(a.spatial_signature())
+        # Different parent_order/child_order -> spatial mismatch -> raise.
+        b = HealpixGrid(7, 13, layout="fullsphere")
+        with pytest.raises(ValueError, match="different grid"):
+            _check_signature(b, built)
+
+    def test_old_full_signature_validates_and_reuses(self):
+        # Back-compat: an OLD-style stored signature carrying output_fields (the
+        # full signature) validates against a matching spatial grid AND is
+        # reusable across differing agg fields (the projection drops output_fields).
+        tdigest = self._grid("atl03_tdigest_healpix")
+        gain_bias = self._grid("atl03_gain_bias_healpix")
+        old = self._catalog(tdigest.signature())  # full sig (incl. output_fields)
+        assert "output_fields" in old["grid_signature"]
+        _check_signature(tdigest, old)  # same config: validates
+        _check_signature(gain_bias, old)  # different agg fields: still reusable
+
+    def test_none_signature_early_return(self):
+        grid = self._grid("atl03_tdigest_healpix")
+        _check_signature(grid, {"metadata": {}})  # no grid_signature key -> no raise
+
+    def test_rectilinear_cross_aggregator_reuse(self):
+        bounds = [359400, 4300740, 369400, 4310740]
+        a = RectilinearGrid("EPSG:32618", 10, bounds, [250, 250],
+                            config=default_config("atl06"))
+        b = RectilinearGrid("EPSG:32618", 10, bounds, [250, 250],
+                            config=default_config("atl06_polar"))
+        assert a.signature() != b.signature()
+        _check_signature(b, self._catalog(a.spatial_signature()))  # no raise
+        _check_signature(b, self._catalog(a.signature()))  # old full sig: also ok
+
+    def test_rectilinear_different_spatial_grid_raises(self):
+        bounds = [359400, 4300740, 369400, 4310740]
+        a = RectilinearGrid("EPSG:32618", 10, bounds, [250, 250])
+        built = self._catalog(a.spatial_signature())
+        # Different resolution/shape -> spatial mismatch.
+        b = RectilinearGrid("EPSG:32618", 20, bounds, [250, 250])
+        with pytest.raises(ValueError, match="different grid"):
+            _check_signature(b, built)
+        # Different CRS -> spatial mismatch.
+        c = RectilinearGrid("EPSG:3031", 10, bounds, [250, 250])
+        with pytest.raises(ValueError, match="different grid"):
+            _check_signature(c, built)
 
 
 class TestDenseDeprecation:
@@ -326,6 +403,7 @@ def _stub_grid():
 
     grid = MagicMock()
     grid.signature.return_value = {}
+    grid.spatial_signature.return_value = {}
     grid.block_index.side_effect = lambda k: (k,)
     grid.emit_template.side_effect = lambda store, overwrite=False: store
     return grid

--- a/tests/test_runner_concurrency.py
+++ b/tests/test_runner_concurrency.py
@@ -30,6 +30,7 @@ def lambda_env(monkeypatch):
     # Stub grid construction (signature must match the catalog).
     grid = MagicMock()
     grid.signature.return_value = {}
+    grid.spatial_signature.return_value = {}
     grid.block_index.side_effect = lambda k: (k,)
     import zagg.grids as grids_mod
 

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -149,8 +149,11 @@ class TestBuildSpherelyBrute:
                 assert set(rec) == {"id", "s3", "https"}
 
     def test_signature_recorded(self, catalog, grid, fake_spherely):
+        # The ShardMap stores the spatial signature only (#89) -- no
+        # output_fields, so the map is reusable across aggregation configs.
         sm = ShardMap.build(catalog, grid, backend="spherely")
-        assert sm.grid_signature == grid.signature()
+        assert sm.grid_signature == grid.spatial_signature()
+        assert "output_fields" not in sm.grid_signature
 
     def test_metadata(self, catalog, grid, fake_spherely):
         sm = ShardMap.build(catalog, grid, backend="spherely")
@@ -261,6 +264,46 @@ class TestIO:
             path = f.name
         with pytest.raises(ValueError, match="missing required key"):
             ShardMap.from_json(path)
+
+    def test_round_trip_preserves_spatial_signature(self, catalog, grid, fake_spherely):
+        # The stored signature is spatial-only and survives JSON round-trip (#89).
+        sm = ShardMap.build(catalog, grid, backend="spherely")
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            sm.to_json(f.name)
+            sm2 = ShardMap.from_json(f.name)
+        assert sm2.grid_signature == grid.spatial_signature()
+        assert "output_fields" not in sm2.grid_signature
+
+
+class TestSpatialSignature:
+    """``spatial_signature()`` is the full signature minus ``output_fields`` (#89)."""
+
+    def test_healpix_excludes_output_fields(self):
+        g = HealpixGrid(6, 12, layout="fullsphere")
+        spatial = g.spatial_signature()
+        assert "output_fields" not in spatial
+        assert g.signature() == {**spatial, "output_fields": g.signature()["output_fields"]}
+
+    def test_rectilinear_excludes_output_fields(self, grid):
+        spatial = grid.spatial_signature()
+        assert "output_fields" not in spatial
+        full = grid.signature()
+        assert full == {**spatial, "output_fields": full["output_fields"]}
+
+    def test_healpix_spatial_signature_invariant_to_agg_fields(self):
+        # Same spatial grid, different aggregation configs -> identical spatial sig.
+        a = HealpixGrid(6, 12, layout="fullsphere", config=default_config("atl06"))
+        b = HealpixGrid(6, 12, layout="fullsphere", config=default_config("atl06_polar"))
+        assert a.signature() != b.signature()  # full sigs differ (output_fields)
+        assert a.spatial_signature() == b.spatial_signature()  # spatial sigs match
+
+    def test_rectilinear_spatial_signature_invariant_to_agg_fields(self):
+        bounds = [359400, 4300740, 369400, 4310740]
+        a = RectilinearGrid("EPSG:32618", 10, bounds, [250, 250],
+                            config=default_config("atl06"))
+        b = RectilinearGrid("EPSG:32618", 10, bounds, [250, 250],
+                            config=default_config("atl06_polar"))
+        assert a.spatial_signature() == b.spatial_signature()
 
     def test_high_base_cell_morton_keys_roundtrip(self):
         """Parent-morton shard keys from southern (base 7-11) cells are large


### PR DESCRIPTION
Closes #89.

## Problem

A ShardMap is a **spatial** artifact (`shard_keys` + granule→shard assignment); it depends only on the spatial grid and the AOI/product/time query, not on what you aggregate. But the reuse guard over-constrained it:

- `runner._check_signature` (`runner.py:287`) did **exact dict-equality** between the run config's `grid.signature()` and the shardmap's stored `grid_signature`.
- `signature()` (both `HealpixGrid` and `RectilinearGrid`) includes `output_fields = output_field_signature(config)`.

So two configs sharing the spatial grid but declaring different aggregation fields produced different signatures and the runner raised `ValueError: ShardMap was built for a different grid than this run config` — even though the shardmap content is byte-identical for both. Concretely, `atl03_tdigest_healpix.yaml` and `atl03_gain_bias_healpix.yaml` share parent_order 11 / chunk_inner 13 / child_order 19, so one shardmap maps both, yet you had to build (and CMR-fetch) two.

## Fix

1. **`spatial_signature()` on both grids** — the structural fingerprint **without** `output_fields` (HEALPix: `type, indexing_scheme, parent_order, child_order, layout`; rect: `type, crs, affine, shape, chunk_shape`). `signature()` now **composes** `spatial_signature()` + `{"output_fields": …}`, so the two stay in sync and `signature()`'s output is byte-identical to before (verified — existing `signature()`/`nests_with` tests unchanged).
2. **`_check_signature` compares the spatial signature**, projecting the stored signature onto the spatial keys: `stored_spatial = {k: expected.get(k) for k in grid.spatial_signature()}`; raise only if `stored_spatial != actual`. The projection drops `output_fields`, so **both** newly-built spatial-only maps **and** old full-signature maps validate, and a map is reusable across agg fields. The `expected is None` early-return is kept.
3. **ShardMap stores the spatial signature going forward** — `ShardMap.build` now stores `grid.spatial_signature()` (field/JSON key stays `grid_signature` for back-compat; `to_json`/`from_json` round-trip unchanged). Docstrings updated.
4. **`nests_with` is unchanged** — it keys on `output_field_signature(self.config)` directly (the #29 co-aggregation guarantee), independent of the signature split.

`grid_from_signature` is not on `main` (it lives in the unmerged #44), so nothing consumes `output_fields` from the stored signature — no extra compat needed there.

## Scope note

**Orchestrator/catalog-side only — no Lambda redeploy.** The worker never calls `_check_signature`; this only affects shardmap build + the run-time reuse guard.

## Files

- `src/zagg/grids/healpix.py`, `src/zagg/grids/rectilinear.py` — add `spatial_signature()`; `signature()` composes it.
- `src/zagg/runner.py` — `_check_signature` projects + compares spatial only.
- `src/zagg/catalog/shardmap.py` — `build` stores spatial signature; docstrings.
- `tests/test_runner.py`, `tests/test_shardmap.py`, `tests/test_runner_concurrency.py` — new coverage + mock-grid stubs for the new method.

## How tested

`uv run pytest -q` → **771 passed, 1 skipped**. `ruff check --select=E,F,W,I --ignore=E501 src tests` clean. mypy unchanged (no new errors/categories vs `main` baseline).

New tests:
- **Headline cross-aggregator reuse** — a shardmap built from `atl03_tdigest_healpix.yaml` validates a run configured with `atl03_gain_bias_healpix.yaml` (same parent11/chunk_inner13/child19 spatial grid, different agg fields), and the reverse, with no raise.
- **Real spatial mismatch still raises** — different `parent_order`/`child_order` (HEALPix); different resolution/shape and different CRS (rect).
- **Back-compat** — an OLD-style stored `grid_signature` carrying `output_fields` (full signature) validates against a matching spatial grid and is reusable across differing agg fields (the projection handles it).
- **`nests_with` semantics unchanged** — covered by existing `signature()`/`nests_with` tests (still distinguishes output-field sets), plus `spatial_signature()` invariance-to-agg-fields tests.
- **Round-trip** — `ShardMap.to_json`/`from_json` preserves the spatial-only signature; `_check_signature` driven directly with built signatures.
- `spatial_signature()` excludes `output_fields` on both grids; `signature() == {**spatial_signature(), "output_fields": …}`.

## Questions for review

- The reuse-guard `ValueError` now prints the **projected** `stored_spatial` (the spatial keys actually compared) rather than the raw stored dict, per the issue's `stored_spatial != actual` framing. If you'd prefer it also echo the raw `expected`, easy to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EN7X53ZAyaCca9rjwv9qZw

---
_Generated by [Claude Code](https://claude.ai/code/session_01EN7X53ZAyaCca9rjwv9qZw)_