### PR TITLE
issue #95: replace shapely per-segment AOI loop with mortie segment->shard mask

### DIFF
--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -271,8 +271,10 @@ def _planned_read_group(
 
     Issue #43 Phase C: when ``data_source.read_plan.spatial_index`` names a coarse
     level whose ``link`` points at the base level, we read the coarse coordinates
-    + link arrays once (small), call :func:`zagg.read_plan.plan_read` to compute
-    which base-rate slices the AOI bbox actually touches, and read base-rate
+    + link arrays once (small), call :func:`zagg.read_plan.plan_read` with the
+    mortie segment->shard mask (``grid.shards_of(grid.assign(...)) == shard_key``,
+    the same exact test the photon path applies) to compute which base-rate
+    slices the shard actually touches, and read base-rate
     coords + variables + filter datasets only over those slices via
     :func:`zagg.read_plan.execute_read_plan`. This avoids the
     ``lat_ph`` + ``lon_ph`` full-coord read (up to ~245 MB per ATL03 beam) that
@@ -344,7 +346,7 @@ def _planned_read_group(
     # shard edge is recovered by ``pad`` (and the photon-level filter below never
     # over-includes); residual omission is bounded to a few edge photons (#95).
     coarse_leaf = grid.assign(np.asarray(coarse_lats), np.asarray(coarse_lons))
-    coarse_mask = grid.shards_of(coarse_leaf) == int(shard_key)
+    coarse_mask = grid.shards_of(coarse_leaf) == shard_key
 
     plan = plan_read(
         np.asarray(coarse_lats),
@@ -526,9 +528,10 @@ def _read_group(h5obj, group: str, data_source: dict, shard_key: int, grid, arro
     filters are unchanged.
 
     *Hierarchical (planned) read* (``read_plan.spatial_index`` set, in addition
-    to ``levels``/``base_level``): the AOI bbox is computed from the grid's
-    shard footprint, the coarse-level spatial-index coordinates are read fully
-    (cheap), and base-rate coords + variables + filter datasets are read only
+    to ``levels``/``base_level``): the coarse-level spatial-index coordinates
+    are read fully (cheap), matched to the shard with the mortie segment->shard
+    mask (``grid.shards_of(grid.assign(...)) == shard_key``), and base-rate
+    coords + variables + filter datasets are read only
     over the planned hyperslices via :func:`zagg.read_plan.execute_read_plan`.
     Empty-AOI groups short-circuit to ``None``. Selectivity above the configured
     threshold falls back to the full-read path; the planned and full paths

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -333,21 +333,18 @@ def _planned_read_group(
     if n_base <= 0:
         return None
 
-    # Compute the shard's WGS84 bbox from the grid (every grid's
-    # ``shard_footprint`` returns a shapely ``Polygon`` or ``MultiPolygon``).
-    # An antimeridian-crossing HEALPix shard's footprint can come back as a
-    # split ``MultiPolygon`` (see ``zagg.viz.shardmap._split_antimeridian``),
-    # in which case ``.bounds`` spans ~360 deg in lon and would neutralize
-    # the IO bound (the AOI would intersect every segment). Same for
-    # globe-spanning polar caps. Detect the wide-bbox case up front and fall
-    # back to ``_read_group_full`` so we don't pretend to optimize.
-    poly = grid.shard_footprint(shard_key)
-    min_lon, min_lat, max_lon, max_lat = poly.bounds
-    if (max_lon - min_lon) >= 180.0:
-        # Hand off to the full-read path; the planned-IO benefit is gone for
-        # this shard and trying to plan would waste the coarse-coord read.
-        return _read_group_full(h5obj, group, data_source, shard_key, grid, arrow=arrow)
-    bbox = (float(min_lon), float(min_lat), float(max_lon), float(max_lat))
+    # Match segments to this shard with the SAME mortie test the photon path
+    # applies below (``grid.shards_of(grid.assign(...)) == shard_key``), not a
+    # loose bbox + per-segment shapely scan (issue #95). It is exact to the leaf
+    # cell, vectorized (~280x faster than the shapely loop on a 181k-segment
+    # ATL03 beam), and antimeridian/polar-correct -- so the wide-bbox bail the
+    # old bbox path needed is gone; a shard that genuinely spans most segments is
+    # still caught by ``plan_read``'s selectivity ``full_read`` fallback. The
+    # mask is rep-point based, so a boundary segment whose photons straddle the
+    # shard edge is recovered by ``pad`` (and the photon-level filter below never
+    # over-includes); residual omission is bounded to a few edge photons (#95).
+    coarse_leaf = grid.assign(np.asarray(coarse_lats), np.asarray(coarse_lons))
+    coarse_mask = grid.shards_of(coarse_leaf) == int(shard_key)
 
     plan = plan_read(
         np.asarray(coarse_lats),
@@ -355,10 +352,10 @@ def _planned_read_group(
         np.asarray(ibeg_arr),
         np.asarray(cnt_arr),
         n_base,
-        bbox,
         index_base=index_base,
         pad=pad,
         full_read_threshold=full_read_threshold,
+        coarse_mask=coarse_mask,
     )
 
     if not plan.parent_runs:

--- a/src/zagg/read_plan.py
+++ b/src/zagg/read_plan.py
@@ -1,9 +1,11 @@
 """Offline-computable read plan for AOI-based hyperslice selection (issue #43, Phase C).
 
-``plan_read`` computes which coarse-level segments (e.g. ATL03 ``land_ice_segments``)
-overlap a bounding-box AOI, merges adjacent runs, translates them to base-level
-(photon) slices, and packages them as h5coro-compatible hyperslice lists.
-``execute_read_plan`` then drives a caller-supplied read function with those slices.
+``plan_read`` takes which coarse-level segments (e.g. ATL03 ``land_ice_segments``)
+match the AOI -- preferably a precomputed mortie segment->shard ``coarse_mask``
+(issue #95), or a bbox fallback -- merges adjacent runs, translates them to
+base-level (photon) slices, and packages them as h5coro-compatible hyperslice
+lists. ``execute_read_plan`` then drives a caller-supplied read function with
+those slices.
 
 Both functions are pure and offline-testable — no h5coro, S3, or credentials needed.
 """
@@ -51,17 +53,30 @@ def plan_read(
     index_beg_arr: np.ndarray,
     count_arr: np.ndarray,
     n_base: int,
-    bbox: tuple[float, float, float, float],
+    bbox: tuple[float, float, float, float] | None = None,
     index_base: int = 0,
     pad: int = 1,
     full_read_threshold: float = 0.9,
+    coarse_mask: np.ndarray | None = None,
 ) -> ReadPlan:
-    """Compute a hyperslice-based read plan for an AOI bounding box (issue #43, Phase C).
+    """Compute a hyperslice-based read plan for an AOI (issue #43, Phase C).
 
-    For each coarse-level parent (segment), checks whether:
-    (a) the rep-point ``(lat_arr[j], lon_arr[j])`` falls within ``bbox``, OR
-    (b) the linestring from ``(lat_arr[j], lon_arr[j])`` to the next parent
-        crosses ``bbox`` (euclidean approximation, fine for 20 m segments).
+    Which coarse-level parents (segments) match the AOI is decided one of two
+    ways:
+
+    * ``coarse_mask`` given (preferred) -- a boolean array, one entry per parent,
+      already computed by the caller. The production path passes the **mortie**
+      segment->shard mask (``grid.shards_of(grid.assign(seg_lat, seg_lon)) ==
+      shard_key``), the same exact test the photon path applies later -- so the
+      coarse filter matches the leaf cell, not a loose bbox, and skips the
+      per-segment shapely scan entirely (issue #95). Because the mask is
+      rep-point based, a boundary segment whose photons straddle the shard edge
+      is recovered by ``pad`` (and the exact photon-level filter never
+      *over*-includes), so the only residual is a bounded edge omission.
+    * ``bbox`` given (no ``coarse_mask``) -- the grid-free fallback: a parent
+      matches when its rep-point ``(lat, lon)`` is in ``bbox`` OR the linestring
+      to the next parent crosses ``bbox`` (euclidean, fine for 20 m segments).
+      Kept for offline/grid-free callers and tests.
 
     Adjacent matched parents are merged into contiguous runs, padded by ``pad``
     elements on each side, then translated to base-level ``[start, end)`` slices.
@@ -72,10 +87,10 @@ def plan_read(
 
     Parameters
     ----------
-    lat_arr : np.ndarray
-        Float array, shape ``(n_coarse,)``. Rep-point latitudes of each parent.
-    lon_arr : np.ndarray
-        Float array, shape ``(n_coarse,)``. Rep-point longitudes of each parent.
+    lat_arr, lon_arr : np.ndarray
+        Float arrays, shape ``(n_coarse,)``. Rep-point coords of each parent.
+        Used only by the ``bbox`` fallback; ignored when ``coarse_mask`` is given
+        (then only their length sets ``n_coarse``).
     index_beg_arr : np.ndarray
         Integer array, shape ``(n_coarse,)``. Base-level start for each parent
         (before ``index_base`` adjustment).
@@ -83,55 +98,58 @@ def plan_read(
         Integer array, shape ``(n_coarse,)``. Number of base-level children per parent.
     n_base : int
         Total size of the base array.
-    bbox : (min_lon, min_lat, max_lon, max_lat)
-        Bounding box for the AOI.
+    bbox : (min_lon, min_lat, max_lon, max_lat), optional
+        AOI bounding box for the fallback matcher. Required when ``coarse_mask``
+        is not given.
     index_base : int
         0 (default) or 1 (ATL03 1-based ``ph_index_beg``).
     pad : int
         Number of extra parents to include on each side of each run (clamped
-        to array bounds). Helps capture partial edge segments.
+        to array bounds). Recovers partial edge segments (the omission knob).
     full_read_threshold : float
         Fraction of ``n_base`` above which the plan falls back to a full read.
+    coarse_mask : np.ndarray, optional
+        Boolean per-parent match mask. Takes precedence over ``bbox``.
 
     Returns
     -------
     ReadPlan
     """
-    n_coarse = len(lat_arr)
+    n_coarse = len(index_beg_arr)  # one entry per coarse parent (segment)
     if n_coarse == 0 or n_base == 0:
         return ReadPlan(parent_runs=[], base_slices=[], chunk_lists=[])
 
-    aoi_box = box(bbox[0], bbox[1], bbox[2], bbox[3])
-
     # -- AOI matching --
-    in_aoi = np.zeros(n_coarse, dtype=bool)
-    for j in range(n_coarse):
-        lat, lon = float(lat_arr[j]), float(lon_arr[j])
-        if bbox[0] <= lon <= bbox[2] and bbox[1] <= lat <= bbox[3]:
-            in_aoi[j] = True
-            continue
-        # Last segment: no next-segment linestring to check; rep-point only.
-        if j + 1 < n_coarse:
-            lat2, lon2 = float(lat_arr[j + 1]), float(lon_arr[j + 1])
-            seg_line = LineString([(lon, lat), (lon2, lat2)])
-            if seg_line.intersects(aoi_box):
+    if coarse_mask is not None:
+        in_aoi = np.asarray(coarse_mask, dtype=bool)
+        if in_aoi.shape != (n_coarse,):
+            raise ValueError(f"coarse_mask shape {in_aoi.shape} != ({n_coarse},) parents")
+    elif bbox is not None:
+        # Grid-free fallback: per-segment rep-point / linestring test against bbox.
+        aoi_box = box(bbox[0], bbox[1], bbox[2], bbox[3])
+        in_aoi = np.zeros(n_coarse, dtype=bool)
+        for j in range(n_coarse):
+            lat, lon = float(lat_arr[j]), float(lon_arr[j])
+            if bbox[0] <= lon <= bbox[2] and bbox[1] <= lat <= bbox[3]:
                 in_aoi[j] = True
+                continue
+            # Last segment: no next-segment linestring to check; rep-point only.
+            if j + 1 < n_coarse:
+                lat2, lon2 = float(lat_arr[j + 1]), float(lon_arr[j + 1])
+                seg_line = LineString([(lon, lat), (lon2, lat2)])
+                if seg_line.intersects(aoi_box):
+                    in_aoi[j] = True
+    else:
+        raise ValueError("plan_read requires either coarse_mask or bbox")
 
     if not in_aoi.any():
         return ReadPlan(parent_runs=[], base_slices=[], chunk_lists=[])
 
     # -- Run merging --
-    # Find contiguous blocks of True in in_aoi.
-    raw_runs: list[tuple[int, int]] = []
-    start_run = None
-    for j in range(n_coarse):
-        if in_aoi[j] and start_run is None:
-            start_run = j
-        elif not in_aoi[j] and start_run is not None:
-            raw_runs.append((start_run, j - 1))
-            start_run = None
-    if start_run is not None:
-        raw_runs.append((start_run, n_coarse - 1))
+    # Contiguous blocks of True in in_aoi, found vectorized via the rising/falling
+    # edges of the mask (sentinel-padded so runs touching either end are closed).
+    edges = np.flatnonzero(np.diff(np.concatenate(([False], in_aoi, [False])).astype(np.int8)))
+    raw_runs: list[tuple[int, int]] = list(zip(edges[::2].tolist(), (edges[1::2] - 1).tolist()))
 
     # -- Padding --
     padded_runs: list[tuple[int, int]] = []

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -3272,6 +3272,53 @@ class TestPlannedReadGroup:
         assert df_pad1["h"].tolist() == [30.0, 40.0, 50.0, 60.0]
         assert df_pad1["h"].tolist() == df_full["h"].tolist()
 
+    def test_pad_does_not_recover_segment_two_runs_away(self):
+        # Pins the omission bound from the PR's rep-point argument (issue #95):
+        # pad recovers an in-band photon only when its OWNING segment is within
+        # ``pad`` of a matched rep-point segment. Here segment 0 has a stray
+        # photon (lat 255) inside the band [190, 260], but seg 0's rep-point (0)
+        # is two segments away from the only matched segment (seg 2, rep 200),
+        # so pad=1 does NOT pull seg 0's run in and the stray photon stays
+        # omitted. The full read keeps it -> the planned read intentionally
+        # diverges, confirming the bound is exactly ``pad`` segments, not "a few
+        # edge photons" unconditionally.
+        seg_lats = np.array([0.0, 100.0, 200.0, 300.0, 400.0])
+        seg_lons = np.zeros(5)
+        # seg 0 owns photons {0,1}, seg 1 {2}, seg 2 {3}, seg 3 {4}, seg 4 {5}.
+        ibeg = np.array([0, 2, 3, 4, 5], dtype=np.int64)
+        cnt = np.array([2, 1, 1, 1, 1], dtype=np.int64)
+        # photon 1 is seg 0's stray, parked inside the band at lat 255.
+        ph_lats = np.array([0.0, 255.0, 100.0, 200.0, 300.0, 400.0])
+        ph_lons = np.zeros(6)
+        h = np.arange(6.0, dtype=np.float32) * 10.0
+        h5 = _FakeH5(
+            {
+                "/seg/lat": seg_lats,
+                "/seg/lon": seg_lons,
+                "/seg/ph_index_beg": ibeg,
+                "/seg/segment_ph_cnt": cnt,
+                "/heights/lat_ph": ph_lats,
+                "/heights/lon_ph": ph_lons,
+                "/heights/h": h,
+            }
+        )
+        grid = _LatBboxGrid((-0.1, 190.0, 0.1, 260.0))  # rep-point band: seg 2 only
+
+        ds_pad1 = _planned_read_data_source()
+        ds_pad1["read_plan"]["pad"] = 1
+        df_pad1 = _read_group(h5, "gt1l", ds_pad1, 0, grid)
+        # Run [2,2] padded to [1,3] -> photons 2..4 -> only seg 2's photon (lat
+        # 200, h=30) is in band; seg 0's stray (h=10) is two runs away, omitted.
+        assert df_pad1["h"].tolist() == [30.0]
+
+        ds_full = {
+            "coordinates": {"latitude": "/heights/lat_ph", "longitude": "/heights/lon_ph"},
+            "variables": {"h": "/heights/h"},
+        }
+        df_full = _read_group(h5, "gt1l", ds_full, 0, grid)
+        # The full read recovers the stray (h=10) the planned read omits at pad=1.
+        assert df_full["h"].tolist() == [10.0, 30.0]
+
     def test_invalid_link_target_raises(self):
         # The spatial_index level's link must point at the base level.
         ds = _planned_read_data_source()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -3147,22 +3147,21 @@ class TestPlannedReadGroup:
     pulls in exactly its two neighbours."""
 
     def test_planned_path_bounds_io_to_matched_segments(self):
-        # Bbox (-0.1, 175, 0.1, 225) directly contains segment 2 (lat=200);
-        # segment 1's (lat 100 -> 200) linestring crosses the lower edge so
-        # plan_read sweeps segment 1 in too. Two adjacent segments -> one
-        # contiguous run -> photons 2..5 in the base array.
+        # Mortie segment->shard mask (issue #95): lat band [100, 250] selects
+        # segments 1 (lat 100) and 2 (lat 200) by rep-point -> one contiguous run
+        # -> photons 2..5; the photon-level mask keeps all four (lat 100..250).
         ds = _planned_read_data_source()
         h5 = _planned_read_h5()
-        grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
+        grid = _LatBboxGrid((-0.1, 100.0, 0.1, 250.0))
         df = _read_group(h5, "gt1l", ds, 0, grid)
         assert df["h"].tolist() == [20.0, 30.0, 40.0, 50.0]
 
     def test_empty_aoi_returns_none(self):
-        # Bbox far from any segment rep-point or linestring -> no parents
-        # match -> short-circuit return None before any base-rate read.
+        # No segment rep-point maps to this shard -> empty coarse mask ->
+        # short-circuit return None before any base-rate read.
         ds = _planned_read_data_source()
         h5 = _planned_read_h5()
-        grid = _BboxGrid((10000.0, 10000.0, 10001.0, 10001.0))
+        grid = _LatBboxGrid((-0.1, 10000.0, 0.1, 10001.0))
         assert _read_group(h5, "gt1l", ds, 0, grid) is None
 
     def test_full_read_fallback_on_high_selectivity(self):
@@ -3237,27 +3236,41 @@ class TestPlannedReadGroup:
         assert df_full["h"].tolist() == [0.0, 10.0]
 
     def test_coarse_filter_via_planned_path(self):
-        # Cross-level (Phase B) filter ANDs with the planned path: drop
-        # segment 1 via podppd; segment 2 (also pulled in by the linestring
-        # sweep) survives. Photons 2,3 dropped; 4,5 kept.
+        # Cross-level (Phase B) filter ANDs with the planned path: lat band
+        # [100, 250] selects segments 1,2 (mortie mask); podppd drops segment 1.
+        # Photons 2,3 dropped; 4,5 kept.
         ds = _planned_read_data_source(with_coarse_filter=True)
         podppd = np.array([0, 1, 0, 0, 0, 0], dtype=np.int8)
         h5 = _planned_read_h5(podppd=podppd)
-        grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
+        grid = _LatBboxGrid((-0.1, 100.0, 0.1, 250.0))
         df = _read_group(h5, "gt1l", ds, 0, grid)
         assert df["h"].tolist() == [40.0, 50.0]
 
-    def test_pad_extends_selection(self):
-        # bbox (490..510) covers segment 5 (last, lat=500) directly; segment
-        # 4's linestring (400 -> 500) crosses the lower edge. With pad=0:
-        # segments 4,5 -> photons 8..11. With pad=1: segments 3,4,5,6(clamped
-        # back to 5) -> photons 6..11.
-        ds = _planned_read_data_source()
-        ds["read_plan"]["pad"] = 1
+    def test_pad_recovers_boundary_segment_and_matches_full(self):
+        # Omission guard for the rep-point mask (issue #95): lat band [150, 310].
+        # The mortie mask selects segments 2 (lat 200) and 3 (lat 300) by
+        # rep-point, but photon 3 (lat 150) belongs to segment 1, whose rep-point
+        # (100) is OUTSIDE the band. With pad=0 it would be omitted; pad=1 pulls
+        # segment 1 into the run, recovering photon 3 -- so the planned read then
+        # matches the full read exactly (no omission at the tested pad).
         h5 = _planned_read_h5()
-        grid = _BboxGrid((-0.1, 490.0, 0.1, 510.0))
-        df = _read_group(h5, "gt1l", ds, 0, grid)
-        assert df["h"].tolist() == [60.0, 70.0, 80.0, 90.0, 100.0, 110.0]
+        grid = _LatBboxGrid((-0.1, 150.0, 0.1, 310.0))
+
+        ds_pad0 = _planned_read_data_source()  # pad=0 default
+        df_pad0 = _read_group(h5, "gt1l", ds_pad0, 0, grid)
+        assert df_pad0["h"].tolist() == [40.0, 50.0, 60.0]  # photon 3 (h=30) omitted
+
+        ds_pad1 = _planned_read_data_source()
+        ds_pad1["read_plan"]["pad"] = 1
+        df_pad1 = _read_group(h5, "gt1l", ds_pad1, 0, grid)
+        # Ground truth: a full read keeps every photon whose lat is in band.
+        ds_full = {
+            "coordinates": {"latitude": "/heights/lat_ph", "longitude": "/heights/lon_ph"},
+            "variables": {"h": "/heights/h"},
+        }
+        df_full = _read_group(h5, "gt1l", ds_full, 0, grid)
+        assert df_pad1["h"].tolist() == [30.0, 40.0, 50.0, 60.0]
+        assert df_pad1["h"].tolist() == df_full["h"].tolist()
 
     def test_invalid_link_target_raises(self):
         # The spatial_index level's link must point at the base level.
@@ -3270,13 +3283,12 @@ class TestPlannedReadGroup:
 
     def test_multi_slice_plan_global_idx_alignment(self):
         # Force a plan with two disjoint base-slices (one ATL03 track that
-        # crosses the AOI lat band twice). Fixture: 10 segments × 1 photon
-        # each, lats wave from 0 -> 100 -> 0 -> 100 -> 0 so plan_read's
-        # linestring + containment check picks up segments {2,3,4} and
-        # {6,7,8} but not {0,1,5,9}. The plan therefore has two runs and
-        # ``global_idx = [2,3,4,6,7,8]``. A cross-level podppd filter that
-        # drops segment 3 must align correctly through that global_idx
-        # (otherwise photon 3's drop hits the wrong row).
+        # crosses the shard lat band twice). Fixture: 10 segments × 1 photon
+        # each, lats wave from 0 -> 100 -> 0 -> 100 -> 0. The mortie mask (lat
+        # band [45, 105]) picks up segments {2,3,4} and {7,8} -> two runs ->
+        # ``global_idx = [2,3,4,7,8]``. A cross-level podppd filter that drops
+        # segment 3 must align correctly through that global_idx (otherwise
+        # photon 3's drop hits the wrong row).
         seg_lats = np.array([0.0, 0.0, 50.0, 100.0, 100.0, 0.0, 0.0, 100.0, 100.0, 0.0])
         seg_lons = np.zeros(10)
         ibeg = np.arange(10, dtype=np.int64)
@@ -3298,12 +3310,12 @@ class TestPlannedReadGroup:
             }
         )
         ds = _planned_read_data_source(with_coarse_filter=True)
-        grid = _BboxGrid((-0.1, 95.0, 0.1, 105.0))
+        grid = _LatBboxGrid((-0.1, 45.0, 0.1, 105.0))
         df = _read_group(h5, "gt1l", ds, 0, grid)
-        # plan covers segments {2,3,4} and {6,7,8} -> base_slices [(2,5),(6,9)]
-        # -> global_idx [2,3,4,6,7,8] -> base photons h = [20,30,40,60,70,80]
+        # mask selects segments {2,3,4} and {7,8} -> base_slices [(2,5),(7,9)]
+        # -> global_idx [2,3,4,7,8] -> in-band photons h = [20,30,40,70,80];
         # cross-level drops segment 3 -> drop photon 3 (h=30) only.
-        assert df["h"].tolist() == [20.0, 40.0, 60.0, 70.0, 80.0]
+        assert df["h"].tolist() == [20.0, 40.0, 70.0, 80.0]
 
     def test_full_read_fallback_carries_filters(self):
         # The selectivity-fallback path must produce the same row set as the
@@ -3319,16 +3331,17 @@ class TestPlannedReadGroup:
         # Full-coord path keeps all 12 photons (permissive grid); qs drops 5,6.
         assert df["h"].tolist() == [0.0, 10.0, 20.0, 30.0, 40.0, 70.0, 80.0, 90.0, 100.0, 110.0]
 
-    def test_antimeridian_grid_falls_back_to_full_read(self):
-        # A grid whose shard_footprint spans ~360 deg in lon (HEALPix
-        # antimeridian / polar cap) gives plan_read a useless bbox. The
-        # planned path detects this and falls back so the full-read path is
-        # used instead -- otherwise the AOI would intersect every segment.
+    def test_low_selectivity_falls_back_to_full_read(self):
+        # The mortie mask needs no antimeridian/polar special-case (issue #95):
+        # ``grid.assign`` is globally correct, so the old wide-bbox bail is gone.
+        # A shard that genuinely owns (nearly) every segment -- here the
+        # permissive grid maps all of them in -- still falls back to the full
+        # read via the selectivity threshold rather than issuing many slices that
+        # sum to the whole file.
         ds = _planned_read_data_source()
         h5 = _planned_read_h5()
-        grid = _BboxGrid((-180.0, -10.0, 180.0, 10.0))  # 360 deg lon span
+        grid = _BboxGrid((-180.0, -10.0, 180.0, 10.0))  # permissive: all segments in shard
         df = _read_group(h5, "gt1l", ds, 0, grid)
-        # Full-coord path with permissive grid keeps all 12 photons.
         assert df["h"].tolist() == [float(i * 10) for i in range(12)]
 
     def test_dispatch_rejects_empty_levels(self):
@@ -3402,19 +3415,14 @@ class TestPlannedReadGroup:
                 "/gt1l/geolocation/segment_ph_cnt": cnt,
             }
         )
-        # Bbox around segment 2 (lat=200); pad=1 (the shipped default) widens
-        # the matched parent run by one on each side. The permissive grid
-        # accepts every photon read so the planned path's output is the
-        # post-filter photon set.
+        # Permissive grid: every segment maps to the shard, so with pad=1 the
+        # run spans all 4 segments and the planned read falls back to the full
+        # read via the selectivity threshold (still index_base=1 arithmetic).
+        # Plan covers photons 0..7; the 2-D signal_conf_ph filter drops photon 4
+        # (uniform TEP -2 across all 5 surface types). Survivors: 0,1,2,3,5,6,7.
         grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
         df = _read_group(h5, "gt1l", ds, 0, grid)
         assert df is not None
-        # Without pad the bbox (lat 175..225) matches seg 2 (lat=200) directly
-        # and seg 1 via the lstr 1->2 sweep (lat 100->200 crosses y=175); seg
-        # 2's own lstr 2->3 (200->300) pulls in seg 2 again. With pad=1 the
-        # run [1, 2] widens to [0, 3]. Plan covers photons 0..7. The 2-D
-        # signal_conf_ph filter drops photon 4 (uniform TEP -2 across all 5
-        # surface types). Survivors: 0, 1, 2, 3, 5, 6, 7.
         assert df["h_ph"].tolist() == [0.0, 10.0, 20.0, 30.0, 50.0, 60.0, 70.0]
 
 
@@ -3535,7 +3543,7 @@ class TestSegmentLevelVariables:
         h5 = _planned_read_h5()
         # 6 segments; dem_h one value per segment.
         h5._arrays["/seg/dem_h"] = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0], dtype=np.float32)
-        grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
+        grid = _LatBboxGrid((-0.1, 100.0, 0.1, 250.0))
         df = _read_group(h5, "gt1l", ds, 0, grid)
         # Planned path selects photons 2,3 (seg 1) and 4,5 (seg 2).
         assert df["h"].tolist() == [20.0, 30.0, 40.0, 50.0]
@@ -3552,7 +3560,7 @@ class TestSegmentLevelVariables:
         qs[3] = 1
         h5 = _planned_read_h5(qs=qs)
         h5._arrays["/seg/dem_h"] = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0], dtype=np.float32)
-        grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
+        grid = _LatBboxGrid((-0.1, 100.0, 0.1, 250.0))
         df = _read_group(h5, "gt1l", ds, 0, grid)
         # Selected photons 2,3 (seg 1) + 4,5 (seg 2); qs drops photon 3.
         assert df["h"].tolist() == [20.0, 40.0, 50.0]
@@ -3567,7 +3575,7 @@ class TestSegmentLevelVariables:
         ds["filters"] = [{"expression": "dem_h > 25.0"}]
         h5 = _planned_read_h5()
         h5._arrays["/seg/dem_h"] = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0], dtype=np.float32)
-        grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
+        grid = _LatBboxGrid((-0.1, 100.0, 0.1, 250.0))
         df = _read_group(h5, "gt1l", ds, 0, grid)
         # Selected photons 2,3 (seg 1, dem_h 20) + 4,5 (seg 2, dem_h 30); the
         # filter drops seg 1 (20 <= 25) and keeps seg 2 (30 > 25).

--- a/tests/test_read_plan.py
+++ b/tests/test_read_plan.py
@@ -4,6 +4,7 @@ All tests use synthetic numpy arrays — no h5coro, S3, or credentials needed.
 """
 
 import numpy as np
+import pytest
 
 from zagg.read_plan import ReadPlan, execute_read_plan, plan_read
 
@@ -291,3 +292,59 @@ class TestExecuteReadPlan:
         out = execute_read_plan(plan, read_fn, "/h", np.float32)
         assert calls == [None]  # full-read call, no hyperslice
         np.testing.assert_array_equal(out, data)
+
+
+class TestPlanReadCoarseMask:
+    """The mortie-mask path (issue #95): a precomputed boolean ``coarse_mask``
+    replaces the shapely/bbox per-segment scan, and the contiguous-run detection
+    is vectorized off that mask."""
+
+    def test_mask_matches_equivalent_bbox(self):
+        # The mask path must produce the same plan as the bbox path picking the
+        # same segments. Segs 0 and 1 in AOI -> one run [0, 1] -> photons 0..19.
+        lats, lons, idx, cnt, n_base = _isolated_setup(5)
+        bbox = (0.0, -0.5, 1.0, 40.5)  # covers segs 0 and 1
+        by_bbox = plan_read(lats, lons, idx, cnt, n_base, bbox, pad=0)
+        mask = np.array([True, True, False, False, False])
+        by_mask = plan_read(lats, lons, idx, cnt, n_base, pad=0, coarse_mask=mask)
+        assert by_mask.parent_runs == by_bbox.parent_runs == [(0, 1)]
+        assert by_mask.base_slices == by_bbox.base_slices == [(0, 20)]
+
+    def test_mask_multiple_disjoint_runs(self):
+        # Vectorized run detection must split non-contiguous True blocks, including
+        # runs that touch the first and last element.
+        lats, lons, idx, cnt, n_base = _isolated_setup(6)
+        mask = np.array([True, False, True, True, False, True])
+        plan = plan_read(lats, lons, idx, cnt, n_base, pad=0, coarse_mask=mask)
+        assert plan.parent_runs == [(0, 0), (2, 3), (5, 5)]
+        assert plan.base_slices == [(0, 10), (20, 40), (50, 60)]
+
+    def test_mask_pad_extends_run(self):
+        lats, lons, idx, cnt, n_base = _isolated_setup(5)
+        mask = np.array([False, False, True, False, False])
+        plan = plan_read(lats, lons, idx, cnt, n_base, pad=1, coarse_mask=mask)
+        assert plan.parent_runs == [(1, 3)]  # seg 2 padded by one on each side
+
+    def test_empty_mask_returns_empty_plan(self):
+        lats, lons, idx, cnt, n_base = _isolated_setup(5)
+        mask = np.zeros(5, dtype=bool)
+        plan = plan_read(lats, lons, idx, cnt, n_base, pad=0, coarse_mask=mask)
+        assert plan.parent_runs == [] and not plan.full_read
+
+    def test_mask_takes_precedence_over_bbox(self):
+        # When both are passed, the mask wins (the bbox is ignored).
+        lats, lons, idx, cnt, n_base = _isolated_setup(5)
+        far_bbox = (100.0, 100.0, 110.0, 110.0)  # would match nothing
+        mask = np.array([True, False, False, False, False])
+        plan = plan_read(lats, lons, idx, cnt, n_base, far_bbox, pad=0, coarse_mask=mask)
+        assert plan.parent_runs == [(0, 0)]
+
+    def test_mask_shape_mismatch_raises(self):
+        lats, lons, idx, cnt, n_base = _isolated_setup(5)
+        with pytest.raises(ValueError, match="coarse_mask shape"):
+            plan_read(lats, lons, idx, cnt, n_base, pad=0, coarse_mask=np.ones(3, dtype=bool))
+
+    def test_neither_mask_nor_bbox_raises(self):
+        lats, lons, idx, cnt, n_base = _isolated_setup(5)
+        with pytest.raises(ValueError, match="requires either coarse_mask or bbox"):
+            plan_read(lats, lons, idx, cnt, n_base)


### PR DESCRIPTION
Closes #95.

## What

`plan_read` (the issue-#43 read pre-filter) decided which segment byte-ranges to fetch with a **Python loop over every coarse segment** that built a shapely `LineString` and called `.intersects()` against the shard's **bbox**. On a 181k-segment ATL03 beam that's ~1.07 s/beam — ~300 s of pure, region-independent CPU for a 47-granule × 6-beam shard, the dominant slice of the 900 s Lambda timeout.

This replaces the segment match with the **same mortie test the photon path already uses** (`grid.shards_of(grid.assign(seg_lat, seg_lon)) == shard_key`, `read.py:401`): exact to the leaf cell, vectorized, ~280× faster.

```
one ATL03 beam, 181,024 segments:
  shapely plan_read : 1069.4 ms
  mortie assign     :    3.8 ms   (279x)
```

## Changes

- **`read_plan.plan_read`**: new optional `coarse_mask` (boolean, one entry per segment). When given it's used directly — no shapely, no bbox. The contiguous-run detection is now vectorized (`np.diff` on the sentinel-padded mask) instead of a per-segment Python loop. The bbox/linestring path is kept as a **grid-free fallback** so the offline `plan_read` unit tests are unchanged; `bbox` is now optional and the function raises if neither `coarse_mask` nor `bbox` is given.
- **`processing._planned_read_group`**: computes `coarse_mask = grid.shards_of(grid.assign(seg_lat, seg_lon)) == shard_key` and passes it. Drops the per-group `shard_footprint`→bbox derivation and the wide-bbox antimeridian/polar bail — mortie `assign` is globally correct, and a shard that genuinely owns most segments is still caught by `plan_read`'s selectivity `full_read` fallback.

## Errors of omission — explicit

The mask is **rep-point** based, so a boundary segment whose ~20 m of photons straddle the shard edge but whose rep-point lands in a neighbor could be skipped. This is **one-directional** (the exact photon-level filter at `read.py:401` still runs, so we never *over*-include — only risk *under*-reading) and **bounded by `pad`**: the segments with ≥1 in-shard photon form a contiguous along-track run; a segment with in-shard photons but out-of-shard rep-point is within ~one segment of the edge and is recovered by `pad` (config `pad: 1`). Recovery holds only when the owning segment is within `pad` of a matched rep-point segment — a stray photon ≥2 segments from any match is *not* recovered at `pad=1` (pinned by `test_pad_does_not_recover_segment_two_runs_away`); at dense ATL03 segment spacing that is effectively unreachable. The residual is a track skimming nearly parallel to a cell edge — a few edge photons, negligible at shard scale; `pad: 2` is cheap insurance. The old bbox path was a looser superset (marginally lower omission) but ~280× slower and itself leaned on `pad`. `pad` is the omission knob.

## Tests

- `tests/test_read_plan.py::TestPlanReadCoarseMask` (7): mask matches the equivalent bbox plan; vectorized multi-run / edge-touching detection; pad; precedence over bbox; shape-mismatch and neither-arg errors. Existing bbox tests unchanged (fallback still covered).
- `tests/test_processing.py`: the `_planned_read_group` tests now drive segment selection through a lat-mask grid (the new production path). Added `test_pad_recovers_boundary_segment_and_matches_full` — the omission guard: a boundary photon whose segment rep-point is out of band is dropped at `pad=0` and **recovered at `pad=1`, matching the full read exactly**. Added `test_pad_does_not_recover_segment_two_runs_away` — pins the upper edge of that bound: a stray photon two segments from the match stays omitted at `pad=1`.

`pytest -q`: 766 passed, 1 skipped. The one failure (`test_lambda_build.py` — build script can't resolve `zarr>=3.1.5` under Python 3.10) is pre-existing and unrelated (not touched, §4). `ruff check` + `ruff format --check` clean.

## Scope / follow-ups (not here)

- The residual heavy-shard cost is **#65**: a 47-granule shard still reads each granule's full segment-coordinate arrays even when the granule contributes **0 photons** (doesn't actually cross the shard) — tighter granule→shard assignment skips them. Measured: most granules on the worst shard return 0 photons.
- The S3 driver builds a fresh boto3 client per granule (~10 s/shard of botocore model-loading) — separate, likely upstream in h5coro.

Refs #43 (the read-plan this fixes), #92 (the shardmap-order fix that made per-shard granule counts realistic and surfaced this).

Closes #53 — this PR moves the HEALPix segment→shard match to mortie (`grid.shards_of(grid.assign(...))`), the core question raised in #53 (use exact mortie cell membership rather than a bbox envelope for the coarse filter). Per the go-ahead on the #53 thread, merging this closes it; the residual "should the grid-free fallback path also be mortie-aware" stays tracked in #60.

## Questions for review

- Dropping the wide-bbox antimeridian bail: I'm relying on mortie `assign` being globally correct (it is) plus the selectivity `full_read` fallback for genuinely-wide shards. Comfortable with that, or keep an explicit guard?