### PR TITLE
Worker-runtime stats + opt-in --profile timing (issue #100)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -53,6 +53,7 @@ full pipeline using only lambda:InvokeFunction.
 import json
 import logging
 import os
+import time
 from typing import Any, Dict
 
 # Import cloud-agnostic processing
@@ -247,6 +248,11 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # Zarr chunk through the sink. At K==1 the sink holds exactly one entry whose
         # ``block_index`` equals ``event["chunk_idx"]``, so the write is unchanged.
         from zagg.processing import process_shard
+        # Opt-in per-phase timing (issue #100). When the orchestrator forwards
+        # ``profile``, ``process_shard`` fills ``metadata["phase_timings"]`` with
+        # read/index/aggregate deltas; the write phase runs here, so we bracket it
+        # below and merge it in. Default (no key) leaves the worker path unchanged.
+        profile = event.get("profile", False)
         chunk_results: list = []
         _df_out, metadata = process_shard(
             grid,
@@ -255,10 +261,12 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             s3_credentials=s3_creds,
             config=config,
             chunk_results=chunk_results,
+            profile=profile,
         )
 
         # Write Zarr to store: one dense region per chunk plus its ragged (CSR)
         # companion. Mirrors the local runner's K>1 write loop (``_process_and_write``).
+        _write_t0 = time.time() if profile else None
         if chunk_results:
             store_path = event["store_path"]
             store = open_store(store_path, **_output_store_kwargs(event))
@@ -305,6 +313,13 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             except Exception as e:
                 logger.error(f"Failed to write zarr to {store_path}: {e}")
                 metadata["error"] = f"Failed to write zarr: {e}"
+
+        # Record the write-phase timing (issue #100). read/index/aggregate come
+        # from ``process_shard``; ``write`` is owned here, so it joins the same
+        # sub-dict only when profiling and a write actually ran (non-empty
+        # ``chunk_results``). The no-data path leaves ``write`` absent.
+        if profile and chunk_results and "phase_timings" in metadata:
+            metadata["phase_timings"]["write"] = time.time() - _write_t0
 
         # Log structured result
         logger.info(

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -310,16 +310,18 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                         grid=grid,
                         shard_key=ragged_key,
                     )
+                # Record the write-phase timing (issue #100) only on a clean write:
+                # read/index/aggregate come from ``process_shard``; ``write`` is owned
+                # here and joins the same sub-dict. Recording inside the ``try`` (and
+                # after the early-return template-missing 500) keeps ``write`` absent
+                # on every failure path, so the runner's per-phase max rollup never
+                # folds in a time-to-failure as a real write duration. The no-data
+                # path returns earlier without writing, so ``write`` stays absent too.
+                if profile and "phase_timings" in metadata:
+                    metadata["phase_timings"]["write"] = time.time() - _write_t0
             except Exception as e:
                 logger.error(f"Failed to write zarr to {store_path}: {e}")
                 metadata["error"] = f"Failed to write zarr: {e}"
-
-        # Record the write-phase timing (issue #100). read/index/aggregate come
-        # from ``process_shard``; ``write`` is owned here, so it joins the same
-        # sub-dict only when profiling and a write actually ran (non-empty
-        # ``chunk_results``). The no-data path leaves ``write`` absent.
-        if profile and chunk_results and "phase_timings" in metadata:
-            metadata["phase_timings"]["write"] = time.time() - _write_t0
 
         # Log structured result
         logger.info(

--- a/src/zagg/__main__.py
+++ b/src/zagg/__main__.py
@@ -40,6 +40,11 @@ examples:
     parser.add_argument("--max-workers", type=int, default=None, help="Max concurrent workers")
     parser.add_argument("--overwrite", action="store_true", help="Overwrite existing Zarr template")
     parser.add_argument("--dry-run", action="store_true", help="Show what would be processed")
+    parser.add_argument(
+        "--profile", action="store_true",
+        help="Emit per-phase worker timings (read/index/aggregate) on the lambda "
+             "backend. Off by default to avoid the per-worker probe tax (issue #100).",
+    )
     parser.add_argument("--region", default="us-west-2", help="AWS region (default: us-west-2)")
     parser.add_argument(
         "--output-creds", default=None, metavar="PATH",
@@ -84,6 +89,7 @@ examples:
         region=args.region,
         output_credentials=output_credentials,
         output_endpoint_url=output_endpoint_url,
+        profile=args.profile,
     )
 
     if args.dry_run:
@@ -99,6 +105,11 @@ examples:
         if "estimated_cost_usd" in results:
             print(f"Lambda compute: {results['lambda_time_s']:.0f}s total, "
                   f"{results['gb_seconds']:.0f} GB-s, ~${results['estimated_cost_usd']:.2f}")
+        if results.get("worker_phase_max"):
+            breakdown = ", ".join(
+                f"{phase} {secs:.0f}s" for phase, secs in results["worker_phase_max"].items()
+            )
+            print(f"Worker phases (max across cells): {breakdown}")
         print(f"Output: {results['store_path']}")
 
 

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -13,6 +13,7 @@ existing tests that ``monkeypatch.setattr("zagg.processing._read_group", ...)``
 """
 
 import logging
+import time
 import warnings
 from datetime import datetime
 from typing import List, Tuple
@@ -56,6 +57,7 @@ def process_shard(
     handoff: str = "pandas",
     ragged_out: dict | None = None,
     chunk_results: list | None = None,
+    profile: bool = False,
 ) -> Tuple[pd.DataFrame, ProcessingMetadata]:
     """Process one shard: read granules, filter to this shard, aggregate, return df.
 
@@ -116,6 +118,14 @@ def process_shard(
         returned ``df_out`` and ragged goes to ``ragged_out`` — byte-for-byte
         unchanged. A caller that passes ``None`` while the grid has K>1 cannot place
         the K carriers, so that combination raises.
+    profile : bool, optional
+        Opt-in per-phase timing (issue #100 phase 2). When ``True``, fills
+        ``metadata["phase_timings"]`` with ``read`` / ``index`` / ``aggregate``
+        wall-clock seconds (``time.time()`` deltas) for the in-worker stages.
+        Default ``False`` takes the current path unchanged — no added timing
+        calls, no ``phase_timings`` key — so the worker pays no probe tax on
+        ordinary runs. (The ``write`` phase runs in the lambda handler, outside
+        this function.)
 
     Returns
     -------
@@ -189,6 +199,11 @@ def process_shard(
     all_reads = []
     files_processed = 0
 
+    # Opt-in per-phase timing (issue #100). Only allocated when profiling so the
+    # default path stays byte-identical (no dict, no time.time() calls).
+    phase_timings: dict | None = {} if profile else None
+    _read_t0 = time.time() if profile else None
+
     # Read files and filter spatially
     for s3_url in granule_urls:
         h5obj = None
@@ -236,11 +251,15 @@ def process_shard(
 
     logger.info(f"  Processed {files_processed}/{len(granule_urls)} files")
     metadata["files_processed"] = files_processed
+    if profile:
+        phase_timings["read"] = time.time() - _read_t0
 
     if not all_reads:
         logger.info(f"  No data after filtering for shard {shard_key} - skipping")
         metadata["error"] = "No data after filtering"
         metadata["duration_s"] = (datetime.now() - start_time).total_seconds()
+        if profile:
+            metadata["phase_timings"] = phase_timings
         return pd.DataFrame(), metadata
 
     data_vars = get_data_vars(config)
@@ -258,6 +277,8 @@ def process_shard(
             f"per-chunk carriers cannot be returned through the single df_out. Pass "
             f"chunk_results=[] (the runner does)."
         )
+
+    _index_t0 = time.time() if profile else None
 
     # ---- Pool the shard's reads ONCE (shared across all K chunks) -------------
     # The shard is read+grouped a single time; only the ``chunk_precompute``
@@ -293,6 +314,10 @@ def process_shard(
         # agnostic; both carriers feed identical numpy arrays into _group_columns).
         col_arrays, cell_to_slice, n_obs_total = _concat_and_group(all_reads, grid, handoff)
         logger.info(f"  Read {n_obs_total:,} observations")
+
+    if profile:
+        phase_timings["index"] = time.time() - _index_t0
+        _aggregate_t0 = time.time()
 
     # ---- Aggregate + build one carrier per finer chunk -----------------------
     # ``iter_chunks`` is the K-chunk seam (issue #30 item 3); a minimal grid (e.g.
@@ -364,6 +389,10 @@ def process_shard(
             single_ragged = ragged
 
     logger.info(f"  Statistics: {cells_with_data} cells with data")
+
+    if profile:
+        phase_timings["aggregate"] = time.time() - _aggregate_t0
+        metadata["phase_timings"] = phase_timings
 
     duration = (datetime.now() - start_time).total_seconds()
     logger.info(f"Completed shard {shard_key} in {duration:.1f}s")

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -14,6 +14,7 @@ Usage from Python (e.g., Jupyter notebook)::
 import json
 import logging
 import os
+import statistics
 import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
@@ -668,6 +669,11 @@ def _run_lambda(
     # function so the orchestrator only needs lambda:InvokeFunction; no
     # direct S3 access to the output bucket is required (works cleanly
     # for cross-account callers like CryoCloud).
+    # Orchestrator phase brackets (always-on; just time.time() deltas around
+    # calls that already happen, so no worker probe tax -- issue #100). They
+    # decompose wall time into setup invoke / fan-out / finalize invoke so
+    # "where did wall time go" is answerable from the summary.
+    setup_start = time.time()
     _invoke_lambda_setup(
         state["lambda_client"],
         function_name,
@@ -679,6 +685,7 @@ def _run_lambda(
         config_dict=config_dict,
         output_creds_event=output_creds_event,
     )
+    setup_s = time.time() - setup_start
 
     start_time = time.time()
     n = len(cells)
@@ -712,10 +719,13 @@ def _run_lambda(
         )
     finally:
         executor.shutdown()
+    fanout_s = time.time() - start_time
 
     # Consolidate metadata via Lambda (same rationale as setup -- avoids
     # requiring orchestrator-side S3 access).
+    finalize_start = time.time()
     executor.finalize()
+    finalize_s = time.time() - finalize_start
     wall_time = time.time() - start_time
 
     # Cost estimate: arm64 pricing = $0.0000133334/GB-second. Compute gb_seconds
@@ -730,6 +740,21 @@ def _run_lambda(
     price_per_gb_sec = LAMBDA_PRICE_PER_GB_SEC
     estimated_cost = gb_seconds * price_per_gb_sec
 
+    # Worker-runtime distribution (issue #100). Wall time on a parallel fan-out
+    # tracks the *straggler*, not the mean, so surface max / median / pstdev of
+    # the billed per-cell durations plus the max's share of the function
+    # Timeout -- the safety margin that flags a skewed shardmap (one fat cell
+    # dominating wall time). Raw material already lives in report.results.
+    function_timeout_s = _get_function_timeout_s(state.get("lambda_client"), function_name)
+    durations = [r["lambda_duration"] for r in report.results if r.get("lambda_duration")]
+    if durations:
+        worker_max_s = max(durations)
+        worker_median_s = statistics.median(durations)
+        worker_pstdev_s = statistics.pstdev(durations)
+        worker_pct_timeout = worker_max_s / function_timeout_s if function_timeout_s else None
+    else:
+        worker_max_s = worker_median_s = worker_pstdev_s = worker_pct_timeout = None
+
     summary = {
         "total_cells": len(cells),
         "cells_with_data": report.cells_with_data,
@@ -740,6 +765,14 @@ def _run_lambda(
         "gb_seconds": gb_seconds,
         "price_per_gb_sec": price_per_gb_sec,
         "estimated_cost_usd": estimated_cost,
+        "setup_s": setup_s,
+        "fanout_s": fanout_s,
+        "finalize_s": finalize_s,
+        "function_timeout_s": function_timeout_s,
+        "worker_max_s": worker_max_s,
+        "worker_median_s": worker_median_s,
+        "worker_pstdev_s": worker_pstdev_s,
+        "worker_pct_timeout": worker_pct_timeout,
         "store_path": store_path,
         "backend": "lambda",
         "function_name": function_name,
@@ -751,6 +784,12 @@ def _run_lambda(
     logger.info(
         f"Lambda compute: {total_lambda_time:.0f}s total, {gb_seconds:.0f} GB-s, ~${estimated_cost:.2f}"
     )
+    if worker_max_s is not None:
+        pct = f"{worker_pct_timeout:.0%}" if worker_pct_timeout is not None else "n/a"
+        logger.info(
+            f"Workers: max {worker_max_s:.0f}s ({pct} of {function_timeout_s:.0f}s timeout), "
+            f"median {worker_median_s:.0f}s, pstdev {worker_pstdev_s:.0f}s"
+        )
     return summary
 
 
@@ -835,6 +874,27 @@ def _log_concurrency_report(report: ConcurrencyReport, max_workers: int) -> None
             f"current={report.current_concurrent}, padding={report.padding}, "
             f"available={report.available} -> using {max_workers} workers"
         )
+
+
+# Function Timeout fallback when get_function_configuration can't be read
+# (permission denied, etc.). Mirrors the CloudFormation default in
+# deployment/aws/template.yaml (Timeout Default: 720).
+_DEFAULT_FUNCTION_TIMEOUT_S = 720
+
+
+def _get_function_timeout_s(lambda_client, function_name):
+    """Read the function's configured Timeout (seconds), once.
+
+    Used for ``worker_pct_timeout`` (issue #100). Falls back to
+    ``_DEFAULT_FUNCTION_TIMEOUT_S`` (the template default) on any failure --
+    permission error, missing client, or a non-integer response -- so the
+    percent is exact when available and still populated otherwise.
+    """
+    try:
+        timeout = lambda_client.get_function_configuration(FunctionName=function_name)["Timeout"]
+        return int(timeout)
+    except Exception:
+        return _DEFAULT_FUNCTION_TIMEOUT_S
 
 
 def _invoke_lambda_setup(

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -86,6 +86,7 @@ def agg(
     output_credentials: dict | None = None,
     output_endpoint_url: str | None = None,
     handoff: str = "pandas",
+    profile: bool = False,
 ) -> dict:
     """Run the aggregation pipeline.
 
@@ -133,6 +134,12 @@ def agg(
         Per-cell aggregation carrier: ``"pandas"`` (default) or ``"arrow"``.
         Both produce byte-for-byte identical scalar outputs (#30); ``"arrow"``
         is opt-in for benchmarking. Only honored by the ``"local"`` backend.
+    profile : bool
+        Opt-in per-phase timing (issue #100). When ``True`` (lambda backend),
+        forwards ``profile`` into each cell event so the worker emits a
+        ``phase_timings`` (read/index/aggregate) sub-dict, and the run prints a
+        per-phase worker breakdown. Default ``False`` leaves the worker path and
+        per-cell event payload byte-identical -- no probe tax.
 
     Returns
     -------
@@ -214,6 +221,7 @@ def agg(
             function_name=function_name,
             output_credentials=output_credentials,
             output_endpoint_url=resolved_endpoint,
+            profile=profile,
         )
     else:
         raise ValueError(f"Unknown backend: {backend!r} (expected 'local' or 'lambda')")
@@ -532,6 +540,7 @@ def _run_lambda(
     function_name,
     output_credentials=None,
     output_endpoint_url=None,
+    profile=False,
 ):
     """Run processing via AWS Lambda invocation.
 
@@ -648,6 +657,7 @@ def _run_lambda(
             config_dict=config_dict,
             output_creds_event=output_creds_event,
             max_workers=state["workers"],
+            profile=profile,
         )
 
     executor = LambdaExecutor(
@@ -755,6 +765,17 @@ def _run_lambda(
     else:
         worker_max_s = worker_median_s = worker_pstdev_s = worker_pct_timeout = None
 
+    # Per-phase worker breakdown (issue #100 phase 2), only when --profile fed
+    # the workers a "profile" event so they emitted body["phase_timings"]. Roll
+    # the straggler (max) per phase across cells, matching the wall-time framing.
+    # Off by default -> no extra summary key, so the default key set is unchanged.
+    worker_phase_max = None
+    if profile:
+        worker_phase_max = {}
+        for r in report.results:
+            for phase, secs in (r.get("body", {}).get("phase_timings") or {}).items():
+                worker_phase_max[phase] = max(worker_phase_max.get(phase, 0.0), secs)
+
     summary = {
         "total_cells": len(cells),
         "cells_with_data": report.cells_with_data,
@@ -778,6 +799,8 @@ def _run_lambda(
         "function_name": function_name,
         "results": report.results,
     }
+    if profile:
+        summary["worker_phase_max"] = worker_phase_max
     logger.info(
         f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"
     )
@@ -790,6 +813,9 @@ def _run_lambda(
             f"Workers: max {worker_max_s:.0f}s ({pct} of {function_timeout_s:.0f}s timeout), "
             f"median {worker_median_s:.0f}s, pstdev {worker_pstdev_s:.0f}s"
         )
+    if profile and worker_phase_max:
+        breakdown = ", ".join(f"{phase} {secs:.0f}s" for phase, secs in worker_phase_max.items())
+        logger.info(f"Worker phases (max across cells): {breakdown}")
     return summary
 
 
@@ -967,11 +993,14 @@ def _invoke_lambda_cell(
     output_creds_event=None,
     max_retries=3,
     max_workers=None,
+    profile=False,
 ):
     """Invoke Lambda for a single cell with retry logic.
 
     ``max_workers`` is used only for the file-descriptor-exhaustion message
-    (#28); it does not affect dispatch.
+    (#28); it does not affect dispatch. ``profile`` (issue #100) forwards a
+    ``"profile": true`` event key so the worker emits ``phase_timings``; when
+    False the event payload is byte-identical to the pre-profile path (no key).
     """
     wall_start = time.time()
 
@@ -995,6 +1024,9 @@ def _invoke_lambda_cell(
         event["config"] = config_dict
     if output_creds_event is not None:
         event["output_credentials"] = output_creds_event
+    # Only add the key when profiling, so default runs stay byte-identical (#100).
+    if profile:
+        event["profile"] = True
 
     last_error = None
     for attempt in range(max_retries):

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -223,9 +223,21 @@ class TestProcessEventProfile:
     write phase it owns, merging ``phase_timings`` into the response body. When
     ``profile`` is absent the worker call and body are unchanged."""
 
-    def _patch(self, handler_mod, monkeypatch, *, worker_phase_timings, chunks):
+    def _patch(
+        self,
+        handler_mod,
+        monkeypatch,
+        *,
+        worker_phase_timings,
+        chunks,
+        template_exists=True,
+        write_raises=False,
+    ):
         """Patch process_shard to record the ``profile`` kwarg and (when given)
-        seed ``metadata['phase_timings']``; fill the sink with ``chunks``."""
+        seed ``metadata['phase_timings']``; fill the sink with ``chunks``.
+        ``template_exists`` toggles the store's existence check (template-missing
+        500 path); ``write_raises`` makes the dense write blow up (failed-write
+        500 path)."""
         import zagg.grids as grids
         import zagg.processing as processing
 
@@ -246,36 +258,46 @@ class TestProcessEventProfile:
             return pd.DataFrame(), meta
 
         store = MagicMock()
-        store.exists.return_value = True
+        store.exists.return_value = template_exists
         grid_stub = MagicMock()
         grid_stub.group_path = "8"
         grid_stub.chunk_grid_shape = (4,)
 
+        def fake_write_dense(*a, **k):
+            if write_raises:
+                raise RuntimeError("boom")
+
         monkeypatch.setattr(processing, "process_shard", fake_process_shard)
         monkeypatch.setattr(grids, "from_config", lambda *a, **k: grid_stub)
         monkeypatch.setattr(handler_mod, "open_store", lambda *a, **k: store)
-        monkeypatch.setattr(handler_mod, "write_dataframe_to_zarr", lambda *a, **k: None)
+        monkeypatch.setattr(handler_mod, "write_dataframe_to_zarr", fake_write_dense)
         monkeypatch.setattr(handler_mod, "write_ragged_to_zarr", lambda *a, **k: None)
         return cap
 
-    def test_profile_forwarded_and_write_bracketed(self, handler_mod, monkeypatch):
-        # profile=True flows into process_shard, and the handler-owned write phase
-        # is appended to the worker's read/index/aggregate timings in the body.
-        cap = self._patch(
-            handler_mod,
-            monkeypatch,
-            worker_phase_timings={"read": 1.0, "index": 0.5, "aggregate": 0.25},
-            chunks=[((0,), pd.DataFrame(), {})],
-        )
+    def _profile_event(self):
         event = _base_event(_healpix_config_dict())
         event["child_order"] = 12
         event["profile"] = True
-        resp = handler_mod._handle_process(event, _context())
+        return event
+
+    def test_profile_forwarded_and_write_bracketed(self, handler_mod, monkeypatch):
+        # profile=True flows into process_shard, the worker's read/index/aggregate
+        # timings pass through unchanged, and the handler-owned write phase is added.
+        worker = {"read": 1.0, "index": 0.5, "aggregate": 0.25}
+        cap = self._patch(
+            handler_mod,
+            monkeypatch,
+            worker_phase_timings=worker,
+            chunks=[((0,), pd.DataFrame(), {})],
+        )
+        resp = handler_mod._handle_process(self._profile_event(), _context())
         assert resp["statusCode"] == 200
         assert cap["profile"] is True
         timings = json.loads(resp["body"])["phase_timings"]
         assert set(timings) == {"read", "index", "aggregate", "write"}
-        assert timings["write"] >= 0.0
+        # worker-seeded phases pass through untouched; write is a non-negative delta.
+        assert {k: timings[k] for k in worker} == worker
+        assert isinstance(timings["write"], float) and timings["write"] >= 0.0
 
     def test_default_off_no_profile_no_timings(self, handler_mod, monkeypatch):
         # No profile key -> process_shard gets profile=False and the body carries
@@ -292,6 +314,50 @@ class TestProcessEventProfile:
         assert resp["statusCode"] == 200
         assert cap["profile"] is False
         assert "phase_timings" not in json.loads(resp["body"])
+
+    def test_profile_no_data_omits_write(self, handler_mod, monkeypatch):
+        # Empty chunk_results (no-data shard): the worker still seeds read but no
+        # write runs, so the body carries phase_timings WITHOUT a write key.
+        self._patch(
+            handler_mod,
+            monkeypatch,
+            worker_phase_timings={"read": 1.0},
+            chunks=[],
+        )
+        resp = handler_mod._handle_process(self._profile_event(), _context())
+        assert resp["statusCode"] == 200
+        timings = json.loads(resp["body"])["phase_timings"]
+        assert "write" not in timings
+
+    def test_profile_failed_write_omits_write(self, handler_mod, monkeypatch):
+        # A raising write loop (500): write timing is recorded only on a clean
+        # write, so a time-to-failure never leaks in as a real write duration.
+        self._patch(
+            handler_mod,
+            monkeypatch,
+            worker_phase_timings={"read": 1.0, "index": 0.5, "aggregate": 0.25},
+            chunks=[((0,), pd.DataFrame(), {})],
+            write_raises=True,
+        )
+        resp = handler_mod._handle_process(self._profile_event(), _context())
+        assert resp["statusCode"] == 500
+        timings = json.loads(resp["body"])["phase_timings"]
+        assert "write" not in timings
+
+    def test_profile_missing_template_omits_write(self, handler_mod, monkeypatch):
+        # Template-missing early return (500) bypasses the write loop, so write
+        # stays absent (the worker-seeded phases still ride along in the body).
+        self._patch(
+            handler_mod,
+            monkeypatch,
+            worker_phase_timings={"read": 1.0, "index": 0.5, "aggregate": 0.25},
+            chunks=[((0,), pd.DataFrame(), {})],
+            template_exists=False,
+        )
+        resp = handler_mod._handle_process(self._profile_event(), _context())
+        assert resp["statusCode"] == 500
+        timings = json.loads(resp["body"])["phase_timings"]
+        assert "write" not in timings
 
 
 class TestSetupTemplate:

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -217,6 +217,83 @@ class TestProcessEventWriteLoop:
         assert cap["ragged"][0][0] == event["shard_key"]
 
 
+class TestProcessEventProfile:
+    """Issue #100 phase 3: the handler bridges the opt-in ``profile`` event key
+    into ``process_shard`` (read/index/aggregate timing) and brackets the
+    write phase it owns, merging ``phase_timings`` into the response body. When
+    ``profile`` is absent the worker call and body are unchanged."""
+
+    def _patch(self, handler_mod, monkeypatch, *, worker_phase_timings, chunks):
+        """Patch process_shard to record the ``profile`` kwarg and (when given)
+        seed ``metadata['phase_timings']``; fill the sink with ``chunks``."""
+        import zagg.grids as grids
+        import zagg.processing as processing
+
+        cap = {}
+
+        def fake_process_shard(grid, shard_key, granule_urls, **kwargs):
+            cap["profile"] = kwargs.get("profile")
+            kwargs["chunk_results"].extend(chunks)
+            meta = {
+                "shard_key": shard_key,
+                "cells_with_data": 1,
+                "total_obs": 1,
+                "duration_s": 0.0,
+                "error": None,
+            }
+            if worker_phase_timings is not None:
+                meta["phase_timings"] = dict(worker_phase_timings)
+            return pd.DataFrame(), meta
+
+        store = MagicMock()
+        store.exists.return_value = True
+        grid_stub = MagicMock()
+        grid_stub.group_path = "8"
+        grid_stub.chunk_grid_shape = (4,)
+
+        monkeypatch.setattr(processing, "process_shard", fake_process_shard)
+        monkeypatch.setattr(grids, "from_config", lambda *a, **k: grid_stub)
+        monkeypatch.setattr(handler_mod, "open_store", lambda *a, **k: store)
+        monkeypatch.setattr(handler_mod, "write_dataframe_to_zarr", lambda *a, **k: None)
+        monkeypatch.setattr(handler_mod, "write_ragged_to_zarr", lambda *a, **k: None)
+        return cap
+
+    def test_profile_forwarded_and_write_bracketed(self, handler_mod, monkeypatch):
+        # profile=True flows into process_shard, and the handler-owned write phase
+        # is appended to the worker's read/index/aggregate timings in the body.
+        cap = self._patch(
+            handler_mod,
+            monkeypatch,
+            worker_phase_timings={"read": 1.0, "index": 0.5, "aggregate": 0.25},
+            chunks=[((0,), pd.DataFrame(), {})],
+        )
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        event["profile"] = True
+        resp = handler_mod._handle_process(event, _context())
+        assert resp["statusCode"] == 200
+        assert cap["profile"] is True
+        timings = json.loads(resp["body"])["phase_timings"]
+        assert set(timings) == {"read", "index", "aggregate", "write"}
+        assert timings["write"] >= 0.0
+
+    def test_default_off_no_profile_no_timings(self, handler_mod, monkeypatch):
+        # No profile key -> process_shard gets profile=False and the body carries
+        # no phase_timings (worker path unchanged).
+        cap = self._patch(
+            handler_mod,
+            monkeypatch,
+            worker_phase_timings=None,
+            chunks=[((0,), pd.DataFrame(), {})],
+        )
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        resp = handler_mod._handle_process(event, _context())
+        assert resp["statusCode"] == 200
+        assert cap["profile"] is False
+        assert "phase_timings" not in json.loads(resp["body"])
+
+
 class TestSetupTemplate:
     """Issue #99: the setup handler used to hand-build the HEALPix grid and drop
     ``chunk_inner``, so the template was chunked at ``parent_order`` while workers

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -327,7 +327,7 @@ class TestInvokeLambdaCellEvent:
 
     _CREDS = {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"}
 
-    def _captured_event(self, *, child_order):
+    def _captured_event(self, *, child_order, profile=False):
         from unittest.mock import MagicMock
 
         from zagg.runner import _invoke_lambda_cell
@@ -342,6 +342,7 @@ class TestInvokeLambdaCellEvent:
             client, (0,), 12345, 6, child_order,
             ["s3://b/g.h5"], "s3://out/x.zarr", self._CREDS,
             function_name="process-shard", config_dict=None, max_workers=4,
+            profile=profile,
         )
         return json.loads(client.invoke.call_args.kwargs["Payload"])
 
@@ -358,6 +359,17 @@ class TestInvokeLambdaCellEvent:
         assert event["shard_key"] == 12345
         assert "child_order" not in event
         assert "parent_morton" not in event
+
+    def test_profile_flag_adds_event_key(self):
+        # issue #100 phase 2: --profile forwards "profile": true into the event.
+        event = self._captured_event(child_order=12, profile=True)
+        assert event["profile"] is True
+
+    def test_default_event_has_no_profile_key(self):
+        # Default (profile off): event payload is byte-identical to pre-profile;
+        # no "profile" key is added.
+        event = self._captured_event(child_order=12, profile=False)
+        assert "profile" not in event
 
 
 class TestHandoffPassthrough:
@@ -487,6 +499,7 @@ class TestSummaryKeysByteIdentical:
         monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
         from unittest.mock import MagicMock
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
         monkeypatch.setattr(
@@ -538,6 +551,7 @@ class TestSummaryKeysByteIdentical:
         monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
         from unittest.mock import MagicMock
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
         monkeypatch.setattr(
@@ -566,11 +580,15 @@ class TestSummaryKeysByteIdentical:
         assert summary["estimated_cost_usd"] == (total * 2.0) * 0.0000133334
 
 
-def _run_lambda_with_durations(monkeypatch, atl06_config, durations, *, timeout=720):
+def _run_lambda_with_durations(
+    monkeypatch, atl06_config, durations, *, timeout=720, profile=False, phase_timings=None
+):
     """Drive ``_run_lambda`` over synthetic per-cell durations.
 
     Returns the summary dict. ``durations`` is consumed one per cell (the
     _run_catalog() has 4 cells); ``timeout`` stubs the function Timeout read.
+    ``profile``/``phase_timings`` exercise the phase-2 opt-in path: when
+    ``phase_timings`` is set it is attached to each cell result body.
     """
     import boto3
 
@@ -596,16 +614,20 @@ def _run_lambda_with_durations(monkeypatch, atl06_config, durations, *, timeout=
         ),
     )
     it = iter(durations)
-    monkeypatch.setattr(
-        runner, "_invoke_lambda_cell",
-        lambda *a, **k: {"status_code": 200, "body": {"total_obs": 1},
-                         "error": None, "lambda_duration": next(it),
-                         "shard_key": 0},
-    )
+
+    def _fake_cell(*a, **k):
+        body = {"total_obs": 1}
+        if phase_timings is not None:
+            body["phase_timings"] = phase_timings
+        return {"status_code": 200, "body": body, "error": None,
+                "lambda_duration": next(it), "shard_key": 0}
+
+    monkeypatch.setattr(runner, "_invoke_lambda_cell", _fake_cell)
     return runner._run_lambda(
         atl06_config, _run_catalog(), "s3://out/x.zarr", 12,
         max_cells=None, morton_cell=None, max_workers=1700, overwrite=False,
         dry_run=False, region="us-west-2", function_name="process-shard",
+        profile=profile,
     )
 
 
@@ -691,7 +713,135 @@ class TestGetFunctionTimeout:
         from zagg.runner import _DEFAULT_FUNCTION_TIMEOUT_S, _get_function_timeout_s
 
         class _Client:
-            def get_function_configuration(self, FunctionName):
+            def get_function_configuration(self, **kwargs):
                 return {"Timeout": "not-a-number"}
 
         assert _get_function_timeout_s(_Client(), "process-shard") == _DEFAULT_FUNCTION_TIMEOUT_S
+
+
+class TestProfilePlumbing:
+    """Phase 2 of issue #100: the opt-in --profile path. Default runs stay
+    byte-identical (no profile event key, no worker_phase_max summary key); when
+    set, the per-cell ``phase_timings`` roll up into ``worker_phase_max``."""
+
+    def test_default_run_omits_worker_phase_max(self, monkeypatch, atl06_config):
+        summary = _run_lambda_with_durations(
+            monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0]
+        )
+        assert "worker_phase_max" not in summary
+
+    def test_profile_run_rolls_up_phase_max(self, monkeypatch, atl06_config):
+        # Every cell reports the same phase_timings; the rollup is the per-phase
+        # max across cells.
+        summary = _run_lambda_with_durations(
+            monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0],
+            profile=True, phase_timings={"read": 5.0, "index": 1.0, "aggregate": 2.0},
+        )
+        assert summary["worker_phase_max"] == {"read": 5.0, "index": 1.0, "aggregate": 2.0}
+
+    def test_profile_run_with_no_phase_timings_is_empty(self, monkeypatch, atl06_config):
+        # profile=True but workers emitted no phase_timings (e.g. handler bridge
+        # not yet wired): the key is present but empty, never raising.
+        summary = _run_lambda_with_durations(
+            monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0], profile=True
+        )
+        assert summary["worker_phase_max"] == {}
+
+    def test_agg_threads_profile_into_run_lambda(self, monkeypatch, atl06_config):
+        from zagg import runner
+
+        captured = {}
+
+        def fake_run_lambda(*a, **k):
+            captured["profile"] = k.get("profile")
+            return {}
+
+        monkeypatch.setattr(runner, "_load_catalog", lambda p: _run_catalog())
+        monkeypatch.setattr(runner, "_run_lambda", fake_run_lambda)
+        runner.agg(
+            atl06_config, catalog="ignored", store="s3://out/x.zarr",
+            backend="lambda", profile=True,
+        )
+        assert captured["profile"] is True
+
+    def test_agg_default_profile_is_false(self, monkeypatch, atl06_config):
+        from zagg import runner
+
+        captured = {}
+        monkeypatch.setattr(runner, "_load_catalog", lambda p: _run_catalog())
+        monkeypatch.setattr(
+            runner, "_run_lambda",
+            lambda *a, **k: captured.update(profile=k.get("profile")) or {},
+        )
+        runner.agg(atl06_config, catalog="ignored", store="s3://out/x.zarr", backend="lambda")
+        assert captured["profile"] is False
+
+
+class TestWorkerPhaseTimings:
+    """``process_shard(profile=...)`` emits ``phase_timings`` only when set, and
+    leaves the default metadata unchanged otherwise (issue #100 phase 2)."""
+
+    def _run(self, monkeypatch, *, profile, with_data=True):
+        import numpy as np
+
+        from zagg.processing import worker
+
+        # Stub the read/group/aggregate seams so process_shard runs without I/O.
+        monkeypatch.setattr(worker._processing, "_make_url_rewriter", lambda d: (lambda u: u))
+
+        class _H5:
+            def __init__(self, *a, **k):
+                pass
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(worker._processing, "h5coro", type("M", (), {"H5Coro": _H5}))
+        monkeypatch.setattr(
+            worker._processing, "_read_group",
+            lambda *a, **k: (object() if with_data else None),
+        )
+        monkeypatch.setattr(
+            worker, "_concat_and_group",
+            lambda reads, grid, handoff: ({"leaf_id": np.array([0])}, {0: slice(0, 1)}, 1),
+        )
+        monkeypatch.setattr(worker, "_has_vector_fields", lambda config: False)
+        monkeypatch.setattr(worker, "_eval_chunk_precompute", lambda config, pooled: {})
+        monkeypatch.setattr(worker, "_pool_chunk_columns", lambda *a, **k: {})
+        monkeypatch.setattr(
+            worker, "_aggregate_chunk_cells",
+            lambda *a, **k: ({}, {}, {}, 1),
+        )
+        monkeypatch.setattr(worker, "_build_output", lambda *a, **k: __import__("pandas").DataFrame())
+
+        from unittest.mock import MagicMock
+        grid = MagicMock()
+        grid.chunks_per_shard = 1
+        grid.block_index.return_value = (0,)
+        grid.children.return_value = np.array([0])
+        del grid.iter_chunks  # force the K==1 fallback path
+
+        from zagg.config import default_config
+        _df, meta = worker.process_shard(
+            grid, 0, ["s3://b/g.h5"], s3_credentials={"accessKeyId": "a"},
+            config=default_config("atl06"), driver="s3",
+            h5coro_driver=object(), profile=profile,
+        )
+        return meta
+
+    def test_no_phase_timings_by_default(self, monkeypatch):
+        meta = self._run(monkeypatch, profile=False)
+        assert "phase_timings" not in meta
+
+    def test_phase_timings_present_when_profiled(self, monkeypatch):
+        meta = self._run(monkeypatch, profile=True)
+        assert set(meta["phase_timings"]) == {"read", "index", "aggregate"}
+        for v in meta["phase_timings"].values():
+            assert v >= 0.0
+
+    def test_phase_timings_on_no_data_path(self, monkeypatch):
+        # Even the "No data after filtering" early return carries read timing
+        # when profiling (index/aggregate never ran).
+        meta = self._run(monkeypatch, profile=True, with_data=False)
+        assert meta["error"] == "No data after filtering"
+        assert set(meta["phase_timings"]) == {"read"}

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -434,7 +434,8 @@ class TestSummaryKeysByteIdentical:
         "total_cells", "cells_with_data", "cells_error", "total_obs",
         "wall_time_s", "lambda_time_s", "gb_seconds", "price_per_gb_sec",
         "estimated_cost_usd", "store_path", "backend", "function_name",
-        "results",
+        "results", "setup_s", "fanout_s", "finalize_s", "function_timeout_s",
+        "worker_max_s", "worker_median_s", "worker_pstdev_s", "worker_pct_timeout",
     }
 
     def test_local_summary_keys_and_counts(self, monkeypatch, atl06_config):
@@ -563,3 +564,134 @@ class TestSummaryKeysByteIdentical:
         # The exact pre-refactor order: one multiply over the summed time.
         assert summary["gb_seconds"] == total * 2.0
         assert summary["estimated_cost_usd"] == (total * 2.0) * 0.0000133334
+
+
+def _run_lambda_with_durations(monkeypatch, atl06_config, durations, *, timeout=720):
+    """Drive ``_run_lambda`` over synthetic per-cell durations.
+
+    Returns the summary dict. ``durations`` is consumed one per cell (the
+    _run_catalog() has 4 cells); ``timeout`` stubs the function Timeout read.
+    """
+    import boto3
+
+    import zagg.grids as grids_mod
+    from zagg import runner
+    from zagg.concurrency import ConcurrencyReport
+
+    monkeypatch.setattr(runner, "get_nsidc_s3_credentials",
+                        lambda: {"accessKeyId": "a", "secretAccessKey": "s",
+                                 "sessionToken": "t"})
+    monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
+    monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: timeout)
+    from unittest.mock import MagicMock
+    monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(
+        runner, "compute_available_workers",
+        lambda requested, *a, **k: (
+            1,  # 1 worker -> deterministic completion order for the iter()
+            ConcurrencyReport(account_limit=1000, current_concurrent=0,
+                              padding=100, available=900, function_reserved=None),
+        ),
+    )
+    it = iter(durations)
+    monkeypatch.setattr(
+        runner, "_invoke_lambda_cell",
+        lambda *a, **k: {"status_code": 200, "body": {"total_obs": 1},
+                         "error": None, "lambda_duration": next(it),
+                         "shard_key": 0},
+    )
+    return runner._run_lambda(
+        atl06_config, _run_catalog(), "s3://out/x.zarr", 12,
+        max_cells=None, morton_cell=None, max_workers=1700, overwrite=False,
+        dry_run=False, region="us-west-2", function_name="process-shard",
+    )
+
+
+class TestWorkerRuntimeStats:
+    """Phase 1 of issue #100: always-on worker-runtime distribution stats and
+    orchestrator phase brackets in the lambda summary."""
+
+    def test_worker_stats_pinned_against_synthetic_durations(self, monkeypatch, atl06_config):
+        import statistics
+
+        durations = [10.0, 20.0, 30.0, 100.0]
+        summary = _run_lambda_with_durations(
+            monkeypatch, atl06_config, durations, timeout=720
+        )
+        assert summary["function_timeout_s"] == 720
+        assert summary["worker_max_s"] == 100.0
+        assert summary["worker_median_s"] == statistics.median(durations)
+        assert summary["worker_pstdev_s"] == statistics.pstdev(durations)
+        assert summary["worker_pct_timeout"] == 100.0 / 720
+
+    def test_worker_pct_timeout_tracks_function_timeout(self, monkeypatch, atl06_config):
+        summary = _run_lambda_with_durations(
+            monkeypatch, atl06_config, [180.0, 60.0, 60.0, 60.0], timeout=900
+        )
+        assert summary["function_timeout_s"] == 900
+        assert summary["worker_pct_timeout"] == 180.0 / 900
+
+    def test_empty_durations_degrade_to_none(self, monkeypatch, atl06_config):
+        # All cells report zero/falsy lambda_duration -> no distribution.
+        summary = _run_lambda_with_durations(
+            monkeypatch, atl06_config, [0, 0, 0, 0], timeout=720
+        )
+        assert summary["worker_max_s"] is None
+        assert summary["worker_median_s"] is None
+        assert summary["worker_pstdev_s"] is None
+        assert summary["worker_pct_timeout"] is None
+        # function_timeout_s is still populated even with no durations.
+        assert summary["function_timeout_s"] == 720
+
+    def test_orchestrator_brackets_present_and_nonnegative(self, monkeypatch, atl06_config):
+        summary = _run_lambda_with_durations(
+            monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0]
+        )
+        for key in ("setup_s", "fanout_s", "finalize_s"):
+            assert key in summary
+            assert summary[key] >= 0.0
+
+
+class TestGetFunctionTimeout:
+    """``_get_function_timeout_s`` reads the configured Timeout, or falls back
+    to the template default on any failure (issue #100)."""
+
+    def test_reads_timeout_from_client(self):
+        from unittest.mock import MagicMock
+
+        from zagg.runner import _get_function_timeout_s
+
+        client = MagicMock()
+        client.get_function_configuration.return_value = {"Timeout": 720}
+        assert _get_function_timeout_s(client, "process-shard") == 720
+        client.get_function_configuration.assert_called_once_with(FunctionName="process-shard")
+
+    def test_falls_back_on_error(self):
+        from unittest.mock import MagicMock
+
+        from zagg.runner import _DEFAULT_FUNCTION_TIMEOUT_S, _get_function_timeout_s
+
+        client = MagicMock()
+        client.get_function_configuration.side_effect = RuntimeError("AccessDenied")
+        assert _get_function_timeout_s(client, "process-shard") == _DEFAULT_FUNCTION_TIMEOUT_S
+
+    def test_falls_back_on_missing_key(self):
+        from unittest.mock import MagicMock
+
+        from zagg.runner import _DEFAULT_FUNCTION_TIMEOUT_S, _get_function_timeout_s
+
+        # Response without a "Timeout" key -> KeyError -> fallback.
+        client = MagicMock()
+        client.get_function_configuration.return_value = {}
+        assert _get_function_timeout_s(client, "process-shard") == _DEFAULT_FUNCTION_TIMEOUT_S
+
+    def test_falls_back_on_non_integer(self):
+        from zagg.runner import _DEFAULT_FUNCTION_TIMEOUT_S, _get_function_timeout_s
+
+        class _Client:
+            def get_function_configuration(self, FunctionName):
+                return {"Timeout": "not-a-number"}
+
+        assert _get_function_timeout_s(_Client(), "process-shard") == _DEFAULT_FUNCTION_TIMEOUT_S


### PR DESCRIPTION
Closes #100.

Instruments the lambda backend with worker-runtime statistics so shardmaps can be sized correctly and the &#34;more workers, lower wall time&#34; paradox is answerable from the run summary. Design is the plan in issue #100 ([plan](https://github.com/englacial/zagg/issues/100#issuecomment-4804172485), [approval](https://github.com/englacial/zagg/issues/100#issuecomment-4804297901)) — both (1) and (2), with (1) always-on (no probe tax) and (2) behind an opt-in `--profile` flag.

## What this does

Wall time on a parallel fan-out tracks the **straggler**, not the mean — so the sum we already keep (`lambda_time_s`) hides the distribution. This surfaces it.

**Phase 1 — always-on (no probe tax):**
- After `dispatch()` returns in `_run_lambda`, computes over `durations = [r["lambda_duration"] for r in report.results if r.get("lambda_duration")]`:
  - `worker_max_s = max(durations)`, `worker_median_s = statistics.median(...)`, `worker_pstdev_s = statistics.pstdev(...)`, `worker_pct_timeout = worker_max_s / function_timeout_s`.
- `function_timeout_s` read once via `get_function_configuration(FunctionName=...)["Timeout"]` on the existing dispatch client, falling back to `720` (the `template.yaml` Timeout default) on permission error / missing key / non-int response (`_get_function_timeout_s`).
- Orchestrator phase brackets `setup_s` / `fanout_s` / `finalize_s` (just `time.time()` deltas around calls that already happen — zero worker tax, so always-on per the approved answer to plan open-question (a)).
- All keys added to the lambda `summary` dict; empty-`durations` degrades to `None`. `wall_time_s` semantics unchanged.
- One extra printed line by `Lambda compute:`: `Workers: max {…}s ({…}% of {…}s timeout), median {…}s, pstdev {…}s`.

**Phase 2 — opt-in `--profile` (CLI only):**
- `--profile` (store_true, default off) in `__main__.py`, threaded `profile=` through `agg(...)` → `_run_lambda`.
- When set, forwards `"profile": true` in the per-cell event; `process_shard(profile=True)` populates a `phase_timings` sub-dict (read / index / aggregate `time.time()` deltas) in its result metadata. The runner rolls the per-phase **max across cells** into `worker_phase_max` (added to the summary only when profiling) and prints a `Worker phases (max across cells): …` line.
- **When off, the worker path and per-cell event payload are byte-identical to before** — no `phase_timings` dict, no `time.time()` calls, no `profile` event key, no extra summary key.

**Phase 3 — deployment-side handler bridge (authorized by @espg, [comment](https://github.com/englacial/zagg/pull/107#issuecomment-4813952501)):**
- `deployment/aws/lambda_handler.py` now (a) reads `event["profile"]` (default `False`), (b) forwards `profile=` into `process_shard`, (c) brackets the **write** phase it owns with `time.time()` and adds `write` to the same `metadata["phase_timings"]` sub-dict, and (d) lets that dict serialize into the response body the runner already consumes. So with `--profile` on, `worker_phase_max` now carries the full read/index/aggregate/**write** breakdown end-to-end.
- `write` is recorded **only on a clean write** (inside the `try`, after the template-missing early-return): every failure path (no-data shard, missing template, raising write loop) leaves `write` absent, so the runner's per-phase `max(...)` rollup never folds a time-to-failure in as a real write duration.
- **Default (no `profile` key) is unchanged:** `process_shard(profile=False)` and no `phase_timings` in the body.

Uses stdlib `statistics` only — no new dependency.

## Phases
- [x] **Phase 1** — always-on worker stats (max/median/pstdev/pct-timeout) + `function_timeout_s` + orchestrator brackets (`setup_s`/`fanout_s`/`finalize_s`) in the lambda summary and one printed line. Tests pin all four stats against a synthetic `report.results` with a stubbed timeout, the empty-durations None-degrade, the brackets, and `_get_function_timeout_s` read/fallback.
- [x] **Phase 2** — `--profile` flag plumbed CLI → `agg` → `_run_lambda` → per-cell event; worker `phase_timings` (read/index/aggregate) only when set; `worker_phase_max` rollup + print only when set; default runs leave the event payload + worker path byte-identical. Tests assert plumbing, byte-identical default event, worker `phase_timings`-only-when-set on success + no-data paths, and the rollup = per-phase max across cells.
- [x] **Phase 3** — handler bridge in `deployment/aws/lambda_handler.py`: read `event["profile"]`, forward `profile=` into `process_shard`, bracket the handler-owned `write` phase, merge into the response body. Recorded only on a clean write (failure paths omit it). New `TestProcessEventProfile` in `tests/test_lambda_handler.py` (import-by-path) covers: profile forwarded + worker timings pass through + `write` added; default-off (no key, no timings); and `write` absent on the empty-`chunk_results`, raising-write, and missing-template paths.

## How tested
- `uv run pytest -q` — full suite green: **838 passed, 1 skipped**.
- `uv run ruff check src/zagg/runner.py src/zagg/__main__.py src/zagg/processing/worker.py deployment/aws/lambda_handler.py tests/test_runner.py tests/test_lambda_handler.py` — clean (full `E,F,W,I,N`). The only `ruff check src tests` finding is a **pre-existing** `N818` in `src/zagg/registry.py` (untouched file) — flagged, not fixed (§4).
- New tests in `tests/test_runner.py`: `TestWorkerRuntimeStats`, `TestGetFunctionTimeout`, `TestProfilePlumbing`, `TestWorkerPhaseTimings`, plus two new cases in `TestInvokeLambdaCellEvent`. New tests in `tests/test_lambda_handler.py`: `TestProcessEventProfile` (7 cases).
- Each phase self-reviewed adversarially in a fresh context (see review comments); Phase 1's `N803` lint blocker and a timeout-stub hygiene fix were folded into the Phase 2 commit, and the Phase 3 review&#39;s write-on-failure finding + failure-path coverage gaps were folded into a follow-up commit.

## Questions for review

1. ~~**`phase_timings` write-phase + handler bridge are deployment-side (§1 boundary) — should I wire them?**~~ **RESOLVED.** @espg green-lit editing the deploy path ([comment](https://github.com/englacial/zagg/pull/107#issuecomment-4813952501): &#34;yes. you can modify the deploy path to enable this for us.&#34;), which satisfies §1&#39;s &#34;unless the issue names it&#34; carve-out for this change. Landed as **Phase 3** above: the 3-line bridge (read `event["profile"]`, forward `profile=`, merge `phase_timings`) plus a handler-owned `write` bracket, recorded only on a clean write.
2. ~~**`runner.py` is now 1100 lines, over the §4 ~1000-line soft limit.**~~ **Closed** per @espg (&#34;ignore it for now&#34;). No split in this PR.
3. ~~**`ruff format` is not repo-clean today.**~~ **Closed** per @espg (&#34;ok&#34;). New code stays in the file&#39;s existing hand-wrapped style; unrelated lines are left unformatted (the enforced bot is `ruff check` per §7, which is clean). `lambda_handler.py`&#39;s remaining `ruff format` diff is entirely pre-existing style on untouched lines.

All three phases complete and green; held in **draft** awaiting @espg review.