### PR TITLE
Lambda build/deploy CI/CD (#25)

### DIFF
--- a/.github/actions/run-benchmark/action.yml
+++ b/.github/actions/run-benchmark/action.yml
@@ -42,6 +42,11 @@ inputs:
     description: PR number, when this is a PR run
     required: false
     default: ""
+  worker-note:
+    description: One-line PR-comment banner when the benchmarked worker is the stable
+      deploy, not this ref's code (issue #25)
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -77,6 +82,7 @@ runs:
         COMMIT: ${{ inputs.commit }}
         REF_LABEL: ${{ inputs.ref-label }}
         PR_NUMBER: ${{ inputs.pr-number }}
+        WORKER_NOTE: ${{ inputs.worker-note }}
         # earthaccess.login() reads these to mint the NSIDC S3 read creds the
         # orchestrator forwards to Lambda. Masked: they arrive from secrets.
         EARTHDATA_USERNAME: ${{ inputs.edl-username }}
@@ -97,6 +103,7 @@ runs:
           --store-prefix "$STORE_PREFIX" \
           --region "$AWS_REGION" \
           --function-name "$FUNCTION_NAME" \
+          --worker-note "$WORKER_NOTE" \
           --event "$EVENT" \
           --commit "$COMMIT" \
           --ref "$REF_LABEL" \

--- a/.github/actions/run-benchmark/action.yml
+++ b/.github/actions/run-benchmark/action.yml
@@ -22,11 +22,8 @@ inputs:
   store-prefix:
     description: S3 prefix for benchmark output stores (s3://bucket/prefix)
     required: true
-  edl-username:
-    description: Earthdata Login username (the orchestrator mints NSIDC S3 read creds)
-    required: true
-  edl-password:
-    description: Earthdata Login password
+  edl-token:
+    description: Earthdata Login bearer token (the orchestrator mints NSIDC S3 read creds)
     required: true
   event:
     description: Trigger kind recorded in the metrics (pr|merge|manual)
@@ -83,10 +80,10 @@ runs:
         REF_LABEL: ${{ inputs.ref-label }}
         PR_NUMBER: ${{ inputs.pr-number }}
         WORKER_NOTE: ${{ inputs.worker-note }}
-        # earthaccess.login() reads these to mint the NSIDC S3 read creds the
-        # orchestrator forwards to Lambda. Masked: they arrive from secrets.
-        EARTHDATA_USERNAME: ${{ inputs.edl-username }}
-        EARTHDATA_PASSWORD: ${{ inputs.edl-password }}
+        # earthaccess.login() reads this to mint the NSIDC S3 read creds the
+        # orchestrator forwards to Lambda (a user bearer token -- urs.earthdata
+        # .nasa.gov/documentation/for_users/user_token). Masked: from a secret.
+        EARTHDATA_TOKEN: ${{ inputs.edl-token }}
       run: |
         set -euo pipefail
         target_flags=()

--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -140,21 +140,27 @@ def _fmt(value, spec: str = "") -> str:
     return format(value, spec) if spec else str(value)
 
 
-def comment_markdown(records: list[dict]) -> str:
+def comment_markdown(records: list[dict], worker_note: str = "") -> str:
     """Render a PR comment table from one run's benchmark records.
 
     Ephemeral (posted on PRs, not retained -- issue #110): one row per target so a
     reviewer sees cost/runtime regressions in the PR thread without the noise of
     keeping every pre-merge point in the series.
+
+    ``worker_note`` (issue #25): a one-line banner shown above the table when the
+    benchmark ran against the *stable* deployed worker but the PR touches
+    lambda-deployed code -- so the numbers don't reflect this PR. Keeps a
+    plausible-but-wrong figure from reading as real.
     """
+    marker = "<!-- zagg-benchmark -->"
     if not records:
-        return "<!-- zagg-benchmark -->\nNo benchmark records were produced."
+        return f"{marker}\nNo benchmark records were produced."
 
     head = records[0]
-    lines = [
-        "<!-- zagg-benchmark -->",
-        f"### Lambda benchmark — `{_fmt(head.get('commit'))[:7]}`",
-        "",
+    lines = [marker, f"### Lambda benchmark — `{_fmt(head.get('commit'))[:7]}`", ""]
+    if worker_note:
+        lines += [f"> ⚠️ {worker_note}", ""]
+    lines += [
         "| target | obs | runtime (s) | cost/shard | cost/100 km² | % timeout |",
         "| --- | ---: | ---: | ---: | ---: | ---: |",
     ]

--- a/.github/scripts/deploy_lambda.sh
+++ b/.github/scripts/deploy_lambda.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Update a Lambda function in place from freshly-built zips (issue #25): publish a
+# new layer version from an S3-staged layer zip, point the function at it, then
+# update the function code. publish-layer-version (not a bare update-function-code)
+# is required so a deps/layer change is actually picked up, and the layer is read
+# from S3 because the zip can exceed Lambda's 50 MB direct-upload cap.
+#
+# Shared by the release path (publish.yml -> production) and the benchmark
+# test-deploy path (lambda-benchmark.yml -> process-shard-test).
+#
+# Usage:
+#   deploy_lambda.sh --function NAME --layer-bucket B --layer-key K \
+#       --function-zip PATH --region R
+#
+# Requires: aws CLI (creds in env). arm64 / python3.12 only (the deployed target).
+set -euo pipefail
+
+FUNCTION="" LAYER_BUCKET="" LAYER_KEY="" FUNCTION_ZIP="" REGION=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --function) FUNCTION="$2"; shift 2 ;;
+    --layer-bucket) LAYER_BUCKET="$2"; shift 2 ;;
+    --layer-key) LAYER_KEY="$2"; shift 2 ;;
+    --function-zip) FUNCTION_ZIP="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+: "${FUNCTION:?--function required}" "${LAYER_BUCKET:?--layer-bucket required}" \
+  "${LAYER_KEY:?--layer-key required}" "${FUNCTION_ZIP:?--function-zip required}" \
+  "${REGION:?--region required}"
+
+LAYER_ARN=$(aws lambda publish-layer-version \
+  --layer-name "${FUNCTION}-deps" \
+  --content "S3Bucket=${LAYER_BUCKET},S3Key=${LAYER_KEY}" \
+  --compatible-architectures arm64 \
+  --compatible-runtimes python3.12 \
+  --region "$REGION" \
+  --query LayerVersionArn --output text)
+
+# Config update (new layer) and code update can't overlap -- wait between them.
+aws lambda update-function-configuration \
+  --function-name "$FUNCTION" --layers "$LAYER_ARN" --region "$REGION"
+aws lambda wait function-updated --function-name "$FUNCTION" --region "$REGION"
+aws lambda update-function-code \
+  --function-name "$FUNCTION" --zip-file "fileb://${FUNCTION_ZIP}" --publish --region "$REGION"
+
+echo "deployed $FUNCTION (layer $LAYER_ARN)"

--- a/.github/scripts/distribute_zips.sh
+++ b/.github/scripts/distribute_zips.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Publish the release Lambda zips to the public distribution bucket (issue #25),
+# keyed by zagg MINOR version (0.N.x -> 0.N), with a per-minor SHA256SUMS and a
+# top-level versions.json index. stand_up.sh lists/reads versions.json to resolve
+# "latest" instead of being hard-pinned to whatever was current at pip-install
+# time. Idempotent: re-running a release overwrites that minor's objects.
+#
+# Usage:
+#   distribute_zips.sh --minor 0.2 --tag 0.2.3 --bucket sliderule-public-cors \
+#       --dir ./zips [--region us-west-2]
+#
+# --dir holds the four release zips (lambda_layer_{arm64,x86_64}.zip,
+# lambda_function_{arm64,x86_64}_*.zip). Requires: aws CLI (write creds in env),
+# python3, sha256sum.
+set -euo pipefail
+
+MINOR="" TAG="" BUCKET="" DIR="" REGION="us-west-2"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --minor) MINOR="$2"; shift 2 ;;
+    --tag) TAG="$2"; shift 2 ;;
+    --bucket) BUCKET="$2"; shift 2 ;;
+    --dir) DIR="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+: "${MINOR:?--minor required}" "${BUCKET:?--bucket required}" "${DIR:?--dir required}"
+
+shopt -s nullglob
+zips=("$DIR"/lambda_layer_arm64.zip "$DIR"/lambda_layer_x86_64.zip \
+      "$DIR"/lambda_function_arm64_*.zip "$DIR"/lambda_function_x86_64_*.zip)
+if [ "${#zips[@]}" -ne 4 ]; then
+  echo "expected 4 zips in $DIR, found ${#zips[@]}: ${zips[*]:-none}" >&2
+  exit 1
+fi
+
+for z in "${zips[@]}"; do
+  aws s3 cp "$z" "s3://$BUCKET/$MINOR/$(basename "$z")" --region "$REGION"
+done
+
+( cd "$DIR" && sha256sum lambda_layer_*.zip lambda_function_*.zip > SHA256SUMS )
+aws s3 cp "$DIR/SHA256SUMS" "s3://$BUCKET/$MINOR/SHA256SUMS" --region "$REGION"
+
+# Merge this minor into the top-level index (read-modify-write; absent => seed).
+aws s3 cp "s3://$BUCKET/versions.json" ./versions.json --region "$REGION" 2>/dev/null \
+  || echo '{"minors": []}' > versions.json
+python3 - "$MINOR" "$TAG" <<'PY'
+import json, sys
+minor, tag = sys.argv[1], sys.argv[2]
+d = json.load(open("versions.json"))
+minors = set(d.get("minors", [])) | {minor}
+ordered = sorted(minors, key=lambda m: tuple(int(x) for x in m.split(".")))
+d["minors"] = ordered
+d["latest"] = ordered[-1]
+if tag:
+    d["latest_tag"] = tag
+json.dump(d, open("versions.json", "w"), indent=2)
+PY
+aws s3 cp ./versions.json "s3://$BUCKET/versions.json" --region "$REGION"
+
+echo "distributed minor $MINOR (tag ${TAG:-n/a}) -> s3://$BUCKET/$MINOR/"

--- a/.github/scripts/distribute_zips.sh
+++ b/.github/scripts/distribute_zips.sh
@@ -28,7 +28,9 @@ done
 : "${MINOR:?--minor required}" "${BUCKET:?--bucket required}" "${DIR:?--dir required}"
 
 shopt -s nullglob
-zips=("$DIR"/lambda_layer_arm64.zip "$DIR"/lambda_layer_x86_64.zip \
+# All four are globs (note the trailing * on the layer names) so nullglob drops
+# any that's missing -- the count check then catches it here, not at `aws s3 cp`.
+zips=("$DIR"/lambda_layer_arm64*.zip "$DIR"/lambda_layer_x86_64*.zip \
       "$DIR"/lambda_function_arm64_*.zip "$DIR"/lambda_function_x86_64_*.zip)
 if [ "${#zips[@]}" -ne 4 ]; then
   echo "expected 4 zips in $DIR, found ${#zips[@]}: ${zips[*]:-none}" >&2

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -148,6 +148,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Skip Lambda dispatch; emit empty-metric records (wiring check).",
     )
+    parser.add_argument(
+        "--worker-note",
+        default="",
+        help="One-line banner for the PR comment when the benchmarked worker is "
+        "the stable deploy, not this PR's code (issue #25).",
+    )
     args = parser.parse_args(argv)
 
     manifest, base = load_targets(args.targets)
@@ -188,7 +194,9 @@ def main(argv: list[str] | None = None) -> int:
 
     Path(args.out_json).write_text(json.dumps(records, indent=2))
     if args.out_comment:
-        Path(args.out_comment).write_text(bench_metrics.comment_markdown(records))
+        Path(args.out_comment).write_text(
+            bench_metrics.comment_markdown(records, worker_note=args.worker_note)
+        )
     return 0
 
 

--- a/.github/workflows/lambda-benchmark-command.yml
+++ b/.github/workflows/lambda-benchmark-command.yml
@@ -27,6 +27,7 @@ jobs:
       pr_sha: ${{ steps.gate.outputs.pr_sha }}
       head_ref: ${{ steps.gate.outputs.head_ref }}
       head_repo: ${{ steps.gate.outputs.head_repo }}
+      worker_note: ${{ steps.gate.outputs.worker_note }}
     steps:
       - name: Gate on maintainer trigger
         id: gate
@@ -70,6 +71,18 @@ jobs:
             core.setOutput('pr_sha', pr.head.sha);
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('head_repo', pr.head.repo.full_name);
+
+            // Fork runs never redeploy -> they benchmark the stable worker. If
+            // this PR touches lambda-deployed code, flag that the numbers don't
+            // reflect it (issue #25, tier 1).
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: prNumber, per_page: 100,
+            });
+            const affecting = /^(src\/zagg\/|deployment\/aws\/|pyproject\.toml)/;
+            const touched = files.some(f => affecting.test(f.filename));
+            core.setOutput('worker_note', touched
+              ? "Worker = stable `main`, not this PR's code — fork PRs aren't redeployed, so cost/runtime here don't reflect changes to lambda-deployed code."
+              : "");
 
   run:
     needs: check
@@ -127,6 +140,7 @@ jobs:
           commit: ${{ needs.check.outputs.pr_sha }}
           ref-label: ${{ needs.check.outputs.head_ref }}
           pr-number: ${{ needs.check.outputs.pr_number }}
+          worker-note: ${{ needs.check.outputs.worker_note }}
 
       - name: Upsert PR comment
         uses: actions/github-script@v7

--- a/.github/workflows/lambda-benchmark-command.yml
+++ b/.github/workflows/lambda-benchmark-command.yml
@@ -134,8 +134,7 @@ jobs:
           aws-region: ${{ vars.BENCHMARK_AWS_REGION }}
           function-name: ${{ vars.BENCHMARK_FUNCTION_NAME }}
           store-prefix: ${{ vars.BENCHMARK_STORE_PREFIX }}
-          edl-username: ${{ secrets.EARTHDATA_USERNAME }}
-          edl-password: ${{ secrets.EARTHDATA_PASSWORD }}
+          edl-token: ${{ secrets.EARTHDATA_TOKEN }}
           event: pr
           commit: ${{ needs.check.outputs.pr_sha }}
           ref-label: ${{ needs.check.outputs.head_ref }}

--- a/.github/workflows/lambda-benchmark-command.yml
+++ b/.github/workflows/lambda-benchmark-command.yml
@@ -86,7 +86,8 @@ jobs:
 
   run:
     needs: check
-    if: needs.check.outputs.should_run == 'true'
+    # Skip cleanly until the benchmark is configured (no role -> nothing to assume).
+    if: needs.check.outputs.should_run == 'true' && vars.BENCHMARK_ROLE_ARN != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lambda-benchmark.yml
+++ b/.github/workflows/lambda-benchmark.yml
@@ -176,8 +176,7 @@ jobs:
           aws-region: ${{ vars.BENCHMARK_AWS_REGION }}
           function-name: ${{ needs.detect.outputs.function_name }}
           store-prefix: ${{ vars.BENCHMARK_STORE_PREFIX }}
-          edl-username: ${{ secrets.EARTHDATA_USERNAME }}
-          edl-password: ${{ secrets.EARTHDATA_PASSWORD }}
+          edl-token: ${{ secrets.EARTHDATA_TOKEN }}
           event: pr
           commit: ${{ github.event.pull_request.head.sha }}
           ref-label: ${{ github.head_ref }}
@@ -225,8 +224,7 @@ jobs:
           aws-region: ${{ vars.BENCHMARK_AWS_REGION }}
           function-name: ${{ needs.detect.outputs.function_name }}
           store-prefix: ${{ vars.BENCHMARK_STORE_PREFIX }}
-          edl-username: ${{ secrets.EARTHDATA_USERNAME }}
-          edl-password: ${{ secrets.EARTHDATA_PASSWORD }}
+          edl-token: ${{ secrets.EARTHDATA_TOKEN }}
           event: merge
           commit: ${{ github.sha }}
           ref-label: ${{ github.ref_name }}

--- a/.github/workflows/lambda-benchmark.yml
+++ b/.github/workflows/lambda-benchmark.yml
@@ -45,6 +45,7 @@ jobs:
     outputs:
       affecting: ${{ steps.d.outputs.affecting }}
       function_name: ${{ steps.d.outputs.function_name }}
+      worker_note: ${{ steps.d.outputs.worker_note }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -83,13 +84,20 @@ jobs:
             if echo "$CHANGED" | grep -qE '^(src/zagg/|deployment/aws/|pyproject\.toml)'; then touched=true; fi
           fi
 
+          note=""
           if [ "$deployable" = "true" ] && [ "$touched" = "true" ]; then
             echo "affecting=true" >> "$GITHUB_OUTPUT"
             echo "function_name=$TEST_FN" >> "$GITHUB_OUTPUT"
           else
             echo "affecting=false" >> "$GITHUB_OUTPUT"
             echo "function_name=$STABLE_FN" >> "$GITHUB_OUTPUT"
+            # Benchmarking stable, but the change touches deployed code -> the
+            # numbers don't reflect this PR's worker. Flag it in the comment.
+            if [ "$touched" = "true" ]; then
+              note="Worker = stable \`main\`, not this PR's code — it changes lambda-deployed code but wasn't redeployed, so cost/runtime here don't reflect it. Real numbers land on merge."
+            fi
           fi
+          echo "worker_note=$note" >> "$GITHUB_OUTPUT"
 
   # Build the arm64 zips and update process-shard-test in place (only when the
   # change is lambda-affecting). Serialized with the benchmark via the workflow
@@ -174,6 +182,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha }}
           ref-label: ${{ github.head_ref }}
           pr-number: ${{ github.event.pull_request.number }}
+          worker-note: ${{ needs.detect.outputs.worker_note }}
 
       - name: Upsert PR comment
         uses: actions/github-script@v7

--- a/.github/workflows/lambda-benchmark.yml
+++ b/.github/workflows/lambda-benchmark.yml
@@ -77,7 +77,9 @@ jobs:
           else
             if [ "$EVENT" = "pull_request" ]; then BASE="$PR_BASE"; HEAD="$PR_HEAD"; else BASE="$PUSH_BEFORE"; HEAD="$PUSH_AFTER"; fi
             if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then BASE="${HEAD}~1"; fi
-            CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || echo "")
+            # No error-masking: a git diff failure aborts the run (set -e) rather
+            # than silently reading as "not affecting" -> benchmarking stale code.
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD")
             if echo "$CHANGED" | grep -qE '^(src/zagg/|deployment/aws/|pyproject\.toml)'; then touched=true; fi
           fi
 
@@ -148,7 +150,7 @@ jobs:
     if: >-
       !cancelled() &&
       needs.detect.result == 'success' &&
-      needs.deploy-test.result != 'failure' &&
+      (needs.deploy-test.result == 'success' || needs.deploy-test.result == 'skipped') &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false
@@ -195,7 +197,7 @@ jobs:
     if: >-
       !cancelled() &&
       needs.detect.result == 'success' &&
-      needs.deploy-test.result != 'failure' &&
+      (needs.deploy-test.result == 'success' || needs.deploy-test.result == 'skipped') &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     # contents: write to push the series + charts to the benchmarks branch.

--- a/.github/workflows/lambda-benchmark.yml
+++ b/.github/workflows/lambda-benchmark.yml
@@ -1,11 +1,19 @@
 name: Lambda Benchmark
 
-# Cost/runtime regression tracking on real Lambda (issue #110).
+# Cost/runtime regression tracking on real Lambda (issues #110, #25).
 #   * non-fork PR to main, non-draft -> run + post an (ephemeral) PR comment
 #   * push to main (a merge)        -> run + retain to the `benchmarks` data
 #                                      branch and re-render the Pages charts
-# Fork PRs are handled on demand (label / slash-command) in
-# lambda-benchmark-command.yml so untrusted code never auto-runs with creds.
+# Tier 2 (issue #25): a benchmark only reflects the PR if the DEPLOYED worker is
+# the PR's code. When the change is "lambda-affecting" (touches src/zagg,
+# deployment/aws, or pyproject) and the deploy is configured, we build the arm64
+# zips and update the `process-shard-test` function, then benchmark against it.
+# Otherwise we benchmark the stable function (correct for orchestrator/doc-only
+# changes, and the path before the AWS-side deploy is set up). Fork PRs never
+# deploy (handled in lambda-benchmark-command.yml).
+#
+# The whole workflow is serialized (a single shared `test` function), so two
+# runs can't deploy/benchmark over each other.
 
 on:
   pull_request:
@@ -25,18 +33,126 @@ permissions:
   id-token: write
   pull-requests: write
 
+concurrency:
+  group: lambda-benchmark
+  cancel-in-progress: false
+
 jobs:
+  # Decide whether to deploy + benchmark the `test` function (lambda-affecting,
+  # configured, non-fork) or just benchmark the stable function.
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      affecting: ${{ steps.d.outputs.affecting }}
+      function_name: ${{ steps.d.outputs.function_name }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - id: d
+        env:
+          DEPLOY_ROLE: ${{ vars.BENCHMARK_DEPLOY_ROLE_ARN }}
+          TEST_FN: ${{ vars.BENCHMARK_TEST_FUNCTION_NAME }}
+          STAGE_BUCKET: ${{ vars.BENCHMARK_TEST_STAGE_BUCKET }}
+          STABLE_FN: ${{ vars.BENCHMARK_FUNCTION_NAME }}
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Tier-2 deploy is possible only when fully configured and not a fork.
+          deployable=true
+          { [ -n "$DEPLOY_ROLE" ] && [ -n "$TEST_FN" ] && [ -n "$STAGE_BUCKET" ]; } || deployable=false
+          [ "$IS_FORK" = "true" ] && deployable=false
+
+          # Does the change touch the deployed Lambda closure? (Over-detection is
+          # safe -- it just redeploys; under-detection would benchmark stale code.)
+          touched=false
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            touched=true
+          else
+            if [ "$EVENT" = "pull_request" ]; then BASE="$PR_BASE"; HEAD="$PR_HEAD"; else BASE="$PUSH_BEFORE"; HEAD="$PUSH_AFTER"; fi
+            if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then BASE="${HEAD}~1"; fi
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || echo "")
+            if echo "$CHANGED" | grep -qE '^(src/zagg/|deployment/aws/|pyproject\.toml)'; then touched=true; fi
+          fi
+
+          if [ "$deployable" = "true" ] && [ "$touched" = "true" ]; then
+            echo "affecting=true" >> "$GITHUB_OUTPUT"
+            echo "function_name=$TEST_FN" >> "$GITHUB_OUTPUT"
+          else
+            echo "affecting=false" >> "$GITHUB_OUTPUT"
+            echo "function_name=$STABLE_FN" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Build the arm64 zips and update process-shard-test in place (only when the
+  # change is lambda-affecting). Serialized with the benchmark via the workflow
+  # concurrency group above.
+  deploy-test:
+    needs: detect
+    if: needs.detect.outputs.affecting == 'true'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - name: Build arm64 layer
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace/deployment/aws \
+            quay.io/pypa/manylinux_2_28_aarch64 \
+            bash -c "yum install -y zip && chmod +x build_layer.sh && ./build_layer.sh arm64"
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Build arm64 function
+        run: |
+          chmod +x deployment/aws/build_function.sh
+          deployment/aws/build_function.sh
+      - name: Assume deploy role (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.BENCHMARK_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.BENCHMARK_AWS_REGION }}
+      - name: Stage layer + deploy test function
+        env:
+          STAGE_BUCKET: ${{ vars.BENCHMARK_TEST_STAGE_BUCKET }}
+          FUNCTION_NAME: ${{ vars.BENCHMARK_TEST_FUNCTION_NAME }}
+          REGION: ${{ vars.BENCHMARK_AWS_REGION }}
+          SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          KEY="lambda-test/${SHA}/lambda_layer_arm64.zip"
+          aws s3 cp deployment/layers/lambda_layer_arm64.zip "s3://${STAGE_BUCKET}/${KEY}" --region "$REGION"
+          .github/scripts/deploy_lambda.sh \
+            --function "$FUNCTION_NAME" \
+            --layer-bucket "$STAGE_BUCKET" \
+            --layer-key "$KEY" \
+            --function-zip "$(ls deployment/builds/lambda_function_arm64_*.zip)" \
+            --region "$REGION"
+
   pr-comment:
+    needs: [detect, deploy-test]
     # Same-repo PRs only (forks can't be trusted with the role); skip drafts.
+    # !cancelled() lets this run when deploy-test was skipped (non-affecting);
+    # a deploy *failure* skips the benchmark (don't measure a broken deploy).
     if: >-
+      !cancelled() &&
+      needs.detect.result == 'success' &&
+      needs.deploy-test.result != 'failure' &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    # One run per PR; a new push supersedes the in-flight (and unbilled) run.
-    concurrency:
-      group: lambda-benchmark-pr-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v5
@@ -48,7 +164,7 @@ jobs:
         with:
           role-arn: ${{ vars.BENCHMARK_ROLE_ARN }}
           aws-region: ${{ vars.BENCHMARK_AWS_REGION }}
-          function-name: ${{ vars.BENCHMARK_FUNCTION_NAME }}
+          function-name: ${{ needs.detect.outputs.function_name }}
           store-prefix: ${{ vars.BENCHMARK_STORE_PREFIX }}
           edl-username: ${{ secrets.EARTHDATA_USERNAME }}
           edl-password: ${{ secrets.EARTHDATA_PASSWORD }}
@@ -75,16 +191,17 @@ jobs:
             }
 
   merge-publish:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: [detect, deploy-test]
+    if: >-
+      !cancelled() &&
+      needs.detect.result == 'success' &&
+      needs.deploy-test.result != 'failure' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     # contents: write to push the series + charts to the benchmarks branch.
     permissions:
       contents: write
       id-token: write
-    # Serialize so concurrent merges don't race on the benchmarks branch.
-    concurrency:
-      group: lambda-benchmark-publish
-      cancel-in-progress: false
     steps:
       - name: Checkout merge commit
         uses: actions/checkout@v5
@@ -95,7 +212,7 @@ jobs:
           targets: ${{ github.event.inputs.targets }}
           role-arn: ${{ vars.BENCHMARK_ROLE_ARN }}
           aws-region: ${{ vars.BENCHMARK_AWS_REGION }}
-          function-name: ${{ vars.BENCHMARK_FUNCTION_NAME }}
+          function-name: ${{ needs.detect.outputs.function_name }}
           store-prefix: ${{ vars.BENCHMARK_STORE_PREFIX }}
           edl-username: ${{ secrets.EARTHDATA_USERNAME }}
           edl-password: ${{ secrets.EARTHDATA_PASSWORD }}

--- a/.github/workflows/lambda-benchmark.yml
+++ b/.github/workflows/lambda-benchmark.yml
@@ -157,6 +157,7 @@ jobs:
     # a deploy *failure* skips the benchmark (don't measure a broken deploy).
     if: >-
       !cancelled() &&
+      vars.BENCHMARK_ROLE_ARN != '' &&
       needs.detect.result == 'success' &&
       (needs.deploy-test.result == 'success' || needs.deploy-test.result == 'skipped') &&
       github.event_name == 'pull_request' &&
@@ -204,6 +205,7 @@ jobs:
     needs: [detect, deploy-test]
     if: >-
       !cancelled() &&
+      vars.BENCHMARK_ROLE_ARN != '' &&
       needs.detect.result == 'success' &&
       (needs.deploy-test.result == 'success' || needs.deploy-test.result == 'skipped') &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/lambda-build-reusable.yml
+++ b/.github/workflows/lambda-build-reusable.yml
@@ -1,0 +1,175 @@
+name: Lambda Build (reusable)
+
+# Reusable dual-arch Lambda build (issue #25). Builds the layer + function zips
+# for x86_64 and arm64, enforces the 250 MB unzipped Lambda gate, and uploads the
+# four zips as run artifacts (lambda-{layer,function}-{x86_64,arm64}). Called by
+# lambda-build.yml (push/PR/dispatch) and by publish.yml (release), so the build
+# is single-sourced and the release flow no longer relies on a cross-workflow
+# event cascade.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build layer + function code for x86_64 (Python 3.12)
+  # ---------------------------------------------------------------------------
+  build-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build Lambda layer (x86_64) in manylinux container
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace/deployment/aws \
+            quay.io/pypa/manylinux_2_28_x86_64 \
+            bash -c "
+              yum install -y zip &&
+              chmod +x build_layer.sh &&
+              ./build_layer.sh x86_64
+            "
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Build function code (x86_64)
+        run: |
+          chmod +x deployment/aws/build_function.sh
+          deployment/aws/build_function.sh
+
+      - name: Check combined size
+        run: |
+          LIMIT=$((250 * 1024 * 1024))
+
+          # Measure layer unzipped size
+          LAYER_ZIP="deployment/layers/lambda_layer_x86_64.zip"
+          LAYER_TMP=$(mktemp -d)
+          unzip -qo "$LAYER_ZIP" -d "$LAYER_TMP"
+          LAYER_BYTES=$(du -sb "$LAYER_TMP" | cut -f1)
+          rm -rf "$LAYER_TMP"
+
+          # Measure function code unzipped size
+          FUNC_ZIP=$(ls deployment/builds/lambda_function_x86_64_*.zip)
+          FUNC_TMP=$(mktemp -d)
+          unzip -qo "$FUNC_ZIP" -d "$FUNC_TMP"
+          FUNC_BYTES=$(du -sb "$FUNC_TMP" | cut -f1)
+          rm -rf "$FUNC_TMP"
+
+          COMBINED=$((LAYER_BYTES + FUNC_BYTES))
+
+          echo "## x86_64 Size Report" >> $GITHUB_STEP_SUMMARY
+          echo "| Component | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Layer | $(numfmt --to=iec $LAYER_BYTES) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Function | $(numfmt --to=iec $FUNC_BYTES) |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Combined** | **$(numfmt --to=iec $COMBINED)** |" >> $GITHUB_STEP_SUMMARY
+          echo "| Limit | $(numfmt --to=iec $LIMIT) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Headroom | $(numfmt --to=iec $((LIMIT - COMBINED))) |" >> $GITHUB_STEP_SUMMARY
+
+          echo ""
+          echo "x86_64 combined size: $(numfmt --to=iec $COMBINED) / $(numfmt --to=iec $LIMIT)"
+
+          if [ "$COMBINED" -gt "$LIMIT" ]; then
+            echo "::error::x86_64 combined size ($COMBINED bytes) exceeds 250MB Lambda limit!"
+            exit 1
+          fi
+
+      - name: Upload layer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda-layer-x86_64
+          path: deployment/layers/lambda_layer_x86_64.zip
+          retention-days: 30
+
+      - name: Upload function artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda-function-x86_64
+          path: deployment/builds/lambda_function_x86_64_*.zip
+          retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Build layer + function code for arm64 (Python 3.12)
+  # ---------------------------------------------------------------------------
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build Lambda layer (arm64) in manylinux container
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace/deployment/aws \
+            quay.io/pypa/manylinux_2_28_aarch64 \
+            bash -c "
+              yum install -y zip &&
+              chmod +x build_layer.sh &&
+              ./build_layer.sh arm64
+            "
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Build function code (arm64)
+        run: |
+          chmod +x deployment/aws/build_function.sh
+          deployment/aws/build_function.sh
+
+      - name: Check combined size
+        run: |
+          LIMIT=$((250 * 1024 * 1024))
+
+          LAYER_ZIP="deployment/layers/lambda_layer_arm64.zip"
+          LAYER_TMP=$(mktemp -d)
+          unzip -qo "$LAYER_ZIP" -d "$LAYER_TMP"
+          LAYER_BYTES=$(du -sb "$LAYER_TMP" | cut -f1)
+          rm -rf "$LAYER_TMP"
+
+          FUNC_ZIP=$(ls deployment/builds/lambda_function_arm64_*.zip)
+          FUNC_TMP=$(mktemp -d)
+          unzip -qo "$FUNC_ZIP" -d "$FUNC_TMP"
+          FUNC_BYTES=$(du -sb "$FUNC_TMP" | cut -f1)
+          rm -rf "$FUNC_TMP"
+
+          COMBINED=$((LAYER_BYTES + FUNC_BYTES))
+
+          echo "## arm64 Size Report" >> $GITHUB_STEP_SUMMARY
+          echo "| Component | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Layer | $(numfmt --to=iec $LAYER_BYTES) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Function | $(numfmt --to=iec $FUNC_BYTES) |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Combined** | **$(numfmt --to=iec $COMBINED)** |" >> $GITHUB_STEP_SUMMARY
+          echo "| Limit | $(numfmt --to=iec $LIMIT) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Headroom | $(numfmt --to=iec $((LIMIT - COMBINED))) |" >> $GITHUB_STEP_SUMMARY
+
+          echo ""
+          echo "arm64 combined size: $(numfmt --to=iec $COMBINED) / $(numfmt --to=iec $LIMIT)"
+
+          if [ "$COMBINED" -gt "$LIMIT" ]; then
+            echo "::error::arm64 combined size ($COMBINED bytes) exceeds 250MB Lambda limit!"
+            exit 1
+          fi
+
+      - name: Upload layer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda-layer-arm64
+          path: deployment/layers/lambda_layer_arm64.zip
+          retention-days: 30
+
+      - name: Upload function artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda-function-arm64
+          path: deployment/builds/lambda_function_arm64_*.zip
+          retention-days: 30

--- a/.github/workflows/lambda-build.yml
+++ b/.github/workflows/lambda-build.yml
@@ -1,5 +1,11 @@
 name: Lambda Build
 
+# Build + size-gate the dual-arch Lambda zips on every push/PR that touches the
+# deployed closure. The actual build lives in the reusable workflow so the
+# release path (publish.yml) builds identically without a cross-workflow event
+# cascade (issue #25). Release-asset attachment + prod deploy + distribution all
+# moved to publish.yml.
+
 on:
   push:
     branches: [lambda, main]
@@ -8,203 +14,19 @@ on:
       - 'deployment/aws/**'
       - 'pyproject.toml'
       - '.github/workflows/lambda-build.yml'
+      - '.github/workflows/lambda-build-reusable.yml'
   pull_request:
     paths:
       - 'src/zagg/**'
       - 'deployment/aws/**'
       - 'pyproject.toml'
       - '.github/workflows/lambda-build.yml'
-  release:
-    types: [published]
+      - '.github/workflows/lambda-build-reusable.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # Build layer + function code for x86_64 (Python 3.12)
-  # ---------------------------------------------------------------------------
-  build-x86_64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Build Lambda layer (x86_64) in manylinux container
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
-            -w /workspace/deployment/aws \
-            quay.io/pypa/manylinux_2_28_x86_64 \
-            bash -c "
-              yum install -y zip &&
-              chmod +x build_layer.sh &&
-              ./build_layer.sh x86_64
-            "
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Build function code (x86_64)
-        run: |
-          chmod +x deployment/aws/build_function.sh
-          deployment/aws/build_function.sh
-
-      - name: Check combined size
-        run: |
-          LIMIT=$((250 * 1024 * 1024))
-
-          # Measure layer unzipped size
-          LAYER_ZIP="deployment/layers/lambda_layer_x86_64.zip"
-          LAYER_TMP=$(mktemp -d)
-          unzip -qo "$LAYER_ZIP" -d "$LAYER_TMP"
-          LAYER_BYTES=$(du -sb "$LAYER_TMP" | cut -f1)
-          rm -rf "$LAYER_TMP"
-
-          # Measure function code unzipped size
-          FUNC_ZIP=$(ls deployment/builds/lambda_function_x86_64_*.zip)
-          FUNC_TMP=$(mktemp -d)
-          unzip -qo "$FUNC_ZIP" -d "$FUNC_TMP"
-          FUNC_BYTES=$(du -sb "$FUNC_TMP" | cut -f1)
-          rm -rf "$FUNC_TMP"
-
-          COMBINED=$((LAYER_BYTES + FUNC_BYTES))
-
-          echo "## x86_64 Size Report" >> $GITHUB_STEP_SUMMARY
-          echo "| Component | Size |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----------|------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Layer | $(numfmt --to=iec $LAYER_BYTES) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Function | $(numfmt --to=iec $FUNC_BYTES) |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Combined** | **$(numfmt --to=iec $COMBINED)** |" >> $GITHUB_STEP_SUMMARY
-          echo "| Limit | $(numfmt --to=iec $LIMIT) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Headroom | $(numfmt --to=iec $((LIMIT - COMBINED))) |" >> $GITHUB_STEP_SUMMARY
-
-          echo ""
-          echo "x86_64 combined size: $(numfmt --to=iec $COMBINED) / $(numfmt --to=iec $LIMIT)"
-
-          if [ "$COMBINED" -gt "$LIMIT" ]; then
-            echo "::error::x86_64 combined size ($COMBINED bytes) exceeds 250MB Lambda limit!"
-            exit 1
-          fi
-
-      - name: Upload layer artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: lambda-layer-x86_64
-          path: deployment/layers/lambda_layer_x86_64.zip
-          retention-days: 30
-
-      - name: Upload function artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: lambda-function-x86_64
-          path: deployment/builds/lambda_function_x86_64_*.zip
-          retention-days: 30
-
-  # ---------------------------------------------------------------------------
-  # Build layer + function code for arm64 (Python 3.12)
-  # ---------------------------------------------------------------------------
-  build-arm64:
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Build Lambda layer (arm64) in manylinux container
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
-            -w /workspace/deployment/aws \
-            quay.io/pypa/manylinux_2_28_aarch64 \
-            bash -c "
-              yum install -y zip &&
-              chmod +x build_layer.sh &&
-              ./build_layer.sh arm64
-            "
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Build function code (arm64)
-        run: |
-          chmod +x deployment/aws/build_function.sh
-          deployment/aws/build_function.sh
-
-      - name: Check combined size
-        run: |
-          LIMIT=$((250 * 1024 * 1024))
-
-          LAYER_ZIP="deployment/layers/lambda_layer_arm64.zip"
-          LAYER_TMP=$(mktemp -d)
-          unzip -qo "$LAYER_ZIP" -d "$LAYER_TMP"
-          LAYER_BYTES=$(du -sb "$LAYER_TMP" | cut -f1)
-          rm -rf "$LAYER_TMP"
-
-          FUNC_ZIP=$(ls deployment/builds/lambda_function_arm64_*.zip)
-          FUNC_TMP=$(mktemp -d)
-          unzip -qo "$FUNC_ZIP" -d "$FUNC_TMP"
-          FUNC_BYTES=$(du -sb "$FUNC_TMP" | cut -f1)
-          rm -rf "$FUNC_TMP"
-
-          COMBINED=$((LAYER_BYTES + FUNC_BYTES))
-
-          echo "## arm64 Size Report" >> $GITHUB_STEP_SUMMARY
-          echo "| Component | Size |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----------|------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Layer | $(numfmt --to=iec $LAYER_BYTES) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Function | $(numfmt --to=iec $FUNC_BYTES) |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Combined** | **$(numfmt --to=iec $COMBINED)** |" >> $GITHUB_STEP_SUMMARY
-          echo "| Limit | $(numfmt --to=iec $LIMIT) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Headroom | $(numfmt --to=iec $((LIMIT - COMBINED))) |" >> $GITHUB_STEP_SUMMARY
-
-          echo ""
-          echo "arm64 combined size: $(numfmt --to=iec $COMBINED) / $(numfmt --to=iec $LIMIT)"
-
-          if [ "$COMBINED" -gt "$LIMIT" ]; then
-            echo "::error::arm64 combined size ($COMBINED bytes) exceeds 250MB Lambda limit!"
-            exit 1
-          fi
-
-      - name: Upload layer artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: lambda-layer-arm64
-          path: deployment/layers/lambda_layer_arm64.zip
-          retention-days: 30
-
-      - name: Upload function artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: lambda-function-arm64
-          path: deployment/builds/lambda_function_arm64_*.zip
-          retention-days: 30
-
-  # ---------------------------------------------------------------------------
-  # Attach the built zips to the GitHub Release (durable artifacts for the
-  # CloudFormation standup — see deployment/aws/template.yaml).
-  # ---------------------------------------------------------------------------
-  publish-release-assets:
-    needs: [build-x86_64, build-arm64]
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Download built artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Upload to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
-            artifacts/lambda-layer-x86_64/lambda_layer_x86_64.zip \
-            artifacts/lambda-layer-arm64/lambda_layer_arm64.zip \
-            artifacts/lambda-function-x86_64/lambda_function_x86_64_*.zip \
-            artifacts/lambda-function-arm64/lambda_function_arm64_*.zip \
-            --repo "${{ github.repository }}" --clobber
+  build:
+    uses: ./.github/workflows/lambda-build-reusable.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,6 +199,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - uses: actions/checkout@v5
     - name: Download arm64 function zip
       uses: actions/download-artifact@v4
       with:
@@ -217,19 +218,10 @@ jobs:
         REGION: ${{ vars.LAMBDA_AWS_REGION }}
       run: |
         set -euo pipefail
-        FN="$FUNCTION_NAME"  # guaranteed non-empty by the job `if:`
-        # Publish a new layer version from the just-distributed S3 object, then
-        # point the function at it (config update must settle before the code update).
-        LAYER_ARN=$(aws lambda publish-layer-version \
-          --layer-name "${FN}-deps" \
-          --content "S3Bucket=${DIST_BUCKET},S3Key=${MINOR}/lambda_layer_arm64.zip" \
-          --compatible-architectures arm64 \
-          --compatible-runtimes python3.12 \
-          --region "$REGION" \
-          --query LayerVersionArn --output text)
-        aws lambda update-function-configuration \
-          --function-name "$FN" --layers "$LAYER_ARN" --region "$REGION"
-        aws lambda wait function-updated --function-name "$FN" --region "$REGION"
-        ZIP=$(ls fn/lambda_function_arm64_*.zip)
-        aws lambda update-function-code \
-          --function-name "$FN" --zip-file "fileb://$ZIP" --publish --region "$REGION"
+        # Layer was staged to the dist bucket by `distribute` (this job needs it).
+        .github/scripts/deploy_lambda.sh \
+          --function "$FUNCTION_NAME" \
+          --layer-bucket "$DIST_BUCKET" \
+          --layer-key "${MINOR}/lambda_layer_arm64.zip" \
+          --function-zip "$(ls fn/lambda_function_arm64_*.zip)" \
+          --region "$REGION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -146,7 +146,10 @@ jobs:
   distribute:
     name: Distribute zips to public bucket
     needs: github-release
-    if: vars.LAMBDA_RELEASE_ROLE_ARN != '' && vars.LAMBDA_DIST_BUCKET != ''
+    if: >-
+      vars.LAMBDA_RELEASE_ROLE_ARN != '' &&
+      vars.LAMBDA_DIST_BUCKET != '' &&
+      vars.LAMBDA_AWS_REGION != ''
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -182,7 +185,14 @@ jobs:
   deploy-prod:
     name: Deploy production Lambda
     needs: [github-release, distribute]
-    if: vars.LAMBDA_RELEASE_ROLE_ARN != ''
+    # Gate on EVERY var this job consumes (not just the role): the "no
+    # unstaged-layer deploy" safety currently rests on distribute's skip
+    # propagating here, and a partial config must skip, never half-deploy prod.
+    if: >-
+      vars.LAMBDA_RELEASE_ROLE_ARN != '' &&
+      vars.LAMBDA_DIST_BUCKET != '' &&
+      vars.LAMBDA_AWS_REGION != '' &&
+      vars.LAMBDA_PROD_FUNCTION_NAME != ''
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -207,7 +217,7 @@ jobs:
         REGION: ${{ vars.LAMBDA_AWS_REGION }}
       run: |
         set -euo pipefail
-        FN="${FUNCTION_NAME:-process-shard}"
+        FN="$FUNCTION_NAME"  # guaranteed non-empty by the job `if:`
         # Publish a new layer version from the just-distributed S3 object, then
         # point the function at it (config update must settle before the code update).
         LAYER_ARN=$(aws lambda publish-layer-version \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,12 +80,22 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
+  # Build the dual-arch Lambda zips in-line (issue #25): self-contained so the
+  # release no longer depends on GITHUB_TOKEN cascade-triggering lambda-build.
+  lambda-build:
+    name: Build Lambda zips
+    needs: publish-to-pypi
+    uses: ./.github/workflows/lambda-build-reusable.yml
+
   github-release:
     name: Create GitHub Release
-    needs: publish-to-pypi
+    needs: lambda-build
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.get_tag.outputs.tag }}
+      minor: ${{ steps.get_tag.outputs.minor }}
 
     steps:
     - uses: actions/checkout@v5
@@ -96,11 +106,17 @@ jobs:
       id: get_tag
       run: |
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          TAG="${{ inputs.tag }}"
         else
-          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          TAG="${GITHUB_REF#refs/tags/}"
         fi
-    - name: Create GitHub Release
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "minor=$(echo "$TAG" | cut -d. -f1,2)" >> "$GITHUB_OUTPUT"
+    - name: Download Lambda zips
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+    - name: Create GitHub Release + attach Lambda zips
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -116,3 +132,94 @@ jobs:
           --repo '${{ github.repository }}' \
           --title "Release $TAG_NAME" \
           --notes-file release_notes.md || echo "Release already exists"
+        # Attach the four zips (the durable CloudFormation/standup artifacts).
+        gh release upload "$TAG_NAME" \
+          artifacts/lambda-layer-x86_64/lambda_layer_x86_64.zip \
+          artifacts/lambda-layer-arm64/lambda_layer_arm64.zip \
+          artifacts/lambda-function-x86_64/lambda_function_x86_64_*.zip \
+          artifacts/lambda-function-arm64/lambda_function_arm64_*.zip \
+          --repo "${{ github.repository }}" --clobber
+
+  # Publish the zips to the public distribution bucket (replaces source.coop;
+  # keyed by minor + a versions.json index). Skips until the bucket/role vars
+  # exist, so a release before the AWS-side setup still attaches zips (above).
+  distribute:
+    name: Distribute zips to public bucket
+    needs: github-release
+    if: vars.LAMBDA_RELEASE_ROLE_ARN != '' && vars.LAMBDA_DIST_BUCKET != ''
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v5
+    - name: Download Lambda zips
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+    - name: Assume release role (OIDC)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.LAMBDA_RELEASE_ROLE_ARN }}
+        aws-region: ${{ vars.LAMBDA_AWS_REGION }}
+    - name: Distribute
+      run: |
+        set -euo pipefail
+        mkdir -p zips
+        find artifacts -name '*.zip' -exec cp {} zips/ \;
+        .github/scripts/distribute_zips.sh \
+          --minor "${{ needs.github-release.outputs.minor }}" \
+          --tag "${{ needs.github-release.outputs.tag }}" \
+          --bucket "${{ vars.LAMBDA_DIST_BUCKET }}" \
+          --region "${{ vars.LAMBDA_AWS_REGION }}" \
+          --dir zips
+
+  # Update the PRODUCTION Lambda in place (tags only). Behind the `production`
+  # GitHub Environment (add a required-reviewer rule). publish-layer-version +
+  # update-function-configuration handles a deps change that the function-code
+  # update alone would miss. Needs `distribute` so the layer is staged in S3 for
+  # publish-layer-version (the layer zip can exceed the 50 MB direct-upload cap).
+  deploy-prod:
+    name: Deploy production Lambda
+    needs: [github-release, distribute]
+    if: vars.LAMBDA_RELEASE_ROLE_ARN != ''
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - name: Download arm64 function zip
+      uses: actions/download-artifact@v4
+      with:
+        name: lambda-function-arm64
+        path: fn
+    - name: Assume release role (OIDC)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.LAMBDA_RELEASE_ROLE_ARN }}
+        aws-region: ${{ vars.LAMBDA_AWS_REGION }}
+    - name: Update function (layer + code, in place)
+      env:
+        FUNCTION_NAME: ${{ vars.LAMBDA_PROD_FUNCTION_NAME }}
+        DIST_BUCKET: ${{ vars.LAMBDA_DIST_BUCKET }}
+        MINOR: ${{ needs.github-release.outputs.minor }}
+        REGION: ${{ vars.LAMBDA_AWS_REGION }}
+      run: |
+        set -euo pipefail
+        FN="${FUNCTION_NAME:-process-shard}"
+        # Publish a new layer version from the just-distributed S3 object, then
+        # point the function at it (config update must settle before the code update).
+        LAYER_ARN=$(aws lambda publish-layer-version \
+          --layer-name "${FN}-deps" \
+          --content "S3Bucket=${DIST_BUCKET},S3Key=${MINOR}/lambda_layer_arm64.zip" \
+          --compatible-architectures arm64 \
+          --compatible-runtimes python3.12 \
+          --region "$REGION" \
+          --query LayerVersionArn --output text)
+        aws lambda update-function-configuration \
+          --function-name "$FN" --layers "$LAYER_ARN" --region "$REGION"
+        aws lambda wait function-updated --function-name "$FN" --region "$REGION"
+        ZIP=$(ls fn/lambda_function_arm64_*.zip)
+        aws lambda update-function-code \
+          --function-name "$FN" --zip-file "fileb://$ZIP" --publish --region "$REGION"

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -1,0 +1,232 @@
+AWSTemplateFormatVersion: "2010-09-09"
+# CI/CD IAM roles + public distribution bucket for the Lambda benchmark + deploy
+# pipeline (issues #110, #25). Kept in its OWN stack (separate from the runtime
+# backend template.yaml) so it rolls back / tears down cleanly and an account
+# admin applies it once. Companion to docs/deployment/benchmark-cicd.md, which
+# also documents the equivalent raw-CLI path.
+#
+# Provisions the THREE GitHub-OIDC roles the workflows assume, plus the public,
+# listable distribution bucket. It does NOT create: the GitHub OIDC provider
+# (already account-global -- referenced by ARN below), the runtime Lambda(s) /
+# their execution roles (template.yaml), the benchmark OUTPUT bucket (the backend
+# stack's OutputBucketName), or any GitHub-side resource (repo vars/secrets, the
+# `benchmarks` branch, the `benchmark` label, the `production` Environment, tag
+# protection) -- those aren't AWS resources. Copy the Outputs into the
+# `gh variable set BENCHMARK_*/LAMBDA_*` step.
+Description: >-
+  zagg CI/CD: GitHub-OIDC roles (benchmark-invoke, test-deploy, release) and the
+  public sliderule-public-cors distribution bucket. See benchmark-cicd.md.
+
+Parameters:
+  GitHubRepo:
+    Type: String
+    Default: englacial/zagg
+    Description: owner/repo whose Actions may assume these roles (the OIDC `sub`).
+
+  BenchmarkFunctionName:
+    Type: String
+    Default: process-shard
+    Description: Stable function the benchmark invokes (and prod deploy target).
+
+  TestFunctionName:
+    Type: String
+    Default: process-shard-test
+    Description: Test function the tier-2 deploy updates + the benchmark invokes.
+
+  BenchmarkStoreBucket:
+    Type: String
+    Default: sliderule-public
+    Description: >-
+      Bucket the orchestrator writes the benchmark output store + the staged test
+      layer (lambda-test/*) into. The invoke + deploy roles are scoped to it.
+
+  DistBucketName:
+    Type: String
+    Default: sliderule-public-cors
+    Description: Public, listable bucket the release distributes the zips to.
+
+  CreateDistBucket:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: Create DistBucketName here, or set false to use an existing one.
+
+  BenchmarkInvokeRoleName:
+    Type: String
+    Default: zagg-benchmark
+  DeployRoleName:
+    Type: String
+    Default: zagg-benchmark-deploy
+  ReleaseRoleName:
+    Type: String
+    Default: zagg-lambda-release
+
+Conditions:
+  ShouldCreateDistBucket: !Equals [!Ref CreateDistBucket, "true"]
+
+Resources:
+  # --- public distribution bucket (issue #25 §10) ----------------------------
+  DistBucket:
+    Type: AWS::S3::Bucket
+    Condition: ShouldCreateDistBucket
+    Properties:
+      BucketName: !Ref DistBucketName
+      # Public read is granted by the bucket POLICY below (not ACLs), so the ACL
+      # blocks stay on; only the policy/restrict blocks are relaxed. NOTE: this
+      # can't override ACCOUNT-level Block Public Access -- relax that separately
+      # (see benchmark-cicd.md §10) if enabled.
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: false
+        RestrictPublicBuckets: false
+      CorsConfiguration:
+        CorsRules:
+          - AllowedOrigins: ["*"]
+            AllowedMethods: [GET, HEAD]
+            AllowedHeaders: ["*"]
+
+  DistBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Condition: ShouldCreateDistBucket
+    Properties:
+      Bucket: !Ref DistBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: PublicReadList
+            Effect: Allow
+            Principal: "*"
+            Action: [s3:GetObject, s3:ListBucket]
+            Resource:
+              - !Sub "arn:aws:s3:::${DistBucketName}"
+              - !Sub "arn:aws:s3:::${DistBucketName}/*"
+
+  # --- benchmark invoke role (issue #110 §2) ---------------------------------
+  BenchmarkInvokeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref BenchmarkInvokeRoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com"
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+              StringLike:
+                "token.actions.githubusercontent.com:sub": !Sub "repo:${GitHubRepo}:*"
+      Policies:
+        - PolicyName: invoke-and-store
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: InvokeBenchmarkFunctions
+                Effect: Allow
+                Action: [lambda:InvokeFunction, lambda:GetFunctionConfiguration]
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}"
+              - Sid: WriteBenchmarkStore
+                Effect: Allow
+                Action: [s3:PutObject, s3:GetObject, s3:DeleteObject]
+                Resource: !Sub "arn:aws:s3:::${BenchmarkStoreBucket}/*"
+              - Sid: ListBenchmarkStore
+                Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub "arn:aws:s3:::${BenchmarkStoreBucket}"
+
+  # --- tier-2 test-deploy role (issue #25 §9) --------------------------------
+  DeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref DeployRoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com"
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+              StringLike:
+                "token.actions.githubusercontent.com:sub": !Sub "repo:${GitHubRepo}:*"
+      Policies:
+        - PolicyName: deploy-test-function
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: UpdateTestFunction
+                Effect: Allow
+                Action:
+                  - lambda:UpdateFunctionCode
+                  - lambda:UpdateFunctionConfiguration
+                  - lambda:GetFunction
+                  - lambda:GetFunctionConfiguration
+                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}"
+              - Sid: PublishTestLayer
+                Effect: Allow
+                Action: lambda:PublishLayerVersion
+                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:${TestFunctionName}-deps"
+              - Sid: StageTestLayer
+                Effect: Allow
+                Action: [s3:PutObject, s3:GetObject]
+                Resource: !Sub "arn:aws:s3:::${BenchmarkStoreBucket}/lambda-test/*"
+
+  # --- tier-3 release role (issue #25 §9) ------------------------------------
+  ReleaseRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref ReleaseRoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com"
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+              StringLike:
+                "token.actions.githubusercontent.com:sub": !Sub "repo:${GitHubRepo}:*"
+      Policies:
+        - PolicyName: deploy-prod-and-distribute
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: UpdateProdFunction
+                Effect: Allow
+                Action:
+                  - lambda:UpdateFunctionCode
+                  - lambda:UpdateFunctionConfiguration
+                  - lambda:GetFunction
+                  - lambda:GetFunctionConfiguration
+                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}"
+              - Sid: PublishProdLayer
+                Effect: Allow
+                Action: lambda:PublishLayerVersion
+                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:${BenchmarkFunctionName}-deps"
+              - Sid: DistributeZips
+                Effect: Allow
+                Action: [s3:PutObject, s3:GetObject]
+                Resource: !Sub "arn:aws:s3:::${DistBucketName}/*"
+
+Outputs:
+  BenchmarkInvokeRoleArn:
+    Description: gh variable set BENCHMARK_ROLE_ARN
+    Value: !GetAtt BenchmarkInvokeRole.Arn
+  DeployRoleArn:
+    Description: gh variable set BENCHMARK_DEPLOY_ROLE_ARN
+    Value: !GetAtt DeployRole.Arn
+  ReleaseRoleArn:
+    Description: gh variable set LAMBDA_RELEASE_ROLE_ARN
+    Value: !GetAtt ReleaseRole.Arn
+  DistBucket:
+    Description: gh variable set LAMBDA_DIST_BUCKET
+    Value: !Ref DistBucketName

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -37,8 +37,9 @@ Parameters:
     Type: String
     Default: sliderule-public
     Description: >-
-      Bucket the orchestrator writes the benchmark output store + the staged test
-      layer (lambda-test/*) into. The invoke + deploy roles are scoped to it.
+      Bucket the staged test layer (lambda-test/*) is uploaded to; the deploy role
+      is scoped to it. (The benchmark output store is written by the Lambda's
+      execution role, not these roles.)
 
   DistBucketName:
     Type: String
@@ -119,25 +120,30 @@ Resources:
                 "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
               StringLike:
                 "token.actions.githubusercontent.com:sub": !Sub "repo:${GitHubRepo}:*"
+      # No S3: the Zarr template write happens INSIDE the Lambda (runner.py
+      # "the orchestrator only needs lambda:InvokeFunction; no direct S3 access"),
+      # so the orchestrator never touches the output bucket directly.
       Policies:
-        - PolicyName: invoke-and-store
+        - PolicyName: invoke-and-probe
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Sid: InvokeBenchmarkFunctions
                 Effect: Allow
-                Action: [lambda:InvokeFunction, lambda:GetFunctionConfiguration]
+                Action:
+                  - lambda:InvokeFunction
+                  - lambda:GetFunctionConfiguration
+                  - lambda:GetFunctionConcurrency
                 Resource:
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}"
-              - Sid: WriteBenchmarkStore
+              # Pre-flight worker-sizing probe (issue #28/#63 via concurrency.py);
+              # these degrade gracefully but are needed for the guard to work.
+              # Neither action supports resource-level scoping -> "*".
+              - Sid: ConcurrencyProbe
                 Effect: Allow
-                Action: [s3:PutObject, s3:GetObject, s3:DeleteObject]
-                Resource: !Sub "arn:aws:s3:::${BenchmarkStoreBucket}/*"
-              - Sid: ListBenchmarkStore
-                Effect: Allow
-                Action: s3:ListBucket
-                Resource: !Sub "arn:aws:s3:::${BenchmarkStoreBucket}"
+                Action: [lambda:GetAccountSettings, cloudwatch:GetMetricStatistics]
+                Resource: "*"
 
   # --- tier-2 test-deploy role (issue #25 §9) --------------------------------
   DeployRole:

--- a/deployment/aws/stand_up.sh
+++ b/deployment/aws/stand_up.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 # Stand up the zagg Lambda backend in your own AWS account, end to end.
 #
-# Lambda code (the deps layer + function zips) is read from the public source.coop
-# mirror. CloudFormation requires that code to live in a SAME-REGION S3 bucket:
+# Lambda code (the deps layer + function zips) is read from the public CORS bucket
+# (s3://sliderule-public-cors), with the legacy source.coop mirror as a fallback
+# for older minors. CloudFormation requires that code to live in a SAME-REGION
+# bucket:
 #
-#   * In us-west-2 (where the mirror lives) the stack reads it straight from the
-#     mirror — no staging bucket of your own needed.
+#   * In us-west-2 (where the sources live) the stack reads it straight from the
+#     source — no staging bucket of your own needed.
 #   * In any other region, provide STAGING_BUCKET (a bucket you own in that
-#     region); the zips are copied from the mirror into it first.
+#     region); the zips are copied from the source into it first.
 #
-# The mirror is keyed by zagg MINOR version (0.N.x -> 0.N). Run from a zagg git
+# Sources are keyed by zagg MINOR version (0.N.x -> 0.N). Run from a zagg git
 # clone and the minor is read from the latest tag (no install needed); otherwise
-# set LAMBDA_VERSION (e.g. LAMBDA_VERSION=0.2).
+# set LAMBDA_VERSION (e.g. LAMBDA_VERSION=0.2). Set LAMBDA_VERSION=latest to read
+# the newest published minor from the CORS bucket's versions.json (so a clone/
+# pip-install isn't hard-pinned to its build-time version).
 #
 # By default the stack creates its own Lambda execution role (needs
 # iam:CreateRole — fine if you admin your own account). In IAM-constrained
@@ -33,6 +37,7 @@ run() { echo "+ $(printf '%q ' "$@")"; "$@"; }
 
 ARCH="${ARCH:-arm64}"                                # arm64 | x86_64
 STACK_NAME="${STACK_NAME:-zagg-backend}"
+FUNCTION_NAME="${FUNCTION_NAME:-process-shard}"      # e.g. process-shard-test for a test stack
 REGION="${REGION:-us-west-2}"
 OUTPUT_BUCKET="${OUTPUT_BUCKET:?Set OUTPUT_BUCKET to the bucket where results go}"
 CREATE_BUCKET="${CREATE_BUCKET:-false}"              # true => the stack creates OUTPUT_BUCKET
@@ -50,10 +55,20 @@ if [ "$CREATE_ROLE" != "true" ] && [ -z "$ROLE_ARN" ]; then
     exit 1
 fi
 
-# Public mirror (override to self-host a copy).
+# Distribution sources (issue #25). The public CORS bucket is primary: listable
+# (a versions.json index), keyed by minor as <minor>/<zip>. The legacy source.coop
+# mirror is the fallback for older minors that predate the new bucket (transition
+# window). Override any of these to self-host a copy.
+DIST_BUCKET="${DIST_BUCKET:-sliderule-public-cors}"
+DIST_PREFIX="${DIST_PREFIX:-}"                       # keys: [<prefix>/]<minor>/<zip>
+DIST_REGION="${DIST_REGION:-us-west-2}"
 MIRROR_BUCKET="${MIRROR_BUCKET:-us-west-2.opendata.source.coop}"
-MIRROR_PREFIX="${MIRROR_PREFIX:-englacial/zagg/lambda}"
+MIRROR_PREFIX="${MIRROR_PREFIX:-englacial/zagg/lambda}"   # keys: <prefix>/<minor>/<zip>
 MIRROR_REGION="${MIRROR_REGION:-us-west-2}"
+
+dist_key()   { local p="$DIST_PREFIX"; [ -n "$p" ] && p="$p/"; echo "${p}${1}/${2}"; }  # minor, zip
+mirror_key() { echo "${MIRROR_PREFIX}/${1}/${2}"; }
+dist_root()  { local p="$DIST_PREFIX"; [ -n "$p" ] && p="$p/"; echo "${p}${1}"; }       # versions.json path
 
 case "$ARCH" in
     arm64)  LAYER_ZIP="lambda_layer_arm64.zip";  FUNC_ZIP="lambda_function_arm64_py312.zip" ;;
@@ -63,9 +78,15 @@ esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Resolve the lambda minor version (0.N). Order: explicit override -> the repo's
-# git tag (works from a fresh clone, no install needed) -> the installed zagg.
-if [ -n "${LAMBDA_VERSION:-}" ]; then
+# Resolve the lambda minor version (0.N). Order: LAMBDA_VERSION=latest (read the
+# CORS bucket's versions.json) -> explicit LAMBDA_VERSION -> the repo's git tag
+# (works from a fresh clone) -> the installed zagg.
+if [ "${LAMBDA_VERSION:-}" = "latest" ]; then
+    MINOR="$(aws s3 cp "s3://$DIST_BUCKET/$(dist_root versions.json)" - --region "$DIST_REGION" --no-sign-request 2>/dev/null \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin)["latest"])' 2>/dev/null || true)"
+    [ -z "$MINOR" ] && { echo "ERROR: could not read 'latest' from s3://$DIST_BUCKET/$(dist_root versions.json)"; exit 1; }
+    echo "Resolved LAMBDA_VERSION=latest -> $MINOR"
+elif [ -n "${LAMBDA_VERSION:-}" ]; then
     MINOR="$LAMBDA_VERSION"
 else
     MINOR="$(git -C "$SCRIPT_DIR" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' | cut -d. -f1,2)"
@@ -73,29 +94,36 @@ else
     if [ -z "$MINOR" ]; then
         echo "ERROR: could not determine the lambda minor version. Run from a zagg git"
         echo "       clone (uses the latest tag), or install zagg, or set LAMBDA_VERSION"
-        echo "       (e.g. LAMBDA_VERSION=0.2)."
+        echo "       (e.g. LAMBDA_VERSION=0.2, or LAMBDA_VERSION=latest)."
         exit 1
     fi
 fi
-
-LAYER_KEY="$MIRROR_PREFIX/$MINOR/$LAYER_ZIP"
-FUNC_KEY="$MIRROR_PREFIX/$MINOR/$FUNC_ZIP"
 echo "zagg lambda artifacts: $MINOR ($ARCH), region $REGION"
 
-if [ "$REGION" = "$MIRROR_REGION" ]; then
-    # Same region as the mirror — deploy straight from it, no staging bucket.
-    echo "Region matches the mirror: deploying directly from s3://$MIRROR_BUCKET/$MIRROR_PREFIX/$MINOR/"
-    ARTIFACT_BUCKET="$MIRROR_BUCKET"
-    LAYER_S3KEY="$LAYER_KEY"
-    FUNC_S3KEY="$FUNC_KEY"
+# Pick the source that actually holds this minor: prefer the CORS bucket; if the
+# layer isn't there (an older minor), fall back to the source.coop mirror.
+SRC_BUCKET="$DIST_BUCKET"; SRC_REGION="$DIST_REGION"
+SRC_LAYER_KEY="$(dist_key "$MINOR" "$LAYER_ZIP")"; SRC_FUNC_KEY="$(dist_key "$MINOR" "$FUNC_ZIP")"
+if ! aws s3api head-object --bucket "$DIST_BUCKET" --key "$SRC_LAYER_KEY" --region "$DIST_REGION" --no-sign-request >/dev/null 2>&1; then
+    echo "note: $MINOR not on s3://$DIST_BUCKET — falling back to the source.coop mirror"
+    SRC_BUCKET="$MIRROR_BUCKET"; SRC_REGION="$MIRROR_REGION"
+    SRC_LAYER_KEY="$(mirror_key "$MINOR" "$LAYER_ZIP")"; SRC_FUNC_KEY="$(mirror_key "$MINOR" "$FUNC_ZIP")"
+fi
+
+if [ "$REGION" = "$SRC_REGION" ]; then
+    # Same region as the source — deploy straight from it, no staging bucket.
+    echo "Deploying directly from s3://$SRC_BUCKET/$SRC_LAYER_KEY"
+    ARTIFACT_BUCKET="$SRC_BUCKET"
+    LAYER_S3KEY="$SRC_LAYER_KEY"
+    FUNC_S3KEY="$SRC_FUNC_KEY"
 else
     # Different region — CloudFormation needs a same-region bucket, so copy the
-    # zips from the mirror into the user's STAGING_BUCKET first.
+    # zips from the source into the user's STAGING_BUCKET first.
     if [ -z "$STAGING_BUCKET" ]; then
-        echo "ERROR: REGION=$REGION is not the mirror region ($MIRROR_REGION)."
+        echo "ERROR: REGION=$REGION is not the source region ($SRC_REGION)."
         echo "       CloudFormation reads Lambda code from a SAME-REGION bucket, so the public"
-        echo "       mirror can't be used directly here. Provide STAGING_BUCKET (a bucket you"
-        echo "       own in $REGION); the zips will be copied into it from the mirror."
+        echo "       source can't be used directly here. Provide STAGING_BUCKET (a bucket you"
+        echo "       own in $REGION); the zips will be copied into it from the source."
         echo "       (Or deploy in us-west-2 to skip staging entirely.)"
         exit 1
     fi
@@ -105,9 +133,9 @@ else
         exit 1
     fi
     TMPDIR="$(mktemp -d)"; trap 'rm -rf "$TMPDIR"' EXIT
-    echo "Copying zips from the mirror into s3://$STAGING_BUCKET/ ..."
-    run aws s3 cp "s3://$MIRROR_BUCKET/$LAYER_KEY" "$TMPDIR/$LAYER_ZIP" --region "$MIRROR_REGION" --no-sign-request
-    run aws s3 cp "s3://$MIRROR_BUCKET/$FUNC_KEY"  "$TMPDIR/$FUNC_ZIP"  --region "$MIRROR_REGION" --no-sign-request
+    echo "Copying zips from s3://$SRC_BUCKET into s3://$STAGING_BUCKET/ ..."
+    run aws s3 cp "s3://$SRC_BUCKET/$SRC_LAYER_KEY" "$TMPDIR/$LAYER_ZIP" --region "$SRC_REGION" --no-sign-request
+    run aws s3 cp "s3://$SRC_BUCKET/$SRC_FUNC_KEY"  "$TMPDIR/$FUNC_ZIP"  --region "$SRC_REGION" --no-sign-request
     run aws s3 cp "$TMPDIR/$LAYER_ZIP" "s3://$STAGING_BUCKET/$LAYER_ZIP" --region "$REGION"
     run aws s3 cp "$TMPDIR/$FUNC_ZIP"  "s3://$STAGING_BUCKET/$FUNC_ZIP"  --region "$REGION"
     ARTIFACT_BUCKET="$STAGING_BUCKET"
@@ -123,6 +151,7 @@ run aws cloudformation deploy \
     --capabilities CAPABILITY_NAMED_IAM \
     --parameter-overrides \
         Architecture="$ARCH" \
+        FunctionName="$FUNCTION_NAME" \
         ArtifactBucket="$ARTIFACT_BUCKET" \
         LayerS3Key="$LAYER_S3KEY" \
         FunctionS3Key="$FUNC_S3KEY" \

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -59,23 +59,65 @@ aws iam list-open-id-connect-providers
 
 ---
 
-## 2. Create the scoped IAM role
+## 2. Create the CI/CD roles + distribution bucket (one CloudFormation stack)
 
-The role is assumable **only** by this repo's Actions, and can do **only** what
-the benchmark needs. Two policy documents: a trust policy (who can assume) and a
-permission policy (what it can do).
+All three GitHub-OIDC roles — **benchmark-invoke** (this section), **test-deploy**
+and **release** (section 9) — plus the public **`sliderule-public-cors`** bucket
+(section 10) are provisioned by one template, `deployment/aws/benchmark_cicd.yaml`,
+kept in its own stack so it rolls back / tears down cleanly (the SlideRule
+CFN-first convention; mirrors `execution_role.yaml`). It references the existing
+OIDC provider from section 1 by account ID, so nothing here recreates it.
 
-### 2a. Trust policy — pin to the repo
+```bash
+aws cloudformation deploy \
+  --template-file deployment/aws/benchmark_cicd.yaml \
+  --stack-name zagg-benchmark-cicd \
+  --region us-west-2 \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+      GitHubRepo=englacial/zagg \
+      BenchmarkFunctionName=process-shard \
+      TestFunctionName=process-shard-test \
+      BenchmarkStoreBucket=sliderule-public \
+      DistBucketName=sliderule-public-cors
+```
 
-`trust.json` — the `sub` wildcard `repo:englacial/zagg:*` restricts assumption to
-**this** repo's Actions (a fork's OIDC `sub` is `repo:<fork>/zagg:*` and can't
-match), which is the standard scope. Branch/PR/fork-context gating is enforced in
-the workflows themselves (same-repo guard for the auto path, write/admin actor
-check for the on-demand path). If you want to tighten the trust at the IAM layer
-too, replace the wildcard with explicit subs (e.g.
-`repo:englacial/zagg:ref:refs/heads/main` and `repo:englacial/zagg:pull_request`)
-— but note the on-demand fork path runs under `pull_request_target`, whose `sub`
-is the **base** ref, so don't over-restrict or you'll lock it out:
+Parameters (all default to the values in this guide):
+
+| Parameter | Default | Scopes |
+| --- | --- | --- |
+| `GitHubRepo` | `englacial/zagg` | the OIDC trust `sub` (`repo:<repo>:*`) on all three roles |
+| `BenchmarkFunctionName` | `process-shard` | the stable function the invoke role calls + the release role deploys |
+| `TestFunctionName` | `process-shard-test` | the function the deploy role updates + the invoke role calls |
+| `BenchmarkStoreBucket` | `sliderule-public` | the benchmark output store + the staged test layer (`lambda-test/*`) |
+| `DistBucketName` | `sliderule-public-cors` | the public distribution bucket (`CreateDistBucket=false` to reuse an existing one) |
+
+The **benchmark-invoke** role (`zagg-benchmark`) gets `lambda:InvokeFunction` +
+`lambda:GetFunctionConfiguration` (the latter for the `worker_pct_timeout` metric)
+on the stable + test functions, and read/write on the benchmark store bucket.
+
+> The Lambda reads the ATL03 source granules itself, using the NSIDC S3
+> credentials the orchestrator forwards — that's the **Lambda execution role**'s
+> concern, not this role's. This role only invokes + writes output.
+
+**Verify** — the stack Outputs hand you the exact ARNs/names for section 4:
+
+```bash
+aws cloudformation describe-stacks --stack-name zagg-benchmark-cicd \
+  --region us-west-2 --query 'Stacks[0].Outputs' --output table
+```
+
+The trust `sub` is the repo wildcard `repo:englacial/zagg:*` (a fork's `sub` can't
+match); branch/PR/fork-context gating lives in the workflows + the `production`
+Environment (section 11). To tighten at the IAM layer, override the roles'
+conditions — but the on-demand fork path runs under `pull_request_target` (base
+`sub`) and the release job under `environment:production`, so don't over-restrict
+or you'll lock them out.
+
+<details><summary>Manual (raw-CLI) alternative for the invoke role</summary>
+
+If you can't use CloudFormation, create just the invoke role with this trust
+(`trust.json`) and permission (`permissions.json`) policy:
 
 ```json
 {
@@ -87,21 +129,12 @@ is the **base** ref, so don't over-restrict or you'll lock it out:
     },
     "Action": "sts:AssumeRoleWithWebIdentity",
     "Condition": {
-      "StringEquals": {
-        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-      },
-      "StringLike": {
-        "token.actions.githubusercontent.com:sub": "repo:englacial/zagg:*"
-      }
+      "StringEquals": { "token.actions.githubusercontent.com:aud": "sts.amazonaws.com" },
+      "StringLike": { "token.actions.githubusercontent.com:sub": "repo:englacial/zagg:*" }
     }
   }]
 }
 ```
-
-### 2b. Permission policy — least privilege
-
-`permissions.json` — invoke the one function, read its config (for the
-`worker_pct_timeout` metric), and read/write the benchmark bucket prefix:
 
 ```json
 {
@@ -117,36 +150,22 @@ is the **base** ref, so don't over-restrict or you'll lock it out:
       "Sid": "BenchmarkBucket",
       "Effect": "Allow",
       "Action": ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"],
-      "Resource": [
-        "arn:aws:s3:::BUCKET",
-        "arn:aws:s3:::BUCKET/PREFIX/*"
-      ]
+      "Resource": ["arn:aws:s3:::BUCKET", "arn:aws:s3:::BUCKET/PREFIX/*"]
     }
   ]
 }
 ```
 
-> The Lambda reads the ATL03 source granules itself, using the NSIDC S3
-> credentials the orchestrator forwards — that's the **Lambda execution role**'s
-> concern, not this role's. This role only invokes + writes output.
-
-### 2c. Create the role and attach the policy
-
 ```bash
 aws iam create-role --role-name zagg-benchmark \
   --assume-role-policy-document file://trust.json
-
 aws iam put-role-policy --role-name zagg-benchmark \
-  --policy-name zagg-benchmark-access \
-  --policy-document file://permissions.json
+  --policy-name zagg-benchmark-access --policy-document file://permissions.json
 ```
 
-**Verify** — note the ARN (you need it in step 4):
-
-```bash
-aws iam get-role --role-name zagg-benchmark --query 'Role.Arn' --output text
-# -> arn:aws:iam::ACCOUNT_ID:role/zagg-benchmark
-```
+(Section 9's deploy/release roles + section 10's bucket then also need their own
+`create-role`/`s3api` commands — the CloudFormation path does all of it at once.)
+</details>
 
 ---
 
@@ -333,8 +352,8 @@ the function.
 
 ## 9. Deploy + release IAM roles (OIDC)
 
-Two more roles, both trusting this repo via the OIDC provider from section 1
-(reuse the same `trust.json`):
+The **`zagg-benchmark-deploy`** and **`zagg-lambda-release`** roles are created by
+the section-2 stack (`benchmark_cicd.yaml`). Their grants, for reference:
 
 - **`zagg-benchmark-deploy`** (test tier) — update the test function + stage the
   layer:
@@ -363,13 +382,17 @@ A **real public** bucket (readable + **listable** from anywhere — unlike
 directly. Listing lets a user resolve `LAMBDA_VERSION=latest` from
 `versions.json` instead of being pinned to their clone's version.
 
+The section-2 stack creates this bucket (with the public read/list policy + CORS
+rule below) when `CreateDistBucket=true` (the default). One **account-level**
+caveat the stack can't handle: if your account has Block Public Access enabled
+(`aws s3control get-public-access-block --account-id ACCOUNT_ID`), the
+bucket-level setting can't override it — relax it at the account level too, or the
+public policy is silently ineffective.
+
+<details><summary>Manual (raw-CLI) alternative</summary>
+
 ```bash
 aws s3 mb s3://sliderule-public-cors --region us-west-2
-# Relax the BUCKET-level block-public-access, then attach the policy below. NOTE:
-# if your ACCOUNT has Block Public Access enabled (aws s3control
-# get-public-access-block --account-id ACCOUNT_ID), the bucket setting can't
-# override it -- you must relax it at the account level too, or the public policy
-# is silently ineffective.
 aws s3api put-public-access-block --bucket sliderule-public-cors \
   --public-access-block-configuration BlockPublicPolicy=false,RestrictPublicBuckets=false
 aws s3api put-bucket-policy --bucket sliderule-public-cors --policy '{
@@ -391,6 +414,7 @@ aws s3api put-bucket-cors --bucket sliderule-public-cors --cors-configuration '{
   }]
 }'
 ```
+</details>
 
 **Verify** (anonymous read + list both work):
 
@@ -405,7 +429,9 @@ aws s3 cp s3://sliderule-public-cors/versions.json - --no-sign-request   # after
 ## 11. GitHub Environments, variables, and tag protection
 
 The deploy/release jobs read these **variables** (and reuse the section-4
-`EARTHDATA_*` secrets):
+`EARTHDATA_*` secrets). The role ARNs are the section-2 stack's Outputs
+(`DeployRoleArn` / `ReleaseRoleArn`) — paste those rather than hand-building the
+ARNs below:
 
 ```bash
 # Benchmark test-deploy (tier 2)

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -30,7 +30,7 @@ Throughout, substitute your values for `ACCOUNT_ID`, `REGION` (e.g.
 | Scoped IAM role (`zagg-benchmark`) | What those creds can do: invoke the one Lambda, read/write the one bucket prefix |
 | S3 bucket / prefix | Where the benchmark Zarr stores are written |
 | Repo **variables** `BENCHMARK_*` | Non-secret config (role ARN, region, function, store prefix) |
-| Repo **secrets** `EARTHDATA_*` | Earthdata Login for the orchestrator to mint NSIDC read creds |
+| Repo **secret** `EARTHDATA_TOKEN` | Earthdata Login bearer token for the orchestrator to mint NSIDC read creds |
 | `benchmarks` branch | Holds the retained parquet series + rendered charts |
 | `benchmark` label | One of the two fork-PR on-demand triggers |
 
@@ -198,16 +198,24 @@ gh variable set BENCHMARK_AWS_REGION    --body "REGION"
 gh variable set BENCHMARK_FUNCTION_NAME --body "FUNCTION_NAME"
 gh variable set BENCHMARK_STORE_PREFIX  --body "s3://BUCKET/PREFIX"
 
-# Secrets (Earthdata Login for the orchestrator)
-gh secret set EARTHDATA_USERNAME --body "your-edl-username"
-gh secret set EARTHDATA_PASSWORD --body "your-edl-password"
+# Secret: an Earthdata Login BEARER TOKEN for the orchestrator (the NSIDC S3
+# credentials endpoint accepts a user token). Generate one at
+# https://urs.earthdata.nasa.gov/documentation/for_users/user_token (Profile ->
+# Generate Token). earthaccess reads it from EARTHDATA_TOKEN.
+gh secret set EARTHDATA_TOKEN --body "<edl-bearer-token>"
 ```
+
+A token is preferred over username/password: it's scoped, expiring (EDL allows up
+to 2 active tokens, ~60-day lifetime), and rotates without touching the EDL
+account password. Set a calendar reminder to regenerate + re-`gh secret set`
+before expiry — an expired token fails the benchmark at the NSIDC-credentials
+step.
 
 **Verify**:
 
 ```bash
 gh variable list   # 4 BENCHMARK_* entries
-gh secret list     # EARTHDATA_USERNAME, EARTHDATA_PASSWORD
+gh secret list     # EARTHDATA_TOKEN
 ```
 
 ---
@@ -277,7 +285,7 @@ gh label create benchmark \
 
 If a run fails at *Assume AWS role*, re-check the trust policy `sub` matches the
 repo and the OIDC provider exists (steps 1–2). If it fails minting NSIDC creds,
-re-check the `EARTHDATA_*` secrets (step 4).
+re-check the `EARTHDATA_TOKEN` secret (step 4) — an expired token fails here.
 
 ---
 
@@ -306,7 +314,7 @@ you want the raw artifacts.
   cost of benchmarking a fork; the role can only invoke the one Lambda and write
   the one bucket prefix.
 - **Rotating creds.** OIDC mints fresh AWS creds per run (nothing to rotate).
-  Rotate the `EARTHDATA_*` secrets per your normal policy.
+  Regenerate the `EARTHDATA_TOKEN` before it expires (EDL tokens are short-lived).
 
 ---
 
@@ -429,7 +437,7 @@ aws s3 cp s3://sliderule-public-cors/versions.json - --no-sign-request   # after
 ## 11. GitHub Environments, variables, and tag protection
 
 The deploy/release jobs read these **variables** (and reuse the section-4
-`EARTHDATA_*` secrets). The role ARNs are the section-2 stack's Outputs
+`EARTHDATA_TOKEN` secret). The role ARNs are the section-2 stack's Outputs
 (`DeployRoleArn` / `ReleaseRoleArn`) — paste those rather than hand-building the
 ARNs below:
 

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -288,3 +288,159 @@ you want the raw artifacts.
   the one bucket prefix.
 - **Rotating creds.** OIDC mints fresh AWS creds per run (nothing to rotate).
   Rotate the `EARTHDATA_*` secrets per your normal policy.
+
+---
+
+# Deploy automation (issue #25)
+
+The benchmark above measures the **deployed** Lambda worker. For a PR's worker
+changes to actually be measured, the PR's code has to be deployed first. This
+second pipeline does that across three tiers:
+
+- **Internal PRs / merges that touch the deployed closure** (`src/zagg/**`,
+  `deployment/aws/**`, `pyproject.toml`) → build arm64 + redeploy a separate
+  `process-shard-test` function, then benchmark against it. Non-affecting changes
+  benchmark the stable function.
+- **Fork PRs** → never redeploy; the benchmark comment is annotated that the
+  numbers reflect the stable worker, not the PR.
+- **Releases (tags)** → update the **production** function in place and publish
+  the zips to a public, listable bucket (`sliderule-public-cors`), replacing the
+  source.coop mirror over a transition window.
+
+This is the **"AWS update for this PR"** step in the rollout order
+(`#112` → benchmark setup → the deploy PR → this). Until these resources +
+variables exist, the deploy/distribute/prod jobs **skip cleanly** — the benchmark
+keeps running against the stable function and releases still attach zips.
+
+## 8. The `process-shard-test` stack
+
+A second copy of the backend stack, named `process-shard-test`, so PR benchmarks
+never touch production. Stand it up **once** (the template already parameterizes
+the function name); subsequent PR deploys only `update-function-code`, no stack
+churn.
+
+```bash
+OUTPUT_BUCKET=sliderule-public \
+STACK_NAME=zagg-backend-test \
+FUNCTION_NAME=process-shard-test \
+  ./deployment/aws/stand_up.sh
+```
+
+(`stand_up.sh` passes `FUNCTION_NAME` to the template's `FunctionName` parameter.)
+Subsequent PR deploys only `update-function-code`, so the stack is stood up once.
+**Verify:** `aws lambda get-function --function-name process-shard-test` returns
+the function.
+
+## 9. Deploy + release IAM roles (OIDC)
+
+Two more roles, both trusting this repo via the OIDC provider from section 1
+(reuse the same `trust.json`):
+
+- **`zagg-benchmark-deploy`** (test tier) — update the test function + stage the
+  layer:
+  - `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`,
+    `lambda:PublishLayerVersion`, `lambda:GetFunction` on `process-shard-test`
+    (+ its `-deps` layer).
+  - `s3:PutObject` on `s3://sliderule-public/lambda-test/*` (the staged layer).
+- **`zagg-lambda-release`** (release tier) — update **production** + publish:
+  - the same `lambda:*` actions on `process-shard` (+ `process-shard-deps`).
+  - `s3:PutObject`/`s3:GetObject` on `s3://sliderule-public-cors/*` (distribute).
+
+**Verify:** `aws iam get-role --role-name zagg-benchmark-deploy` /
+`zagg-lambda-release`.
+
+> The release role can mutate production, so gate it (section 11) — don't rely on
+> the trust policy alone.
+
+## 10. The `sliderule-public-cors` distribution bucket
+
+A **real public** bucket (readable + **listable** from anywhere — unlike
+`s3://sliderule-public`, which is cryocloud-only and no-list), in **us-west-2**
+(CloudFormation reads Lambda code same-region) so `stand_up.sh` can fetch it
+directly. Listing lets a user resolve `LAMBDA_VERSION=latest` from
+`versions.json` instead of being pinned to their clone's version.
+
+```bash
+aws s3 mb s3://sliderule-public-cors --region us-west-2
+# Disable the account block-public-access for this bucket, then:
+aws s3api put-public-access-block --bucket sliderule-public-cors \
+  --public-access-block-configuration BlockPublicPolicy=false,RestrictPublicBuckets=false
+aws s3api put-bucket-policy --bucket sliderule-public-cors --policy '{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "PublicReadList",
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": ["s3:GetObject", "s3:ListBucket"],
+    "Resource": ["arn:aws:s3:::sliderule-public-cors",
+                 "arn:aws:s3:::sliderule-public-cors/*"]
+  }]
+}'
+aws s3api put-bucket-cors --bucket sliderule-public-cors --cors-configuration '{
+  "CORSRules": [{
+    "AllowedOrigins": ["*"],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedHeaders": ["*"]
+  }]
+}'
+```
+
+**Verify** (anonymous read + list both work):
+
+```bash
+aws s3 ls s3://sliderule-public-cors/ --no-sign-request
+aws s3 cp s3://sliderule-public-cors/versions.json - --no-sign-request   # after the first release
+```
+
+> The bucket must be in the same region as the **production** Lambda — the
+> release job's `publish-layer-version` reads the layer zip from it in-region.
+
+## 11. GitHub Environments, variables, and tag protection
+
+The deploy/release jobs read these **variables** (and reuse the section-4
+`EARTHDATA_*` secrets):
+
+```bash
+# Benchmark test-deploy (tier 2)
+gh variable set BENCHMARK_DEPLOY_ROLE_ARN    --body "arn:aws:iam::ACCOUNT_ID:role/zagg-benchmark-deploy"
+gh variable set BENCHMARK_TEST_FUNCTION_NAME --body "process-shard-test"
+gh variable set BENCHMARK_TEST_STAGE_BUCKET  --body "sliderule-public"
+# Release (tier 3)
+gh variable set LAMBDA_RELEASE_ROLE_ARN   --body "arn:aws:iam::ACCOUNT_ID:role/zagg-lambda-release"
+gh variable set LAMBDA_PROD_FUNCTION_NAME --body "process-shard"
+gh variable set LAMBDA_DIST_BUCKET        --body "sliderule-public-cors"
+gh variable set LAMBDA_AWS_REGION         --body "us-west-2"
+```
+
+Protect the production deploy:
+
+- **`production` Environment** (Settings → Environments → New → `production`) with
+  a **required reviewer** — the release workflow's `deploy-prod` job waits for an
+  approval before it mutates the live function.
+- **Tag protection** for `*.*.*` so only maintainers can cut a release (a tag is
+  what triggers the prod deploy + PyPI publish).
+
+**Verify:** `gh variable list` shows the seven new vars; the Environments page
+shows `production` with a reviewer.
+
+## 12. Verify the deploy tiers
+
+1. **Tier 2.** Open an internal PR that edits `src/zagg/processing/` — the
+   benchmark run should include a `deploy-test` job and the comment should have no
+   stale-worker banner. A docs-only PR should skip the deploy and (correctly) show
+   no banner either.
+2. **Tier 1.** On a fork PR that touches `src/zagg/`, a maintainer `/benchmark` →
+   the comment carries the **"worker = stable `main`"** banner.
+3. **Tier 3.** Cut a pre-release tag → the GitHub release gets the four zips
+   attached, `s3://sliderule-public-cors/<minor>/` is populated with a
+   `versions.json`, and (after the `production` approval) `process-shard` is
+   updated. `LAMBDA_VERSION=latest ./stand_up.sh` then resolves the new minor.
+
+## Distribution transition (source.coop → CORS bucket)
+
+`stand_up.sh` now prefers `sliderule-public-cors` and **falls back to the
+source.coop mirror** for any minor not yet on the new bucket — so older standups
+keep working while new releases populate the new bucket. Once enough releases have
+published to the CORS bucket, retire the source.coop mirror (and its
+`publish_mirror.sh` step) in a follow-up. Set `LAMBDA_VERSION=latest` to always
+pull the newest published minor.

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -339,11 +339,14 @@ Two more roles, both trusting this repo via the OIDC provider from section 1
 - **`zagg-benchmark-deploy`** (test tier) — update the test function + stage the
   layer:
   - `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`,
-    `lambda:PublishLayerVersion`, `lambda:GetFunction` on `process-shard-test`
-    (+ its `-deps` layer).
+    `lambda:PublishLayerVersion`, `lambda:GetFunction`,
+    `lambda:GetFunctionConfiguration` on `process-shard-test` (+ its `-deps`
+    layer). `GetFunctionConfiguration` is required: `deploy_lambda.sh` calls
+    `aws lambda wait function-updated`, whose waiter polls it.
   - `s3:PutObject` on `s3://sliderule-public/lambda-test/*` (the staged layer).
 - **`zagg-lambda-release`** (release tier) — update **production** + publish:
-  - the same `lambda:*` actions on `process-shard` (+ `process-shard-deps`).
+  - the same five `lambda:*` actions (incl. `lambda:GetFunctionConfiguration`)
+    on `process-shard` (+ `process-shard-deps`).
   - `s3:PutObject`/`s3:GetObject` on `s3://sliderule-public-cors/*` (distribute).
 
 **Verify:** `aws iam get-role --role-name zagg-benchmark-deploy` /
@@ -362,7 +365,11 @@ directly. Listing lets a user resolve `LAMBDA_VERSION=latest` from
 
 ```bash
 aws s3 mb s3://sliderule-public-cors --region us-west-2
-# Disable the account block-public-access for this bucket, then:
+# Relax the BUCKET-level block-public-access, then attach the policy below. NOTE:
+# if your ACCOUNT has Block Public Access enabled (aws s3control
+# get-public-access-block --account-id ACCOUNT_ID), the bucket setting can't
+# override it -- you must relax it at the account level too, or the public policy
+# is silently ineffective.
 aws s3api put-public-access-block --bucket sliderule-public-cors \
   --public-access-block-configuration BlockPublicPolicy=false,RestrictPublicBuckets=false
 aws s3api put-bucket-policy --bucket sliderule-public-cors --policy '{

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -438,8 +438,8 @@ aws s3 cp s3://sliderule-public-cors/versions.json - --no-sign-request   # after
 
 ## 11. GitHub Environments, variables, and tag protection
 
-The deploy/release jobs read these **variables** (and reuse the section-4
-`EARTHDATA_TOKEN` secret). The role ARNs are the section-2 stack's Outputs
+The deploy/release jobs read these **variables** (no extra secrets — only the
+benchmark jobs use `EARTHDATA_TOKEN`). The role ARNs are the section-2 stack's Outputs
 (`DeployRoleArn` / `ReleaseRoleArn`) — paste those rather than hand-building the
 ARNs below:
 

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -27,7 +27,7 @@ Throughout, substitute your values for `ACCOUNT_ID`, `REGION` (e.g.
 | Piece | Why |
 | --- | --- |
 | GitHub OIDC provider in AWS | Lets Actions mint short-lived AWS creds with **no stored secret** |
-| Scoped IAM role (`zagg-benchmark`) | What those creds can do: invoke the one Lambda, read/write the one bucket prefix |
+| Scoped IAM role (`zagg-benchmark`) | What those creds can do: invoke the Lambda + probe account concurrency (no direct S3 — the Lambda writes the store) |
 | S3 bucket / prefix | Where the benchmark Zarr stores are written |
 | Repo **variables** `BENCHMARK_*` | Non-secret config (role ARN, region, function, store prefix) |
 | Repo **secret** `EARTHDATA_TOKEN` | Earthdata Login bearer token for the orchestrator to mint NSIDC read creds |
@@ -93,12 +93,14 @@ Parameters (all default to the values in this guide):
 | `DistBucketName` | `sliderule-public-cors` | the public distribution bucket (`CreateDistBucket=false` to reuse an existing one) |
 
 The **benchmark-invoke** role (`zagg-benchmark`) gets `lambda:InvokeFunction` +
-`lambda:GetFunctionConfiguration` (the latter for the `worker_pct_timeout` metric)
-on the stable + test functions, and read/write on the benchmark store bucket.
+`lambda:GetFunctionConfiguration` + `lambda:GetFunctionConcurrency` on the stable +
+test functions, plus the worker-sizing probe (`lambda:GetAccountSettings` +
+`cloudwatch:GetMetricStatistics`, issue #28/#63). **No S3** — the Zarr template
+write happens inside the Lambda, so the orchestrator never touches the bucket.
 
 > The Lambda reads the ATL03 source granules itself, using the NSIDC S3
 > credentials the orchestrator forwards — that's the **Lambda execution role**'s
-> concern, not this role's. This role only invokes + writes output.
+> concern, not this role's. This role only invokes + probes concurrency.
 
 **Verify** — the stack Outputs hand you the exact ARNs/names for section 4:
 
@@ -143,14 +145,14 @@ If you can't use CloudFormation, create just the invoke role with this trust
     {
       "Sid": "InvokeBenchmarkLambda",
       "Effect": "Allow",
-      "Action": ["lambda:InvokeFunction", "lambda:GetFunctionConfiguration"],
+      "Action": ["lambda:InvokeFunction", "lambda:GetFunctionConfiguration", "lambda:GetFunctionConcurrency"],
       "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME"
     },
     {
-      "Sid": "BenchmarkBucket",
+      "Sid": "ConcurrencyProbe",
       "Effect": "Allow",
-      "Action": ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"],
-      "Resource": ["arn:aws:s3:::BUCKET", "arn:aws:s3:::BUCKET/PREFIX/*"]
+      "Action": ["lambda:GetAccountSettings", "cloudwatch:GetMetricStatistics"],
+      "Resource": "*"
     }
   ]
 }

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -147,6 +147,17 @@ def test_comment_markdown_empty():
     assert "<!-- zagg-benchmark -->" in bench_metrics.comment_markdown([])
 
 
+def test_comment_markdown_worker_note_banner():
+    g = HealpixGrid(parent_order=11, child_order=19)
+    rec = bench_metrics.build_record(_summary(), grid=g, context={"target": "t", "commit": "abc"})
+    note = "Worker = stable main, not this PR's code."
+    md = bench_metrics.comment_markdown([rec], worker_note=note)
+    assert f"> ⚠️ {note}" in md  # banner rendered above the table
+    assert md.index(note) < md.index("| target |")  # ...and before the table
+    # Default (no note) has no banner.
+    assert "⚠️" not in bench_metrics.comment_markdown([rec])
+
+
 # --- run_benchmark wiring (dry-run, no AWS) -------------------------------
 
 

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -1,0 +1,82 @@
+"""Test the shared in-place Lambda deploy script (.github/scripts/deploy_lambda.sh).
+
+Runs the real script with a stub ``aws`` (no AWS) and asserts it issues the four
+calls in the required order with the right function/layer wiring: publish a layer
+version, point the function at it, wait, then update the code. The ordering (wait
+between the config + code updates) and the layer-from-S3 wiring are the parts that
+matter for a correct in-place deploy.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / ".github" / "scripts" / "deploy_lambda.sh"
+
+# Stub `aws`: log the full arg line; emit a LayerVersionArn on stdout for the
+# publish-layer-version call (the script captures it).
+STUB_AWS = """#!/bin/bash
+echo "$*" >> "$AWS_LOG"
+if [ "$2" = "publish-layer-version" ]; then
+  echo "arn:aws:lambda:us-west-2:1:layer:demo-deps:7"
+fi
+exit 0
+"""
+
+
+def test_deploy_sequence(tmp_path):
+    if shutil.which("bash") is None:
+        pytest.skip("bash unavailable")
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "aws").write_text(STUB_AWS)
+    (bindir / "aws").chmod(0o755)
+    fn_zip = tmp_path / "lambda_function_arm64_py312.zip"
+    fn_zip.write_bytes(b"zip")
+
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "AWS_LOG": str(tmp_path / "aws.log"),
+    }
+    subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "--function",
+            "process-shard-test",
+            "--layer-bucket",
+            "sliderule-public",
+            "--layer-key",
+            "lambda-test/abc/lambda_layer_arm64.zip",
+            "--function-zip",
+            str(fn_zip),
+            "--region",
+            "us-west-2",
+        ],
+        check=True,
+        env=env,
+    )
+    log = (tmp_path / "aws.log").read_text().splitlines()
+    # Four calls, in order.
+    assert "lambda publish-layer-version" in log[0]
+    assert "process-shard-test-deps" in log[0]  # layer named after the function
+    assert "S3Key=lambda-test/abc/lambda_layer_arm64.zip" in log[0]
+    assert "lambda update-function-configuration" in log[1]
+    assert "arn:aws:lambda:us-west-2:1:layer:demo-deps:7" in log[1]  # uses published ARN
+    assert "lambda wait function-updated" in log[2]  # settle before code update
+    assert "lambda update-function-code" in log[3]
+    assert f"fileb://{fn_zip}" in log[3]
+
+
+def test_missing_required_arg_errors(tmp_path):
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--function", "f"],  # missing the rest
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -1,0 +1,144 @@
+"""Test the release distribution script (.github/scripts/distribute_zips.sh).
+
+Runs the real script with a stub ``aws`` on PATH (no network), and asserts it
+uploads the four zips + SHA256SUMS under the minor prefix and maintains the
+top-level versions.json index. The versions.json read-modify-write is the part
+with real logic, so it's covered against both the seed (absent) and merge paths.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / ".github" / "scripts" / "distribute_zips.sh"
+
+# A stub `aws` CLI: logs every `s3 cp`, fails the versions.json *download* unless
+# a seed exists in $SEED_DIR, and captures every *upload* into $CAPTURE_DIR so the
+# test can read back what the script produced.
+STUB_AWS = """#!/bin/bash
+set -euo pipefail
+if [ "$1" = "s3" ] && [ "$2" = "cp" ]; then
+  SRC="$3"; DST="$4"
+  echo "$SRC -> $DST" >> "$AWS_LOG"
+  if [[ "$SRC" == s3://* ]]; then
+    # download: serve a seeded versions.json if present, else fail (not found).
+    base="$(basename "$SRC")"
+    if [ -f "$SEED_DIR/$base" ]; then cp "$SEED_DIR/$base" "$DST"; exit 0; fi
+    exit 1
+  else
+    # upload: capture under the destination key.
+    key="${DST#s3://}"; key="${key#*/}"
+    mkdir -p "$CAPTURE_DIR/$(dirname "$key")"
+    cp "$SRC" "$CAPTURE_DIR/$key"
+    exit 0
+  fi
+fi
+exit 0
+"""
+
+
+def _run(tmp_path, *, seed_versions=None):
+    if not shutil.which("sha256sum"):
+        pytest.skip("sha256sum not available")
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "aws").write_text(STUB_AWS)
+    (bindir / "aws").chmod(0o755)
+
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    if seed_versions is not None:
+        (seed_dir / "versions.json").write_text(json.dumps(seed_versions))
+    capture = tmp_path / "capture"
+    capture.mkdir()
+
+    zips = tmp_path / "zips"
+    zips.mkdir()
+    for name in (
+        "lambda_layer_arm64.zip",
+        "lambda_layer_x86_64.zip",
+        "lambda_function_arm64_py312.zip",
+        "lambda_function_x86_64_py312.zip",
+    ):
+        (zips / name).write_bytes(b"dummy-" + name.encode())
+
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "AWS_LOG": str(tmp_path / "aws.log"),
+        "SEED_DIR": str(seed_dir),
+        "CAPTURE_DIR": str(capture),
+    }
+    subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "--minor",
+            "0.3",
+            "--tag",
+            "0.3.1",
+            "--bucket",
+            "sliderule-public-cors",
+            "--dir",
+            str(zips),
+        ],
+        check=True,
+        env=env,
+        cwd=tmp_path,
+    )
+    log = (tmp_path / "aws.log").read_text()
+    return capture, log
+
+
+def test_uploads_four_zips_and_sums(tmp_path):
+    capture, log = _run(tmp_path)
+    for name in (
+        "lambda_layer_arm64.zip",
+        "lambda_layer_x86_64.zip",
+        "lambda_function_arm64_py312.zip",
+        "lambda_function_x86_64_py312.zip",
+        "SHA256SUMS",
+    ):
+        assert (capture / "0.3" / name).exists(), f"{name} not uploaded under 0.3/"
+
+
+def test_versions_index_seeds_when_absent(tmp_path):
+    capture, _ = _run(tmp_path)  # no seed -> download fails -> seed {"minors": []}
+    index = json.loads((capture / "versions.json").read_text())
+    assert index["minors"] == ["0.3"]
+    assert index["latest"] == "0.3"
+    assert index["latest_tag"] == "0.3.1"
+
+
+def test_versions_index_merges_and_sorts(tmp_path):
+    capture, _ = _run(tmp_path, seed_versions={"minors": ["0.1", "0.10", "0.2"]})
+    index = json.loads((capture / "versions.json").read_text())
+    # New minor merged; sorted numerically (0.10 > 0.3, not lexically); latest correct.
+    assert index["minors"] == ["0.1", "0.2", "0.3", "0.10"]
+    assert index["latest"] == "0.10"
+
+
+def test_errors_when_zip_count_wrong(tmp_path):
+    if not shutil.which("sha256sum"):
+        pytest.skip("sha256sum not available")
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "aws").write_text("#!/bin/bash\nexit 0\n")
+    (bindir / "aws").chmod(0o755)
+    zips = tmp_path / "zips"
+    zips.mkdir()
+    (zips / "lambda_layer_arm64.zip").write_bytes(b"x")  # only 1 of 4
+    env = {**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}"}
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--minor", "0.3", "--bucket", "b", "--dir", str(zips)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "expected 4 zips" in result.stderr


### PR DESCRIPTION
Closes #25. Refs #110.

Automates Lambda build/deploy across the three tiers from #25, on top of the #112 benchmark harness. Every new job **no-ops/skips when its vars/secrets are absent**, so merging this can't break releases or the existing benchmark before the AWS-side setup exists (order: #112 ✅ → benchmark setup → this PR → AWS update for this PR).

## Phases — all complete
- [x] **Phase 1 — Tier 3 (closes #25):** dual-arch build extracted into a reusable `workflow_call`; `publish.yml` is self-contained — build → create release **+ attach the 4 zips** with `GITHUB_TOKEN` (no cascade, no PAT) → `distribute` to `sliderule-public-cors` (minor-keyed + `versions.json`) → `deploy-prod` updates production in place (publish-layer-version + update-function-config + update-function-code, `production` Environment). New `distribute_zips.sh` + tests.
- [x] **Phase 2 — Tier 2:** `lambda-benchmark.yml` gains a `detect` job (lambda-affecting? configured? non-fork?) + a `deploy-test` job (build arm64 → `update-function-code` on `process-shard-test`), routing the benchmark at the resolved function. Workflow-level `concurrency` serializes runs (shared test fn). Shared `deploy_lambda.sh` (also used by deploy-prod). merge tracks test/staging.
- [x] **Phase 3 — Tier 1:** a `> ⚠️` banner in the PR comment whenever the benchmark ran against the **stable** worker but the change touches deployed code (same-repo pre-deploy + fork PRs), so a plausible-but-wrong number never reads as real.
- [x] **Phase 4 — distribution:** `stand_up.sh` prefers the listable `sliderule-public-cors` bucket (with `LAMBDA_VERSION=latest` via `versions.json`) and **falls back to source.coop** for older minors (no stranded standups); `FUNCTION_NAME` knob to stand up the `process-shard-test` stack. The setup guide gains the full "AWS update" section (test stack, deploy/release roles, CORS bucket policy + CORS config, the 7 new vars, `production` Environment + tag protection, verification).
- [x] **Phase 5 — CloudFormation (SlideRule CFN-first):** `deployment/aws/benchmark_cicd.yaml` provisions the 3 OIDC roles (invoke/test-deploy/release) + the `sliderule-public-cors` bucket (public read/list + CORS) in one rollback-able stack, referencing the existing OIDC provider by account id, with role-ARN Outputs. Guide §2/§9/§10 rewritten CFN-first (raw CLI kept as collapsed fallback). cfn-lint clean.

### Also (post-review)
- **Earthdata auth → bearer token.** The benchmark now authenticates with a single `EARTHDATA_TOKEN` secret (an EDL user token) instead of username+password — tested locally end-to-end (token authenticates **and** the NSIDC S3-credentials endpoint accepts it). No zagg code change (earthaccess reads `EARTHDATA_TOKEN`); composite action + workflows + docs updated.


## How it was tested
- `pytest tests/test_distribute_zips.py tests/test_deploy_lambda.py tests/test_benchmark.py` — 28 pass (real scripts driven by a stub `aws`, no network; the worker-note banner; versions.json seed/merge/numeric-sort; the deploy publish→config→wait→code ordering).
- **actionlint** clean on all workflows; `bash -n` on the scripts; `mkdocs build --strict` clean.
- **Not exercised live:** the OIDC deploy/distribute/prod jobs + the real CORS bucket (need the AWS-update setup). Guarded off until the vars exist.

## Scope / authorization
Touches `.github/workflows/**`, `.github/scripts/`, `.github/actions/`, `deployment/aws/stand_up.sh`, and docs — walled off by §1 generally, but issue #25 names this work explicitly. Nothing runs live AWS from an agent.

## Key decisions (confirmed in-thread)
Self-contained release (no PAT); serialized shared `process-shard-test` via `update-function-code`; `versions.json` index; merge → test/staging worker; inline arm64 build; fail-and-leave-attached on a post-release deploy failure; prod in-place via publish-layer-version (handles a deps/layer change, layer staged in S3 for the >50 MB cap).

_All adversarial-review findings (Phases 1–4) folded; threads replied._
