### PR TITLE
Capture per-shard max memory and color benchmark markers by % of cap

### DIFF
--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -51,6 +51,9 @@ RECORD_COLUMNS = [
     "memory_gb",
     "price_per_gb_sec",
     "zagg_version",
+    # Appended for issue #120 (stable schema -> new columns go last). Peak worker
+    # RSS in MB; null on rows recorded before the worker reported it.
+    "max_memory_mb",
 ]
 
 
@@ -86,6 +89,22 @@ def _runtime_s(summary: dict) -> float | None:
         if val is not None:
             return float(val)
     return None
+
+
+def memory_pct_of_cap(max_memory_mb, memory_gb) -> float | None:
+    """Fraction of the Lambda memory cap a shard peaked at (issue #120).
+
+    ``max_memory_mb / (memory_gb * 1024)`` -- 0.0 at idle, ~1.0 at the OOM wall.
+    None when either input is missing or the cap is non-positive, so callers
+    (chart colouring, comment table) degrade gracefully on legacy rows. Not
+    clamped: a value slightly over 1.0 is a real OOM signal worth surfacing.
+    """
+    if max_memory_mb is None or memory_gb is None:
+        return None
+    cap_mb = memory_gb * 1024.0
+    if cap_mb <= 0:
+        return None
+    return max_memory_mb / cap_mb
 
 
 def build_record(
@@ -130,6 +149,8 @@ def build_record(
         "memory_gb": LAMBDA_MEMORY_GB,
         "price_per_gb_sec": LAMBDA_PRICE_PER_GB_SEC,
         "zagg_version": zagg_version,
+        # Null-safe: absent on an empty/legacy summary -> None -> null parquet cell.
+        "max_memory_mb": summary.get("max_memory_mb"),
     }
     return record
 
@@ -161,18 +182,21 @@ def comment_markdown(records: list[dict], worker_note: str = "") -> str:
     if worker_note:
         lines += [f"> ⚠️ {worker_note}", ""]
     lines += [
-        "| target | obs | runtime (s) | cost/shard | cost/100 km² | % timeout |",
-        "| --- | ---: | ---: | ---: | ---: | ---: |",
+        "| target | obs | runtime (s) | cost/shard | cost/100 km² | % timeout | mem (MB) | % cap |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for r in records:
+        mem_pct = memory_pct_of_cap(r.get("max_memory_mb"), r.get("memory_gb"))
         lines.append(
-            "| {target} | {obs} | {rt} | ${cost} | ${c100} | {pct} |".format(
+            "| {target} | {obs} | {rt} | ${cost} | ${c100} | {pct} | {mem} | {mempct} |".format(
                 target=_fmt(r.get("target")),
                 obs=_fmt(r.get("total_obs"), ",d") if r.get("total_obs") is not None else "n/a",
                 rt=_fmt(r.get("runtime_s"), ".1f"),
                 cost=_fmt(r.get("cost_per_shard_usd"), ".5f"),
                 c100=_fmt(r.get("cost_per_100km2_usd"), ".5f"),
                 pct=_fmt(r.get("worker_pct_timeout"), ".0%"),
+                mem=_fmt(r.get("max_memory_mb"), ".0f"),
+                mempct=_fmt(mem_pct, ".0%"),
             )
         )
     lines += [

--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -95,11 +95,15 @@ def memory_pct_of_cap(max_memory_mb, memory_gb) -> float | None:
     """Fraction of the Lambda memory cap a shard peaked at (issue #120).
 
     ``max_memory_mb / (memory_gb * 1024)`` -- 0.0 at idle, ~1.0 at the OOM wall.
-    None when either input is missing or the cap is non-positive, so callers
-    (chart colouring, comment table) degrade gracefully on legacy rows. Not
-    clamped: a value slightly over 1.0 is a real OOM signal worth surfacing.
+    None when either input is missing (``None`` or the float ``NaN`` a legacy
+    parquet row degrades to) or the cap is non-positive, so callers (chart
+    colouring, comment table) degrade gracefully on legacy rows. Not clamped: a
+    value slightly over 1.0 is a real OOM signal worth surfacing.
     """
     if max_memory_mb is None or memory_gb is None:
+        return None
+    # A legacy parquet row reads back as NaN, not None, after the reindex.
+    if isinstance(max_memory_mb, float) and math.isnan(max_memory_mb):
         return None
     cap_mb = memory_gb * 1024.0
     if cap_mb <= 0:

--- a/.github/scripts/plot_series.py
+++ b/.github/scripts/plot_series.py
@@ -15,15 +15,41 @@ from __future__ import annotations
 
 import argparse
 import math
+import sys
 from pathlib import Path
 
 import pandas as pd
+
+# Allow ``import bench_metrics`` whether run as a script or imported by tests.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_metrics  # noqa: E402
 
 # Cost metric -> (column, human label) for the two retained-series figures.
 FIGURES = {
     "cost_per_shard": ("cost_per_shard_usd", "cost / shard (USD)"),
     "cost_per_100km2": ("cost_per_100km2_usd", "cost / 100 km² (USD)"),
 }
+
+# green->red colormap for memory headroom (issue #120): 0% of the cap reads
+# green, the OOM wall reads red. ``_r`` flips the stock green->red ramp.
+MEMORY_CMAP = "RdYlGn_r"
+
+
+def memory_fractions(sub: pd.DataFrame) -> list[float | None]:
+    """Per-row memory headroom as a fraction of the Lambda cap (issue #120).
+
+    ``max_memory_mb / (memory_gb * 1024)`` via the shared ``bench_metrics``
+    helper, so a row missing either column degrades to ``None`` (plotted as an
+    uncoloured marker) instead of crashing the render.
+    """
+    cols = sub.columns
+    return [
+        bench_metrics.memory_pct_of_cap(
+            row["max_memory_mb"] if "max_memory_mb" in cols else None,
+            row["memory_gb"] if "memory_gb" in cols else None,
+        )
+        for _, row in sub.iterrows()
+    ]
 
 
 def _merge_history(df: pd.DataFrame) -> pd.DataFrame:
@@ -41,6 +67,8 @@ def make_figure(df: pd.DataFrame, cost_col: str, cost_label: str, out_png: Path)
 
     matplotlib.use("Agg")  # headless CI
     import matplotlib.pyplot as plt
+    from matplotlib.cm import ScalarMappable
+    from matplotlib.colors import Normalize
 
     hist = _merge_history(df)
     if hist.empty:
@@ -54,17 +82,36 @@ def make_figure(df: pd.DataFrame, cost_col: str, cost_label: str, out_png: Path)
     nrows = math.ceil(n / ncols)
     fig, axes = plt.subplots(nrows, ncols, figsize=(7 * ncols, 3.2 * nrows), squeeze=False)
 
+    # Fixed [0, 1] normalisation so colour means the same fraction-of-cap in
+    # every panel and across both figures -- 1.0 (red) is the OOM wall.
+    norm = Normalize(vmin=0.0, vmax=1.0)
+
     for i, target in enumerate(targets):
         ax = axes[i // ncols][i % ncols]
         sub = hist[hist["target"] == target]
-        x = range(len(sub))
+        x = list(range(len(sub)))
         labels = [str(c)[:7] for c in sub["commit"]]
 
-        ax.plot(x, sub[cost_col], "o-", color="C0", label=cost_label)
+        # Connecting line stays cost-blue; the markers carry the memory signal
+        # (colour = % of the Lambda memory cap, green->red). Rows missing memory
+        # plot uncoloured (grey) rather than dropping out.
+        fracs = memory_fractions(sub)
+        ax.plot(x, sub[cost_col], "-", color="C0", zorder=1, label=cost_label)
+        ax.scatter(
+            x,
+            sub[cost_col],
+            c=[f if f is not None else float("nan") for f in fracs],
+            cmap=MEMORY_CMAP,
+            norm=norm,
+            edgecolors="C0",
+            linewidths=0.6,
+            zorder=2,
+            plotnonfinite=True,
+        )
         ax.set_ylabel(cost_label, color="C0")
         ax.tick_params(axis="y", labelcolor="C0")
         ax.set_title(target, fontsize=10)
-        ax.set_xticks(list(x))
+        ax.set_xticks(x)
         ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=7)
 
         rt = ax.twinx()
@@ -76,10 +123,14 @@ def make_figure(df: pd.DataFrame, cost_col: str, cost_label: str, out_png: Path)
     for j in range(n, nrows * ncols):
         axes[j // ncols][j % ncols].axis("off")
 
+    # One shared colorbar for the memory scale (issue #120).
+    sm = ScalarMappable(norm=norm, cmap=MEMORY_CMAP)
+    cbar = fig.colorbar(sm, ax=axes.ravel().tolist(), fraction=0.025, pad=0.02)
+    cbar.set_label("peak memory (% of cap)")
+
     fig.suptitle(f"zagg Lambda benchmark — {cost_label} vs merge history")
-    fig.tight_layout(rect=(0, 0, 1, 0.97))
     out_png.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_png, dpi=120)
+    fig.savefig(out_png, dpi=120, bbox_inches="tight")
     plt.close(fig)
     return True
 

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -189,7 +189,8 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"[{name}] obs={record['total_obs']} runtime_s={record['runtime_s']} "
             f"cost/shard=${record['cost_per_shard_usd']} "
-            f"cost/100km2=${record['cost_per_100km2_usd']}"
+            f"cost/100km2=${record['cost_per_100km2_usd']} "
+            f"max_memory_mb={record['max_memory_mb']}"
         )
 
     Path(args.out_json).write_text(json.dumps(records, indent=2))

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -53,6 +53,7 @@ full pipeline using only lambda:InvokeFunction.
 import json
 import logging
 import os
+import resource
 import time
 from typing import Any, Dict
 
@@ -69,6 +70,17 @@ from zagg.store import open_store
 # Set up structured logging
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+
+def _max_memory_mb() -> float:
+    """Peak resident set size of this worker in MB (issue #120).
+
+    ``ru_maxrss`` is a high-water mark over the whole process, so reading it at
+    the end of the invocation captures read+index+aggregate+write. On Linux
+    (the Lambda runtime) the field is in kibibytes; tracks CloudWatch's "Max
+    Memory Used" closely.
+    """
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
 
 
 def _output_store_kwargs(event: Dict[str, Any]) -> Dict[str, Any]:
@@ -333,6 +345,11 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 logger.error(f"Failed to write zarr to {store_path}: {e}")
                 metadata["error"] = f"Failed to write zarr: {e}"
 
+        # Peak worker RSS (issue #120): captured here, after the write phase, so
+        # it covers the full invocation. Threaded back via the result body so the
+        # orchestrator can surface OOM-proximity without CloudWatch access.
+        metadata["max_memory_mb"] = _max_memory_mb()
+
         # Log structured result
         logger.info(
             json.dumps(
@@ -342,6 +359,7 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                     "cells_with_data": metadata["cells_with_data"],
                     "total_obs": metadata["total_obs"],
                     "duration_s": metadata["duration_s"],
+                    "max_memory_mb": metadata["max_memory_mb"],
                     "error": metadata.get("error"),
                     "request_id": context.aws_request_id,
                 }

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -772,6 +772,17 @@ def _run_lambda(
     else:
         worker_max_s = worker_median_s = worker_pstdev_s = worker_pct_timeout = None
 
+    # Peak worker memory (issue #120). The Lambda handler stamps body[
+    # "max_memory_mb"] (RSS high-water mark, KB->MB) on every successful
+    # invocation; roll the straggler (max) across cells, matching the wall-time
+    # framing. None when no worker reported it (e.g. local backend).
+    worker_memory = [
+        r["body"]["max_memory_mb"]
+        for r in report.results
+        if (r.get("body") or {}).get("max_memory_mb") is not None
+    ]
+    max_memory_mb = max(worker_memory) if worker_memory else None
+
     # Per-phase worker breakdown (issue #100 phase 2), only when --profile fed
     # the workers a "profile" event so they emitted body["phase_timings"]. Roll
     # the straggler (max) per phase across cells, matching the wall-time framing.
@@ -801,6 +812,7 @@ def _run_lambda(
         "worker_median_s": worker_median_s,
         "worker_pstdev_s": worker_pstdev_s,
         "worker_pct_timeout": worker_pct_timeout,
+        "max_memory_mb": max_memory_mb,
         "store_path": store_path,
         "backend": "lambda",
         "function_name": function_name,
@@ -819,6 +831,12 @@ def _run_lambda(
         logger.info(
             f"Workers: max {worker_max_s:.0f}s ({pct} of {function_timeout_s:.0f}s timeout), "
             f"median {worker_median_s:.0f}s, pstdev {worker_pstdev_s:.0f}s"
+        )
+    if max_memory_mb is not None:
+        cap_mb = memory_gb * 1024.0
+        logger.info(
+            f"Worker peak memory: {max_memory_mb:.0f} MB ({max_memory_mb / cap_mb:.0%} of "
+            f"{cap_mb:.0f} MB cap)"
         )
     if profile and worker_phase_max:
         breakdown = ", ".join(f"{phase} {secs:.0f}s" for phase, secs in worker_phase_max.items())

--- a/src/zagg/schema.py
+++ b/src/zagg/schema.py
@@ -4,19 +4,20 @@ The actual implementation lives on ``zagg.grids.HealpixGrid``. These functions
 preserve the pre-refactor public API: pass ``n_parent_cells`` for dense pack,
 omit it for full sphere.
 """
+
 from __future__ import annotations
 
 import warnings
 
 from pydantic_zarr.experimental.v3 import GroupSpec
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 from zarr.abc.store import Store
 
 from zagg.config import PipelineConfig
 from zagg.grids.healpix import HEALPIX_BASE_CELLS, HealpixGrid
 
 
-class ProcessingMetadata(TypedDict, total=False):
+class ProcessingMetadata(TypedDict):
     shard_key: int
     cells_with_data: int
     total_obs: int
@@ -26,11 +27,11 @@ class ProcessingMetadata(TypedDict, total=False):
     error: str | None
     # Peak resident memory (RSS) of the worker process in MB. Stamped by the
     # Lambda handler from ``resource.getrusage`` after the write phase (issue
-    # #120); absent on the local runner path, hence ``total=False``.
-    max_memory_mb: float
+    # #120); absent on the local runner path, hence ``NotRequired``.
+    max_memory_mb: NotRequired[float]
     # Per-phase wall timings (read/index/aggregate/write), present only when the
     # worker is dispatched with ``profile=True`` (issue #100).
-    phase_timings: dict[str, float]
+    phase_timings: NotRequired[dict[str, float]]
 
 
 def xdggs_spec(

--- a/src/zagg/schema.py
+++ b/src/zagg/schema.py
@@ -16,7 +16,7 @@ from zagg.config import PipelineConfig
 from zagg.grids.healpix import HEALPIX_BASE_CELLS, HealpixGrid
 
 
-class ProcessingMetadata(TypedDict):
+class ProcessingMetadata(TypedDict, total=False):
     shard_key: int
     cells_with_data: int
     total_obs: int
@@ -24,6 +24,13 @@ class ProcessingMetadata(TypedDict):
     files_processed: int
     duration_s: float
     error: str | None
+    # Peak resident memory (RSS) of the worker process in MB. Stamped by the
+    # Lambda handler from ``resource.getrusage`` after the write phase (issue
+    # #120); absent on the local runner path, hence ``total=False``.
+    max_memory_mb: float
+    # Per-phase wall timings (read/index/aggregate/write), present only when the
+    # worker is dispatched with ``profile=True`` (issue #100).
+    phase_timings: dict[str, float]
 
 
 def xdggs_spec(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -358,3 +358,39 @@ def test_make_figure_returns_false_when_no_targets(tmp_path):
     rows = [_rec_row("c1", None, event="merge")]
     df = update_series.records_to_frame(rows)
     assert plot_series.make_figure(df, "cost_per_shard_usd", "cost", tmp_path / "x.png") is False
+
+
+# --- marker memory colouring (issue #120) ---------------------------------
+
+
+def test_memory_fractions_maps_each_row():
+    import plot_series
+
+    # 1024 MB / 2048 -> 0.5; 1963 MB / 2048 -> ~0.96 (the OOM-adjacent figure).
+    sub = update_series.records_to_frame(
+        [_rec_row("c1", "t1", mem=1024.0), _rec_row("c2", "t1", mem=1963.0)]
+    )
+    fracs = plot_series.memory_fractions(sub)
+    assert fracs[0] == pytest.approx(0.5)
+    assert fracs[1] == pytest.approx(0.9585, abs=1e-3)  # near the red end of the scale
+
+
+def test_memory_fractions_none_when_memory_missing():
+    import plot_series
+
+    sub = update_series.records_to_frame([_rec_row("c1", "t1")])
+    sub = sub.assign(max_memory_mb=None)  # legacy row: no memory recorded
+    assert plot_series.memory_fractions(sub) == [None]
+
+
+def test_make_figure_colours_markers_by_memory(tmp_path):
+    pytest.importorskip("matplotlib")
+    import plot_series
+
+    # Two points with distinct memory -> the scatter carries the fraction array,
+    # and a memory colorbar is attached to the figure.
+    rows = [_rec_row("c0", "t1", mem=512.0), _rec_row("c1", "t1", mem=1963.0)]
+    df = update_series.records_to_frame(rows)
+    out = tmp_path / "fig.png"
+    assert plot_series.make_figure(df, "cost_per_shard_usd", "cost", out) is True
+    assert out.exists()

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -132,6 +132,8 @@ def test_memory_pct_of_cap_null_safe():
     assert bench_metrics.memory_pct_of_cap(None, 2.0) is None
     assert bench_metrics.memory_pct_of_cap(1000.0, None) is None
     assert bench_metrics.memory_pct_of_cap(1000.0, 0.0) is None
+    # A legacy parquet row degrades to NaN (not None) -> still treated as missing.
+    assert bench_metrics.memory_pct_of_cap(float("nan"), 2.0) is None
 
 
 def test_build_record_runtime_fallback():
@@ -383,14 +385,63 @@ def test_memory_fractions_none_when_memory_missing():
     assert plot_series.memory_fractions(sub) == [None]
 
 
-def test_make_figure_colours_markers_by_memory(tmp_path):
+def test_make_figure_colours_markers_by_memory(tmp_path, monkeypatch):
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import plot_series
+    from matplotlib.collections import PathCollection
+
+    # Stop make_figure from closing the figure so we can introspect the artists.
+    captured = {}
+    real_close = plt.close
+
+    def _capture_close(fig):
+        captured["fig"] = fig  # grab the figure on its way out
+
+    monkeypatch.setattr(plt, "close", _capture_close)
+
+    # Round-trip through parquet so the (commit, target) points land in order and
+    # carry real memory; 512/2048 -> 0.25, 1963/2048 -> ~0.96 (near the red end).
+    rows = [_rec_row("c0", "t1", mem=512.0), _rec_row("c1", "t1", mem=1963.0)]
+    series = tmp_path / "series.parquet"
+    update_series.save_series(update_series.records_to_frame(rows), series)
+    df = update_series.load_series(series)
+
+    out = tmp_path / "fig.png"
+    assert plot_series.make_figure(df, "cost_per_shard_usd", "cost", out) is True
+    assert out.exists()
+    fig = captured["fig"]
+
+    # The cost markers are a scatter whose colour array IS the memory fraction.
+    scatters = [c for ax in fig.axes for c in ax.collections if isinstance(c, PathCollection)]
+    arrays = [s.get_array() for s in scatters if s.get_array() is not None]
+    assert any(
+        len(a) == 2 and a[0] == pytest.approx(0.25) and a[1] == pytest.approx(0.9585, abs=1e-3)
+        for a in arrays
+    )
+    # A colorbar (its own axes) is attached for the memory scale.
+    assert len(fig.axes) > 1
+    real_close(fig)
+
+
+def test_make_figure_null_memory_renders_uncoloured(tmp_path):
     pytest.importorskip("matplotlib")
     import plot_series
 
-    # Two points with distinct memory -> the scatter carries the fraction array,
-    # and a memory colorbar is attached to the figure.
-    rows = [_rec_row("c0", "t1", mem=512.0), _rec_row("c1", "t1", mem=1963.0)]
+    # A legacy row reads back as NaN memory -> uncoloured marker, no crash.
+    rows = [_rec_row("c0", "t1", mem=900.0), _rec_row("c1", "t1")]
+    series = tmp_path / "series.parquet"
     df = update_series.records_to_frame(rows)
+    df = df.assign(max_memory_mb=[900.0, None])
+    update_series.save_series(df, series)
     out = tmp_path / "fig.png"
-    assert plot_series.make_figure(df, "cost_per_shard_usd", "cost", out) is True
+    assert (
+        plot_series.make_figure(
+            update_series.load_series(series), "cost_per_shard_usd", "cost", out
+        )
+        is True
+    )
     assert out.exists()

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -84,6 +84,7 @@ def _summary():
         "estimated_cost_usd": 0.00547,
         "function_timeout_s": 720,
         "worker_pct_timeout": 0.285,
+        "max_memory_mb": 1963.0,
     }
 
 
@@ -109,7 +110,28 @@ def test_build_record_cost_per_100km2():
     assert rec["runtime_s"] == 205.0  # worker_max_s preferred
     assert rec["n_granules"] == 44
     assert rec["zagg_version"] == "9.9.9"
+    assert rec["max_memory_mb"] == 1963.0  # threaded from the summary (issue #120)
     assert set(rec) == set(bench_metrics.RECORD_COLUMNS)
+
+
+def test_build_record_max_memory_null_safe():
+    # An empty/legacy summary leaves max_memory_mb null so old rows degrade.
+    g = HealpixGrid(parent_order=11, child_order=19)
+    rec = bench_metrics.build_record({}, grid=g, context={"target": "t"})
+    assert rec["max_memory_mb"] is None
+    assert "max_memory_mb" in bench_metrics.RECORD_COLUMNS
+
+
+def test_memory_pct_of_cap_maps_near_red():
+    # 1963 MB on a 2 GB cap -> ~0.96 (the OOM-adjacent run #1 figure, issue #120).
+    pct = bench_metrics.memory_pct_of_cap(1963.0, 2.0)
+    assert pct == pytest.approx(0.9585, abs=1e-3)
+
+
+def test_memory_pct_of_cap_null_safe():
+    assert bench_metrics.memory_pct_of_cap(None, 2.0) is None
+    assert bench_metrics.memory_pct_of_cap(1000.0, None) is None
+    assert bench_metrics.memory_pct_of_cap(1000.0, 0.0) is None
 
 
 def test_build_record_runtime_fallback():
@@ -224,7 +246,7 @@ def test_targets_manifest_consistent():
 # --- update_series (parquet store) ----------------------------------------
 
 
-def _rec_row(commit, target, event="merge", cost=0.005, rt=200.0):
+def _rec_row(commit, target, event="merge", cost=0.005, rt=200.0, mem=1200.0):
     return {
         "timestamp": f"2026-01-01T00:00:0{len(commit) % 10}Z",
         "commit": commit,
@@ -248,6 +270,7 @@ def _rec_row(commit, target, event="merge", cost=0.005, rt=200.0):
         "memory_gb": 2.0,
         "price_per_gb_sec": 1.33334e-05,
         "zagg_version": "9.9.9",
+        "max_memory_mb": mem,
     }
 
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -132,6 +132,17 @@ class TestProcessEventDispatch:
         assert resp["statusCode"] == 200
         assert captured["shard_key"] == 12345
 
+    def test_body_reports_max_memory_mb(self, handler_mod, monkeypatch):
+        """Issue #120: every successful invocation stamps a positive
+        ``max_memory_mb`` (the worker's peak RSS) into the result body so the
+        orchestrator can roll up OOM-proximity without CloudWatch access."""
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        resp, _ = self._run(handler_mod, monkeypatch, event)
+        body = json.loads(resp["body"])
+        assert isinstance(body["max_memory_mb"], float)
+        assert body["max_memory_mb"] > 0.0
+
 
 class TestProcessEventWriteLoop:
     """Issue #82 phase 7: the handler drives ``process_shard`` with a

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -448,6 +448,7 @@ class TestSummaryKeysByteIdentical:
         "estimated_cost_usd", "store_path", "backend", "function_name",
         "results", "setup_s", "fanout_s", "finalize_s", "function_timeout_s",
         "worker_max_s", "worker_median_s", "worker_pstdev_s", "worker_pct_timeout",
+        "max_memory_mb",
     }
 
     def test_local_summary_keys_and_counts(self, monkeypatch, atl06_config):
@@ -581,7 +582,14 @@ class TestSummaryKeysByteIdentical:
 
 
 def _run_lambda_with_durations(
-    monkeypatch, atl06_config, durations, *, timeout=720, profile=False, phase_timings=None
+    monkeypatch,
+    atl06_config,
+    durations,
+    *,
+    timeout=720,
+    profile=False,
+    phase_timings=None,
+    memories=None,
 ):
     """Drive ``_run_lambda`` over synthetic per-cell durations.
 
@@ -589,6 +597,8 @@ def _run_lambda_with_durations(
     _run_catalog() has 4 cells); ``timeout`` stubs the function Timeout read.
     ``profile``/``phase_timings`` exercise the phase-2 opt-in path: when
     ``phase_timings`` is set it is attached to each cell result body.
+    ``memories`` (issue #120), when given, is consumed one per cell and attached
+    as ``body["max_memory_mb"]`` so the peak-memory rollup can be pinned.
     """
     import boto3
 
@@ -614,11 +624,14 @@ def _run_lambda_with_durations(
         ),
     )
     it = iter(durations)
+    mem_it = iter(memories) if memories is not None else None
 
     def _fake_cell(*a, **k):
         body = {"total_obs": 1}
         if phase_timings is not None:
             body["phase_timings"] = phase_timings
+        if mem_it is not None:
+            body["max_memory_mb"] = next(mem_it)
         return {"status_code": 200, "body": body, "error": None,
                 "lambda_duration": next(it), "shard_key": 0}
 
@@ -674,6 +687,27 @@ class TestWorkerRuntimeStats:
         for key in ("setup_s", "fanout_s", "finalize_s"):
             assert key in summary
             assert summary[key] >= 0.0
+
+
+class TestWorkerMemory:
+    """Issue #120: the lambda summary rolls up the straggler's peak RSS from the
+    per-cell ``body['max_memory_mb']`` the worker stamps."""
+
+    def test_max_memory_is_straggler_across_cells(self, monkeypatch, atl06_config):
+        summary = _run_lambda_with_durations(
+            monkeypatch,
+            atl06_config,
+            [1.0, 2.0, 3.0, 4.0],
+            memories=[800.0, 1963.0, 1200.0, 900.0],
+        )
+        assert summary["max_memory_mb"] == 1963.0  # max, mirroring the wall-time framing
+
+    def test_max_memory_none_when_unreported(self, monkeypatch, atl06_config):
+        # No worker stamped memory (e.g. an older deployed layer) -> null, not 0.
+        summary = _run_lambda_with_durations(
+            monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0]
+        )
+        assert summary["max_memory_mb"] is None
 
 
 class TestGetFunctionTimeout:


### PR DESCRIPTION
Closes #120

## What & approach

The benchmark recorded runtime/cost but not memory, yet memory was the decisive story on run #1 (`gain_bias` pegging 2046/2048 MB → OOM, `tdigest_o10` at ~96%) — visible only in CloudWatch. This makes peak per-shard memory a first-class metric end to end.

Following the issue's **primary** ask (worker-side `ru_maxrss`, not the cross-account `LogType="Tail"` alternative — the orchestrator deliberately omits Tail because cross-account callers lack CloudWatch access, see the comment in `_invoke_lambda_cell`):

- **Worker captures peak RSS.** `lambda_handler._handle_process` reads `resource.getrusage(RUSAGE_SELF).ru_maxrss` (KB→MB) *after* the write phase, so it covers read+index+aggregate+write, and stamps `metadata["max_memory_mb"]`. `ProcessingMetadata` gains the key (TypedDict made `total=False` since it's absent on the local-runner path; `phase_timings` is also now declared there rather than assigned off-schema).
- **Threaded back through the summary.** The worker stamps it on the result body; `runner.agg` rolls up the straggler (max) across cells into `summary["max_memory_mb"]` (mirrors the wall-time framing) and logs a `Worker peak memory: N MB (P% of cap)` line. `None` when no worker reported it (older layer / local backend).
- **Into the series.** `bench_metrics.build_record` reads `summary["max_memory_mb"]` (null-safe) and `RECORD_COLUMNS` gains a trailing `max_memory_mb` column, so existing parquet rows null-degrade via the `reindex` in `update_series.records_to_frame`. The PR-comment table gains `mem (MB)` and `% cap` columns.
- **On the charts (marker color).** `plot_series.make_figure` overlays the cost markers as a `scatter` colored by `% of the memory cap` on a green→red (`RdYlGn_r`) scale with a fixed `[0,1]` norm and a shared colorbar; runtime stays on the right axis, cost on the left. A red marker with `obs=0` then reads instantly as "OOM'd." A shared `memory_pct_of_cap(max_memory_mb, memory_gb)` helper in `bench_metrics` does the normalization (used by both the table and the chart).

## Phases

- [x] **Phase 1** — worker `ru_maxrss` capture (`lambda_handler.py`), `ProcessingMetadata` key (`schema.py`), summary rollup + log line (`runner.py`); handler + runner tests.
- [x] **Phase 2** — `max_memory_mb` column in `bench_metrics.RECORD_COLUMNS` + `build_record` (null-safe), `memory_pct_of_cap` helper, comment-table columns, `run_benchmark` print; tests.
- [x] **Phase 3** — green→red marker coloring + colorbar in `plot_series`, `memory_fractions` helper; tests.

## How tested

`uv run pytest -q` green (full suite). Targeted:
- `tests/test_lambda_handler.py::TestProcessEventDispatch::test_body_reports_max_memory_mb` — every successful invocation stamps a positive `max_memory_mb` in the body.
- `tests/test_runner.py::TestWorkerMemory` — the summary rolls up the straggler peak (`1963.0` over `[800, 1963, 1200, 900]`) and null-degrades when unreported; `TestSummaryKeysByteIdentical` pins the new key.
- `tests/test_benchmark.py` — `build_record` threads/null-degrades the column; `memory_pct_of_cap(1963, 2) ≈ 0.96` (the OOM-adjacent run #1 figure → red end); `memory_fractions` maps each row; `make_figure` colors markers + writes the figure.

`uv run ruff check --select=E,F,W,I --ignore=E501 src tests` clean.

## Questions for review

- **`ru_maxrss` units.** Linux reports `ru_maxrss` in **KiB** (Lambda is Linux), so I divide by 1024. The issue notes this tracks CloudWatch's "Max Memory Used" closely but isn't byte-identical; flagging in case you want the authoritative REPORT-line number instead (that would need `LogType="Tail"` threaded through `_run_lambda`, which only works same-account — happy to add it behind a benchmark-only flag if you prefer).
- **Pre-existing `ruff format` drift (not touched).** `ruff format --check` flags `src/zagg/schema.py` and `tests/test_runner.py` (plus a few others) **on `origin/main` already** — manual multi-line formatting the lint bot's `ruff check` doesn't enforce. Per the "don't fix unrelated CI failures" rule I left these alone; my own added lines are format-clean. Say the word if you'd like a separate format-only pass.
- **Marker color when memory is missing.** Legacy rows (no `max_memory_mb`) plot as an uncolored (grey, `plotnonfinite`) marker rather than dropping out. Reasonable?


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfLQpJ8qTPh64VDT2nxpNS)_