### PR TITLE
Don't retry deterministic Lambda failures (OOM); expose max_retries

### DIFF
--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -102,6 +102,9 @@ def run_target(
             function_name=function_name,
             overwrite=True,
             profile=True,
+            # A benchmark measures one clean invocation and records a failure as
+            # a failure -- never re-invoke (and never pay) to re-fail (#119).
+            max_retries=1,
         )
 
     return bench_metrics.build_record(

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1092,6 +1092,9 @@ def _invoke_lambda_cell(
                     is_timeout = True
                     last_error = f"Lambda timeout: {error_payload[:100]}"
                 elif "Runtime.OutOfMemory" in error_payload:
+                    # ``Runtime.OutOfMemory`` is AWS's documented errorType for an
+                    # OOM-killed invocation; if AWS reworded it the tag would just
+                    # fall to the generic branch below (still no retry).
                     last_error = f"Lambda OOM: {error_payload[:100]}"
                 else:
                     last_error = f"Lambda error ({function_error}): {error_payload[:100]}"

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1068,14 +1068,22 @@ def _invoke_lambda_cell(
             function_error = response.get("FunctionError")
             is_timeout = False
             if function_error:
+                # Every ``FunctionError`` on a synchronous invoke is deterministic
+                # for a given shard -- a timeout, ``Runtime.OutOfMemory``, or an
+                # exception that escaped the handler -- so none are retried: they
+                # all return immediately, exactly as timeouts already did (#119).
+                # (Transient throttle/network faults are a separate channel,
+                # retried with backoff in the ``except`` block below.) The error
+                # is tagged with its real mode so a benchmark records an OOM as an
+                # OOM rather than masking it behind a later retry's outcome.
                 error_payload = response["Payload"].read().decode("utf-8")
                 if "Task timed out" in error_payload:
                     is_timeout = True
                     last_error = f"Lambda timeout: {error_payload[:100]}"
+                elif "Runtime.OutOfMemory" in error_payload:
+                    last_error = f"Lambda OOM: {error_payload[:100]}"
                 else:
                     last_error = f"Lambda error ({function_error}): {error_payload[:100]}"
-                if not is_timeout:
-                    continue
 
             result = json.loads(response["Payload"].read()) if not function_error else {}
             try:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -88,6 +88,7 @@ def agg(
     output_endpoint_url: str | None = None,
     handoff: str = "pandas",
     profile: bool = False,
+    max_retries: int = 3,
 ) -> dict:
     """Run the aggregation pipeline.
 
@@ -141,6 +142,13 @@ def agg(
         ``phase_timings`` (read/index/aggregate) sub-dict, and the run prints a
         per-phase worker breakdown. Default ``False`` leaves the worker path and
         per-cell event payload byte-identical -- no probe tax.
+    max_retries : int
+        Lambda-only (issue #119). Per-cell retry budget for *transient*
+        client-side faults (throttle/network) in ``_invoke_lambda_cell``;
+        deterministic Lambda ``FunctionError``s (timeout, OOM, unhandled
+        exception) are never retried regardless. Default ``3``. Ignored by the
+        ``"local"`` backend. Set to ``1`` (e.g. the CI benchmark) to measure one
+        clean invocation and record a failure as a failure.
 
     Returns
     -------
@@ -223,6 +231,7 @@ def agg(
             output_credentials=output_credentials,
             output_endpoint_url=resolved_endpoint,
             profile=profile,
+            max_retries=max_retries,
         )
     else:
         raise ValueError(f"Unknown backend: {backend!r} (expected 'local' or 'lambda')")
@@ -548,6 +557,7 @@ def _run_lambda(
     output_credentials=None,
     output_endpoint_url=None,
     profile=False,
+    max_retries=3,
 ):
     """Run processing via AWS Lambda invocation.
 
@@ -663,6 +673,7 @@ def _run_lambda(
             function_name=function_name,
             config_dict=config_dict,
             output_creds_event=output_creds_event,
+            max_retries=max_retries,
             max_workers=state["workers"],
             profile=profile,
         )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -467,6 +467,56 @@ class TestInvokeLambdaCellRetry:
         assert result["error"] == "AccessDeniedException"
 
 
+class TestMaxRetriesPassthrough:
+    """`agg(max_retries=...)` threads the per-cell retry budget down to
+    ``_invoke_lambda_cell`` on the lambda backend (#119), default 3."""
+
+    def _drive(self, monkeypatch, atl06_config, catalog_file, **agg_kwargs):
+        import boto3
+
+        import zagg.grids as grids_mod
+        from zagg import runner
+        from zagg.concurrency import ConcurrencyReport
+
+        captured = {}
+
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials",
+                            lambda: {"accessKeyId": "a", "secretAccessKey": "s",
+                                     "sessionToken": "t"})
+        monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
+        monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        from unittest.mock import MagicMock
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(
+            runner, "compute_available_workers",
+            lambda requested, *a, **k: (
+                1,
+                ConcurrencyReport(account_limit=1000, current_concurrent=0,
+                                  padding=100, available=900, function_reserved=None),
+            ),
+        )
+
+        def _fake_cell(*a, **k):
+            captured["max_retries"] = k.get("max_retries")
+            return {"status_code": 200, "body": {"total_obs": 1}, "error": None,
+                    "lambda_duration": 1.0, "shard_key": 0}
+
+        monkeypatch.setattr(runner, "_invoke_lambda_cell", _fake_cell)
+        agg(atl06_config, catalog=catalog_file, store="s3://out/x.zarr",
+            backend="lambda", **agg_kwargs)
+        return captured
+
+    def test_max_retries_threaded_end_to_end(self, monkeypatch, atl06_config, catalog_file):
+        captured = self._drive(monkeypatch, atl06_config, catalog_file, max_retries=1)
+        assert captured["max_retries"] == 1
+
+    def test_default_max_retries_is_three(self, monkeypatch, atl06_config, catalog_file):
+        captured = self._drive(monkeypatch, atl06_config, catalog_file)
+        assert captured["max_retries"] == 3
+
+
 class TestHandoffPassthrough:
     """`agg(handoff=...)` threads the carrier choice down to process_shard."""
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -372,6 +372,101 @@ class TestInvokeLambdaCellEvent:
         assert "profile" not in event
 
 
+class TestInvokeLambdaCellRetry:
+    """Retry policy (#119): deterministic ``FunctionError``s (OOM / runtime
+    crash) return immediately -- they are never re-invoked -- while transient
+    client-side faults (throttle/network) still retry with backoff.
+    """
+
+    _CREDS = {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"}
+
+    def _invoke(self, client, *, max_retries=3):
+        from zagg.runner import _invoke_lambda_cell
+
+        return _invoke_lambda_cell(
+            client, (0,), 12345, 6, 12,
+            ["s3://b/g.h5"], "s3://out/x.zarr", self._CREDS,
+            function_name="process-shard", config_dict=None, max_workers=4,
+            max_retries=max_retries,
+        )
+
+    def _function_error_response(self, error_payload):
+        from unittest.mock import MagicMock
+
+        payload = MagicMock()
+        payload.read.return_value = error_payload.encode()
+        return {"Payload": payload, "FunctionError": "Unhandled"}
+
+    def test_oom_function_error_not_retried(self):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        client.invoke.return_value = self._function_error_response(
+            '{"errorType": "Runtime.OutOfMemory"}'
+        )
+        result = self._invoke(client)
+        # A deterministic FunctionError is invoked exactly once, regardless of
+        # max_retries, and the recorded error reflects the OOM (not masked).
+        assert client.invoke.call_count == 1
+        assert result["retries"] == 0
+        assert result["error"].startswith("Lambda OOM:")
+        assert result["status_code"] is None
+
+    def test_generic_function_error_not_retried(self):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        client.invoke.return_value = self._function_error_response(
+            '{"errorType": "RuntimeError", "errorMessage": "boom"}'
+        )
+        result = self._invoke(client)
+        assert client.invoke.call_count == 1
+        assert result["retries"] == 0
+        assert result["error"].startswith("Lambda error (Unhandled):")
+
+    def test_transient_client_error_retried_with_backoff(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        import zagg.runner as runner
+
+        sleeps = []
+        monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
+
+        ok_payload = MagicMock()
+        ok_payload.read.return_value = json.dumps(
+            {"statusCode": 200, "body": json.dumps({"total_obs": 7, "duration_s": 1.0})}
+        ).encode()
+        ok = {"Payload": ok_payload, "FunctionError": None}
+
+        client = MagicMock()
+        client.invoke.side_effect = [
+            Exception("TooManyRequestsException: Rate exceeded"),
+            ok,
+        ]
+        result = self._invoke(client)
+        # Transient fault retried: invoked twice, slept once with backoff.
+        assert client.invoke.call_count == 2
+        assert len(sleeps) == 1
+        assert result["status_code"] == 200
+        assert result["retries"] == 1
+
+    def test_non_retryable_client_error_breaks(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        import zagg.runner as runner
+
+        sleeps = []
+        monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
+
+        client = MagicMock()
+        client.invoke.side_effect = Exception("AccessDeniedException")
+        result = self._invoke(client)
+        # A non-transient client error is not retried (break), no backoff sleep.
+        assert client.invoke.call_count == 1
+        assert sleeps == []
+        assert result["error"] == "AccessDeniedException"
+
+
 class TestHandoffPassthrough:
     """`agg(handoff=...)` threads the carrier choice down to process_shard."""
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -404,13 +404,30 @@ class TestInvokeLambdaCellRetry:
         client.invoke.return_value = self._function_error_response(
             '{"errorType": "Runtime.OutOfMemory"}'
         )
-        result = self._invoke(client)
+        # max_retries=5 proves the deterministic return is invariant to the
+        # budget -- a FunctionError no longer consumes attempts at all (#119).
+        result = self._invoke(client, max_retries=5)
         # A deterministic FunctionError is invoked exactly once, regardless of
         # max_retries, and the recorded error reflects the OOM (not masked).
         assert client.invoke.call_count == 1
         assert result["retries"] == 0
         assert result["error"].startswith("Lambda OOM:")
         assert result["status_code"] is None
+
+    def test_timeout_function_error_not_retried(self):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        client.invoke.return_value = self._function_error_response(
+            "Task timed out after 720.00 seconds"
+        )
+        # Timeouts already returned immediately pre-#119; pin that the shared
+        # simplified branch keeps that behavior (single invoke, timeout=True).
+        result = self._invoke(client, max_retries=5)
+        assert client.invoke.call_count == 1
+        assert result["retries"] == 0
+        assert result["timeout"] is True
+        assert result["error"].startswith("Lambda timeout:")
 
     def test_generic_function_error_not_retried(self):
         from unittest.mock import MagicMock


### PR DESCRIPTION
Closes #119

## What this does

`_invoke_lambda_cell` (`src/zagg/runner.py`) retried up to `max_retries` (default 3) on **any** non-timeout `FunctionError`. But every `FunctionError` on a synchronous `RequestResponse` invoke is **deterministic** for a given shard (a timeout, `Runtime.OutOfMemory`, or an exception that escaped the handler), so retrying an OOM just pays the compute again on a shard that can never succeed — and the retry's different outcome (e.g. `No data after filtering`) **masks** the real failure in the recorded result.

This PR:

1. **Stops retrying deterministic `FunctionError`s.** Removed the `if not is_timeout: continue` so any `FunctionError` returns immediately, exactly as timeouts already did. Transient throttle/network faults are a separate channel — they raise client-side exceptions caught in the `except` block and are still retried with backoff against the `retryable` list (`TooManyRequestsException`, `Rate exceeded`, `Read timeout`, …) — that block is **untouched**.
2. **Tags the failure mode.** Adds a `Runtime.OutOfMemory` → `Lambda OOM: …` tag so the recorded `error` reflects the OOM rather than a later retry's outcome.
3. **Threads `max_retries` through the API.** `agg(max_retries=3)` → `_run_lambda(..., max_retries=3)` → `_cell_work` closure → `_invoke_lambda_cell(..., max_retries=...)`. Lambda-only; the `local` backend ignores it. Default stays `3` (transient faults still want a bounded retry), so normal runs are unchanged.
4. **Benchmark passes `max_retries=1`** (`.github/scripts/run_benchmark.py` → `run_target` → `agg(...)`) so it measures one clean invocation and records a failure as a failure. This script is a benchmark *runner*, not a workflow under `.github/workflows/`, and is named in the issue's asks.

Approach note: with (1), `FunctionError`s no longer consume retry attempts regardless of `max_retries`, so the default `3` only ever affects transient client-side faults.

## Phases

- [x] Phase 1 — stop retrying `FunctionError`s + tag OOM in `_invoke_lambda_cell`; tests pin no-retry / OOM tag / timeout-not-retried / transient-retry / non-retryable-break.
- [x] Phase 2 — thread `max_retries` through `agg()` → `_run_lambda()` → `_invoke_lambda_cell()` (default 3); end-to-end passthrough tests.
- [x] Phase 3 — benchmark runner passes `max_retries=1`.

## How tested

`pytest tests/test_runner.py tests/test_benchmark.py` green; full local suite green (901 passed / 10 skipped). New tests:

- `TestInvokeLambdaCellRetry` — deterministic OOM `FunctionError` → `invoke.call_count == 1` (with `max_retries=5`, proving invariance to the budget), `error` starts `Lambda OOM:`, `retries == 0`; generic `FunctionError` → one invoke; timeout `FunctionError` → one invoke, `timeout=True`; transient client error (`TooManyRequestsException`) → retried with backoff (`call_count == 2`, one `time.sleep`); non-retryable client error → no retry, no sleep.
- `TestMaxRetriesPassthrough` — `agg(..., backend="lambda", max_retries=1)` reaches `_invoke_lambda_cell` with `max_retries=1`; default is `3`.

`ruff check --select=E,F,W,I --ignore=E501` clean on all touched files.

## Questions for review

- `tests/test_runner.py` is authored in a tight manual layout that is not `ruff format`-clean **independent of this change** (the format diff touches only pre-existing lines). New code matches the surrounding compact style and passes `ruff check` (E,F,W,I), which is what the PR lint bot runs. Left the file's existing formatting untouched to avoid reformatting unrelated lines — flag if you'd prefer a separate format pass.
- The run-level retry budget noted under the issue's "Related" is explicitly out of scope; the per-cell `dispatch`/`LAMBDA_RETRY` path in `dispatch.py` is untouched.
- `src/zagg/runner.py` is now ~1144 lines (was ~1125 on `main`; this PR adds ~14 net source lines), past the ~1000-line soft limit. Splitting the module is out of scope here and warrants its own discussion — flagging, not acting.