### PR TITLE
HEALPix ShardingCodec output: decouple write/dispatch shards from 64×64 read chunks

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -58,7 +58,11 @@ from typing import Any, Dict
 
 # Import cloud-agnostic processing
 from zagg.config import load_config_from_dict
-from zagg.processing import write_dataframe_to_zarr, write_ragged_to_zarr
+from zagg.processing import (
+    write_dataframe_to_zarr,
+    write_ragged_to_zarr,
+    write_shard_to_zarr,
+)
 from zagg.processing.write import _block_index_key
 from zagg.store import open_store
 
@@ -92,9 +96,7 @@ def _output_store_kwargs(event: Dict[str, Any]) -> Dict[str, Any]:
         return {"region": region}
     missing = [k for k in ("accessKeyId", "secretAccessKey") if k not in creds]
     if missing:
-        raise ValueError(
-            f"output_credentials missing keys: {', '.join(missing)}"
-        )
+        raise ValueError(f"output_credentials missing keys: {', '.join(missing)}")
     kwargs: Dict[str, Any] = {
         "region": creds.get("region", region),
         "credentials": creds,
@@ -148,8 +150,7 @@ def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
         return {"statusCode": 200, "body": json.dumps({"ok": True, "mode": "setup"})}
     except Exception as e:
         logger.exception(e)
-        return {"statusCode": 500,
-                "body": json.dumps({"error": str(e), "mode": "setup"})}
+        return {"statusCode": 500, "body": json.dumps({"error": str(e), "mode": "setup"})}
 
 
 def _handle_finalize(event: Dict[str, Any]) -> Dict[str, Any]:
@@ -163,8 +164,7 @@ def _handle_finalize(event: Dict[str, Any]) -> Dict[str, Any]:
         return {"statusCode": 200, "body": json.dumps({"ok": True, "mode": "finalize"})}
     except Exception as e:
         logger.exception(e)
-        return {"statusCode": 500,
-                "body": json.dumps({"error": str(e), "mode": "finalize"})}
+        return {"statusCode": 500, "body": json.dumps({"error": str(e), "mode": "finalize"})}
 
 
 def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -228,8 +228,10 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # Build grid (writer needs group_path + chunk_shape; no populated_shards
         # required because the orchestrator already computed chunk_idx).
         from zagg.grids import from_config
+
         if config is None:
             from zagg.config import default_config
+
             config = default_config("atl06")
 
         # child_order is required for HEALPix runs (drives the leaf order); it is
@@ -248,6 +250,7 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # Zarr chunk through the sink. At K==1 the sink holds exactly one entry whose
         # ``block_index`` equals ``event["chunk_idx"]``, so the write is unchanged.
         from zagg.processing import process_shard
+
         # Opt-in per-phase timing (issue #100). When the orchestrator forwards
         # ``profile``, ``process_shard`` fills ``metadata["phase_timings"]`` with
         # read/index/aggregate deltas; the write phase runs here, so we bracket it
@@ -287,29 +290,36 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             single_chunk = len(chunk_results) == 1
             shard_key = event["shard_key"]
             try:
-                for block_index, carrier, ragged in chunk_results:
-                    # write_dataframe_to_zarr no-ops on an empty carrier, so no
-                    # per-chunk emptiness check is needed. Use each chunk's own
-                    # block_index (from iter_chunks), not event["chunk_idx"].
-                    write_dataframe_to_zarr(
-                        carrier,
-                        store,
-                        grid=grid,
-                        chunk_idx=block_index,
-                    )
-                    # Persist this chunk's ragged (CSR) fields (issue #48). At K==1 the
-                    # chunk IS the shard, so the CSR subgroup is keyed by ``shard_key``
-                    # (cell-resolution contract); at K>1 each finer chunk is keyed by
-                    # its own block index. No-ops when ``ragged`` is empty.
-                    ragged_key = (
-                        int(shard_key) if single_chunk else _block_index_key(block_index, grid)
-                    )
-                    write_ragged_to_zarr(
-                        ragged,
-                        store,
-                        grid=grid,
-                        shard_key=ragged_key,
-                    )
+                # Sharded output (issue #108): bundle the shard's K inner chunks into
+                # one ShardingCodec shard object — write the whole shard in one block
+                # selection per dense array (mirrors the local runner). A per-inner-
+                # chunk loop would read-modify-write the same shard object.
+                if getattr(grid, "sharded", False):
+                    write_shard_to_zarr(chunk_results, store, grid=grid, shard_key=int(shard_key))
+                else:
+                    for block_index, carrier, ragged in chunk_results:
+                        # write_dataframe_to_zarr no-ops on an empty carrier, so no
+                        # per-chunk emptiness check is needed. Use each chunk's own
+                        # block_index (from iter_chunks), not event["chunk_idx"].
+                        write_dataframe_to_zarr(
+                            carrier,
+                            store,
+                            grid=grid,
+                            chunk_idx=block_index,
+                        )
+                        # Persist this chunk's ragged (CSR) fields (issue #48). At K==1
+                        # the chunk IS the shard, so the CSR subgroup is keyed by
+                        # ``shard_key`` (cell-resolution contract); at K>1 each finer
+                        # chunk is keyed by its own block index. No-ops when empty.
+                        ragged_key = (
+                            int(shard_key) if single_chunk else _block_index_key(block_index, grid)
+                        )
+                        write_ragged_to_zarr(
+                            ragged,
+                            store,
+                            grid=grid,
+                            shard_key=ragged_key,
+                        )
                 # Record the write-phase timing (issue #100) only on a clean write:
                 # read/index/aggregate come from ``process_shard``; ``write`` is owned
                 # here and joins the same sub-dict. Recording inside the ``try`` (and

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -1,0 +1,88 @@
+# Sharded output (zarr ShardingCodec)
+
+zagg can bundle a dispatch shard's inner read-chunks into **one zarr
+`ShardingCodec` shard object** instead of writing them as many independent
+regular chunk objects. This decouples the **write/dispatch granularity** (the
+unit a Lambda worker processes) from the **read granularity** (the small chunk a
+reader partial-decodes), without drowning the reader in millions of tiny objects
+at global/dense scale.
+
+It is opt-in (default off) and builds directly on `chunk_inner` — it changes
+only the *storage form* of the inner chunks, not the grid geometry.
+
+## How it relates to `chunk_inner`
+
+`chunk_inner` sets the geometry: the **shard** is the dispatch unit (HEALPix
+`parent_order`; rectilinear `chunk_shape`), the **inner chunk** is the smaller
+read chunk (HEALPix `chunk_inner` order, e.g. 13 = a 64×64 = 4096-cell chunk;
+rectilinear `chunk_inner` = `[inner_h, inner_w]`), and one shard owns
+`K = (shard cells) / (inner-chunk cells)` inner chunks.
+
+`sharded` only picks how those `K` inner chunks are stored:
+
+| | `sharded: false` (default) | `sharded: true` |
+|---|---|---|
+| storage | `K` regular chunk objects per shard | **1** shard object per shard |
+| object count | high (empties absent) | low (~`K`× fewer) |
+| sub-shard sparsity | absent objects | shard-index entries inside the object |
+| reader 64×64 access | one object per chunk | byte-range partial decode within the shard |
+
+With `zarr-shard == dispatch-shard`, each worker writes exactly one whole shard
+object, alone — the canonical single-writer pattern: no read-modify-write, no
+cross-worker contention. Empty inner chunks (e.g. a track corridor crossing only
+part of a shard) are omitted from the shard index, so sub-shard sparsity is
+preserved *inside* the object.
+
+## Config
+
+The knob lives on the grid/chunk block, next to `chunk_inner`:
+
+```yaml
+# HEALPix
+output:
+  grid:
+    type: healpix
+    parent_order: 8      # dispatch shard
+    child_order: 19      # leaf cell order
+    chunk_inner: 13      # inner read chunk (64×64 = 4096 cells) -> K = 4^(13-8) = 1024
+    sharded: true
+```
+
+```yaml
+# Rectilinear
+output:
+  grid:
+    type: rectilinear
+    crs: EPSG:3031
+    resolution: 5000
+    bounds: [-3200000, -3200000, 3200000, 3200000]
+    chunk_shape: [256, 256]   # dispatch shard tile
+    chunk_inner: [64, 64]     # inner read chunk -> K = (256/64)^2 = 16
+    sharded: true
+```
+
+`sharded` is only valid when `chunk_inner` makes `K > 1` (a shard with more than
+one inner chunk). Sharding a `K == 1` shard is a no-op shard of one chunk, so it
+is **validated and rejected** at grid construction (before any Lambda
+deployment), with a clear message — matching the grid-mismatch errors zagg
+already raises.
+
+## Storage layout
+
+- The dense per-cell arrays (`<group>/<varname>`) carry a `sharding_indexed`
+  codec: the **outer** chunk is the whole shard, the **inner** chunk is the read
+  chunk. Inner codecs stay **bytes-only/uncompressed** (zagg's policy), so the
+  on-disk bytes for a populated inner chunk are identical to the regular path.
+- `resolution: chunk` companion arrays and (HEALPix) the 1-D coordinate / (rect)
+  the 1-D `x`/`y` arrays are **not** sharded — they keep their regular layout.
+- The worker writes the whole shard in **one** `set_block_selection` per dense
+  array (block selection is shard-granular on a sharded array), so a single shard
+  object is produced per dispatch shard.
+
+## Reader note
+
+This is currently a **writer-side** feature plus offline round-trip read-back.
+Consuming sharded stores from the higher-level read helpers (shard-index /
+byte-range reads instead of `list_prefix` enumeration) is tracked as a
+follow-up; the underlying zarr partial-decode of a 64×64 chunk within a shard
+already works through the standard zarr array API.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - "Design":
       - "Architecture": "design/architecture.md"
       - "Schema": "design/schema.md"
+      - "Sharded output": "sharding.md"
   - "Deployment":
       - "Standing Up the Backend": "deployment/standup.md"
       - "AWS Lambda": "deployment/lambda.md"

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1170,6 +1170,18 @@ def get_layout(config: PipelineConfig) -> str:
     return config.output.get("grid", {}).get("layout", "fullsphere")
 
 
+def get_sharded(config: PipelineConfig) -> bool:
+    """Return whether the output grid uses ShardingCodec storage (issue #108).
+
+    The ``sharded`` knob lives on the grid/chunk block next to ``chunk_inner``
+    (mirroring its accessor), default ``False``. When ``True`` the grid bundles a
+    dispatch shard's K inner chunks into one zarr shard object instead of K
+    independent regular chunk objects; it is only valid when ``chunk_inner`` gives
+    K>1 (the grid raises otherwise, validated before deployment).
+    """
+    return bool(config.output.get("grid", {}).get("sharded", False))
+
+
 def get_store_path(config: PipelineConfig) -> str | None:
     """Return the store path from the output config, or None.
 

--- a/src/zagg/grids/__init__.py
+++ b/src/zagg/grids/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import warnings
 
-from zagg.config import PipelineConfig, get_child_order
+from zagg.config import PipelineConfig, get_child_order, get_sharded
 from zagg.grids.base import InconsistentShardError, OutputGrid, ShardKey
 from zagg.grids.healpix import HEALPIX_BASE_CELLS, HealpixGrid
 from zagg.grids.rectilinear import OOB_SENTINEL, RectilinearGrid
@@ -53,6 +53,7 @@ def from_config(
             config=config,
             populated_shards=populated_shards,
             chunk_inner=grid_cfg.get("chunk_inner"),
+            sharded=get_sharded(config),
         )
     if grid_type == "rectilinear":
         required = ("crs", "resolution", "bounds")

--- a/src/zagg/grids/__init__.py
+++ b/src/zagg/grids/__init__.py
@@ -68,6 +68,7 @@ def from_config(
             chunk_shape=tuple(grid_cfg.get("chunk_shape", (256, 256))),
             config=config,
             chunk_inner=tuple(chunk_inner) if chunk_inner is not None else None,
+            sharded=get_sharded(config),
         )
     raise ValueError(f"Unknown output.grid.type: {grid_type!r}")
 

--- a/src/zagg/grids/base.py
+++ b/src/zagg/grids/base.py
@@ -140,6 +140,68 @@ def chunk_array_spec(base, *, chunk_grid_shape, chunk_dims):
     )
 
 
+def sharded_array_spec(base, *, shard_shape, inner_chunk_shape):
+    """Wrap a dense data-var ``ArraySpec`` in a zarr ``ShardingCodec`` (issue #108).
+
+    Decouples the **write/dispatch** granularity (one shard object per dispatch
+    shard) from the **read** granularity (the inner 64×64 chunk). The K inner
+    chunks of one shard become ONE shard object (empties omitted from the shard
+    index, so sub-shard sparsity is preserved *inside* the object) instead of K
+    independent regular chunk objects.
+
+    The transform: the array's outer chunk grid is re-set to ``shard_shape`` (the
+    whole dispatch shard) and a ``sharding_indexed`` codec replaces the array's
+    top-level codecs, carrying the inner ``chunk_shape`` (the 64×64 read chunk)
+    plus the array's existing (bytes-only) codecs as its INNER codecs. Building
+    the codec config by hand — rather than ``ArraySpec.from_array`` (which drops
+    the sharding codec in pydantic-zarr 0.10.0) or ``zarr.create_array`` (which
+    silently injects a zstd level-0 compressor) — is what preserves zagg's
+    bytes-only/uncompressed on-disk policy (the two prototype caveats on
+    issue #108).
+
+    Parameters
+    ----------
+    base : ArraySpec
+        The dense data-var spec whose ``chunk_grid`` currently chunks at the
+        inner chunk shape; its ``codecs`` are the bytes-only inner codecs.
+    shard_shape : tuple of int
+        Outer chunk (== shard) shape: the whole dispatch shard's cell extent.
+    inner_chunk_shape : tuple of int
+        Inner chunk shape (the 64×64 read chunk); ``prod(shard_shape) //
+        prod(inner_chunk_shape) == K`` inner chunks per shard.
+
+    Returns
+    -------
+    ArraySpec
+    """
+    from pydantic_zarr.experimental.v3 import NamedConfig
+
+    inner_codecs = [c.model_dump() if hasattr(c, "model_dump") else dict(c) for c in base.codecs]
+    # crc32c on the shard index matches zarr's create_array default; the index
+    # payload is bytes-only (no compression), keeping the policy bytes-only.
+    index_codecs = [
+        {"name": "bytes", "configuration": {"endian": "little"}},
+        {"name": "crc32c"},
+    ]
+    sharding = NamedConfig(
+        name="sharding_indexed",
+        configuration={
+            "chunk_shape": list(inner_chunk_shape),
+            "codecs": inner_codecs,
+            "index_codecs": index_codecs,
+            "index_location": "end",
+        },
+    )
+    chunk_grid = NamedConfig(name="regular", configuration={"chunk_shape": list(shard_shape)})
+    return type(base)(
+        **{
+            **base.model_dump(),
+            "chunk_grid": chunk_grid,
+            "codecs": (sharding,),
+        }
+    )
+
+
 class InconsistentShardError(ValueError):
     """Raised by shard_of when input cells don't all share a shard."""
 
@@ -246,4 +308,5 @@ __all__ = [
     "InconsistentShardError",
     "vector_array_spec",
     "chunk_array_spec",
+    "sharded_array_spec",
 ]

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -221,6 +221,31 @@ class HealpixGrid:
             children = generate_morton_children(int(sub), self.child_order)
             yield (block, children)
 
+    def shard_slab_shape(self) -> tuple[int, ...]:
+        """Cell extent of one whole sharded shard (issue #108).
+
+        The shape the sharded worker assembles per dense array before the single
+        whole-shard ``set_block_selection`` — ``(cells_per_shard,)`` for HEALPix
+        (the K inner chunks laid out contiguously, matching the ShardingCodec's
+        inner-chunk tiling of the outer shard).
+        """
+        return (self.cells_per_shard,)
+
+    def shard_local_region(self, block_index, shard_key) -> tuple:
+        """Slice(s) an inner chunk occupies within its shard slab (issue #108).
+
+        ``block_index`` is the inner chunk's global block (from :meth:`iter_chunks`);
+        its position inside the shard is ``local = block - block_index(shard)·K``,
+        and it occupies the contiguous ``[local·cells_per_chunk, +cells_per_chunk)``
+        run of the ``cells_per_shard`` slab (HEALPix nested ids tile the shard in
+        ascending order, so this matches the carrier's canonical chunk order).
+        """
+        (shard_block,) = self.block_index(shard_key)
+        (inner_block,) = tuple(int(b) for b in block_index)
+        local = inner_block - shard_block * self.chunks_per_shard
+        start = local * self.cells_per_chunk
+        return (slice(start, start + self.cells_per_chunk),)
+
     @property
     def group_path(self) -> str:
         """Zarr group path emitted by ``emit_template`` (e.g. ``'12'``)."""

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -16,7 +16,12 @@ from zagg.config import (
     get_output_signature,
     output_field_signature,
 )
-from zagg.grids.base import InconsistentShardError, chunk_array_spec, vector_array_spec
+from zagg.grids.base import (
+    InconsistentShardError,
+    chunk_array_spec,
+    sharded_array_spec,
+    vector_array_spec,
+)
 from zagg.grids.morton import to_morton_array
 
 HEALPIX_BASE_CELLS: int = 12
@@ -64,6 +69,7 @@ class HealpixGrid:
         config: PipelineConfig | None = None,
         populated_shards: list[int] | None = None,
         chunk_inner: int | None = None,
+        sharded: bool = False,
     ):
         if child_order < parent_order:
             raise ValueError(
@@ -102,6 +108,25 @@ class HealpixGrid:
         # number of chunks one shard owns (K, == 1 when unset).
         self.cells_per_chunk = 4 ** (child_order - chunk_order)
         self.chunks_per_shard = 4 ** (chunk_order - parent_order)
+        # Cells per dispatch shard == the whole shard's leaf extent (n_children).
+        # When sharded (issue #108), this is the zarr SHARD shape: the K inner
+        # chunks (each ``cells_per_chunk``) bundle into one shard object.
+        self.cells_per_shard = self.n_children
+        # Sharded storage (issue #108): bundle the shard's K inner chunks into one
+        # zarr ShardingCodec shard object instead of K independent regular chunk
+        # objects. Only meaningful when K > 1 (a finer ``chunk_inner`` gives the
+        # shard multiple inner chunks); sharding a K==1 shard is a no-op shard of
+        # one chunk, so reject it with a clear message (validated pre-deployment,
+        # matching the grid-mismatch errors). HEALPix lands first (issue #108).
+        if sharded and self.chunks_per_shard <= 1:
+            raise ValueError(
+                "sharded output requires chunk_inner to give more than one inner "
+                f"chunk per shard (K>1), but chunk_order ({chunk_order}) == "
+                f"parent_order ({parent_order}) gives K=1; set chunk_inner finer "
+                "than parent_order (e.g. chunk_inner=13 for the 64x64 read chunk) "
+                "or disable sharded"
+            )
+        self.sharded = bool(sharded)
         self.layout = layout
         self.config = config or default_config("atl06")
         self._position_map: dict[int, int] | None = None
@@ -383,11 +408,29 @@ class HealpixGrid:
             fill_value="NaN",
         )
 
+        # Sharded storage (issue #108): wrap each dense per-cell array in a
+        # ShardingCodec — outer (shard) chunk == ``cells_per_shard``, inner chunk ==
+        # ``cells_per_chunk`` (the 64x64 read chunk). Applied to the per-cell
+        # coord/data-var arrays only; the ``resolution: chunk`` companions stay
+        # regular (they are already one block per chunk on the coarse chunk grid).
+        def _shard(arr):
+            if not self.sharded:
+                return arr
+            # The inner chunk is the array's current chunk shape (``cells_per_chunk``
+            # on the cells axis; a vector field's trailing payload dim is chunked
+            # whole and stays whole). The outer shard widens only the cells axis to
+            # ``cells_per_shard`` (== K inner chunks); trailing dims are unchanged.
+            cg = arr.chunk_grid
+            cfg = cg["configuration"] if isinstance(cg, dict) else cg.configuration
+            inner = tuple(int(c) for c in cfg["chunk_shape"])
+            shard = (self.cells_per_shard, *inner[1:])
+            return sharded_array_spec(arr, shard_shape=shard, inner_chunk_shape=inner)
+
         members = {}
         for name, meta in self.config.aggregation.get("coordinates", {}).items():
             dtype = meta.get("dtype", "float32")
             fill = meta.get("fill_value", "NaN")
-            members[name] = base.with_data_type(dtype).with_fill_value(fill)
+            members[name] = _shard(base.with_data_type(dtype).with_fill_value(fill))
         for name, meta in get_agg_fields(self.config).items():
             sig = get_output_signature(meta)
             # Ragged fields (issue #48) are stored as CSR subgroups
@@ -422,11 +465,13 @@ class HealpixGrid:
                 continue
             # A vector field (issue #29) gets a trailing payload dim chunked
             # whole; scalars are returned unchanged.
-            members[name] = vector_array_spec(
-                spec,
-                sig,
-                base_dims=("cells",),
-                base_chunk_shape=(self.cells_per_chunk,),
+            members[name] = _shard(
+                vector_array_spec(
+                    spec,
+                    sig,
+                    base_dims=("cells",),
+                    base_chunk_shape=(self.cells_per_chunk,),
+                )
             )
 
         return GroupSpec(members=members, attributes=self._dggs_attrs())

--- a/src/zagg/grids/rectilinear.py
+++ b/src/zagg/grids/rectilinear.py
@@ -49,7 +49,7 @@ from zagg.config import (
     get_output_signature,
     output_field_signature,
 )
-from zagg.grids.base import chunk_array_spec, vector_array_spec
+from zagg.grids.base import chunk_array_spec, sharded_array_spec, vector_array_spec
 
 OOB_SENTINEL: int = -1
 
@@ -91,6 +91,7 @@ class RectilinearGrid:
         chunk_shape=(256, 256),
         config: PipelineConfig | None = None,
         chunk_inner=None,
+        sharded: bool = False,
     ):
         if len(bounds) != 4:
             raise ValueError("bounds must be (xmin, ymin, xmax, ymax)")
@@ -118,6 +119,20 @@ class RectilinearGrid:
                     f"chunk_inner ({self.inner_h}, {self.inner_w}) must evenly divide the "
                     f"shard tile ({self.chunk_h}, {self.chunk_w})"
                 )
+        # Sharded storage (issue #108): bundle the shard tile's K inner chunks into
+        # one zarr ShardingCodec shard object. Only meaningful when chunk_inner gives
+        # K>1 (a finer inner chunk subdivides the shard tile); sharding a K==1 tile is
+        # a no-op shard of one chunk, so reject it with a clear message (validated
+        # pre-deployment, matching the grid-mismatch errors).
+        n_inner = (self.chunk_h // self.inner_h) * (self.chunk_w // self.inner_w)
+        if sharded and n_inner <= 1:
+            raise ValueError(
+                "sharded output requires chunk_inner to give more than one inner "
+                f"chunk per shard (K>1), but chunk_inner ({self.inner_h}, {self.inner_w}) "
+                f"== shard tile ({self.chunk_h}, {self.chunk_w}) gives K=1; set a finer "
+                "chunk_inner or disable sharded"
+            )
+        self.sharded = bool(sharded)
         self.config = config or default_config("atl06")
 
         span_x = self.xmax - self.xmin
@@ -231,6 +246,32 @@ class RectilinearGrid:
                 children = (rows * self.width + cols).reshape(-1).astype(np.int64)
                 block = (r0 // self.inner_h, c0 // self.inner_w)
                 yield (block, children)
+
+    def shard_slab_shape(self) -> tuple[int, int]:
+        """Cell extent of one whole sharded shard tile (issue #108).
+
+        The ``(chunk_h, chunk_w)`` slab the sharded worker assembles per dense array
+        before the single whole-shard ``set_block_selection`` — the K inner chunks
+        tiled across the shard tile (matching the ShardingCodec's inner tiling).
+        """
+        return (self.chunk_h, self.chunk_w)
+
+    def shard_local_region(self, block_index, shard_key) -> tuple:
+        """Slices an inner chunk occupies within its shard slab (issue #108).
+
+        ``block_index`` is the inner chunk's global ``(rb, cb)`` (from
+        :meth:`iter_chunks`); its position inside the shard tile is the global block
+        minus the shard tile's top-left inner block, and it occupies the
+        ``inner_h × inner_w`` sub-tile there.
+        """
+        rb, cb = self._unpack(int(shard_key))
+        gir, gic = (int(b) for b in block_index)
+        lir = gir - rb * (self.chunk_h // self.inner_h)
+        lic = gic - cb * (self.chunk_w // self.inner_w)
+        return (
+            slice(lir * self.inner_h, (lir + 1) * self.inner_h),
+            slice(lic * self.inner_w, (lic + 1) * self.inner_w),
+        )
 
     @property
     def group_path(self) -> str:
@@ -462,6 +503,21 @@ class RectilinearGrid:
             .with_attributes({"standard_name": "projection_y_coordinate", "units": "m"})
         )
 
+        # Sharded storage (issue #108): wrap each dense per-cell array in a
+        # ShardingCodec — outer (shard) chunk == the shard tile (chunk_h, chunk_w),
+        # inner chunk == (inner_h, inner_w). Applied to the per-cell data-var arrays
+        # only; the 1-D x/y coords and ``resolution: chunk`` companions stay regular.
+        def _shard(arr):
+            if not self.sharded:
+                return arr
+            cg = arr.chunk_grid
+            cfg = cg["configuration"] if isinstance(cg, dict) else cg.configuration
+            inner = tuple(int(c) for c in cfg["chunk_shape"])
+            # Widen only the spatial (y, x) axes to the shard tile; trailing payload
+            # dims (vector fields) are chunked whole and stay whole.
+            shard = (self.chunk_h, self.chunk_w, *inner[2:])
+            return sharded_array_spec(arr, shard_shape=shard, inner_chunk_shape=inner)
+
         members = {"x": coord_x, "y": coord_y}
         for name, meta in self.config.aggregation.get("coordinates", {}).items():
             # DGGS-specific coord names (cell_ids, morton) don't apply here.
@@ -469,7 +525,7 @@ class RectilinearGrid:
                 continue
             dtype = meta.get("dtype", "float32")
             fill = meta.get("fill_value", "NaN")
-            members[name] = base.with_data_type(dtype).with_fill_value(fill)
+            members[name] = _shard(base.with_data_type(dtype).with_fill_value(fill))
         for name, meta in get_agg_fields(self.config).items():
             sig = get_output_signature(meta)
             # Ragged fields (issue #48) are CSR subgroups written fresh by
@@ -502,11 +558,13 @@ class RectilinearGrid:
                 continue
             # A vector field (issue #29) gets a trailing payload dim chunked
             # whole; scalars are returned unchanged.
-            members[name] = vector_array_spec(
-                spec,
-                sig,
-                base_dims=("y", "x"),
-                base_chunk_shape=self.chunk_shape,
+            members[name] = _shard(
+                vector_array_spec(
+                    spec,
+                    sig,
+                    base_dims=("y", "x"),
+                    base_chunk_shape=self.chunk_shape,
+                )
             )
 
         return GroupSpec(members=members, attributes=self._geozarr_attrs())

--- a/src/zagg/processing/__init__.py
+++ b/src/zagg/processing/__init__.py
@@ -68,6 +68,7 @@ from zagg.processing.write import (
     _iter_carrier_columns,
     write_dataframe_to_zarr,
     write_ragged_to_zarr,
+    write_shard_to_zarr,
 )
 
 # The four public entry points the package commits to, plus every previously
@@ -85,6 +86,7 @@ __all__ = [
     "process_shard",
     "write_dataframe_to_zarr",
     "write_ragged_to_zarr",
+    "write_shard_to_zarr",
     # aggregate-stage helpers
     "_KERNEL_FUNCS",
     "_build_groups",

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -279,6 +279,18 @@ def write_shard_to_zarr(
                 zarr_format=3,
                 consolidated=False,
             )
+            if trailing:
+                # Mirror write_dataframe_to_zarr's single-trailing-chunk invariant
+                # (issue #29): a vector field's trailing payload dim must be one whole
+                # (inner) chunk, or set_block_selection at trailing block 0 would
+                # silently write only part of it.
+                target_trailing_chunks = array.chunks[len(slab_shape) :]
+                if target_trailing_chunks != trailing:
+                    raise ValueError(
+                        f"vector field {name!r}: trailing chunk "
+                        f"{target_trailing_chunks} must equal trailing shape "
+                        f"{trailing} (the payload dim must be one whole chunk)"
+                    )
             array.set_block_selection(block_idx, slab)
     return store
 

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -211,12 +211,13 @@ def write_shard_to_zarr(
     them from the shard index (sub-shard sparsity preserved inside the object).
 
     ``chunk_results`` is the worker's ``[(block_index, carrier, ragged), ...]`` —
-    one entry per inner chunk (from ``grid.iter_chunks``). Dense per-cell columns
-    (data vars + coords) are placed by their ``cell_ids`` into the shard slab
-    (cell id ``c`` lands at shard-relative offset ``c - shard_lo``). The
-    ``resolution: chunk`` companions and ragged (CSR) fields are NOT sharded —
-    they are delegated to :func:`write_dataframe_to_zarr` / :func:`write_ragged_to_zarr`
-    per inner chunk, exactly as on the regular path.
+    one entry per inner chunk (from ``grid.iter_chunks``). Each dense per-cell
+    column (data vars + coords) is placed into the shard slab by the chunk's own
+    region (``grid.shard_local_region(block_index, shard_key)``), reshaped to the
+    inner chunk's cell shape (``grid.chunk_shape``) — grid-agnostic, so HEALPix
+    (1-D) and rectilinear (2-D) share one path. The ``resolution: chunk``
+    companions and ragged (CSR) fields are NOT sharded — they are written per inner
+    chunk via the existing seams, exactly as on the regular path.
 
     Parameters
     ----------
@@ -225,58 +226,40 @@ def write_shard_to_zarr(
     store : Store
         Zarr store with the (sharded) template already written.
     grid : OutputGrid
-        Must be ``sharded`` with a ``cells_per_shard`` and ``block_index``.
+        Must be ``sharded`` with ``shard_slab_shape`` / ``shard_local_region``.
     shard_key : int
-        The dispatch shard's key (HEALPix parent morton id).
+        The dispatch shard's key (HEALPix parent morton id / rect packed tile).
 
     Returns
     -------
     Store
     """
     chunk_res_fields = _chunk_resolution_fields(getattr(grid, "config", None))
-    (shard_block,) = tuple(int(i) for i in grid.block_index(shard_key))
-    cells_per_shard = int(grid.cells_per_shard)
-    shard_lo = shard_block * cells_per_shard
+    shard_block = tuple(int(i) for i in grid.block_index(shard_key))
+    slab_shape = tuple(int(s) for s in grid.shard_slab_shape())
+    inner_shape = tuple(int(s) for s in grid.chunk_shape)
 
     # Accumulate each dense per-cell column into one shard-wide slab; companions
     # and ragged are written per inner chunk via the existing seams.
     slabs: dict = {}
-    fills: dict = {}
     for block_index, carrier, ragged in chunk_results:
-        if _carrier_empty(carrier):
-            # Still flush this chunk's companion/ragged below (they may be empty
-            # no-ops); an empty dense carrier contributes nothing to the slab.
-            write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=block_index)
-            write_ragged_to_zarr(
-                ragged, store, grid=grid, shard_key=_block_index_key(block_index, grid)
-            )
-            continue
-        cell_ids = None
-        for name, values in _iter_carrier_columns(carrier):
-            if name == "cell_ids":
-                cell_ids = np.asarray(values).astype(np.int64)
-        if cell_ids is None:
-            raise ValueError(
-                "sharded write requires a 'cell_ids' coord column to place cells "
-                f"within the shard, but carrier for shard {shard_key} has none"
-            )
-        offsets = cell_ids - shard_lo
-        for name, values in _iter_carrier_columns(carrier):
-            if name in chunk_res_fields:
-                continue  # companion (resolution: chunk) — handled below, unsharded
-            values = np.asarray(values)
-            trailing = values.shape[1:]
-            if name not in slabs:
-                array = open_array(
-                    store,
-                    path=f"{grid.group_path}/{name}",
-                    zarr_format=3,
-                    consolidated=False,
-                )
-                fill = array.metadata.fill_value
-                fills[name] = fill
-                slabs[name] = np.full((cells_per_shard, *trailing), fill, dtype=values.dtype)
-            slabs[name][offsets] = values
+        if not _carrier_empty(carrier):
+            region = grid.shard_local_region(block_index, shard_key)
+            for name, values in _iter_carrier_columns(carrier):
+                if name in chunk_res_fields:
+                    continue  # companion (resolution: chunk) — handled below, unsharded
+                values = np.asarray(values)
+                trailing = values.shape[1:]
+                if name not in slabs:
+                    array = open_array(
+                        store,
+                        path=f"{grid.group_path}/{name}",
+                        zarr_format=3,
+                        consolidated=False,
+                    )
+                    fill = array.metadata.fill_value
+                    slabs[name] = np.full((*slab_shape, *trailing), fill, dtype=values.dtype)
+                slabs[name][region] = values.reshape((*inner_shape, *trailing))
         # Companions + ragged for this inner chunk are not sharded: write them
         # straight through (companion array is one block per chunk; ragged is CSR).
         if chunk_res_fields:
@@ -287,8 +270,8 @@ def write_shard_to_zarr(
 
     # One block selection per dense array == one shard object write.
     for name, slab in slabs.items():
-        trailing = slab.shape[1:]
-        block_idx = (shard_block, *((0,) * len(trailing)))
+        trailing = slab.shape[len(slab_shape) :]
+        block_idx = (*shard_block, *((0,) * len(trailing)))
         with config.set({"async.concurrency": 128}):
             array = open_array(
                 store,

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -191,6 +191,141 @@ def write_dataframe_to_zarr(
     return store
 
 
+def write_shard_to_zarr(
+    chunk_results: list,
+    store: Store,
+    *,
+    grid,
+    shard_key: int,
+) -> Store:
+    """Write a whole sharded shard in ONE block selection per dense array (issue #108).
+
+    On a ``ShardingCodec`` array (``grid.sharded``) the K inner chunks of one
+    dispatch shard live inside a single shard object, and ``set_block_selection``
+    is **shard-granular** (one block == one shard). Writing the K inner chunks as K
+    separate block selections would each trigger a read-modify-write on the *same*
+    shard object — racy and slow. The worker already holds all K chunk carriers
+    (it reads the shard's granules once), so this assembles them into one
+    shard-wide slab per dense per-cell array and writes it at the shard block in a
+    single call. Empty inner chunks are left as fill, so the ShardingCodec omits
+    them from the shard index (sub-shard sparsity preserved inside the object).
+
+    ``chunk_results`` is the worker's ``[(block_index, carrier, ragged), ...]`` —
+    one entry per inner chunk (from ``grid.iter_chunks``). Dense per-cell columns
+    (data vars + coords) are placed by their ``cell_ids`` into the shard slab
+    (cell id ``c`` lands at shard-relative offset ``c - shard_lo``). The
+    ``resolution: chunk`` companions and ragged (CSR) fields are NOT sharded —
+    they are delegated to :func:`write_dataframe_to_zarr` / :func:`write_ragged_to_zarr`
+    per inner chunk, exactly as on the regular path.
+
+    Parameters
+    ----------
+    chunk_results : list of (block_index, carrier, ragged)
+        The worker's per-inner-chunk results for one dispatch shard.
+    store : Store
+        Zarr store with the (sharded) template already written.
+    grid : OutputGrid
+        Must be ``sharded`` with a ``cells_per_shard`` and ``block_index``.
+    shard_key : int
+        The dispatch shard's key (HEALPix parent morton id).
+
+    Returns
+    -------
+    Store
+    """
+    chunk_res_fields = _chunk_resolution_fields(getattr(grid, "config", None))
+    (shard_block,) = tuple(int(i) for i in grid.block_index(shard_key))
+    cells_per_shard = int(grid.cells_per_shard)
+    shard_lo = shard_block * cells_per_shard
+
+    # Accumulate each dense per-cell column into one shard-wide slab; companions
+    # and ragged are written per inner chunk via the existing seams.
+    slabs: dict = {}
+    fills: dict = {}
+    for block_index, carrier, ragged in chunk_results:
+        if _carrier_empty(carrier):
+            # Still flush this chunk's companion/ragged below (they may be empty
+            # no-ops); an empty dense carrier contributes nothing to the slab.
+            write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=block_index)
+            write_ragged_to_zarr(
+                ragged, store, grid=grid, shard_key=_block_index_key(block_index, grid)
+            )
+            continue
+        cell_ids = None
+        for name, values in _iter_carrier_columns(carrier):
+            if name == "cell_ids":
+                cell_ids = np.asarray(values).astype(np.int64)
+        if cell_ids is None:
+            raise ValueError(
+                "sharded write requires a 'cell_ids' coord column to place cells "
+                f"within the shard, but carrier for shard {shard_key} has none"
+            )
+        offsets = cell_ids - shard_lo
+        for name, values in _iter_carrier_columns(carrier):
+            if name in chunk_res_fields:
+                continue  # companion (resolution: chunk) — handled below, unsharded
+            values = np.asarray(values)
+            trailing = values.shape[1:]
+            if name not in slabs:
+                array = open_array(
+                    store,
+                    path=f"{grid.group_path}/{name}",
+                    zarr_format=3,
+                    consolidated=False,
+                )
+                fill = array.metadata.fill_value
+                fills[name] = fill
+                slabs[name] = np.full((cells_per_shard, *trailing), fill, dtype=values.dtype)
+            slabs[name][offsets] = values
+        # Companions + ragged for this inner chunk are not sharded: write them
+        # straight through (companion array is one block per chunk; ragged is CSR).
+        if chunk_res_fields:
+            _write_companion_columns(carrier, store, grid, block_index, chunk_res_fields)
+        write_ragged_to_zarr(
+            ragged, store, grid=grid, shard_key=_block_index_key(block_index, grid)
+        )
+
+    # One block selection per dense array == one shard object write.
+    for name, slab in slabs.items():
+        trailing = slab.shape[1:]
+        block_idx = (shard_block, *((0,) * len(trailing)))
+        with config.set({"async.concurrency": 128}):
+            array = open_array(
+                store,
+                path=f"{grid.group_path}/{name}",
+                zarr_format=3,
+                consolidated=False,
+            )
+            array.set_block_selection(block_idx, slab)
+    return store
+
+
+def _write_companion_columns(carrier, store, grid, block_index, chunk_res_fields):
+    """Write a chunk's ``resolution: chunk`` companion columns (unsharded path).
+
+    A ``resolution: chunk`` companion array is shaped at the coarse chunk grid
+    (one block per chunk), never sharded, so it keeps the per-chunk write even on
+    the sharded path. Reuses the same chunk-uniform collapse + block placement as
+    :func:`write_dataframe_to_zarr`'s companion branch.
+    """
+    block_idx = tuple(int(i) for i in block_index)
+    for name, values in _iter_carrier_columns(carrier):
+        if name not in chunk_res_fields:
+            continue
+        chunk_value = np.asarray(_chunk_uniform_value(name, values))
+        trailing = chunk_value.shape
+        block = chunk_value.reshape((1,) * len(block_idx) + trailing)
+        target = block_idx + (0,) * len(trailing)
+        with config.set({"async.concurrency": 128}):
+            array = open_array(
+                store,
+                path=f"{grid.group_path}/{name}",
+                zarr_format=3,
+                consolidated=False,
+            )
+            array.set_block_selection(target, block)
+
+
 def write_ragged_to_zarr(
     ragged: dict,
     store: Store,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -51,6 +51,7 @@ from zagg.processing import (
     process_shard,
     write_dataframe_to_zarr,
     write_ragged_to_zarr,
+    write_shard_to_zarr,
 )
 from zagg.processing.write import _block_index_key
 from zagg.store import open_store
@@ -360,6 +361,12 @@ def _process_and_write(
         handoff=handoff,
         chunk_results=chunk_results,
     )
+    # Sharded output (issue #108): the shard's K inner chunks bundle into one
+    # ShardingCodec shard object — write the whole shard in one block selection per
+    # dense array (a per-inner-chunk loop would read-modify-write the shard object).
+    if getattr(grid, "sharded", False):
+        write_shard_to_zarr(chunk_results, zarr_store, grid=grid, shard_key=int(shard_key))
+        return metadata
     single_chunk = len(chunk_results) == 1
     for block_index, carrier, ragged in chunk_results:
         # write_dataframe_to_zarr no-ops on an empty carrier (DataFrame or Arrow

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,7 @@ from zagg.config import (
     get_filters,
     get_levels,
     get_output_signature,
+    get_sharded,
     get_store_path,
     load_config,
     load_config_from_dict,
@@ -1049,6 +1050,23 @@ class TestOutputHelpers:
         cfg = PipelineConfig(output={"grid": {"type": "healpix"}})
         with pytest.raises(ValueError, match="child_order"):
             get_child_order(cfg)
+
+    def test_get_sharded_default_false(self, atl06_config):
+        assert get_sharded(atl06_config) is False
+
+    def test_get_sharded_true(self):
+        cfg = PipelineConfig(
+            output={
+                "grid": {
+                    "type": "healpix",
+                    "parent_order": 6,
+                    "child_order": 12,
+                    "chunk_inner": 8,
+                    "sharded": True,
+                }
+            }
+        )
+        assert get_sharded(cfg) is True
 
     def test_get_store_path(self):
         cfg = PipelineConfig(

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -928,3 +928,43 @@ class TestSharded:
         dense_bytes = len(store._store_dict[f"8/h_mean/c/{shard_block}"])
 
         assert sparse_bytes < dense_bytes
+
+    def test_vector_field_shards_and_roundtrips(self):
+        # A kind: vector field's trailing payload dim stays whole inside the shard:
+        # outer shard (cells_per_shard, T), inner chunk (cells_per_chunk, T). A whole-
+        # shard slab round-trips, and one shard object holds the K inner chunks.
+        from mortie import geo2mort
+        from zarr import open_array
+
+        g = HealpixGrid(
+            parent_order=4,
+            child_order=8,
+            layout="fullsphere",
+            config=_vector_config(bins=4, dtype="float32"),
+            chunk_inner=6,
+            sharded=True,
+        )
+        store = MemoryStore()
+        g.emit_template(store)
+        arr = open_array(store, path="8/hist", zarr_format=3, consolidated=False)
+        assert arr.chunks == (g.cells_per_chunk, 4)
+        assert arr.shards == (g.cells_per_shard, 4)
+
+        parent = int(geo2mort(-78.5, -132.0, order=4)[0])
+        (shard_block,) = g.block_index(parent)
+        slab = np.zeros((g.cells_per_shard, 4), dtype="float32")
+        slab[: g.cells_per_chunk] = np.arange(g.cells_per_chunk * 4).reshape(g.cells_per_chunk, 4)
+        arr.set_block_selection((shard_block, 0), slab)
+
+        shard_keys = [k for k in store._store_dict if k.startswith("8/hist/c/")]
+        assert shard_keys == [f"8/hist/c/{shard_block}/0"]
+        lo = shard_block * g.cells_per_shard
+        np.testing.assert_array_equal(arr[lo : lo + g.cells_per_shard], slab)
+
+    def test_sharded_not_in_signature(self):
+        # sharded is a storage form, not a spatial-layout change, so it must not
+        # alter the shard-map fingerprint (parallels chunk_inner's exclusion).
+        cfg = default_config("atl06")
+        g0 = HealpixGrid(4, 8, layout="fullsphere", config=cfg, chunk_inner=6)
+        g1 = HealpixGrid(4, 8, layout="fullsphere", config=cfg, chunk_inner=6, sharded=True)
+        assert g0.signature() == g1.signature()

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -296,6 +296,35 @@ class TestFromConfig:
         with pytest.raises(ValueError, match="Unknown output.grid.type"):
             from_config(cfg, parent_order=6)
 
+    def test_sharded_default_off(self, cfg):
+        # The knob is absent by default -> regular (non-sharded) storage (issue #108).
+        g = from_config(cfg, parent_order=6)
+        assert g.sharded is False
+
+    def test_sharded_flag_threads_through(self, cfg):
+        # sharded on the grid block, with chunk_inner giving K>1, yields a sharded grid.
+        cfg.output["grid"]["chunk_inner"] = 8
+        cfg.output["grid"]["sharded"] = True
+        g = from_config(cfg, parent_order=6)
+        assert g.sharded is True
+        assert g.chunks_per_shard > 1
+
+    def test_sharded_k1_validated_pre_deployment(self, cfg):
+        # sharded without chunk_inner (K==1) is meaningless -> error at construction
+        # (validated before lambda deployment, matching the grid-mismatch errors).
+        cfg.output["grid"]["sharded"] = True
+        with pytest.raises(ValueError, match="K>1"):
+            from_config(cfg, parent_order=6)
+
+    def test_sharded_off_byte_identical_template(self, cfg):
+        # Flag off must reproduce the regular template byte-for-byte even when
+        # chunk_inner is set (sharding is purely opt-in storage form).
+        cfg.output["grid"]["chunk_inner"] = 8
+        g_off = from_config(cfg, parent_order=6)
+        cfg.output["grid"]["sharded"] = False
+        g_explicit_off = from_config(cfg, parent_order=6)
+        assert g_off._spec().model_dump() == g_explicit_off._spec().model_dump()
+
 
 class TestBackcompatWrapper:
     """xdggs_zarr_template (the public API) must keep producing the same

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -327,7 +327,7 @@ def _vector_config(bins=4, dtype="int64"):
     agg = {
         "coordinates": base.aggregation.get("coordinates", {}),
         "variables": {
-            "count": {"function": "len", "source": "h_li"},
+            "count": {"function": "len", "source": "h_mean"},
             "hist": {
                 "function": "np.bincount",
                 "source": "b",
@@ -454,11 +454,11 @@ def _chunk_resolution_config():
     agg = {
         "coordinates": base.aggregation.get("coordinates", {}),
         "chunk_precompute": {
-            "chunk_anchor": {"expression": "np.float32(np.median(h_li))", "source": "h_li"}
+            "chunk_anchor": {"expression": "np.float32(np.median(h_mean))", "source": "h_mean"}
         },
         "variables": {
-            "count": {"function": "len", "source": "h_li"},
-            "anchor_h": {"expression": "chunk_anchor", "source": "h_li", "resolution": "chunk"},
+            "count": {"function": "len", "source": "h_mean"},
+            "anchor_h": {"expression": "chunk_anchor", "source": "h_mean", "resolution": "chunk"},
         },
     }
     return PipelineConfig(data_source=base.data_source, aggregation=agg, output=base.output)
@@ -783,3 +783,119 @@ class TestChunkInnerMultiChunk:
             "EPSG:3031", 100000.0, bounds, chunk_shape=(8, 8), config=cfg, chunk_inner=(4, 4)
         )
         assert g0.signature() == g1.signature()
+
+
+class TestSharded:
+    """Issue #108: HEALPix ShardingCodec output — one shard object per dispatch
+    shard, K inner read-chunks bundled inside (empties omitted)."""
+
+    # parent 4, child 8, chunk_inner 6 -> K = 4^(6-4) = 16 inner chunks/shard,
+    # each cells_per_chunk = 4^(8-6) = 16 cells; cells_per_shard = 256.
+    def _grid(self, sharded=True):
+        cfg = default_config("atl06")
+        return HealpixGrid(
+            parent_order=4,
+            child_order=8,
+            layout="fullsphere",
+            config=cfg,
+            chunk_inner=6,
+            sharded=sharded,
+        )
+
+    def test_k1_sharded_rejected(self):
+        cfg = default_config("atl06")
+        # No chunk_inner -> K == 1 -> sharding is a no-op shard of one chunk.
+        with pytest.raises(ValueError, match="K>1"):
+            HealpixGrid(4, 8, layout="fullsphere", config=cfg, sharded=True)
+
+    def test_template_emits_sharding_codec(self):
+        g = self._grid()
+        assert g.cells_per_shard == 256
+        assert g.cells_per_chunk == 16
+        store = MemoryStore()
+        g.emit_template(store)
+        group = open_group(store, path="8", mode="r")
+        for name in group:
+            arr = group[name]
+            # Sharded: zarr chunks == inner read chunk; shards == dispatch shard.
+            assert arr.chunks == (16,), name
+            assert arr.shards == (256,), name
+            assert any("sharding" in type(c).__name__.lower() for c in arr.metadata.codecs), name
+
+    def test_flag_off_byte_identical_to_regular(self):
+        # Sharded OFF must reproduce the existing regular template exactly.
+        g_off = self._grid(sharded=False)
+        g_reg = HealpixGrid(
+            4, 8, layout="fullsphere", config=default_config("atl06"), chunk_inner=6
+        )
+        assert g_off._spec().model_dump() == g_reg._spec().model_dump()
+
+    def test_inner_codecs_are_bytes_only(self):
+        # The bytes-only/uncompressed policy must survive the sharding wrap: the
+        # inner codecs carry no compressor (caveat: zarr.create_array injects zstd).
+        g = self._grid()
+        spec = g._spec()
+        h_mean = spec.members["h_mean"].model_dump()
+        (codec,) = h_mean["codecs"]
+        assert codec["name"] == "sharding_indexed"
+        inner = codec["configuration"]["codecs"]
+        assert [c["name"] for c in inner] == ["bytes"]
+        assert codec["configuration"]["chunk_shape"] == [16]
+
+    def test_one_shard_object_empties_omitted_and_roundtrip(self):
+        from mortie import geo2mort
+        from zarr import open_array
+
+        g = self._grid()
+        store = MemoryStore()
+        g.emit_template(store)
+        arr = open_array(store, path="8/h_mean", zarr_format=3, consolidated=False)
+
+        # Populate ONE dispatch shard, only its first inner chunk (sub-shard
+        # sparsity): a whole-shard slab that is mostly fill.
+        parent = int(geo2mort(-78.5, -132.0, order=4)[0])
+        (shard_block,) = g.block_index(parent)
+        slab = np.full(g.cells_per_shard, np.nan, dtype="float32")
+        slab[: g.cells_per_chunk] = np.arange(g.cells_per_chunk, dtype="float32")
+        # Block selection is shard-granular on a sharded array (issue #108): one
+        # block == one shard, so this writes the whole shard in a single call.
+        arr.set_block_selection((shard_block,), slab)
+
+        # Exactly one shard object on disk for the one populated shard.
+        shard_keys = [k for k in store._store_dict if k.startswith("8/h_mean/c/")]
+        assert shard_keys == [f"8/h_mean/c/{shard_block}"]
+
+        # Byte-exact read-back of the whole shard.
+        lo = shard_block * g.cells_per_shard
+        read = arr[lo : lo + g.cells_per_shard]
+        np.testing.assert_array_equal(read[: g.cells_per_chunk], np.arange(g.cells_per_chunk))
+        assert np.all(np.isnan(read[g.cells_per_chunk :]))
+
+        # Partial decode: read just the populated inner (read) chunk via a slice
+        # narrower than the shard — the sharding index serves it without the rest.
+        chunk = arr[lo : lo + g.cells_per_chunk]
+        np.testing.assert_array_equal(chunk, np.arange(g.cells_per_chunk))
+
+    def test_sparse_shard_omits_empty_inner_chunks(self):
+        # A shard object holding one populated 16-cell inner chunk must be far
+        # smaller than a fully-dense shard (empty inner chunks absent from index).
+        from mortie import geo2mort
+        from zarr import open_array
+
+        g = self._grid()
+        store = MemoryStore()
+        g.emit_template(store)
+        arr = open_array(store, path="8/h_mean", zarr_format=3, consolidated=False)
+        parent = int(geo2mort(-78.5, -132.0, order=4)[0])
+        (shard_block,) = g.block_index(parent)
+
+        sparse = np.full(g.cells_per_shard, np.nan, dtype="float32")
+        sparse[: g.cells_per_chunk] = 1.0
+        arr.set_block_selection((shard_block,), sparse)
+        sparse_bytes = len(store._store_dict[f"8/h_mean/c/{shard_block}"])
+
+        dense = np.ones(g.cells_per_shard, dtype="float32")
+        arr.set_block_selection((shard_block,), dense)
+        dense_bytes = len(store._store_dict[f"8/h_mean/c/{shard_block}"])
+
+        assert sparse_bytes < dense_bytes

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -327,7 +327,7 @@ def _vector_config(bins=4, dtype="int64"):
     agg = {
         "coordinates": base.aggregation.get("coordinates", {}),
         "variables": {
-            "count": {"function": "len", "source": "h_mean"},
+            "count": {"function": "len", "source": "h_li"},
             "hist": {
                 "function": "np.bincount",
                 "source": "b",
@@ -454,11 +454,11 @@ def _chunk_resolution_config():
     agg = {
         "coordinates": base.aggregation.get("coordinates", {}),
         "chunk_precompute": {
-            "chunk_anchor": {"expression": "np.float32(np.median(h_mean))", "source": "h_mean"}
+            "chunk_anchor": {"expression": "np.float32(np.median(h_li))", "source": "h_li"}
         },
         "variables": {
-            "count": {"function": "len", "source": "h_mean"},
-            "anchor_h": {"expression": "chunk_anchor", "source": "h_mean", "resolution": "chunk"},
+            "count": {"function": "len", "source": "h_li"},
+            "anchor_h": {"expression": "chunk_anchor", "source": "h_li", "resolution": "chunk"},
         },
     }
     return PipelineConfig(data_source=base.data_source, aggregation=agg, output=base.output)

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -176,6 +176,9 @@ class TestProcessEventWriteLoop:
         grid_stub = MagicMock()
         grid_stub.group_path = "8"
         grid_stub.chunk_grid_shape = (4,)
+        # Regular (non-sharded) write path — a MagicMock attr is truthy by default,
+        # so pin it off explicitly (issue #108 routes sharded grids elsewhere).
+        grid_stub.sharded = False
 
         monkeypatch.setattr(processing, "process_shard", fake_process_shard)
         monkeypatch.setattr(grids, "from_config", lambda *a, **k: grid_stub)
@@ -262,6 +265,9 @@ class TestProcessEventProfile:
         grid_stub = MagicMock()
         grid_stub.group_path = "8"
         grid_stub.chunk_grid_shape = (4,)
+        # Regular (non-sharded) write path — a MagicMock attr is truthy by default,
+        # so pin it off explicitly (issue #108 routes sharded grids elsewhere).
+        grid_stub.sharded = False
 
         def fake_write_dense(*a, **k):
             if write_raises:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -93,6 +93,113 @@ class TestWriteDataframeToZarr:
             write_dataframe_to_zarr(df_out, store, grid=grid, chunk_idx=chunk_idx)
 
 
+class TestWriteShardToZarr:
+    """Issue #108 phase 2: the sharded worker writes a whole shard in ONE block
+    selection per dense array, byte-identical to the per-inner-chunk regular path."""
+
+    # parent 6, child 8, chunk_inner 7 -> K = 4 inner chunks/shard, cells_per_chunk
+    # 4, cells_per_shard 16. Small enough to enumerate, K>1 so sharding is valid.
+    @staticmethod
+    def _grids(cfg):
+        from mortie import geo2mort
+
+        kw = dict(layout="fullsphere", config=cfg, chunk_inner=7)
+        sharded = HealpixGrid(6, 8, sharded=True, **kw)
+        regular = HealpixGrid(6, 8, **kw)
+        shard_key = int(geo2mort(-78.5, -132.0, order=6)[0])
+        return sharded, regular, shard_key
+
+    @staticmethod
+    def _patch_reads(monkeypatch, df):
+        calls = {"n": 0}
+
+        def one_shot(*args, **kwargs):
+            calls["n"] += 1
+            return df if calls["n"] == 1 else None
+
+        monkeypatch.setattr("zagg.processing._read_group", one_shot)
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+
+    def _read_df(self, grid, shard_key):
+        # Two distinct cells in two distinct inner chunks of the shard, so the
+        # written shard spans more than one inner read-chunk.
+        children = grid.children(shard_key)
+        c_first = int(children[0])  # inner chunk 0
+        c_last = int(children[-1])  # inner chunk K-1
+        return pd.DataFrame(
+            {
+                "h_li": np.array([3.0, 1.0, 7.0], dtype=np.float32),
+                "s_li": np.array([0.1, 0.1, 0.1], dtype=np.float32),
+                "leaf_id": np.array([c_first, c_first, c_last], dtype=np.uint64),
+            }
+        )
+
+    def _run(self, grid, shard_key, df, monkeypatch):
+        from zagg.processing import write_shard_to_zarr
+
+        store = MemoryStore()
+        grid.emit_template(store)
+        self._patch_reads(monkeypatch, df)
+        chunk_results: list = []
+        process_shard(
+            grid,
+            shard_key,
+            ["s3://x"],
+            s3_credentials={},
+            config=grid.config,
+            chunk_results=chunk_results,
+        )
+        if getattr(grid, "sharded", False):
+            write_shard_to_zarr(chunk_results, store, grid=grid, shard_key=shard_key)
+        else:
+            for block_index, carrier, _ragged in chunk_results:
+                write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=block_index)
+        return store
+
+    def test_sharded_matches_regular_byte_for_byte(self, monkeypatch):
+        cfg = default_config()
+        sharded, regular, shard_key = self._grids(cfg)
+        df = self._read_df(regular, shard_key)
+
+        s_store = self._run(sharded, shard_key, df, monkeypatch)
+        r_store = self._run(regular, shard_key, df.copy(), monkeypatch)
+
+        s_grp = open_group(store=s_store, mode="r", path="8")
+        r_grp = open_group(store=r_store, mode="r", path="8")
+        # The whole-shard slab contents must equal the per-inner-chunk writes.
+        for name in r_grp.array_keys():
+            np.testing.assert_array_equal(
+                s_grp[name][:], r_grp[name][:], err_msg=f"sharded vs regular differ in {name}"
+            )
+
+    def test_one_shard_object_per_dispatch_shard(self, monkeypatch):
+        cfg = default_config()
+        sharded, _regular, shard_key = self._grids(cfg)
+        df = self._read_df(sharded, shard_key)
+        store = self._run(sharded, shard_key, df, monkeypatch)
+
+        # Exactly one shard object per populated dense array (h_mean), not K.
+        (shard_block,) = sharded.block_index(shard_key)
+        h_keys = [k for k in store._store_dict if k.startswith("8/h_mean/c/")]
+        assert h_keys == [f"8/h_mean/c/{shard_block}"]
+
+    def test_readback_places_cells_at_correct_positions(self, monkeypatch):
+        cfg = default_config()
+        sharded, _regular, shard_key = self._grids(cfg)
+        df = self._read_df(sharded, shard_key)
+        store = self._run(sharded, shard_key, df, monkeypatch)
+
+        grp = open_group(store=store, mode="r", path="8")
+        children = sharded.children(shard_key)
+        cell_ids = sharded.encode_cell_ids(children)
+        first, last = int(cell_ids[0]), int(cell_ids[-1])
+        # Populated cells carry data; an interior empty cell stays NaN fill.
+        assert grp["count"][first] == 2  # two photons in the first cell
+        assert grp["count"][last] == 1
+        assert np.isnan(grp["h_mean"][int(cell_ids[1])])
+
+
 class TestCalculateCellStatistics:
     def test_empty_data_returns_zeros_and_nans(self):
         result = calculate_cell_statistics({"h_li": np.array([]), "s_li": np.array([])})

--- a/tests/test_rectilinear.py
+++ b/tests/test_rectilinear.py
@@ -38,7 +38,10 @@ class TestConstruction:
         # 1280 == 5*256 already, so auto-pad is a no-op and bounds are unchanged.
         assert grid.array_shape == (1280, 1280)
         assert (grid.xmin, grid.ymax, grid.xmax, grid.ymin) == (
-            -3_200_000, 3_200_000, 3_200_000, -3_200_000
+            -3_200_000,
+            3_200_000,
+            3_200_000,
+            -3_200_000,
         )
 
     def test_uneven_chunk_padded(self, cfg):
@@ -62,17 +65,21 @@ class TestConstruction:
         # span not a whole multiple of resolution -> round cells UP to cover it
         # (chunk_shape (1,1) isolates the cover-rounding from chunk-padding).
         g = RectilinearGrid(
-            crs="EPSG:3031", resolution=5000,
+            crs="EPSG:3031",
+            resolution=5000,
             bounds=(0, 0, 5000 * 130 + 100, 5000 * 130 + 100),
-            chunk_shape=(1, 1), config=cfg,
+            chunk_shape=(1, 1),
+            config=cfg,
         )
         assert g.array_shape == (131, 131)  # ceil(130.02) -> 131
 
     def test_signature_reflects_padding(self, cfg):
         g = RectilinearGrid(
-            crs="EPSG:3031", resolution=5000,
+            crs="EPSG:3031",
+            resolution=5000,
             bounds=(-3_200_000, -3_200_000, 3_200_000, 3_200_000),
-            chunk_shape=(300, 300), config=cfg,
+            chunk_shape=(300, 300),
+            config=cfg,
         )
         sig = g.signature()
         assert sig["shape"] == [1500, 1500]
@@ -81,18 +88,27 @@ class TestConstruction:
     def test_invalid_bounds(self, cfg):
         with pytest.raises(ValueError, match="bounds"):
             RectilinearGrid(
-                crs="EPSG:3031", resolution=5000,
-                bounds=(0, 0, -100, -100), chunk_shape=(2, 2), config=cfg,
+                crs="EPSG:3031",
+                resolution=5000,
+                bounds=(0, 0, -100, -100),
+                chunk_shape=(2, 2),
+                config=cfg,
             )
 
     def test_scalar_vs_tuple_resolution(self, cfg):
         g1 = RectilinearGrid(
-            crs="EPSG:3031", resolution=5000,
-            bounds=(0, 0, 10000, 10000), chunk_shape=(2, 2), config=cfg,
+            crs="EPSG:3031",
+            resolution=5000,
+            bounds=(0, 0, 10000, 10000),
+            chunk_shape=(2, 2),
+            config=cfg,
         )
         g2 = RectilinearGrid(
-            crs="EPSG:3031", resolution=[5000, 5000],
-            bounds=(0, 0, 10000, 10000), chunk_shape=(2, 2), config=cfg,
+            crs="EPSG:3031",
+            resolution=[5000, 5000],
+            bounds=(0, 0, 10000, 10000),
+            chunk_shape=(2, 2),
+            config=cfg,
         )
         assert g1.array_shape == g2.array_shape
 
@@ -226,6 +242,21 @@ class TestFromConfig:
         with pytest.raises(ValueError, match="missing required"):
             from_config(cfg)
 
+    def test_sharded_default_off(self, cfg):
+        assert from_config(cfg).sharded is False
+
+    def test_sharded_threads_through(self, cfg):
+        cfg.output["grid"]["chunk_inner"] = [128, 128]
+        cfg.output["grid"]["sharded"] = True
+        g = from_config(cfg)
+        assert g.sharded is True
+        assert g.chunks_per_shard > 1
+
+    def test_sharded_k1_validated(self, cfg):
+        cfg.output["grid"]["sharded"] = True  # no chunk_inner -> K == 1
+        with pytest.raises(ValueError, match="K>1"):
+            from_config(cfg)
+
 
 class TestCoverage:
     def test_coverage_contains_point_shard(self, grid):
@@ -251,9 +282,11 @@ class TestCoverage:
 
 def _grid(cfg, res, chunk):
     return RectilinearGrid(
-        crs="EPSG:3031", resolution=res,
+        crs="EPSG:3031",
+        resolution=res,
         bounds=(-3_200_000, -3_200_000, 3_200_000, 3_200_000),
-        chunk_shape=chunk, config=cfg,
+        chunk_shape=chunk,
+        config=cfg,
     )
 
 
@@ -267,8 +300,7 @@ class TestSignature:
         assert len(sig["affine"]) == 6
 
     def test_distinguishes_grids(self, cfg):
-        assert _grid(cfg, 5000, (256, 256)).signature() != \
-            _grid(cfg, 8000, (200, 200)).signature()
+        assert _grid(cfg, 5000, (256, 256)).signature() != _grid(cfg, 8000, (200, 200)).signature()
 
 
 class TestNesting:
@@ -284,8 +316,10 @@ class TestNesting:
 
     def test_cross_crs(self, cfg):
         utm = RectilinearGrid(
-            crs="EPSG:32618", resolution=10,
-            bounds=[359400, 4300740, 369400, 4310740], chunk_shape=[250, 250],
+            crs="EPSG:32618",
+            resolution=10,
+            bounds=[359400, 4300740, 369400, 4310740],
+            chunk_shape=[250, 250],
             config=cfg,
         )
         assert not _grid(cfg, 5000, (256, 256)).nests_with(utm)
@@ -313,9 +347,7 @@ class TestNesting:
                 },
             },
         }
-        vcfg = PipelineConfig(
-            data_source=cfg.data_source, aggregation=agg, output=cfg.output
-        )
+        vcfg = PipelineConfig(data_source=cfg.data_source, aggregation=agg, output=cfg.output)
         scalar = _grid(cfg, 5000, (256, 256))
         vector = _grid(vcfg, 5000, (256, 256))
         # Same CRS / whole-ratio / aligned — only the field set differs.
@@ -338,5 +370,90 @@ class TestValidateCompatible:
         from zagg.grids import HealpixGrid, validate_compatible
 
         with pytest.raises(ValueError, match="do not nest"):
-            validate_compatible([_grid(cfg, 5000, (256, 256)),
-                                 HealpixGrid(6, 12, layout="fullsphere")])
+            validate_compatible(
+                [_grid(cfg, 5000, (256, 256)), HealpixGrid(6, 12, layout="fullsphere")]
+            )
+
+
+class TestSharded:
+    """Issue #108 phase 4: rectilinear ShardingCodec — one shard object per shard
+    tile, K inner chunks bundled inside, byte-identical to the regular path."""
+
+    # shard tile 8x8, inner 4x4 -> K = 4 inner chunks/shard.
+    def _grids(self, cfg):
+        kw = dict(
+            crs="EPSG:3031",
+            resolution=100000.0,
+            bounds=(-4e5, -4e5, 4e5, 4e5),
+            chunk_shape=(8, 8),
+            config=cfg,
+            chunk_inner=(4, 4),
+        )
+        return RectilinearGrid(sharded=True, **kw), RectilinearGrid(**kw)
+
+    def test_k1_sharded_rejected(self, cfg):
+        with pytest.raises(ValueError, match="K>1"):
+            RectilinearGrid(
+                "EPSG:3031",
+                100000.0,
+                (-4e5, -4e5, 4e5, 4e5),
+                chunk_shape=(8, 8),
+                config=cfg,
+                sharded=True,  # no chunk_inner -> K == 1
+            )
+
+    def test_template_emits_sharding_codec(self, cfg):
+        sharded, _regular = self._grids(cfg)
+        store = MemoryStore()
+        sharded.emit_template(store)
+        group = open_group(store, path="rectilinear", mode="r")
+        for name in ("h_mean", "count"):
+            arr = group[name]
+            assert arr.chunks == (4, 4), name  # inner read chunk
+            assert arr.shards == (8, 8), name  # dispatch shard tile
+            assert any("sharding" in type(c).__name__.lower() for c in arr.metadata.codecs)
+        # 1-D x/y coords are never sharded.
+        assert group["x"].shards is None
+        assert group["y"].shards is None
+
+    def test_flag_off_byte_identical(self, cfg):
+        sharded_off = RectilinearGrid(
+            "EPSG:3031",
+            100000.0,
+            (-4e5, -4e5, 4e5, 4e5),
+            chunk_shape=(8, 8),
+            config=cfg,
+            chunk_inner=(4, 4),
+        )
+        _sharded, regular = self._grids(cfg)
+        assert sharded_off._spec().model_dump() == regular._spec().model_dump()
+
+    def test_whole_shard_write_roundtrip(self, cfg):
+        import pandas as pd
+
+        from zagg.processing import write_shard_to_zarr
+
+        sharded, _regular = self._grids(cfg)
+        store = MemoryStore()
+        sharded.emit_template(store)
+
+        # Build one carrier per inner chunk: each cell carries its own global cell
+        # id as the h_mean value, in the chunk's row-major order (as the worker does).
+        shard_key = sharded._pack(0, 0)
+        chunk_results = []
+        for block_index, children in sharded.iter_chunks(shard_key):
+            df = pd.DataFrame({"h_mean": np.asarray(children, dtype=np.float32)})
+            chunk_results.append((block_index, df, {}))
+        write_shard_to_zarr(chunk_results, store, grid=sharded, shard_key=shard_key)
+
+        # Exactly one shard object for the populated dense array.
+        h_keys = [k for k in store._store_dict if k.startswith("rectilinear/h_mean/c/")]
+        assert h_keys == ["rectilinear/h_mean/c/0/0"]
+
+        # Read-back: every cell in the shard tile holds its own global id.
+        group = open_group(store, path="rectilinear", mode="r")
+        arr = group["h_mean"][:8, :8]
+        expected = (np.arange(8)[:, None] * sharded.width + np.arange(8)[None, :]).astype(
+            np.float32
+        )
+        np.testing.assert_array_equal(arr, expected)


### PR DESCRIPTION
Closes #108

## What

Adds an opt-in zarr `ShardingCodec` storage form for HEALPix and rectilinear output. It bundles the `K = (shard cells) / (inner-chunk cells)` inner read-chunks of one dispatch shard into **one shard object** instead of K independent regular chunk objects, with empty inner chunks omitted from the shard index (sub-shard sparsity preserved *inside* the object). This is what makes "push dispatch to a coarser order" viable without drowning the reader in millions of tiny chunk objects.

The knob lives **on the grid/chunk block next to `chunk_inner`** (design locked by @espg in the issue thread), defaults **off**, and is only valid when `chunk_inner` gives K>1 (validated, errors otherwise).

## Approach

- **Geometry** (unchanged, set by `chunk_inner`): shard = dispatch unit (HEALPix `parent_order` / rect `chunk_shape`) = zarr **shard**; inner chunk = the 64×64 read chunk (HEALPix `chunk_inner` order / rect `chunk_inner` shape) = zarr **inner chunk**.
- **`emit_template`**: the dense per-cell `ArraySpec`s get a `sharding_indexed` codec — outer chunk grid widened to the whole shard, inner `chunk_shape` = the read chunk. Built **by hand** with **explicit bytes-only inner codecs** (the two prototype caveats: `ArraySpec.from_array` drops the sharding codec in pydantic-zarr 0.10.0; `zarr.create_array` silently injects zstd level-0). 1-D coords and `resolution: chunk` companions stay regular.
- **Worker**: on the sharded path the K inner chunks are assembled into one shard-wide slab per dense array and written in a single shard-granular `set_block_selection` (avoids read-modify-write on the shared shard object). Placement is grid-agnostic via `grid.shard_slab_shape()` + `grid.shard_local_region(block_index, shard_key)`, so HEALPix (1-D) and rectilinear (2-D) share one write path. The regular (non-sharded) path is byte-identical.

## Phases (all complete)

- [x] **Phase 1 — HEALPix sharded `emit_template`** (`0c5b25e`). `sharded_array_spec` helper in `grids/base.py`; `sharded=` flag on `HealpixGrid` with K>1 validation; sharding codec applied to dense per-cell arrays in `_spec`. Round-trip regression `tests/test_grids.py::TestSharded`: one shard object per dispatch shard, empty inner chunks omitted, byte-exact read-back, narrow read-chunk partial decode, flag-off byte-identity, bytes-only inner codecs, K==1 error.
- [x] **Phase 2 — Worker whole-shard write** (`d8a5e8a`). `write_shard_to_zarr`; runner + lambda handler route sharded grids to it; regular path unchanged. End-to-end `tests/test_processing.py::TestWriteShardToZarr` proves sharded == regular byte-for-byte + one-shard-object. Also folds the phase-1 self-review (reverted an unrelated `h_li`→`h_mean` test-helper scope creep).
- [x] **Phase 3 — Config flag + validation + accessor** (`ba4be30`). `get_sharded` accessor (mirrors `get_layout`); `from_config` threads it through; default off; K==1 surfaces as a pre-deployment error. Tests in `TestFromConfig` + `TestOutputHelpers` incl. flag-off byte-identity and the K==1 error.
- [x] **Phase 4 — Rectilinear engine** (`1766108`). `sharded` on `RectilinearGrid` (flag + K>1 validation + `shard_slab_shape`/`shard_local_region` + sharding codec in `_spec`); wired into rect's `from_config`. Refactored `write_shard_to_zarr` to grid-agnostic block-based placement (HEALPix path stays byte-identical — verified). Tests in `tests/test_rectilinear.py::TestSharded`.
- [x] **Phase 5 — Docs + follow-up note** (`fbf88cb`). `docs/sharding.md` (the sharded layout, config, K==1 rule, reader note) + mkdocs nav entry.
- [ ] **Follow-up (NOT in this PR — for @espg to open):** open a follow-up issue/PR for the #79/#81 read helpers to consume sharded stores (shard-index / byte-range reads instead of `list_prefix` enumeration). Reader side is deliberately deferred per the locked design; this PR is writer-side + round-trip read-back only. (Opening that issue is a side-effecting action, so it is left for @espg rather than done here.)

## How tested

Local (zagg is pure-Python, no build): `ruff check --select=E,F,W,I --ignore=E501 src tests` clean; `ruff format --check` clean on all touched files; `codespell` clean on the new docs. Test runs: `tests/test_grids.py` (64), `tests/test_rectilinear.py` (45), `tests/test_processing.py` (165, incl. the slow sharded end-to-end), `tests/test_config.py`/`test_runner.py`/`test_runner_concurrency.py`/`test_lambda_handler.py` — all green; no new failures. `tests/test_shardmap.py` is uncollectable in the local env (missing optional `stac_geoparquet` from the `catalog` extra) — pre-existing/unrelated, not touched.

The sharded round-trips are verified on a `MemoryStore` mirroring the target geometry: HEALPix (parent 4 / child 8 / chunk_inner 6 → K=16) and rect (shard 8×8 / inner 4×4 → K=4) each emit one `c/<shard>` object per populated shard, sparse-shard byte size < dense-shard, byte-exact read-back, and cell placement verified against the regular per-inner-chunk path.

## Notes

- **No new dependency** — sharding is stock zarr v3 (§4).
- **Benchmark** (write-phase fraction, object/request counts at parent_order 10/9/8) is deferred to live AWS, out of routine scope (ties to #110); offline round-trip tests land here. No dependency encoded (either merge order works).

## Questions for review

- Sharding is applied to **vector** per-cell arrays too (trailing payload dim kept whole, only the spatial axes widened to the shard). No config in the test suite ships a sharded *vector* field, so that combination is covered structurally (spec shape) but not by a full vector round-trip — flag if you'd prefer to restrict sharded to scalar-only for v1, or want a vector round-trip test added.
- `sharded` is deliberately **excluded from the grid `signature()`** (consistent with `chunk_inner`, which also isn't in the signature) since it is a storage form, not a spatial-layout change — the shard map stays reusable across sharded/regular. Flag if you'd rather it be part of the fingerprint.
