### PR TITLE
Release per-granule h5coro cache in process_shard (issue #66)

### DIFF
--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -225,13 +225,16 @@ def process_shard(
             # ThreadPoolExecutor pinning ``self``, so without an explicit release
             # each granule's ~tens-of-MB HDF5-navigation cache stays resident for
             # the whole loop (~40 granules × ~67 MB ≈ 2.7 GB → Lambda OOM, even for
-            # trivial data volumes). Every array retained in ``all_reads`` is a
-            # boolean-mask copy made in ``_read_group`` (numpy boolean indexing
-            # always copies — never a memoryview into the cache lines), so freeing
-            # the cache here cannot corrupt already-read data. Prefer the upstream
-            # ``close()`` (h5coro 1.0.5's fix/resource-leak branch) and fall back to
-            # ``cache.clear()`` on 1.0.4; the ``hasattr`` guard keeps this
-            # forward-compatible without bumping the h5coro pin.
+            # trivial data volumes). Nothing retained in ``all_reads`` aliases the
+            # cache lines: ``_read_group`` builds every column by boolean indexing
+            # (a numpy copy) and returns ``pd.DataFrame(data_dict)`` (which copies
+            # its numpy inputs into managed blocks), so freeing the cache here
+            # cannot corrupt already-read data. The pinned h5coro 1.0.4 has
+            # ``close()`` (it does ``cache.clear()`` + ``cache_locks.clear()`` +
+            # ``driver.close()``), so that is the live path; the ``cache.clear()``
+            # branch is a defensive fallback for any build lacking ``close()``. The
+            # ``hasattr`` guard keeps this forward-compatible without bumping the
+            # h5coro pin.
             if h5obj is not None:
                 try:
                     if hasattr(h5obj, "close"):

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -191,6 +191,7 @@ def process_shard(
 
     # Read files and filter spatially
     for s3_url in granule_urls:
+        h5obj = None
         try:
             resource_path = _rewrite_url(s3_url)
 
@@ -218,6 +219,28 @@ def process_shard(
         except Exception as e:
             logger.warning(f"  Error processing file {s3_url}: {e}")
             continue
+        finally:
+            # Release this granule's h5coro cache before moving on (issue #66).
+            # h5coro caches reads in 4 MB lines with no eviction and leaves a
+            # ThreadPoolExecutor pinning ``self``, so without an explicit release
+            # each granule's ~tens-of-MB HDF5-navigation cache stays resident for
+            # the whole loop (~40 granules × ~67 MB ≈ 2.7 GB → Lambda OOM, even for
+            # trivial data volumes). Every array retained in ``all_reads`` is a
+            # boolean-mask copy made in ``_read_group`` (numpy boolean indexing
+            # always copies — never a memoryview into the cache lines), so freeing
+            # the cache here cannot corrupt already-read data. Prefer the upstream
+            # ``close()`` (h5coro 1.0.5's fix/resource-leak branch) and fall back to
+            # ``cache.clear()`` on 1.0.4; the ``hasattr`` guard keeps this
+            # forward-compatible without bumping the h5coro pin.
+            if h5obj is not None:
+                try:
+                    if hasattr(h5obj, "close"):
+                        h5obj.close()
+                    elif getattr(h5obj, "cache", None) is not None:
+                        h5obj.cache.clear()
+                except Exception:
+                    logger.debug("h5coro cache release failed", exc_info=True)
+            h5obj = None
 
     logger.info(f"  Processed {files_processed}/{len(granule_urls)} files")
     metadata["files_processed"] = files_processed

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -220,21 +220,11 @@ def process_shard(
             logger.warning(f"  Error processing file {s3_url}: {e}")
             continue
         finally:
-            # Release this granule's h5coro cache before moving on (issue #66).
-            # h5coro caches reads in 4 MB lines with no eviction and leaves a
-            # ThreadPoolExecutor pinning ``self``, so without an explicit release
-            # each granule's ~tens-of-MB HDF5-navigation cache stays resident for
-            # the whole loop (~40 granules × ~67 MB ≈ 2.7 GB → Lambda OOM, even for
-            # trivial data volumes). Nothing retained in ``all_reads`` aliases the
-            # cache lines: ``_read_group`` builds every column by boolean indexing
-            # (a numpy copy) and returns ``pd.DataFrame(data_dict)`` (which copies
-            # its numpy inputs into managed blocks), so freeing the cache here
-            # cannot corrupt already-read data. The pinned h5coro 1.0.4 has
-            # ``close()`` (it does ``cache.clear()`` + ``cache_locks.clear()`` +
-            # ``driver.close()``), so that is the live path; the ``cache.clear()``
-            # branch is a defensive fallback for any build lacking ``close()``. The
-            # ``hasattr`` guard keeps this forward-compatible without bumping the
-            # h5coro pin.
+            # Release this granule's h5coro cache before the next one (issue #66):
+            # without it each granule's unevicted cache stays resident for the whole
+            # loop → Lambda OOM. ``close()`` is the live path; ``cache.clear()`` is a
+            # fallback for builds lacking it. Retained ``all_reads`` data is already
+            # copied off the cache lines (see PR #94), so releasing here is safe.
             if h5obj is not None:
                 try:
                     if hasattr(h5obj, "close"):
@@ -243,7 +233,6 @@ def process_shard(
                         h5obj.cache.clear()
                 except Exception:
                     logger.debug("h5coro cache release failed", exc_info=True)
-            h5obj = None
 
     logger.info(f"  Processed {files_processed}/{len(granule_urls)} files")
     metadata["files_processed"] = files_processed

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4218,12 +4218,20 @@ class TestProcessShardCacheRelease:
         assert len(clears) == 2
 
     def test_retained_data_survives_cache_clear(self, monkeypatch):
-        """Copy-before-clear correctness: the stub backs its returned arrays with
-        memoryviews into a buffer it ZEROES on ``close()``. If anything retained in
-        ``all_reads`` were a view into that buffer (rather than a numpy boolean-mask
-        copy), the aggregation output would be corrupted after the release. Assert
-        the output reflects the ORIGINAL bytes, proving the retained columns are
-        copies."""
+        """End-to-end copy-before-clear: drive the full ``process_shard`` loop with a
+        stub that hands out buffer-backed views (as real h5coro does — memoryviews
+        into 4 MB cache lines) and ZEROES every buffer on ``close()`` (the
+        per-granule release simulating cache-line eviction). Assert the aggregation
+        output reflects the ORIGINAL bytes — the worker's retained data is detached
+        from the cache before the release fires, so per-granule release is safe.
+
+        Note this guards the SYSTEM-LEVEL invariant (the worker's output survives the
+        release), which is what the fix relies on. It is a two-layer guarantee:
+        ``_read_group`` builds columns by boolean-mask indexing (a numpy copy) AND
+        ``pd.DataFrame``/``pa.table`` copy their numpy inputs at construction. A test
+        on a DataFrame-returning helper cannot isolate the read-site layer (pandas
+        copies regardless), so this asserts the property that actually matters: no
+        retained array references the evicted cache."""
 
         class _ViewBackedH5:
             """Returns memoryview-backed arrays into a private buffer per dataset;
@@ -4260,7 +4268,7 @@ class TestProcessShardCacheRelease:
         )
         # The single cell pooled both photons (h_li = 100, 200) BEFORE the buffer
         # was zeroed; h_min must be the original 100.0, not 0.0 (corrupted) and the
-        # count must be 2. A retained view would read back 0.0 here.
+        # count must be 2.
         assert meta["total_obs"] == 2
         assert df_out["count"].to_numpy()[0] == 2
         assert df_out["h_min"].to_numpy()[0] == np.float32(100.0)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4052,3 +4052,215 @@ class TestChunkPrecompute:
         assert not np.array_equal(
             df_chunk["offset"].to_numpy(), np.array([1.0, 101.0], dtype=np.float32)
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-granule h5coro cache release in process_shard (issue #66)
+# ---------------------------------------------------------------------------
+
+
+class _ReleaseGrid:
+    """Grid stub for the #66 release tests: leaf id == row index, every row maps
+    to ``shard_key`` 0 (so the flat read keeps all rows), and the post-read
+    methods (``cells_of``/``children``/``chunk_coords``) collapse every row onto a
+    single cell. Drives the real ``_read_group`` → aggregate → ``_build_output``
+    path so the per-granule ``close()`` in the loop actually runs."""
+
+    @staticmethod
+    def assign(lats, lons):
+        return np.arange(len(lats), dtype=np.int64)
+
+    @staticmethod
+    def shards_of(leaf_ids):
+        return np.zeros(len(leaf_ids), dtype=np.int64)
+
+    def children(self, shard_key):
+        return np.array([0], dtype=np.int64)
+
+    def cells_of(self, leaf_ids):
+        return np.zeros(len(leaf_ids), dtype=np.int64)
+
+    def chunk_coords(self, shard_key):
+        return {"cell_lat": np.zeros(1), "cell_lon": np.zeros(1)}
+
+
+def _release_cfg():
+    """Minimal flat config: one group, lat/lon coords + one variable ``h_li``,
+    aggregated to count/min so ``process_shard`` runs end-to-end on canned reads."""
+    from zagg.config import PipelineConfig
+
+    return PipelineConfig(
+        data_source={
+            "groups": ["gt1l"],
+            "coordinates": {"latitude": "/{group}/lat", "longitude": "/{group}/lon"},
+            "variables": {"h_li": "/{group}/h_li"},
+        },
+        aggregation={
+            "variables": {
+                "count": {"function": "len", "dtype": "int32", "fill_value": 0},
+                "h_min": {"function": "min", "source": "h_li", "dtype": "float32"},
+            }
+        },
+    )
+
+
+def _serve_datasets(arrays, datasets):
+    """Shared ``readDatasets`` body: honor the same path/hyperslice contract as
+    :class:`_FakeH5` (mirrors the real h5coro driver)."""
+    out = {}
+    for d in datasets:
+        if isinstance(d, str):
+            out[d] = arrays[d]
+            continue
+        path = d["dataset"]
+        arr = arrays[path]
+        hs = d.get("hyperslice")
+        if hs is not None:
+            lo, hi = hs[0]
+            arr = arr[lo:hi]
+        out[path] = arr
+    return out
+
+
+class _CloseRecordingH5:
+    """h5coro-1.0.5-shaped stub: serves canned arrays and records ``close()`` calls
+    on a shared ``log`` (``("close", id)``), one entry per release."""
+
+    def __init__(self, arrays, log):
+        self._arrays = arrays
+        self._log = log
+
+    def readDatasets(self, datasets):  # noqa: N802 (mirror real h5coro API)
+        return _serve_datasets(self._arrays, datasets)
+
+    def close(self):
+        self._log.append(("close", id(self)))
+
+
+class _RecordingCache(dict):
+    """A cache whose ``clear()`` records the release (so the 1.0.4 fallback —
+    ``h5obj.cache.clear()`` — is observable)."""
+
+    def __init__(self, log):
+        super().__init__()
+        self._log = log
+        self["line0"] = b"x"  # non-empty so clear() actually frees something.
+
+    def clear(self):
+        self._log.append(("clear", id(self)))
+        super().clear()
+
+
+class _ClearOnlyH5:
+    """h5coro-1.0.4-shaped stub: NO ``close()`` (so ``hasattr(h5obj, "close")`` is
+    False), only a ``cache`` whose ``clear()`` records the release."""
+
+    def __init__(self, arrays, log):
+        self._arrays = arrays
+        self.cache = _RecordingCache(log)
+
+    def readDatasets(self, datasets):  # noqa: N802 (mirror real h5coro API)
+        return _serve_datasets(self._arrays, datasets)
+
+
+def _canned_arrays():
+    """Two photons in shard 0; lat/lon keep both rows under ``_ReleaseGrid``."""
+    return {
+        "/gt1l/lat": np.array([10.0, 11.0]),
+        "/gt1l/lon": np.array([20.0, 21.0]),
+        "/gt1l/h_li": np.array([100.0, 200.0], dtype=np.float32),
+    }
+
+
+class TestProcessShardCacheRelease:
+    """Issue #66: ``process_shard`` must release each granule's h5coro cache once
+    per granule (not zero, not once at the end), and the release must not corrupt
+    the data already extracted into ``all_reads`` (copy-before-clear)."""
+
+    def _patch_h5(self, monkeypatch, factory):
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", factory)
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+
+    def test_close_called_once_per_granule(self, monkeypatch):
+        """A close-bearing stub (h5coro 1.0.5 shape) is closed exactly once for each
+        of three granules — the per-granule release fires inside the loop."""
+        log: list = []
+
+        def factory(*a, **k):
+            return _CloseRecordingH5(_canned_arrays(), log)
+
+        self._patch_h5(monkeypatch, factory)
+        df_out, meta = process_shard(
+            _ReleaseGrid(),
+            0,
+            ["s3://a", "s3://b", "s3://c"],
+            s3_credentials={},
+            config=_release_cfg(),
+        )
+        closes = [e for e in log if e[0] == "close"]
+        # One release per granule, inside the loop — not zero, not once at the end.
+        assert len(closes) == 3
+        assert meta["files_processed"] == 3
+
+    def test_cache_clear_fallback_on_1_0_4(self, monkeypatch):
+        """When the object has no ``close()`` (h5coro 1.0.4), the loop falls back to
+        ``cache.clear()`` — also once per granule."""
+        log: list = []
+
+        def factory(*a, **k):
+            return _ClearOnlyH5(_canned_arrays(), log)
+
+        self._patch_h5(monkeypatch, factory)
+        process_shard(
+            _ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=_release_cfg()
+        )
+        clears = [e for e in log if e[0] == "clear"]
+        assert len(clears) == 2
+
+    def test_retained_data_survives_cache_clear(self, monkeypatch):
+        """Copy-before-clear correctness: the stub backs its returned arrays with
+        memoryviews into a buffer it ZEROES on ``close()``. If anything retained in
+        ``all_reads`` were a view into that buffer (rather than a numpy boolean-mask
+        copy), the aggregation output would be corrupted after the release. Assert
+        the output reflects the ORIGINAL bytes, proving the retained columns are
+        copies."""
+
+        class _ViewBackedH5:
+            """Returns memoryview-backed arrays into a private buffer per dataset;
+            ``close()`` zeroes every buffer (simulating cache-line eviction)."""
+
+            def __init__(self, arrays):
+                # keep a writable bytearray-backed copy per path; hand out views.
+                self._buffers = {k: bytearray(v.tobytes()) for k, v in arrays.items()}
+                self._dtypes = {k: v.dtype for k, v in arrays.items()}
+
+            def readDatasets(self, datasets):  # noqa: N802
+                out = {}
+                for d in datasets:
+                    path = d if isinstance(d, str) else d["dataset"]
+                    buf = self._buffers[path]
+                    arr = np.frombuffer(buf, dtype=self._dtypes[path])  # view into buffer
+                    if not isinstance(d, str) and d.get("hyperslice") is not None:
+                        lo, hi = d["hyperslice"][0]
+                        arr = arr[lo:hi]
+                    out[path] = arr
+                return out
+
+            def close(self):
+                for buf in self._buffers.values():
+                    for i in range(len(buf)):
+                        buf[i] = 0  # corrupt any surviving view
+
+        def factory(*a, **k):
+            return _ViewBackedH5(_canned_arrays())
+
+        self._patch_h5(monkeypatch, factory)
+        df_out, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=_release_cfg()
+        )
+        # The single cell pooled both photons (h_li = 100, 200) BEFORE the buffer
+        # was zeroed; h_min must be the original 100.0, not 0.0 (corrupted) and the
+        # count must be 2. A retained view would read back 0.0 here.
+        assert meta["total_obs"] == 2
+        assert df_out["count"].to_numpy()[0] == 2
+        assert df_out["h_min"].to_numpy()[0] == np.float32(100.0)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4272,3 +4272,64 @@ class TestProcessShardCacheRelease:
         assert meta["total_obs"] == 2
         assert df_out["count"].to_numpy()[0] == 2
         assert df_out["h_min"].to_numpy()[0] == np.float32(100.0)
+
+    def test_constructor_failure_releases_nothing_and_others_proceed(self, monkeypatch):
+        """If ``H5Coro(...)`` raises for one granule, the loop-top ``h5obj = None``
+        guard means the ``finally`` has nothing to release (no spurious ``close()`` on
+        the failed granule), the granule is skipped (caught by the outer ``except`` →
+        ``continue``), and the remaining granules still process and release normally."""
+        log: list = []
+        calls = {"n": 0}
+
+        def factory(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 2:  # second granule's constructor blows up
+                raise RuntimeError("h5coro open failed")
+            return _CloseRecordingH5(_canned_arrays(), log)
+
+        self._patch_h5(monkeypatch, factory)
+        df_out, meta = process_shard(
+            _ReleaseGrid(),
+            0,
+            ["s3://a", "s3://b", "s3://c"],
+            s3_credentials={},
+            config=_release_cfg(),
+        )
+        closes = [e for e in log if e[0] == "close"]
+        # Only the two granules whose constructor SUCCEEDED are closed; the failed one
+        # left ``h5obj is None`` so the ``finally`` released nothing for it.
+        assert len(closes) == 2
+        # The two good granules were still read end-to-end.
+        assert meta["files_processed"] == 2
+        assert meta["total_obs"] == 4  # 2 photons × 2 surviving granules
+
+    def test_read_exception_still_releases_in_finally(self, monkeypatch):
+        """The whole point of ``try/finally`` (vs. a post-read ``close()``): if a read
+        raises AFTER the H5Coro is constructed, the ``finally`` still releases that
+        granule's cache exactly once."""
+        log: list = []
+
+        class _RaisingReadH5:
+            """Constructs fine, records ``close()``, but its read raises."""
+
+            def __init__(self, log):
+                self._log = log
+
+            def readDatasets(self, datasets):  # noqa: N802 (mirror real h5coro API)
+                raise RuntimeError("byte-range read failed")
+
+            def close(self):
+                self._log.append(("close", id(self)))
+
+        def factory(*a, **k):
+            return _RaisingReadH5(log)
+
+        self._patch_h5(monkeypatch, factory)
+        df_out, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=_release_cfg()
+        )
+        closes = [e for e in log if e[0] == "close"]
+        # close() fired exactly once despite the read raising — the finally ran.
+        assert len(closes) == 1
+        # No data survived the failed read, so the shard reports the empty path.
+        assert meta["error"] == "No data after filtering"


### PR DESCRIPTION
Closes #66

## The leak

`process_shard` opens one `h5coro.H5Coro` per granule in its read loop and never releases it (`src/zagg/processing/worker.py` ~`:197`). h5coro caches reads in 4 MB lines with no eviction and leaves a `ThreadPoolExecutor` whose worker closures capture `self`, so each granule's HDF5-navigation cache stays resident for the whole loop even after `h5obj` is reassigned. Per the measurements in #66, the per-granule coarse geolocation read alone pins ~16 lines ≈ **67 MB**, and with the full-mission catalog ~40 granules are assigned per 64-cell shard → **~40 × 67 MB ≈ 2.7 GB > 2 GB Lambda → `Runtime.OutOfMemory`**, even for trivial data volumes (the pinned memory is HDF5 metadata, not photon data).

## Investigation — what's retained in `all_reads`, copy vs view

Traced the read path (`src/zagg/processing/read.py`: `_read_group` → `_planned_read_group` / `_read_group_full`). **Every array placed into the returned DataFrame/Table is a numpy boolean-mask copy, not a memoryview into h5coro's cache lines:**

- Base-rate variable columns: `values = arrays_by_path[path][mask_spatial]` (then optionally `[keep_mask]`) — boolean fancy-indexing, which **always copies** in numpy.
- `leaf_id`: `leaf_after_spatial[keep_mask]` (or `leaf_ids[mask_spatial]` when `keep_mask is None`) — boolean-index copy.
- In `_read_group_full`: `leaf_ids[min_idx:max_idx]` is a view, but the subsequent `[mask_sliced]` boolean index copies; same for the variable columns.
- Segment-level broadcasts (`_read_segment_broadcasts` / `_broadcast_segment_to_base`): freshly `np.full`/`np.zeros`-allocated, then boolean-sliced — never an h5coro view.
- Expression-filter path: `{k: v[emask] for ...}` — boolean-index copy.

`mask_spatial` / `mask_sliced` are always boolean arrays (results of `==`), so there is no slice-view-only retention path. On top of that, `pd.DataFrame(data_dict)` / `pa.table(data_dict)` also copy their numpy inputs at construction. **Conclusion: everything retained past a granule's lifetime is detached from the cache (a two-layer guarantee: boolean-mask copy AND construction-time copy)**, so freeing the cache after each granule cannot corrupt already-read data — copy-before-clear is satisfied by construction and needs no extra `np.array(..., copy=True)`.

## The fix

In `process_shard`'s granule loop, wrap each granule's read in `try/finally` and release the cache per granule (`src/zagg/processing/worker.py`):

```python
finally:
    if h5obj is not None:
        try:
            if hasattr(h5obj, "close"):
                h5obj.close()
            elif getattr(h5obj, "cache", None) is not None:
                h5obj.cache.clear()
        except Exception:
            logger.debug("h5coro cache release failed", exc_info=True)
    h5obj = None
```

- **Per granule, after extraction** — the release runs in the `finally` of each loop iteration, after the granule's data is fully copied into `all_reads`, not once at the end. `h5obj` is set to `None` at the top of each iteration, so a constructor failure leaves nothing to release (the `if h5obj is not None` guard skips it).
- **`close()` is the live path on the pinned h5coro 1.0.4.** 1.0.4 already ships `close()` (its `_cleanup` does `cache.clear()` + `cache_locks.clear()` + `driver.close()`), so the `hasattr(h5obj, "close")` branch is taken against the real dependency and genuinely frees the cache lines. The `cache.clear()` branch is a defensive fallback for any build lacking `close()`. The `hasattr` guard also stays correct when the pin later moves to h5coro 1.0.5 — no `pyproject.toml` change here.

## Tests (`tests/test_processing.py`, no network / no real S3 / no RSS sampling)

New `TestProcessShardCacheRelease`, mirroring the existing stub-H5Coro / `monkeypatch.setattr("zagg.processing.h5coro.H5Coro", ...)` pattern, driving the **real** `_read_group` → aggregate → `_build_output` path so the loop's release actually runs:

- `test_close_called_once_per_granule` — close-bearing stub over 3 granules; asserts `close()` recorded exactly 3× (once per granule, inside the loop — not zero, not once at the end). Because a fresh stub is minted per granule, a release moved outside the loop would close only the last object → 1 ≠ 3, so this also catches the "once at the end" regression.
- `test_cache_clear_fallback_on_1_0_4` — stub with no `close()` and a `cache` whose `clear()` is recorded; asserts the `hasattr` fallback fires once per granule.
- `test_retained_data_survives_cache_clear` — copy-before-clear regression guard. A stub hands out `np.frombuffer` views into private buffers and **zeroes every buffer on `close()`** (simulating cache-line eviction); asserts the worker's aggregation output reflects the **original** bytes (`h_min == 100.0`, `count == 2`), proving no retained array references the evicted cache. (This guards the system-level invariant; a DataFrame-returning read helper can't isolate the read-site copy layer because pandas copies at construction anyway — the test docstring says so.)

Existing `test_processing.py` (163) and `test_integration.py` stay byte-identical and green. Full suite: **763 passed, 1 skipped** (pre-existing).

## Lint / format / types

- `ruff check --select=E,F,W,I --ignore=E501 src tests` — clean.
- `ruff format --check` — my two changed files are clean. The format check also flags pre-existing drift in unrelated files (`src/zagg/catalog/shardmap.py`, `src/zagg/catalog/sources.py`, `src/zagg/runner.py`, `src/zagg/schema.py`, `tests/test_catalog.py`, `tests/test_integration.py`, `tests/test_rectilinear.py`, `tests/test_runner.py`) — left untouched per "don't fix unrelated CI failures"; flagging here.
- mypy: no new error categories (remaining errors are pre-existing import-stub/assignment/arg-type at untouched lines 142/209/284).

## Deployment note

Worker-side only (`src/zagg/processing/worker.py`); no `deployment/aws/` or `pyproject.toml` pin changes. Needs a Lambda **function redeploy** (`build_function.sh` + update) to take effect on Lambda — the maintainer's step.

## Questions for review

- On the pinned h5coro 1.0.4, `close()` frees the cache lines but does **not** shut down the leaked `ThreadPoolExecutor` (that gap is tracked upstream on `fix/resource-leak-1.0.5`, per the latest #66 comment). Bounding peak RSS by the freed cache lines is the dominant win here; the executor-thread pin is out of zagg's scope.
- `test_retained_data_survives_cache_clear` is a system-level (whole-worker) regression guard rather than a read-site copy isolation test — because `pd.DataFrame`/`pa.table` copy at construction, no DataFrame-returning test can distinguish a read-site view from a copy. Flagging the test's altitude in case a tighter read-internal assertion is wanted.
