### PR TITLE
Fix gain_bias dem_h broadcast dropping all photons on empty ATL03 segments

### DIFF
--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -73,12 +73,19 @@ def _expand_mask_to_base(
     for p, keep in enumerate(coarse_mask):
         if not keep:
             continue
+        cnt = int(count_arr[p])
+        # Empty parents cover no base rows. Real ATL03 marks them with
+        # ``count == 0`` AND ``ph_index_beg == 0`` (issue #116), so under
+        # ``index_base=1`` they would otherwise give ``beg = 0 - 1 = -1`` and
+        # raise below; skip them, mirroring the non-empty-only contract
+        # ``read_plan.plan_read`` already uses (its ``cnt > 0`` skip).
+        if cnt == 0:
+            continue
         beg = int(index_beg_arr[p]) - index_base
         if beg < 0:
             raise ValueError(
                 f"index_beg_arr[{p}]={index_beg_arr[p]} is less than index_base={index_base}"
             )
-        cnt = int(count_arr[p])
         out[beg : beg + cnt] = True
     return out
 
@@ -131,12 +138,19 @@ def _broadcast_segment_to_base(
     else:
         out = np.zeros(total_base_size, dtype=seg_values.dtype)
     for p in range(len(seg_values)):
+        cnt = int(count_arr[p])
+        # Empty segments cover no photons. Real ATL03 marks them with
+        # ``count == 0`` AND ``ph_index_beg == 0`` (issue #116, see
+        # ``read_plan.plan_read``'s ``cnt > 0`` skip); under ``index_base=1``
+        # that gives ``beg = 0 - 1 = -1`` and would raise below, which is what
+        # made the gain_bias dem_h broadcast drop every photon. Skip them.
+        if cnt == 0:
+            continue
         beg = int(index_beg_arr[p]) - index_base
         if beg < 0:
             raise ValueError(
                 f"index_beg_arr[{p}]={index_beg_arr[p]} is less than index_base={index_base}"
             )
-        cnt = int(count_arr[p])
         if beg + cnt > total_base_size:
             raise ValueError(
                 f"segment {p} range [{beg}:{beg + cnt}] exceeds base size {total_base_size}; "

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -78,7 +78,10 @@ def _expand_mask_to_base(
         # ``count == 0`` AND ``ph_index_beg == 0`` (issue #116), so under
         # ``index_base=1`` they would otherwise give ``beg = 0 - 1 = -1`` and
         # raise below; skip them, mirroring the non-empty-only contract
-        # ``read_plan.plan_read`` already uses (its ``cnt > 0`` skip).
+        # ``read_plan.plan_read`` already uses (its ``cnt > 0`` skip). Skipping
+        # intentionally bypasses the ``beg < 0`` validation for these parents --
+        # correct, since they map to zero base rows (a non-empty parent with
+        # ``beg < 0`` still raises).
         if cnt == 0:
             continue
         beg = int(index_beg_arr[p]) - index_base
@@ -143,7 +146,10 @@ def _broadcast_segment_to_base(
         # ``count == 0`` AND ``ph_index_beg == 0`` (issue #116, see
         # ``read_plan.plan_read``'s ``cnt > 0`` skip); under ``index_base=1``
         # that gives ``beg = 0 - 1 = -1`` and would raise below, which is what
-        # made the gain_bias dem_h broadcast drop every photon. Skip them.
+        # made the gain_bias dem_h broadcast drop every photon. Skip them; this
+        # intentionally bypasses the ``beg < 0`` / ``beg + cnt > base`` checks
+        # for empties (they map to zero base rows). A non-empty segment with
+        # ``beg < 0`` or an over-extending range still raises below.
         if cnt == 0:
             continue
         beg = int(index_beg_arr[p]) - index_base

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -265,15 +265,17 @@ def process_shard(
         phase_timings["read"] = time.time() - _read_t0
 
     if not all_reads:
-        # Distinguish a genuinely-empty read from one where every group raised
-        # (issue #116): the latter is a real read error masquerading as
-        # "no data", so report it as such instead of the misleading text.
+        # Distinguish a genuinely-empty read from one where a group read raised
+        # (issue #116): a raised read is a real error masquerading as "no data",
+        # so report it as such instead of the misleading text. Some groups may
+        # have returned ``None`` (legitimately empty) rather than raised, so the
+        # message is "no data AND N raised", not "all groups raised".
         if read_errors:
             logger.warning(
-                f"  Read raised on all groups for shard {shard_key} "
-                f"({read_errors} read error(s)) - skipping"
+                f"  No data after filtering for shard {shard_key} and "
+                f"{read_errors} group read(s) raised - skipping"
             )
-            metadata["error"] = f"All group reads raised ({read_errors} read errors)"
+            metadata["error"] = f"No data after filtering ({read_errors} group reads raised)"
         else:
             logger.info(f"  No data after filtering for shard {shard_key} - skipping")
             metadata["error"] = "No data after filtering"

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -198,6 +198,7 @@ def process_shard(
     use_arrow = handoff in ("arrow", "arrow-kernel")
     all_reads = []
     files_processed = 0
+    read_errors = 0
 
     # Opt-in per-phase timing (issue #100). Only allocated when profiling so the
     # default path stays byte-identical (no dict, no time.time() calls).
@@ -226,7 +227,14 @@ def process_shard(
                     if chunk is not None:
                         all_reads.append(chunk)
                 except Exception as e:
-                    logger.debug(f"  Error reading track {g}: {e}")
+                    # A raised read error is always a real failure: a
+                    # legitimately-empty group returns ``None`` (no exception),
+                    # so promoting this to WARNING does not get noisy on shards
+                    # where many granules simply contribute 0 photons (issue
+                    # #116). Logging it at DEBUG hid the dem_h broadcast failure
+                    # behind the misleading "No data after filtering" below.
+                    read_errors += 1
+                    logger.warning(f"  Error reading track {g}: {e}")
                     continue
 
             files_processed += 1
@@ -251,12 +259,24 @@ def process_shard(
 
     logger.info(f"  Processed {files_processed}/{len(granule_urls)} files")
     metadata["files_processed"] = files_processed
+    if read_errors:
+        metadata["read_errors"] = read_errors
     if profile:
         phase_timings["read"] = time.time() - _read_t0
 
     if not all_reads:
-        logger.info(f"  No data after filtering for shard {shard_key} - skipping")
-        metadata["error"] = "No data after filtering"
+        # Distinguish a genuinely-empty read from one where every group raised
+        # (issue #116): the latter is a real read error masquerading as
+        # "no data", so report it as such instead of the misleading text.
+        if read_errors:
+            logger.warning(
+                f"  Read raised on all groups for shard {shard_key} "
+                f"({read_errors} read error(s)) - skipping"
+            )
+            metadata["error"] = f"All group reads raised ({read_errors} read errors)"
+        else:
+            logger.info(f"  No data after filtering for shard {shard_key} - skipping")
+            metadata["error"] = "No data after filtering"
         metadata["duration_s"] = (datetime.now() - start_time).total_seconds()
         if profile:
             metadata["phase_timings"] = phase_timings

--- a/src/zagg/schema.py
+++ b/src/zagg/schema.py
@@ -32,6 +32,11 @@ class ProcessingMetadata(TypedDict):
     # Per-phase wall timings (read/index/aggregate/write), present only when the
     # worker is dispatched with ``profile=True`` (issue #100).
     phase_timings: NotRequired[dict[str, float]]
+    # Count of per-group reads that raised during the read loop (issue #116).
+    # Present (and non-zero) only when at least one group read failed; a raised
+    # read is always a real error, so this surfaces a shard whose "no data"
+    # result is actually a read failure rather than a legitimately-empty read.
+    read_errors: NotRequired[int]
 
 
 def xdggs_spec(

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -3000,6 +3000,17 @@ class TestExpandMaskToBase:
         with pytest.raises(ValueError, match="less than index_base"):
             _expand_mask_to_base(coarse, ibeg, cnt, index_base=1, total_base_size=3)
 
+    def test_empty_parent_skipped_index_base_1(self):
+        # Issue #116 twin: an empty parent (``ph_index_beg == 0, cnt == 0``)
+        # under ``index_base=1`` must be skipped, not raise on ``beg = -1`` --
+        # the same fix applied to ``_broadcast_segment_to_base``. A non-empty
+        # parent with ``beg < 0`` still raises (covered by ``test_negative_beg``).
+        coarse = np.array([True, True, True])
+        ibeg = np.array([1, 0, 3])  # middle parent is an empty (ph_index_beg == 0)
+        cnt = np.array([2, 0, 2])
+        out = _expand_mask_to_base(coarse, ibeg, cnt, index_base=1, total_base_size=4)
+        np.testing.assert_array_equal(out, [True, True, True, True])
+
 
 class TestReadGroupCrossLevel:
     """Phase B: cross-level filters expand coarse verdicts to base-rate rows."""
@@ -3604,6 +3615,21 @@ class TestSegmentLevelVariables:
         out = _broadcast_segment_to_base(seg, ibeg, cnt, index_base=1, total_base_size=4)
         assert out.tolist() == [10.0, 10.0, 20.0, 20.0]
 
+    def test_broadcast_skips_empty_segments_index_base_1(self):
+        # Issue #116: real ATL03 marks empty segments with ``ph_index_beg == 0,
+        # cnt == 0``. Under ``index_base=1`` that gave ``beg = 0 - 1 = -1`` and
+        # raised, dropping every photon in the gain_bias dem_h broadcast. The
+        # empties must now be skipped (cover no photons) and the non-empty
+        # segments still land their value on the right photons.
+        seg = np.array([10.0, 0.0, 20.0, 0.0, 30.0], dtype=np.float32)
+        ibeg = np.array([1, 0, 3, 0, 5])  # 1-based; empties carry ph_index_beg == 0
+        cnt = np.array([2, 0, 2, 0, 2])
+        out = _broadcast_segment_to_base(seg, ibeg, cnt, index_base=1, total_base_size=6)
+        assert out.tolist() == [10.0, 10.0, 20.0, 20.0, 30.0, 30.0]
+        # Equals np.repeat over the non-empty segments only.
+        nonempty = cnt > 0
+        assert out.tolist() == np.repeat(seg[nonempty], cnt[nonempty]).tolist()
+
     def _data_source(self):
         return {
             "coordinates": {"latitude": "/lat", "longitude": "/lon"},
@@ -3688,6 +3714,83 @@ class TestSegmentLevelVariables:
         assert df["h"].tolist() == [2.0, 3.0, 4.0, 5.0]
         assert df["dem_h"].tolist() == [200.0, 200.0, 300.0, 300.0]
 
+    def _atl03_like_data_source(self, *, with_dem_h):
+        # A realistic ATL03-style segment table (index_base=1) used for the
+        # gain_bias-vs-tdigest parity regression (issue #116). When
+        # ``with_dem_h`` is set, the segments level declares the dem_h broadcast
+        # (the gain_bias config); otherwise the level carries no readable
+        # variables (the tdigest config). Everything else is identical.
+        ds = {
+            "coordinates": {"latitude": "/lat", "longitude": "/lon"},
+            "variables": {"h": "/h"},
+            "base_level": "photons",
+            "levels": {
+                "photons": {
+                    "path": "/heights",
+                    "coordinates": ["lat", "lon"],
+                    "variables": ["h"],
+                    "link": None,
+                },
+                "segments": {
+                    "path": "/geolocation",
+                    "coordinates": [],
+                    "variables": ({"dem_h": "/dem_h"} if with_dem_h else {}),
+                    "link": {
+                        "to": "photons",
+                        "index_beg": "/ph_index_beg",
+                        "count": "/segment_ph_cnt",
+                        "index_base": 1,  # ATL03 ph_index_beg is 1-based
+                    },
+                },
+            },
+        }
+        return ds
+
+    def _atl03_like_h5(self):
+        # 4 segments x 2 photons = 8 photons, but with two EMPTY segments
+        # interspersed (ph_index_beg == 0, cnt == 0) -- exactly how real ATL03
+        # marks segments with no photons (issue #116). Non-empty segments are
+        # 1-based contiguous: seg0 -> photons 1-2, seg2 -> 3-4, seg4 -> 5-6,
+        # seg5 -> 7-8. The first non-empty run does NOT need to start at file
+        # index 0 in spirit; empties are scattered so the broadcast must skip
+        # them rather than place at beg = 0 - 1 = -1.
+        return _FakeH5(
+            {
+                "/lat": np.arange(8.0),
+                "/lon": np.arange(8.0),
+                "/h": np.arange(8.0, dtype=np.float32),
+                # 6 segments: indices 1 and 3 are empties.
+                "/ph_index_beg": np.array([1, 0, 3, 0, 5, 7]),
+                "/segment_ph_cnt": np.array([2, 0, 2, 0, 2, 2]),
+                "/dem_h": np.array([10.0, 0.0, 20.0, 0.0, 30.0, 40.0], dtype=np.float32),
+            }
+        )
+
+    def test_gain_bias_reads_same_obs_as_tdigest_with_empty_segments(self):
+        # Issue #116 regression: on the same shard/photons and an ATL03-style
+        # segment table with empty segments (index_base=1), the gain_bias-style
+        # data source (segment dem_h broadcast) must read the SAME observation
+        # count as the tdigest-style one (no broadcast) -- the unit analogue of
+        # the observed "gain_bias 0 vs tdigest 20,710" drop. Before the fix the
+        # broadcast raised on the first empty segment, returning 0 rows.
+        tdigest = _read_group(
+            self._atl03_like_h5(),
+            "gt1l",
+            self._atl03_like_data_source(with_dem_h=False),
+            0,
+            _ShardGrid(),
+        )
+        gain_bias = _read_group(
+            self._atl03_like_h5(),
+            "gt1l",
+            self._atl03_like_data_source(with_dem_h=True),
+            0,
+            _ShardGrid(),
+        )
+        assert len(gain_bias) == len(tdigest) == 8
+        # Each photon carries its own (non-empty) segment's dem_h.
+        assert gain_bias["dem_h"].tolist() == [10.0, 10.0, 20.0, 20.0, 30.0, 30.0, 40.0, 40.0]
+
     def test_planned_partial_read_aligns_dem_h(self):
         # Partial read plan (NOT a full read): the bbox selects only segments
         # 1-2 (photons 2..5). Each selected photon must carry its own segment's
@@ -3700,6 +3803,42 @@ class TestSegmentLevelVariables:
         grid = _LatBboxGrid((-0.1, 100.0, 0.1, 250.0))
         df = _read_group(h5, "gt1l", ds, 0, grid)
         # Planned path selects photons 2,3 (seg 1) and 4,5 (seg 2).
+        assert df["h"].tolist() == [20.0, 30.0, 40.0, 50.0]
+        assert df["dem_h"].tolist() == [20.0, 20.0, 30.0, 30.0]
+
+    def test_planned_read_skips_empty_segments_index_base_1(self):
+        # Issue #116 regression on the PLANNED path: an ATL03-style table with
+        # an empty segment (ph_index_beg == 0, cnt == 0) under index_base=1 must
+        # not raise in the dem_h broadcast. The planned broadcast iterates the
+        # FULL segment table (then subsets by seg_global_idx), so the empty must
+        # be skipped just like the full path. The bbox selects a run that does
+        # not start at file index 0.
+        ds = _planned_read_data_source()
+        ds["levels"]["segments"]["link"]["index_base"] = 1
+        ds["levels"]["segments"]["variables"] = {"dem_h": "/seg/dem_h"}
+        # Six segments, one EMPTY (index 2). Non-empty segments tile the 10
+        # photons 1-based contiguously: seg0 -> ph 1-2, seg1 -> 3-4, seg3 -> 5-6,
+        # seg4 -> 7-8, seg5 -> 9-10. dem_h carries a marker for the empty.
+        seg_lats = np.array([0.0, 100.0, 200.0, 300.0, 400.0, 500.0])
+        ph_lats = np.array([0.0, 50.0, 100.0, 150.0, 200.0, 250.0, 300.0, 350.0, 400.0, 450.0])
+        h5 = _FakeH5(
+            {
+                "/seg/lat": seg_lats,
+                "/seg/lon": np.zeros(6),
+                "/seg/ph_index_beg": np.array([1, 3, 0, 5, 7, 9], dtype=np.int64),
+                "/seg/segment_ph_cnt": np.array([2, 2, 0, 2, 2, 2], dtype=np.int64),
+                "/seg/dem_h": np.array([10.0, 20.0, -1.0, 30.0, 40.0, 50.0], dtype=np.float32),
+                "/heights/lat_ph": ph_lats,
+                "/heights/lon_ph": np.zeros(10),
+                "/heights/h": np.arange(10.0, dtype=np.float32) * 10.0,
+            }
+        )
+        # Select segments 1 and 3 (photons 3-4 and 5-6) -- a run starting past
+        # file index 0, straddling the empty segment 2.
+        grid = _LatBboxGrid((-0.1, 100.0, 0.1, 300.0))
+        df = _read_group(h5, "gt1l", ds, 0, grid)
+        # seg1 (lat 100) -> photons 2,3 (h 20,30); seg3 (lat 300) -> photons 4,5
+        # (h 40,50). Each photon carries its own segment's dem_h (20 then 30).
         assert df["h"].tolist() == [20.0, 30.0, 40.0, 50.0]
         assert df["dem_h"].tolist() == [20.0, 20.0, 30.0, 30.0]
 
@@ -4493,5 +4632,8 @@ class TestProcessShardCacheRelease:
         closes = [e for e in log if e[0] == "close"]
         # close() fired exactly once despite the read raising — the finally ran.
         assert len(closes) == 1
-        # No data survived the failed read, so the shard reports the empty path.
-        assert meta["error"] == "No data after filtering"
+        # A raised read is a real error, NOT a legitimately-empty read (issue
+        # #116): the shard reports the read-error path and counts the failure,
+        # rather than the misleading "No data after filtering".
+        assert meta["error"] == "All group reads raised (1 read errors)"
+        assert meta["read_errors"] == 1

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4635,5 +4635,5 @@ class TestProcessShardCacheRelease:
         # A raised read is a real error, NOT a legitimately-empty read (issue
         # #116): the shard reports the read-error path and counts the failure,
         # rather than the misleading "No data after filtering".
-        assert meta["error"] == "All group reads raised (1 read errors)"
+        assert meta["error"] == "No data after filtering (1 group reads raised)"
         assert meta["read_errors"] == 1


### PR DESCRIPTION
Closes #116

## Root cause

On the same shard/granules the `gain_bias` template read **0** observations while `tdigest` read ~200k. The only `data_source` difference is the segment-level `dem_h` read on the `segments` level (`src/zagg/configs/atl03_gain_bias_healpix.yaml`), which routes `gain_bias` through the segment→photon broadcast (`_read_segment_broadcasts` / `_broadcast_segment_to_base` in `src/zagg/processing/read.py`) that `tdigest` never touches.

Real ATL03 marks **empty segments** with `count == 0` **and `ph_index_beg == 0`**. Under `index_base: 1` (`atl03_gain_bias_healpix.yaml`), such a segment gives `beg = 0 - 1 = -1 < 0`, which raised `index_beg_arr[..]=0 is less than index_base=1` in `_broadcast_segment_to_base`. The per-group read in `worker.py` was wrapped in a bare `except Exception` logged at **DEBUG**, so the raise was swallowed for every beam/granule, `all_reads` stayed empty, and the worker reported the misleading `No data after filtering`. `tdigest`, with no broadcast, never raised.

`read_plan.plan_read` already skips empty (`cnt == 0`) segments; `_broadcast_segment_to_base` (and its twin `_expand_mask_to_base`) had no such guard. This was empirically confirmed in the issue thread: every beam on every granule raised the empty-segment `ValueError`, and a `cnt == 0` guard alone restored byte-identical obs to `tdigest`. The "index-space reconciliation" (step 3 of the original diagnosis) is **not** needed and was confirmed out of scope by @espg.

## Approach (phases)

- [x] **Phase 1 — make the failure visible.** Promote the swallowed per-group read error from DEBUG → WARNING in `worker.py` (a raised read is always a real error; a legitimately-empty group returns `None`, so this does not get noisy). Track a per-shard `read_errors` count in `ProcessingMetadata` and, when every group raised, report the real error instead of `No data after filtering`.
- [x] **Phase 2 — fix the broadcast.** Add an `if cnt == 0: continue` guard (before the `beg < 0` check) to `_broadcast_segment_to_base`, mirroring `plan_read`'s non-empty-only contract. Apply the identical guard to the twin `_expand_mask_to_base` (same latent bug; @espg approved the consistent guard).
- [x] **Phase 3 — regression tests.** Realistic ATL03-style segment table with interspersed empty segments (`ph_index_beg == 0, cnt == 0`) under `index_base = 1`, plus a planned-path run that does not start at file index 0.

## What changed

- `src/zagg/processing/read.py` — `cnt == 0` skip in `_broadcast_segment_to_base` and `_expand_mask_to_base`.
- `src/zagg/processing/worker.py` — per-group read error → WARNING; `read_errors` counter; all-raised path reports a real error.
- `src/zagg/schema.py` — `read_errors: NotRequired[int]` on `ProcessingMetadata`.
- `tests/test_processing.py` — new regression tests + updated `test_read_exception_still_releases_in_finally` to assert the new (correct) read-error reporting.

## How tested

- New regression tests assert `gain_bias` reads the **same observation count** as `tdigest` on a table with empty segments (the unit analogue of the locally-observed `20,710 == 20,710`), that the broadcast does not raise under `index_base=1` with `cnt == 0` empties, and that `dem_h` lands on the correct photons on **both** the full and planned read paths.
- `tests/test_processing.py` and `tests/test_runner.py` green via `uv run --extra test python -m pytest`.
- `ruff check --select=E,F,W,I --ignore=E501 src tests` and `ruff format --check` on touched files pass.

## Questions for review

1. **#117 sequencing.** The tracking note asks for #116 + #117 (gain_bias OOM) to land together as one PR (`Closes #116 #117`). This PR is scoped to the `dem_h` broadcast (the #116 root cause) only — #117 is a distinct root cause (full-grid vector allocation) inside the same template and re-surfaces once this fix re-enables the waveform path. Should the #117 footprint work be folded onto this branch, or land as its own PR? Left to @espg since folding it in changes this PR's agreed scope.
2. **mypy baseline.** Running mypy ad-hoc on the touched modules surfaces only pre-existing errors (missing `pandas`/`h5coro` stubs, the `phase_timings: dict | None` union, the `DataSourceDict` arg-type) on lines this PR does not touch; the new `read_errors` field and assignments are clean. Not "fixed" here per the convention on pre-existing unrelated failures — flagging instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPps6JqgR2hMhbE9Xm9R5t)_