### PR TITLE
issue #92: key mortie shardmap MOC order to grid chunk_order

### DIFF
--- a/benchmarks/mortie_order_sweep.py
+++ b/benchmarks/mortie_order_sweep.py
@@ -1,0 +1,149 @@
+"""Mortie MOC-order sweep for the shardmap builder (PR #93 / issue #92).
+
+Benchmarks ``ShardMap.build(..., backend="mortie", mortie_order=K)`` across the
+morton orders @espg requested on the PR -- [9, 12, 13, 15, 16, 17, 18] -- over
+the NEON Maryland AOI (the AOI the PR evidence table used), reporting wall-time,
+total granules selected, and mean granules-per-shard at each order.
+
+OFFLINE NOTE -- this environment has no Earthdata/CMR credentials, so the real
+catalog fetch is not reachable. The granule set here is a **synthetic but
+representative** catalog of thin ICESat-2-style RGT tracks crossing the AOI: each
+"granule" is a narrow (~90 m wide) near-polar diagonal swath, the geometry that
+drove the #92 upsampling degeneracy. Absolute numbers are therefore
+representative, not measured from production granules; the *relative* cost across
+orders (the thing this isolates) is what the sweep compares. Run it in a
+credentialed session against a real ``Catalog`` to get production absolutes.
+
+Run::
+
+    uv run python benchmarks/mortie_order_sweep.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pyarrow as pa
+import stac_geoparquet.arrow as sga
+
+from zagg.catalog.shardmap import _intersect_mortie, _region_parts, _resolve_mortie_order
+from zagg.catalog.sources import Catalog
+from zagg.grids import HealpixGrid
+
+# NEON Maryland AOI, the 10 km box from benchmarks/region_timing.py
+# (center lon=-76.56, lat=38.89; half_lat 0.045, half_lon 0.045/cos(lat)).
+_LAT, _LON = 38.89, -76.56
+_HALF_LAT = 0.045
+_HALF_LON = 0.045 / max(np.cos(np.radians(_LAT)), 1e-3)
+AOI_BBOX = (_LON - _HALF_LON, _LAT - _HALF_LAT, _LON + _HALF_LON, _LAT + _HALF_LAT)
+
+ORDERS = [9, 12, 13, 15, 16, 17, 18]
+
+# Production HEALPix grid from the shipped atl03 healpix configs: parent_order 11
+# shards, chunk_inner 13 inner chunks, child_order 19 leaves.
+GRID = HealpixGrid(11, 19, layout="fullsphere", chunk_inner=13)
+
+
+def _track_item(gid: str, frac: float, n: int = 40) -> dict:
+    """A thin near-polar RGT-style swath crossing the AOI at horizontal offset ``frac``.
+
+    The track runs roughly south->north (high inclination) and is ~90 m wide --
+    the thin diagonal geometry that, at a too-coarse MOC order, upsamples onto
+    every shard (#92). ``frac`` in [0, 1] places it across the AOI width.
+    """
+    x0, y0, x1, y1 = AOI_BBOX
+    lon_c = x0 + frac * (x1 - x0)
+    # ~0.02 deg inclination skew over the AOI height, ~0.0004 deg (~90 m) half-width.
+    lats = np.linspace(y0, y1, n)
+    skew = 0.02 * (lats - y0) / (y1 - y0)
+    lon_l = lon_c - 0.0004 + skew
+    lon_r = lon_c + 0.0004 + skew
+    ring_lon = np.concatenate([lon_l, lon_r[::-1], lon_l[:1]])
+    ring_lat = np.concatenate([lats, lats[::-1], lats[:1]])
+    ring = [[float(lo), float(la)] for lo, la in zip(ring_lon, ring_lat)]
+    return {
+        "type": "Feature",
+        "stac_version": "1.0.0",
+        "id": gid,
+        "geometry": {"type": "Polygon", "coordinates": [ring]},
+        "bbox": [
+            float(ring_lon.min()),
+            float(ring_lat.min()),
+            float(ring_lon.max()),
+            float(ring_lat.max()),
+        ],
+        "properties": {"datetime": "2025-06-01T00:00:00Z"},
+        "collection": "ATL03",
+        "stac_extensions": [],
+        "links": [],
+        "assets": {
+            "data": {"href": f"https://h/{gid}.h5", "roles": ["data"]},
+            "data_s3": {"href": f"s3://b/{gid}.h5", "roles": ["data"]},
+        },
+    }
+
+
+def _catalog(n_tracks: int = 12) -> Catalog:
+    """``n_tracks`` thin swaths fanned across the AOI.
+
+    A sparse fan (default 12) so footprints do not blanket every shard -- the
+    regime where a finer MOC order can tighten footprint edges and a coarser one
+    over-commits. (66, the PR evidence count, blankets this small AOI and hides
+    the cross-order footprint difference; the sparse fan exposes it.)
+    """
+    items = [_track_item(f"G{i:03d}", i / max(n_tracks - 1, 1)) for i in range(n_tracks)]
+    return Catalog(
+        pa.table(sga.parse_stac_items_to_arrow(items)),
+        {"collection": "ATL03", "bbox": list(AOI_BBOX)},
+    )
+
+
+def main() -> None:
+    catalog = _catalog()
+    n_granules = len(catalog.granule_records())
+    print(f"AOI bbox: {AOI_BBOX}")
+    print(
+        f"grid: parent_order={GRID.parent_order} chunk_order={GRID.chunk_order} "
+        f"child_order={GRID.child_order}"
+    )
+    print(f"synthetic granules in catalog: {n_granules}\n")
+
+    records = catalog.granule_records()
+    parts = _region_parts(None, catalog.metadata)
+    all_shards = set(int(s) for s in GRID.coverage(parts))
+    print(f"AOI shards (order {GRID.parent_order}) covering the box: {len(all_shards)}\n")
+
+    # Order at or below parent_order trips the #92 guard in the real builder; the
+    # sweep still *measures* what those orders would do by calling the intersection
+    # directly, flagging which orders the production guard rejects.
+    rows = []
+    for order in ORDERS:
+        guard_ok = True
+        try:
+            _resolve_mortie_order(order, GRID)
+        except ValueError:
+            guard_ok = False
+        t0 = time.perf_counter()
+        shard_to_idx = _intersect_mortie(records, GRID, all_shards, order=order)
+        wall = time.perf_counter() - t0
+        n_shards = len(shard_to_idx)
+        pairs = sum(len(v) for v in shard_to_idx.values())
+        gps = pairs / n_shards if n_shards else 0.0
+        sel = len({i for v in shard_to_idx.values() for i in v})
+        rows.append((order, wall, sel, n_shards, gps, guard_ok))
+        flag = "" if guard_ok else "  (REJECTED by #92 guard: order < parent_order)"
+        print(
+            f"order={order:>2}  wall={wall:7.3f}s  granules_selected={sel:>3}  "
+            f"shards={n_shards:>5}  granules/shard={gps:7.2f}{flag}"
+        )
+
+    print("\n| morton order | run time (s) | granules selected | granules/shard (mean) | guard |")
+    print("|---|---|---|---|---|")
+    for order, wall, sel, _n, gps, guard_ok in rows:
+        state = "ok" if guard_ok else "rejected (<parent_order)"
+        print(f"| {order} | {wall:.3f} | {sel} | {gps:.2f} | {state} |")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -83,20 +83,27 @@ def _resolve_mortie_order(mortie_order, grid) -> int:
     order resolves to 13. Keying the MOC to the chunk order matches the unit work
     is dispatched at: footprints resolve no finer than the chunk the worker reads,
     which is enough to keep ``moc_to_order`` from upsampling onto neighbor shards
-    (#92) at near-minimal compute -- a benchmark sweep showed granules/shard is
-    flat for every order >= ``parent_order`` while wall-time grows with order, so
-    a finer MOC buys precision the order-``parent_order`` shard cells can't see.
+    (#92) at near-minimal compute -- the order-sweep benchmark
+    (``benchmarks/mortie_order_sweep.py``) shows granules/shard flat for every
+    order >= ``parent_order`` while wall-time grows with order, so a finer MOC
+    buys precision the order-``parent_order`` shard cells can't see.
     The order is still clamped to ``MORTIE_MOC_ORDER_CAP`` (mortie's order-18
     coverage cap) before the ``parent_order`` guard, so an exotic ``chunk_order``
     past the cap can't make mortie raise into the swallowing ``except`` (silent
-    coverage loss). An explicit ``mortie_order`` is honored but still validated
-    against ``parent_order``. Non-HEALPix grids (no ``parent_order`` /
-    ``child_order``) keep the legacy default of 8.
+    coverage loss). The clamp comes *before* the guard, so a ``parent_order``
+    itself above the cap (the clamp then lands at 18 < ``parent_order``) still
+    trips the raise rather than passing an order coarser than the shards. An
+    explicit ``mortie_order`` is honored but still validated against
+    ``parent_order``. Non-HEALPix grids (no ``parent_order`` / ``child_order``)
+    keep the legacy default of 8.
     """
     is_healpix = hasattr(grid, "parent_order") and hasattr(grid, "child_order")
     if mortie_order is not None:
         order = int(mortie_order)
     elif is_healpix:
+        # ``chunk_order`` is the inner-chunk order on HealpixGrid (always set;
+        # == parent_order when chunk_inner is unset). The getattr default only
+        # covers a duck-typed grid that exposes parent/child but not chunk_order.
         chunk_order = getattr(grid, "chunk_order", grid.parent_order)
         order = min(int(chunk_order), MORTIE_MOC_ORDER_CAP)
     else:

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -35,14 +35,21 @@ from typing import Dict, List
 
 import numpy as np
 
-# Resolve the granule-footprint MOC this many HEALPix levels ABOVE the leaf
-# (``child_order``). A few levels coarser than the leaf keeps footprint edges
-# reasonably tight while staying well above the shard order (``parent_order``) --
-# so ``moc_to_order`` never upsamples a footprint onto every shard (#92) -- and
+# Resolve the granule-footprint MOC this many HEALPix levels *coarser than* the
+# leaf (``child_order``) -- i.e. subtracting N gives an order N levels above the
+# leaf. A few levels coarser than the leaf keeps footprint edges reasonably tight
+# while staying well above the shard order (``parent_order``) -- so
+# ``moc_to_order`` never upsamples a footprint onto every shard (#92) -- and
 # comfortably under mortie's order-18 coverage cap (child_order 19 -> order 16).
 # Once mortie lifts that cap (espg/mortie#60) this offset can shrink for tighter
 # edges.
 MOC_LEVELS_BELOW_LEAF = 3
+
+# Upper bound on the MOC order mortie's ``morton_coverage`` /
+# ``morton_coverage_moc`` accept; a higher order raises inside mortie. The
+# derived order is clamped to this so a large ``child_order`` can't push the MOC
+# order past the cap and silently lose coverage (#92).
+MORTIE_MOC_ORDER_CAP = 18
 
 # ── granule footprint helpers ────────────────────────────────────────────────
 
@@ -78,18 +85,22 @@ def _resolve_mortie_order(mortie_order, grid) -> int:
     fixed default of 8 against ``parent_order=13`` expanded each cell to 1024
     shards, putting ~every granule in ~every shard and OOMing the workers (#92).
 
-    ``None`` (the default) pins the order to ``child_order -
-    MOC_LEVELS_BELOW_LEAF`` so footprints resolve a few levels above the leaf --
-    tight enough to track the granule yet under mortie's order-18 coverage cap.
-    An explicit ``mortie_order`` is honored but still validated against
-    ``parent_order``. Non-HEALPix grids (no ``parent_order``/``child_order``)
-    keep the legacy default of 8.
+    ``None`` (the default) pins the order to ``min(child_order -
+    MOC_LEVELS_BELOW_LEAF, MORTIE_MOC_ORDER_CAP)`` so footprints resolve a few
+    levels above the leaf -- tight enough to track the granule yet never past
+    mortie's order-18 coverage cap (a large ``child_order`` would otherwise push
+    the order past the cap and make mortie raise, silently losing coverage).
+    The clamp is applied first, then the order is still validated against
+    ``parent_order`` -- so if the clamp ever lands at or below ``parent_order``
+    the raise still fires. An explicit ``mortie_order`` is honored but still
+    validated against ``parent_order``. Non-HEALPix grids (no
+    ``parent_order``/``child_order``) keep the legacy default of 8.
     """
     is_healpix = hasattr(grid, "parent_order") and hasattr(grid, "child_order")
     if mortie_order is not None:
         order = int(mortie_order)
     elif is_healpix:
-        order = int(grid.child_order) - MOC_LEVELS_BELOW_LEAF
+        order = min(int(grid.child_order) - MOC_LEVELS_BELOW_LEAF, MORTIE_MOC_ORDER_CAP)
     else:
         order = 8
     if is_healpix and order < grid.parent_order:
@@ -316,10 +327,12 @@ class ShardMap:
             mortie for HEALPix grids (non-HEALPix grids require spherely and
             raise an ``ImportError`` with an install pointer when it is absent).
         mortie_order : int, optional
-            MOC order for the mortie backend. ``None`` (default) pins it to the
-            grid's ``child_order`` (clamped to mortie's order-18 cap) so granule
-            footprints resolve at leaf resolution; a coarser order upsamples
-            every footprint onto all shards (#92). Must be >= ``parent_order``.
+            MOC order for the mortie backend. ``None`` (default) pins it to
+            ``min(child_order - MOC_LEVELS_BELOW_LEAF, 18)`` -- a few levels above
+            the leaf, never past mortie's order-18 coverage cap -- so footprints
+            resolve tight to the granule; a coarser order upsamples every
+            footprint onto all shards (#92). Raises if the resolved order is
+            coarser than ``parent_order``.
 
         Returns
         -------

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -35,19 +35,9 @@ from typing import Dict, List
 
 import numpy as np
 
-# Resolve the granule-footprint MOC this many HEALPix levels *coarser than* the
-# leaf (``child_order``) -- i.e. subtracting N gives an order N levels above the
-# leaf. A few levels coarser than the leaf keeps footprint edges reasonably tight
-# while staying well above the shard order (``parent_order``) -- so
-# ``moc_to_order`` never upsamples a footprint onto every shard (#92) -- and
-# comfortably under mortie's order-18 coverage cap (child_order 19 -> order 16).
-# Once mortie lifts that cap (espg/mortie#60) this offset can shrink for tighter
-# edges.
-MOC_LEVELS_BELOW_LEAF = 3
-
 # Upper bound on the MOC order mortie's ``morton_coverage`` /
 # ``morton_coverage_moc`` accept; a higher order raises inside mortie. The
-# derived order is clamped to this so a large ``child_order`` can't push the MOC
+# derived order is clamped to this so an exotic ``chunk_order`` can't push the MOC
 # order past the cap and silently lose coverage (#92).
 MORTIE_MOC_ORDER_CAP = 18
 
@@ -85,22 +75,30 @@ def _resolve_mortie_order(mortie_order, grid) -> int:
     fixed default of 8 against ``parent_order=13`` expanded each cell to 1024
     shards, putting ~every granule in ~every shard and OOMing the workers (#92).
 
-    ``None`` (the default) pins the order to ``min(child_order -
-    MOC_LEVELS_BELOW_LEAF, MORTIE_MOC_ORDER_CAP)`` so footprints resolve a few
-    levels above the leaf -- tight enough to track the granule yet never past
-    mortie's order-18 coverage cap (a large ``child_order`` would otherwise push
-    the order past the cap and make mortie raise, silently losing coverage).
-    The clamp is applied first, then the order is still validated against
-    ``parent_order`` -- so if the clamp ever lands at or below ``parent_order``
-    the raise still fires. An explicit ``mortie_order`` is honored but still
-    validated against ``parent_order``. Non-HEALPix grids (no
-    ``parent_order``/``child_order``) keep the legacy default of 8.
+    ``None`` (the default) pins the order to the grid's **inner-chunk order**
+    (``grid.chunk_order``) -- the Zarr-chunk order between the shard order
+    (``parent_order``) and the leaf (``child_order``), set by ``chunk_inner`` and
+    defaulting to ``parent_order`` when unset (so chunk == shard). The shipped
+    ATL03 HEALPix configs use ``chunk_inner=13`` (parent 11, child 19), so the
+    order resolves to 13. Keying the MOC to the chunk order matches the unit work
+    is dispatched at: footprints resolve no finer than the chunk the worker reads,
+    which is enough to keep ``moc_to_order`` from upsampling onto neighbor shards
+    (#92) at near-minimal compute -- a benchmark sweep showed granules/shard is
+    flat for every order >= ``parent_order`` while wall-time grows with order, so
+    a finer MOC buys precision the order-``parent_order`` shard cells can't see.
+    The order is still clamped to ``MORTIE_MOC_ORDER_CAP`` (mortie's order-18
+    coverage cap) before the ``parent_order`` guard, so an exotic ``chunk_order``
+    past the cap can't make mortie raise into the swallowing ``except`` (silent
+    coverage loss). An explicit ``mortie_order`` is honored but still validated
+    against ``parent_order``. Non-HEALPix grids (no ``parent_order`` /
+    ``child_order``) keep the legacy default of 8.
     """
     is_healpix = hasattr(grid, "parent_order") and hasattr(grid, "child_order")
     if mortie_order is not None:
         order = int(mortie_order)
     elif is_healpix:
-        order = min(int(grid.child_order) - MOC_LEVELS_BELOW_LEAF, MORTIE_MOC_ORDER_CAP)
+        chunk_order = getattr(grid, "chunk_order", grid.parent_order)
+        order = min(int(chunk_order), MORTIE_MOC_ORDER_CAP)
     else:
         order = 8
     if is_healpix and order < grid.parent_order:
@@ -327,11 +325,12 @@ class ShardMap:
             mortie for HEALPix grids (non-HEALPix grids require spherely and
             raise an ``ImportError`` with an install pointer when it is absent).
         mortie_order : int, optional
-            MOC order for the mortie backend. ``None`` (default) pins it to
-            ``min(child_order - MOC_LEVELS_BELOW_LEAF, 18)`` -- a few levels above
-            the leaf, never past mortie's order-18 coverage cap -- so footprints
-            resolve tight to the granule; a coarser order upsamples every
-            footprint onto all shards (#92). Raises if the resolved order is
+            MOC order for the mortie backend. ``None`` (default) pins it to the
+            grid's inner-chunk order ``grid.chunk_order`` (the ``chunk_inner``
+            order, defaulting to ``parent_order`` when unset), clamped to mortie's
+            order-18 coverage cap -- the dispatch chunk's own resolution, enough
+            to keep ``moc_to_order`` from upsampling a footprint onto neighbor
+            shards (#92) at near-minimal compute. Raises if the resolved order is
             coarser than ``parent_order``.
 
         Returns

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -24,6 +24,7 @@ shapely is no longer an intersection backend -- its WGS84 STRtree path had
 antimeridian/near-pole correctness bugs (#36). shapely remains a dependency for
 WKB decode (``sources.py``) and footprint geometry (``grids/``).
 """
+
 from __future__ import annotations
 
 import importlib
@@ -34,7 +35,17 @@ from typing import Dict, List
 
 import numpy as np
 
+# Resolve the granule-footprint MOC this many HEALPix levels ABOVE the leaf
+# (``child_order``). A few levels coarser than the leaf keeps footprint edges
+# reasonably tight while staying well above the shard order (``parent_order``) --
+# so ``moc_to_order`` never upsamples a footprint onto every shard (#92) -- and
+# comfortably under mortie's order-18 coverage cap (child_order 19 -> order 16).
+# Once mortie lifts that cap (espg/mortie#60) this offset can shrink for tighter
+# edges.
+MOC_LEVELS_BELOW_LEAF = 3
+
 # ── granule footprint helpers ────────────────────────────────────────────────
+
 
 def _to_spherely_polygon(lats, lons):
     """Build a closed sphere-aware polygon, or None on validation failure.
@@ -55,6 +66,39 @@ def _to_spherely_polygon(lats, lons):
         return spherely.create_polygon(shell=list(zip(lons, lats)), oriented=False)
     except (ValueError, RuntimeError):
         return None
+
+
+def _resolve_mortie_order(mortie_order, grid) -> int:
+    """Choose the MOC order for the mortie backend.
+
+    The MOC order must be **>= the shard order** (``parent_order``). A coarser
+    MOC upsamples in ``moc_to_order(moc, parent_order)``: every coarse cell
+    becomes all ``4^(parent_order - order)`` order-``parent_order`` descendants,
+    fattening a thin granule track to fill every shard under that cell. The old
+    fixed default of 8 against ``parent_order=13`` expanded each cell to 1024
+    shards, putting ~every granule in ~every shard and OOMing the workers (#92).
+
+    ``None`` (the default) pins the order to ``child_order -
+    MOC_LEVELS_BELOW_LEAF`` so footprints resolve a few levels above the leaf --
+    tight enough to track the granule yet under mortie's order-18 coverage cap.
+    An explicit ``mortie_order`` is honored but still validated against
+    ``parent_order``. Non-HEALPix grids (no ``parent_order``/``child_order``)
+    keep the legacy default of 8.
+    """
+    is_healpix = hasattr(grid, "parent_order") and hasattr(grid, "child_order")
+    if mortie_order is not None:
+        order = int(mortie_order)
+    elif is_healpix:
+        order = int(grid.child_order) - MOC_LEVELS_BELOW_LEAF
+    else:
+        order = 8
+    if is_healpix and order < grid.parent_order:
+        raise ValueError(
+            f"mortie MOC order {order} is coarser than the grid's parent_order "
+            f"{grid.parent_order}; this upsamples every granule footprint onto all "
+            f"shards under each MOC cell (#92). Use order >= {grid.parent_order}."
+        )
+    return order
 
 
 def _resolve_backend(backend: str, grid) -> str:
@@ -222,6 +266,7 @@ _BACKENDS = {
 
 # ── ShardMap ─────────────────────────────────────────────────────────────────
 
+
 @dataclass
 class ShardMap:
     """Work-distribution manifest: shard key -> granules, tied to one grid.
@@ -253,7 +298,7 @@ class ShardMap:
         *,
         region=None,
         backend: str = "auto",
-        mortie_order: int = 8,
+        mortie_order: int | None = None,
     ) -> "ShardMap":
         """Build a ShardMap from a ``Catalog`` and an output grid.
 
@@ -270,8 +315,11 @@ class ShardMap:
             Geometry backend. ``"auto"`` -> spherely when importable, else
             mortie for HEALPix grids (non-HEALPix grids require spherely and
             raise an ``ImportError`` with an install pointer when it is absent).
-        mortie_order : int
-            MOC order for the mortie backend.
+        mortie_order : int, optional
+            MOC order for the mortie backend. ``None`` (default) pins it to the
+            grid's ``child_order`` (clamped to mortie's order-18 cap) so granule
+            footprints resolve at leaf resolution; a coarser order upsamples
+            every footprint onto all shards (#92). Must be >= ``parent_order``.
 
         Returns
         -------
@@ -287,6 +335,7 @@ class ShardMap:
 
         t0 = time.perf_counter()
         if chosen == "mortie":
+            mortie_order = _resolve_mortie_order(mortie_order, grid)
             shard_to_idx = _intersect_mortie(records, grid, all_shards, order=mortie_order)
         else:
             shard_to_idx = _BACKENDS[chosen](records, grid, all_shards)
@@ -316,12 +365,17 @@ class ShardMap:
         """Write the manifest as JSON."""
         from pathlib import Path
 
-        Path(path).write_text(json.dumps({
-            "metadata": self.metadata,
-            "grid_signature": self.grid_signature,
-            "shard_keys": self.shard_keys,
-            "granules": self.granules,
-        }, indent=2))
+        Path(path).write_text(
+            json.dumps(
+                {
+                    "metadata": self.metadata,
+                    "grid_signature": self.grid_signature,
+                    "shard_keys": self.shard_keys,
+                    "granules": self.granules,
+                },
+                indent=2,
+            )
+        )
 
     @classmethod
     def from_json(cls, path: str) -> "ShardMap":
@@ -332,8 +386,7 @@ class ShardMap:
         for key in ("grid_signature", "shard_keys", "granules"):
             if key not in d:
                 raise ValueError(f"{path}: missing required key {key!r}")
-        return cls(d["grid_signature"], d["shard_keys"], d["granules"],
-                   d.get("metadata", {}))
+        return cls(d["grid_signature"], d["shard_keys"], d["granules"], d.get("metadata", {}))
 
 
 __all__ = ["ShardMap"]

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -18,7 +18,7 @@ import pytest
 import stac_geoparquet.arrow as sga
 
 from zagg.catalog import shardmap
-from zagg.catalog.shardmap import MOC_LEVELS_BELOW_LEAF, ShardMap, _resolve_backend
+from zagg.catalog.shardmap import ShardMap, _resolve_backend
 from zagg.catalog.sources import Catalog
 from zagg.config import default_config
 from zagg.grids import HealpixGrid, RectilinearGrid
@@ -256,37 +256,43 @@ class TestMortieOrder:
     @pytest.fixture
     def hp_grid(self):
         # parent_order 11 shards (~0.03 deg), child_order 17 leaves over the AOI.
+        # chunk_inner unset -> chunk_order == parent_order == 11.
         return HealpixGrid(11, 17, layout="fullsphere")
 
-    def test_default_offsets_below_child_order(self, catalog, hp_grid):
-        # child_order 17 - MOC_LEVELS_BELOW_LEAF (3) = 14.
+    def test_default_keys_to_chunk_order(self, catalog):
+        # chunk_inner=13 (the shipped ATL03 config) -> MOC order 13, the inner
+        # chunk the worker dispatches at.
+        g = HealpixGrid(11, 19, layout="fullsphere", chunk_inner=13)
+        assert g.chunk_order == 13
+        sm = ShardMap.build(catalog, g, backend="mortie")
+        assert sm.metadata["mortie_order"] == 13
+
+    def test_default_falls_back_to_parent_order(self, catalog, hp_grid):
+        # chunk_inner unset -> chunk_order == parent_order, so the MOC order is the
+        # bare shard order (the "else the shard order" branch of the directive).
+        assert hp_grid.chunk_order == hp_grid.parent_order == 11
         sm = ShardMap.build(catalog, hp_grid, backend="mortie")
-        assert sm.metadata["mortie_order"] == 17 - MOC_LEVELS_BELOW_LEAF == 14
+        assert sm.metadata["mortie_order"] == 11
 
     def test_default_under_mortie_cap_at_leaf_order_19(self, catalog):
-        # child_order 19 (the ~10 m leaf) -> order 16, under mortie's order-18 cap.
-        g = HealpixGrid(13, 19, layout="fullsphere")
+        # The shipped production grid (chunk_inner 13) -> 13, under the order-18 cap.
+        g = HealpixGrid(11, 19, layout="fullsphere", chunk_inner=13)
         sm = ShardMap.build(catalog, g, backend="mortie")
-        assert sm.metadata["mortie_order"] == 16
+        assert sm.metadata["mortie_order"] == 13
 
     def test_coarse_order_rejected(self, catalog, hp_grid):
         # An explicit order coarser than parent_order would fatten -> raise.
         with pytest.raises(ValueError, match="coarser than the grid's parent_order"):
             ShardMap.build(catalog, hp_grid, backend="mortie", mortie_order=8)
 
-    def test_derived_coarse_order_rejected(self, catalog):
-        # The None (derived) path also trips the guard: child_order 14 - 3 = 11
-        # is coarser than parent_order 13 -> raise (#92).
-        g = HealpixGrid(13, 14, layout="fullsphere")
-        with pytest.raises(ValueError, match="coarser than the grid's parent_order"):
-            ShardMap.build(catalog, g, backend="mortie")
-
     def test_derived_order_clamped_to_cap(self):
-        # A child_order whose derived order would exceed mortie's order-18 cap is
-        # clamped to 18, never an illegal order that mortie would reject (#92).
+        # A chunk_order above mortie's order-18 cap is clamped to 18, never an
+        # illegal order that mortie would reject (#92). chunk_inner=19 > cap, with
+        # parent_order 15 so the clamped 18 still clears the parent_order guard.
         from zagg.catalog.shardmap import MORTIE_MOC_ORDER_CAP, _resolve_mortie_order
 
-        g = HealpixGrid(15, 22, layout="fullsphere")  # 22 - 3 = 19 > cap
+        g = HealpixGrid(15, 22, layout="fullsphere", chunk_inner=19)
+        assert g.chunk_order == 19
         assert _resolve_mortie_order(None, g) == MORTIE_MOC_ORDER_CAP == 18
 
     def test_no_fattening_west_east_disjoint(self, hp_grid):

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -285,6 +285,16 @@ class TestMortieOrder:
         with pytest.raises(ValueError, match="coarser than the grid's parent_order"):
             ShardMap.build(catalog, hp_grid, backend="mortie", mortie_order=8)
 
+    def test_derived_order_clamped_below_parent_rejected(self):
+        # The derived path can still trip the guard: when parent_order exceeds the
+        # order-18 cap, the clamp drives the order to 18 < parent_order, so the
+        # guard fires (#92). chunk_order 19 -> clamped 18 < parent_order 19.
+        from zagg.catalog.shardmap import _resolve_mortie_order
+
+        g = HealpixGrid(19, 20, layout="fullsphere")  # chunk_order == parent_order == 19
+        with pytest.raises(ValueError, match="coarser than the grid's parent_order"):
+            _resolve_mortie_order(None, g)
+
     def test_derived_order_clamped_to_cap(self):
         # A chunk_order above mortie's order-18 cap is clamped to 18, never an
         # illegal order that mortie would reject (#92). chunk_inner=19 > cap, with

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -274,6 +274,21 @@ class TestMortieOrder:
         with pytest.raises(ValueError, match="coarser than the grid's parent_order"):
             ShardMap.build(catalog, hp_grid, backend="mortie", mortie_order=8)
 
+    def test_derived_coarse_order_rejected(self, catalog):
+        # The None (derived) path also trips the guard: child_order 14 - 3 = 11
+        # is coarser than parent_order 13 -> raise (#92).
+        g = HealpixGrid(13, 14, layout="fullsphere")
+        with pytest.raises(ValueError, match="coarser than the grid's parent_order"):
+            ShardMap.build(catalog, g, backend="mortie")
+
+    def test_derived_order_clamped_to_cap(self):
+        # A child_order whose derived order would exceed mortie's order-18 cap is
+        # clamped to 18, never an illegal order that mortie would reject (#92).
+        from zagg.catalog.shardmap import MORTIE_MOC_ORDER_CAP, _resolve_mortie_order
+
+        g = HealpixGrid(15, 22, layout="fullsphere")  # 22 - 3 = 19 > cap
+        assert _resolve_mortie_order(None, g) == MORTIE_MOC_ORDER_CAP == 18
+
     def test_no_fattening_west_east_disjoint(self, hp_grid):
         # A west granule and an east granule must occupy disjoint shard sets --
         # under the old order-8 default both spread onto every AOI shard.

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -18,7 +18,7 @@ import pytest
 import stac_geoparquet.arrow as sga
 
 from zagg.catalog import shardmap
-from zagg.catalog.shardmap import ShardMap, _resolve_backend
+from zagg.catalog.shardmap import MOC_LEVELS_BELOW_LEAF, ShardMap, _resolve_backend
 from zagg.catalog.sources import Catalog
 from zagg.config import default_config
 from zagg.grids import HealpixGrid, RectilinearGrid
@@ -243,6 +243,51 @@ class TestResolveBackend:
         )
         with pytest.raises(SystemExit):
             main()
+
+
+class TestMortieOrder:
+    """The mortie MOC order must track the grid, not a fixed coarse default (#92).
+
+    A MOC order below ``parent_order`` upsamples in ``moc_to_order``, fattening
+    every granule footprint onto all shards under each coarse cell -- the
+    order-8-vs-order-13 degeneracy that put ~every granule in ~every shard.
+    """
+
+    @pytest.fixture
+    def hp_grid(self):
+        # parent_order 11 shards (~0.03 deg), child_order 17 leaves over the AOI.
+        return HealpixGrid(11, 17, layout="fullsphere")
+
+    def test_default_offsets_below_child_order(self, catalog, hp_grid):
+        # child_order 17 - MOC_LEVELS_BELOW_LEAF (3) = 14.
+        sm = ShardMap.build(catalog, hp_grid, backend="mortie")
+        assert sm.metadata["mortie_order"] == 17 - MOC_LEVELS_BELOW_LEAF == 14
+
+    def test_default_under_mortie_cap_at_leaf_order_19(self, catalog):
+        # child_order 19 (the ~10 m leaf) -> order 16, under mortie's order-18 cap.
+        g = HealpixGrid(13, 19, layout="fullsphere")
+        sm = ShardMap.build(catalog, g, backend="mortie")
+        assert sm.metadata["mortie_order"] == 16
+
+    def test_coarse_order_rejected(self, catalog, hp_grid):
+        # An explicit order coarser than parent_order would fatten -> raise.
+        with pytest.raises(ValueError, match="coarser than the grid's parent_order"):
+            ShardMap.build(catalog, hp_grid, backend="mortie", mortie_order=8)
+
+    def test_no_fattening_west_east_disjoint(self, hp_grid):
+        # A west granule and an east granule must occupy disjoint shard sets --
+        # under the old order-8 default both spread onto every AOI shard.
+        cat = _catalog([_item("Gwest", -76.62, -76.59), _item("Geast", -76.53, -76.50)])
+        sm = ShardMap.build(cat, hp_grid, backend="mortie")
+        gs = _granule_shards(sm)
+        assert gs["Gwest"] and gs["Geast"]
+        assert gs["Gwest"].isdisjoint(gs["Geast"])
+
+    def test_non_healpix_keeps_legacy_default(self, grid):
+        # Non-HEALPix grids have no parent/child order -> legacy default of 8.
+        from zagg.catalog.shardmap import _resolve_mortie_order
+
+        assert _resolve_mortie_order(None, grid) == 8
 
 
 class TestIO:


### PR DESCRIPTION
Closes #92.

## What

The `mortie` shardmap backend computed each granule footprint as a MOC at a fixed `mortie_order=8`, then mapped it to the order-`parent_order` shard cells via `moc_to_order`. When `mortie_order < parent_order`, that call **upsamples**: each coarse cell becomes all `4^(parent_order - order)` shards beneath it, fattening a thin granule track onto every shard. On the NEON ATL03 AOI every order-8 cell expanded to many shards, so ~every granule landed in ~every shard and the Lambda workers OOMed (`Runtime.OutOfMemory`).

This pins the MOC order to the grid instead of a fixed coarse constant. Per @espg's review (https://github.com/englacial/zagg/pull/93#issuecomment-4783625863), the order is keyed to the grid's **inner-chunk order** (`grid.chunk_order`, set by `chunk_inner`, defaulting to `parent_order` when unset) — the unit work is dispatched at:

- `mortie_order` defaults to `None`, resolved by `_resolve_mortie_order(mortie_order, grid)` to `min(grid.chunk_order, MORTIE_MOC_ORDER_CAP)`. The shipped ATL03 HEALPix configs (`atl03_gain_bias_healpix.yaml`, `atl03_tdigest_healpix.yaml`) use `parent_order=11`, `chunk_inner=13`, `child_order=19`, so this resolves to **13** — comfortably above `parent_order=11` (no upsampling) and under mortie's order-18 coverage cap.
- A grid with `chunk_inner` unset has `chunk_order == parent_order`, so the MOC resolves to the bare shard order — the "else the shard order" branch of the directive.
- Any order (explicit or derived) coarser than `parent_order` still **raises** rather than silently fattening — a guard against this whole bug class. The cap clamp is applied first, then the guard, so a clamp landing at/under `parent_order` still raises.
- Non-HEALPix grids keep the legacy default of 8 (byte-identical).
- The resolved order is recorded in `metadata["mortie_order"]`.

This supersedes the earlier `child_order - 3` (= 16 for the production grid) default; see the benchmark below for why the coarser chunk-order default loses no footprint precision.

## Benchmark (per @espg, https://github.com/englacial/zagg/pull/93#issuecomment-4783435855 + https://github.com/englacial/zagg/pull/93#issuecomment-4783625863)

`benchmarks/mortie_order_sweep.py` sweeps `_intersect_mortie` over morton orders `[9, 12, 13, 15, 16, 17, 18]` on the NEON Maryland AOI against the production grid (`parent_order=11`, `chunk_inner=13`, `child_order=19`), reporting wall-time, granules selected, and mean granules/shard.

**Offline note:** this environment has no Earthdata/CMR credentials, so the real catalog fetch is not reachable. The granule set is a **synthetic but representative** catalog of thin (~90 m) RGT-style swaths over the AOI — the geometry that drove the #92 degeneracy. Absolute counts are representative, not measured from production granules; the *relative* cost across orders is the comparison @espg asked for. Re-run in a credentialed session against a real `Catalog` for production absolutes.

20 order-11 shards cover the AOI; 12 synthetic swaths:

| morton order | run time (median) | granules selected | granules/shard (mean) | guard |
|---|---|---|---|---|
| 9  | 2.8 ms  | 12 | 9.65 | **rejected** (< parent_order) |
| 12 | 3.2 ms  | 12 | 2.95 | ok |
| 13 | 3.2 ms  | 12 | 2.95 | ok |
| 15 | 4.2 ms  | 12 | 2.95 | ok |
| 16 | 6.8 ms  | 12 | 2.95 | ok |
| 17 | 10.9 ms | 12 | 2.95 | ok |
| 18 | 21.1 ms | 12 | 2.95 | ok |

Reading: **granules/shard is flat (2.95) for every order ≥ `parent_order`**, while wall-time grows monotonically (~7× from order 12 → 18). The shard footprints are order-11 cells, so a MOC resolved at 13 vs 16 vs 18 collapses to the *same* order-11 shards via `moc_to_order` — a finer MOC buys precision the shard grid can't see, at strictly more compute. Below `parent_order` (order 9) the footprint upsamples to 9.65 granules/shard (the #92 fattening) and the guard rejects it. So keying to `chunk_order = 13` gets the tight-footprint result at ~⅓ the wall-time of the old `child_order - 3 = 16` default, with identical granule placement.

## Tests

`tests/test_shardmap.py::TestMortieOrder`:
- `test_default_keys_to_chunk_order` — `chunk_inner=13` resolves the MOC to 13.
- `test_default_falls_back_to_parent_order` — `chunk_inner` unset → `chunk_order == parent_order`, MOC resolves to the bare shard order.
- `test_default_under_mortie_cap_at_leaf_order_19` — the shipped production grid resolves to 13, under mortie's cap.
- `test_coarse_order_rejected` — an explicit order below `parent_order` raises.
- `test_derived_order_clamped_to_cap` — `chunk_inner=19` (> cap, parent 15) clamps to 18, never an illegal order.
- `test_no_fattening_west_east_disjoint` — a west and an east granule occupy disjoint shard sets (the regression).
- `test_non_healpix_keeps_legacy_default` — rectilinear grids keep order 8.

`pytest tests/test_shardmap.py -q`: 25 passed, 1 skipped (spherely-fork SpatialIndex test). Full suite `pytest -q`: 767 passed, 1 skipped. `ruff check --select=E,F,W,I --ignore=E501` + `ruff format --check` clean on all touched files (incl. `benchmarks/mortie_order_sweep.py`).

## Follow-ups (not in this PR)

- The degenerate NEON shardmaps need rebuilding once this lands.
- Tighter-still footprint edges depend on espg/mortie#60 (coverage order cap) — moot at the chunk-order default, which sits well under the cap.
- Milder multi-beam swath over-coverage is tracked separately in #65.

## Questions for review

None outstanding — the offset judgment call from the prior revision is resolved by keying to `chunk_order`. Flagging only that the benchmark numbers are from a synthetic (offline) catalog as noted above; a credentialed re-run would confirm the production absolutes (the cross-order *trend* is geometry-driven and won't change).
