### PR TITLE
Fix un-awaited store.exists() Zarr-template check in lambda_handler

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -57,6 +57,9 @@ import resource
 import time
 from typing import Any, Dict
 
+from zarr import open_group
+from zarr.errors import GroupNotFoundError
+
 # Import cloud-agnostic processing
 from zagg.config import load_config_from_dict
 from zagg.processing import (
@@ -286,10 +289,16 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             store_path = event["store_path"]
             store = open_store(store_path, **_output_store_kwargs(event))
 
-            # Validate that Zarr template exists before writing
-            template_key = f"{grid.group_path}/zarr.json"
-            if not store.exists(template_key):
-                error_msg = f"Zarr template not found at {store_path}/{template_key}"
+            # Validate that the Zarr template exists before writing. ``store`` is a
+            # zarr v3 ``Store`` whose ``exists()`` is async, so open the group via
+            # the high-level sync API and catch the missing-node error instead
+            # (issue #118). Mirrors the open-and-catch pattern in
+            # ``readers/tdigest_tensor.py``. ``GroupNotFoundError`` is raised
+            # identically on the LocalStore and obstore-backed (S3) paths.
+            try:
+                open_group(store, path=grid.group_path, mode="r", zarr_format=3)
+            except GroupNotFoundError:
+                error_msg = f"Zarr template not found at {store_path}/{grid.group_path}"
                 logger.error(error_msg)
                 metadata["error"] = error_msg
                 return {

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -292,9 +292,10 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             # Validate that the Zarr template exists before writing. ``store`` is a
             # zarr v3 ``Store`` whose ``exists()`` is async, so open the group via
             # the high-level sync API and catch the missing-node error instead
-            # (issue #118). Mirrors the open-and-catch pattern in
+            # (issue #118), in the same open-and-catch spirit as
             # ``readers/tdigest_tensor.py``. ``GroupNotFoundError`` is raised
-            # identically on the LocalStore and obstore-backed (S3) paths.
+            # identically on the LocalStore and obstore-backed (S3) paths; a
+            # present-but-wrong-type node surfaces as a real error, not "missing".
             try:
                 open_group(store, path=grid.group_path, mode="r", zarr_format=3)
             except GroupNotFoundError:

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -9,6 +9,7 @@ other grids.
 
 import importlib.util
 import json
+import warnings
 from dataclasses import asdict
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -16,6 +17,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 from zarr import open_group
+from zarr.errors import GroupNotFoundError
 from zarr.storage import MemoryStore
 
 from zagg.config import default_config
@@ -172,9 +174,9 @@ class TestProcessEventWriteLoop:
             }
             return pd.DataFrame(), meta
 
-        # A store whose template always exists; record nothing on it.
+        # A store whose template always exists; record nothing on it. The handler
+        # checks existence via ``open_group`` (issue #118), so stub that to succeed.
         store = MagicMock()
-        store.exists.return_value = True
 
         def fake_write_dense(carrier, st, *, grid, chunk_idx):
             cap["dense"].append(chunk_idx)
@@ -194,6 +196,7 @@ class TestProcessEventWriteLoop:
         monkeypatch.setattr(processing, "process_shard", fake_process_shard)
         monkeypatch.setattr(grids, "from_config", lambda *a, **k: grid_stub)
         monkeypatch.setattr(handler_mod, "open_store", lambda *a, **k: store)
+        monkeypatch.setattr(handler_mod, "open_group", lambda *a, **k: MagicMock())
         monkeypatch.setattr(handler_mod, "write_dataframe_to_zarr", fake_write_dense)
         monkeypatch.setattr(handler_mod, "write_ragged_to_zarr", fake_write_ragged)
         return cap
@@ -249,9 +252,9 @@ class TestProcessEventProfile:
     ):
         """Patch process_shard to record the ``profile`` kwarg and (when given)
         seed ``metadata['phase_timings']``; fill the sink with ``chunks``.
-        ``template_exists`` toggles the store's existence check (template-missing
-        500 path); ``write_raises`` makes the dense write blow up (failed-write
-        500 path)."""
+        ``template_exists`` toggles the ``open_group`` existence check
+        (template-missing 500 path, via ``GroupNotFoundError``); ``write_raises``
+        makes the dense write blow up (failed-write 500 path)."""
         import zagg.grids as grids
         import zagg.processing as processing
 
@@ -272,13 +275,19 @@ class TestProcessEventProfile:
             return pd.DataFrame(), meta
 
         store = MagicMock()
-        store.exists.return_value = template_exists
         grid_stub = MagicMock()
         grid_stub.group_path = "8"
         grid_stub.chunk_grid_shape = (4,)
         # Regular (non-sharded) write path — a MagicMock attr is truthy by default,
         # so pin it off explicitly (issue #108 routes sharded grids elsewhere).
         grid_stub.sharded = False
+
+        # Existence check goes through ``open_group`` (issue #118): present ->
+        # returns a group; missing -> raises ``GroupNotFoundError``.
+        def fake_open_group(*a, **k):
+            if not template_exists:
+                raise GroupNotFoundError(grid_stub.group_path)
+            return MagicMock()
 
         def fake_write_dense(*a, **k):
             if write_raises:
@@ -287,6 +296,7 @@ class TestProcessEventProfile:
         monkeypatch.setattr(processing, "process_shard", fake_process_shard)
         monkeypatch.setattr(grids, "from_config", lambda *a, **k: grid_stub)
         monkeypatch.setattr(handler_mod, "open_store", lambda *a, **k: store)
+        monkeypatch.setattr(handler_mod, "open_group", fake_open_group)
         monkeypatch.setattr(handler_mod, "write_dataframe_to_zarr", fake_write_dense)
         monkeypatch.setattr(handler_mod, "write_ragged_to_zarr", lambda *a, **k: None)
         return cap
@@ -375,6 +385,68 @@ class TestProcessEventProfile:
         assert resp["statusCode"] == 500
         timings = json.loads(resp["body"])["phase_timings"]
         assert "write" not in timings
+
+
+class TestTemplateExistenceGuard:
+    """Issue #118: the pre-write template check used ``store.exists()``, whose
+    zarr v3 implementation is async — the un-awaited coroutine is always truthy,
+    so ``if not store.exists(...)`` never fired (dead code) and emitted
+    ``RuntimeWarning: coroutine ... was never awaited``. The fix checks via
+    ``open_group(..., mode="r")`` and catches ``GroupNotFoundError``."""
+
+    def _patch(self, handler_mod, monkeypatch, *, raises_missing):
+        import zagg.grids as grids
+        import zagg.processing as processing
+
+        def fake_process_shard(grid, shard_key, granule_urls, **kwargs):
+            kwargs["chunk_results"].append(((0,), pd.DataFrame(), {}))
+            meta = {
+                "shard_key": shard_key,
+                "cells_with_data": 1,
+                "total_obs": 1,
+                "duration_s": 0.0,
+                "error": None,
+            }
+            return pd.DataFrame(), meta
+
+        grid_stub = MagicMock()
+        grid_stub.group_path = "8"
+        grid_stub.chunk_grid_shape = (4,)
+        grid_stub.sharded = False
+
+        def fake_open_group(*a, **k):
+            if raises_missing:
+                raise GroupNotFoundError(grid_stub.group_path)
+            return MagicMock()
+
+        monkeypatch.setattr(processing, "process_shard", fake_process_shard)
+        monkeypatch.setattr(grids, "from_config", lambda *a, **k: grid_stub)
+        monkeypatch.setattr(handler_mod, "open_store", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(handler_mod, "open_group", fake_open_group)
+        monkeypatch.setattr(handler_mod, "write_dataframe_to_zarr", lambda *a, **k: None)
+        monkeypatch.setattr(handler_mod, "write_ragged_to_zarr", lambda *a, **k: None)
+
+    def _event(self):
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        return event
+
+    def test_missing_template_returns_500(self, handler_mod, monkeypatch):
+        # The guard must FIRE when the template group is absent. Against the
+        # pre-fix un-awaited ``store.exists`` this returned 200 (dead guard).
+        self._patch(handler_mod, monkeypatch, raises_missing=True)
+        resp = handler_mod._handle_process(self._event(), _context())
+        assert resp["statusCode"] == 500
+        assert "Zarr template not found" in json.loads(resp["body"])["error"]
+
+    def test_present_template_proceeds_without_runtimewarning(self, handler_mod, monkeypatch):
+        # Present template -> guard passes (200), and no ``coroutine ... was never
+        # awaited`` warning leaks (the foot-gun the fix removes).
+        self._patch(handler_mod, monkeypatch, raises_missing=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            resp = handler_mod._handle_process(self._event(), _context())
+        assert resp["statusCode"] == 200
 
 
 class TestSetupTemplate:

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -439,14 +439,75 @@ class TestTemplateExistenceGuard:
         assert resp["statusCode"] == 500
         assert "Zarr template not found" in json.loads(resp["body"])["error"]
 
-    def test_present_template_proceeds_without_runtimewarning(self, handler_mod, monkeypatch):
-        # Present template -> guard passes (200), and no ``coroutine ... was never
-        # awaited`` warning leaks (the foot-gun the fix removes).
+    def test_present_template_proceeds(self, handler_mod, monkeypatch):
+        # Present template (open_group succeeds) -> guard passes through to 200.
+        # The meaningful no-RuntimeWarning check rides on the real-store test
+        # below; here open_group is mocked, so a coroutine is never created.
         self._patch(handler_mod, monkeypatch, raises_missing=False)
+        resp = handler_mod._handle_process(self._event(), _context())
+        assert resp["statusCode"] == 200
+
+    def _patch_real_store(self, handler_mod, monkeypatch, store):
+        """Wire the handler to a real zarr ``store`` so the existence check runs the
+        actual ``open_group`` (not a mock) — the un-awaited-coroutine regression
+        would reappear here if the fix were reverted."""
+        import zagg.grids as grids
+        import zagg.processing as processing
+
+        def fake_process_shard(grid, shard_key, granule_urls, **kwargs):
+            kwargs["chunk_results"].append(((0,), pd.DataFrame(), {}))
+            meta = {
+                "shard_key": shard_key,
+                "cells_with_data": 1,
+                "total_obs": 1,
+                "duration_s": 0.0,
+                "error": None,
+            }
+            return pd.DataFrame(), meta
+
+        grid_stub = MagicMock()
+        grid_stub.group_path = "8"
+        grid_stub.chunk_grid_shape = (4,)
+        grid_stub.sharded = False
+
+        monkeypatch.setattr(processing, "process_shard", fake_process_shard)
+        monkeypatch.setattr(grids, "from_config", lambda *a, **k: grid_stub)
+        monkeypatch.setattr(handler_mod, "open_store", lambda *a, **k: store)
+        monkeypatch.setattr(handler_mod, "write_dataframe_to_zarr", lambda *a, **k: None)
+        monkeypatch.setattr(handler_mod, "write_ragged_to_zarr", lambda *a, **k: None)
+
+    def test_real_store_missing_group_returns_500(self, handler_mod, monkeypatch):
+        # End-to-end through the real ``open_group`` on an empty store: the missing
+        # group raises GroupNotFoundError, so the guard returns the 500.
+        store = MemoryStore()
+        self._patch_real_store(handler_mod, monkeypatch, store)
+        resp = handler_mod._handle_process(self._event(), _context())
+        assert resp["statusCode"] == 500
+        assert "Zarr template not found" in json.loads(resp["body"])["error"]
+
+    def test_real_store_present_group_proceeds(self, handler_mod, monkeypatch):
+        # The group exists -> the real ``open_group`` succeeds, the guard passes
+        # (200), and no un-awaited-coroutine RuntimeWarning leaks.
+        store = MemoryStore()
+        open_group(store, path="8", mode="w", zarr_format=3)
+        self._patch_real_store(handler_mod, monkeypatch, store)
         with warnings.catch_warnings():
             warnings.simplefilter("error", RuntimeWarning)
             resp = handler_mod._handle_process(self._event(), _context())
         assert resp["statusCode"] == 200
+
+    def test_present_but_not_a_group_is_not_masked_as_missing(self, handler_mod, monkeypatch):
+        # A node present at the template path but of the wrong kind (an array) must
+        # NOT be swallowed as "template not found" — open_group raises a non-
+        # GroupNotFoundError that escapes the guard and surfaces as a real error,
+        # so the response is not the clean template-missing 500.
+        from zarr import create_array
+
+        store = MemoryStore()
+        create_array(store, name="8", shape=(1,), chunks=(1,), dtype="int64", zarr_format=3)
+        self._patch_real_store(handler_mod, monkeypatch, store)
+        resp = handler_mod._handle_process(self._event(), _context())
+        assert "Zarr template not found" not in resp["body"]
 
 
 class TestSetupTemplate:


### PR DESCRIPTION
Closes #118

## What

`deployment/aws/lambda_handler.py` guarded the Zarr write path with `if not store.exists(template_key):`, but `store` (from `open_store`) is a zarr v3 `Store` whose `.exists()` is `async def`. The call returned a truthy coroutine, so the guard never fired (dead code) and the runtime emitted `RuntimeWarning: coroutine 'ObjectStore.exists' was never awaited`. A genuinely missing template slipped past, surfacing later as an opaque write failure instead of a clean 500.

## Approach — option (B)

Per the locked decision ([@espg, "We're going with option (B)"](https://github.com/englacial/zagg/issues/118#issuecomment-4835229490) and the [grounding comment](https://github.com/englacial/zagg/issues/118#issuecomment-4835276250)): replace the async `store.exists()` call with an open-and-catch via zarr's high-level sync API, catching the missing-node exception. This is in the same open-and-catch spirit as `src/zagg/readers/tdigest_tensor.py`.

```python
from zarr import open_group
from zarr.errors import GroupNotFoundError
...
try:
    open_group(store, path=grid.group_path, mode="r", zarr_format=3)
except GroupNotFoundError:
    error_msg = f"Zarr template not found at {store_path}/{grid.group_path}"
    logger.error(error_msg)
    metadata["error"] = error_msg
    return {"statusCode": 500, "body": json.dumps(metadata)}
```

`GroupNotFoundError` (not bare `FileNotFoundError`) is caught: it is the precise, intent-revealing, backend-uniform error (verified raised identically on `LocalStore` and the obstore-backed `ObjectStore` in zarr 3.2.1). `FileNotFoundError` only catches these today via the quirky `BaseZarrError(ValueError, FileNotFoundError)` MRO, which a future zarr could tidy away — re-introducing the exact never-fires bug this issue is about. A present-but-malformed/wrong-type template now surfaces as a real error rather than as "missing," which is the desirable behavior.

The change is confined to the existence-check call site + the two zarr imports. No other infra/deploy edits.

## Phases

- [x] Phase 1 — fix the call site (`open_group` + `except GroupNotFoundError`) and add the imports.
- [x] Phase 2 — fix the tests that masked the bug. The stub previously made `store.exists` return a bool; under (B) the handler calls `open_group(...)`, so the missing-template case now makes `open_group` raise `GroupNotFoundError`. Added `TestTemplateExistenceGuard`: a mock-based regression test asserting the 500 + "Zarr template not found" body (fails against the pre-fix un-awaited code, which fell through to 200), plus real-`MemoryStore` tests that exercise the un-mocked `open_group` path (missing group → 500; present group → 200 with no `RuntimeWarning`; present-but-array node not masked as "missing").

## How tested

- `pytest -v tests/test_lambda_handler.py` — 21 passed (incl. the new `TestTemplateExistenceGuard` cases).
- Broader `pytest -q` (excluding the pre-existing `test_shardmap.py` collection failure below) — 846 passed, 9 skipped.
- `ruff check --select=E,F,W,I --ignore=E501 src tests` and `ruff format --check` on the touched files — green.
- Verified empirically against the installed zarr (3.2.1, the pinned `>=3.1.5` floor) that `open_group(store, mode="r")` on a missing group raises `GroupNotFoundError` on both `LocalStore` and the obstore-backed `ObjectStore`.

## Questions for review

None — the option-(B) decision and the exact exception (`GroupNotFoundError`) are locked in the issue thread.

Pre-existing, unrelated: `tests/test_shardmap.py` fails to collect in this env due to a missing `stac_geoparquet` (catalog extra not installed) — not touched by this PR; flagged, not fixed.
