### PR TITLE
arro3-core carrier for the Lambda worker; drop pyarrow + arrow-kernel (#130)

### DIFF
--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -49,6 +49,33 @@ def _resolve(base: Path, rel: str) -> Path:
     return (base / rel).resolve()
 
 
+def all_target_names(manifest: dict) -> list[str]:
+    """Names that ``run all`` iterates: the committed merge matrix only.
+
+    ``provisional_targets`` (issue #130) are PR-tree-only and runnable by explicit
+    ``--target`` name, but are deliberately excluded here so they never join the
+    permanent every-merge matrix until the kernel decision is made.
+    """
+    return list(manifest["targets"].keys())
+
+
+def _resolve_target(manifest: dict, name: str) -> dict:
+    """Look a target up in the committed matrix, then the provisional block.
+
+    ``provisional_targets`` lets ``/benchmark --target <name>`` run a PR-tree-only
+    target (the arrow/arrow-kernel comparisons, issue #130) without that target
+    being part of ``targets`` (the committed merge matrix).
+    """
+    targets = manifest.get("targets", {})
+    if name in targets:
+        return targets[name]
+    provisional = manifest.get("provisional_targets", {})
+    if name in provisional:
+        return provisional[name]
+    known = list(targets) + list(provisional)
+    raise KeyError(f"unknown target '{name}'; have {known}")
+
+
 def run_target(
     name: str,
     manifest: dict,
@@ -63,13 +90,17 @@ def run_target(
     """Dispatch one target's shard and return its benchmark record."""
     from zagg import __version__ as zagg_version
 
-    target = manifest["targets"][name]
+    target = _resolve_target(manifest, name)
     shardmap_key = target["shardmap"]
     shardmap_meta = manifest["shardmaps"][shardmap_key]
     config_path = _resolve(base, target["config"])
     shardmap_path = _resolve(base, shardmap_meta["path"])
     shard_key = int(shardmap_meta["shard_key"])
     n_granules = shardmap_meta.get("n_granules")
+
+    # Per-cell carrier/reducer (issue #130). Default "pandas" keeps the dispatched
+    # event byte-identical to a pre-handoff run; arrow/arrow-kernel targets set it.
+    handoff = target.get("handoff", "pandas")
 
     config = load_config(str(config_path))
     # parent_order lives in the config grid for HEALPix; the kwarg is just a
@@ -101,6 +132,7 @@ def run_target(
             region=region,
             function_name=function_name,
             overwrite=True,
+            handoff=handoff,
             profile=True,
             # A benchmark measures one clean invocation and records a failure as
             # a failure -- never re-invoke (and never pay) to re-fail (#119).
@@ -160,7 +192,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     manifest, base = load_targets(args.targets)
-    names = args.target or list(manifest["targets"].keys())
+    # "run all" (no --target) iterates the committed merge matrix only; provisional
+    # (PR-tree-only) targets are run by explicit --target name (issue #130).
+    names = args.target or all_target_names(manifest)
+    known = set(manifest.get("targets", {})) | set(manifest.get("provisional_targets", {}))
 
     pr_number = int(args.pr_number) if args.pr_number not in (None, "", "0") else None
     context = {
@@ -173,8 +208,8 @@ def main(argv: list[str] | None = None) -> int:
 
     records = []
     for name in names:
-        if name not in manifest["targets"]:
-            raise SystemExit(f"unknown target '{name}'; have {list(manifest['targets'])}")
+        if name not in known:
+            raise SystemExit(f"unknown target '{name}'; have {sorted(known)}")
         store = None
         if args.store_prefix:
             store = f"{args.store_prefix.rstrip('/')}/{name}.zarr"

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -54,7 +54,7 @@ def all_target_names(manifest: dict) -> list[str]:
 
     ``provisional_targets`` (issue #130) are PR-tree-only and runnable by explicit
     ``--target`` name, but are deliberately excluded here so they never join the
-    permanent every-merge matrix until the kernel decision is made.
+    permanent every-merge matrix until the carrier decision is made.
     """
     return list(manifest["targets"].keys())
 
@@ -63,7 +63,7 @@ def _resolve_target(manifest: dict, name: str) -> dict:
     """Look a target up in the committed matrix, then the provisional block.
 
     ``provisional_targets`` lets ``/benchmark --target <name>`` run a PR-tree-only
-    target (the arrow/arrow-kernel comparisons, issue #130) without that target
+    target (the pandas-vs-arrow carrier comparison, issue #130) without that target
     being part of ``targets`` (the committed merge matrix).
     """
     targets = manifest.get("targets", {})
@@ -98,8 +98,8 @@ def run_target(
     shard_key = int(shardmap_meta["shard_key"])
     n_granules = shardmap_meta.get("n_granules")
 
-    # Per-cell carrier/reducer (issue #130). Default "pandas" keeps the dispatched
-    # event byte-identical to a pre-handoff run; arrow/arrow-kernel targets set it.
+    # Per-cell carrier (issue #130). Default "pandas" keeps the dispatched event
+    # byte-identical to a pre-handoff run; the arrow (arro3) target sets it.
     handoff = target.get("handoff", "pandas")
 
     config = load_config(str(config_path))

--- a/benchmarks/handoff_bench.py
+++ b/benchmarks/handoff_bench.py
@@ -1,26 +1,21 @@
-"""Synthetic benchmark for the per-cell aggregation handoff (issue #30).
+"""Synthetic benchmark for the per-cell aggregation handoff (issue #30 / #130).
 
-Times the per-shard grouping + aggregation for four approaches on synthetic
+Times the per-shard grouping + aggregation for three approaches on synthetic
 in-memory observations:
 
   * ``mask-loop``    -- the pre-#30 O(n_children x n_obs) boolean-mask loop (reference)
   * ``pandas-group`` -- sort/hash grouping, pandas carrier (current default)
-  * ``arrow-group``  -- sort/hash grouping, Arrow carrier (opt-in)
-  * ``arrow-kernel`` -- EXPERIMENTAL pyarrow.compute hash-aggregate reducer (phase 2b)
+  * ``arrow-group``  -- sort/hash grouping, arro3-core Arrow carrier (opt-in)
 
-The first three feed identical numpy arrays into the reducer, so their stats are
-asserted byte-for-byte identical. ``arrow-kernel`` reduces via pyarrow's C++ hash
-kernels, whose float mean/variance differ from numpy by ~1 ULP; it is asserted
-*close* (``np.allclose`` at ``KERNEL_RTOL``), not identical. Its count/min/max are
-asserted *exact*; this synthetic data is NaN-free, so the kernel's NaN-propagation
-fix (pyarrow min/max skip NaN, numpy propagate) is covered in the unit tests, not
-here.
+All three feed identical numpy arrays into the reducer, so their stats are
+asserted byte-for-byte identical. (The earlier ``arrow-kernel`` pyarrow.compute
+hash-aggregate path was dropped with pyarrow in the #130 path-C pivot — arro3 has
+no hash-aggregate — so this benchmark now isolates only the carrier cost.)
 
 This is the CI-runnable half of #30's benchmark: it isolates the grouping
-algorithm, the carrier representation cost, and the kernel reducer with no I/O,
-so it runs anywhere without credentials. The real-data (ATL03 region) timings —
-which decide whether the experimental kernel path is kept — land as phase 3
-(needs earthaccess/S3).
+algorithm and the carrier representation cost with no I/O, so it runs anywhere
+without credentials. The real-data (ATL03 region) carrier timings land via the
+``provisional_targets`` benchmark matrix (needs earthaccess/S3).
 
 Memory is reported via ``tracemalloc`` (Python-domain peak): it does not capture
 raw numpy data buffers, but it does capture the pandas BlockManager/Index and
@@ -39,22 +34,12 @@ import tracemalloc
 import numpy as np
 import pandas as pd
 
-from zagg.config import default_config, get_data_vars
+from zagg.config import default_config
 from zagg.processing import (
-    KERNEL_RTOL,
     _build_groups,
     _group_columns,
-    _kernel_aggregate,
     calculate_cell_statistics,
 )
-
-
-class _IdentityGrid:
-    """Grid stub: the synthetic ``leaf_id`` already *is* the destination cell."""
-
-    @staticmethod
-    def cells_of(leaf_ids):
-        return np.asarray(leaf_ids)
 
 
 def make_synthetic(n_obs: int, n_cells: int, seed: int = 0):
@@ -112,26 +97,6 @@ def stats_equal(a, b):
     return True, None
 
 
-def stats_close(a, b, rtol):
-    """Like ``stats_equal`` but tolerant — for the kernel path's float divergence."""
-    for child in a:
-        for key in a[child]:
-            x, y = float(a[child][key]), float(b[child][key])
-            if np.isnan(x) and np.isnan(y):
-                continue
-            if not np.isclose(x, y, rtol=rtol, equal_nan=True):
-                return False, (child, key, x, y)
-    return True, None
-
-
-def kernel_arrays_to_stats(stats_arrays, children):
-    """Adapt ``_kernel_aggregate``'s ``name -> ndarray`` output to the per-cell dict."""
-    return {
-        int(child): {name: stats_arrays[name][i] for name in stats_arrays}
-        for i, child in enumerate(children)
-    }
-
-
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--n-obs", type=int, default=2_000_000)
@@ -153,49 +118,26 @@ def main():
     res_pd, dt_pd, mem_pd = timed(run_pandas)
 
     def run_arrow():
-        import pyarrow as pa
+        from arro3.core import Array, Table
 
-        table = pa.table(col_dict).combine_chunks()
-        leaf = table.column("leaf_id").to_numpy(zero_copy_only=False)
-        carrier = {n: table.column(n).to_numpy(zero_copy_only=False) for n in table.column_names}
-        col_arrays, cell_to_slice = _group_columns(carrier, leaf)
+        table = Table.from_pydict({k: Array.from_numpy(v) for k, v in col_dict.items()})
+        carrier = {n: table.column(n).combine_chunks().to_numpy() for n in table.column_names}
+        col_arrays, cell_to_slice = _group_columns(carrier, carrier["leaf_id"])
         return agg_grouped(col_arrays, cell_to_slice, children, cfg)
 
     res_ar, dt_ar, mem_ar = timed(run_arrow)
 
-    def run_kernel():
-        import pyarrow as pa
-
-        table = pa.table(col_dict).combine_chunks()
-        cell = _IdentityGrid.cells_of(table.column("leaf_id").to_numpy(zero_copy_only=False))
-        out = _kernel_aggregate(table, cell, children, "h_li", cfg)
-        return kernel_arrays_to_stats(out["stats_arrays"], children)
-
-    res_kn, dt_kn, mem_kn = timed(run_kernel)
-
     ok_pd, diff_pd = stats_equal(ref, res_pd)
     ok_ar, diff_ar = stats_equal(ref, res_ar)
-    ok_kn, diff_kn = stats_close(ref, res_kn, KERNEL_RTOL)
     assert ok_pd, f"pandas grouping diverged from mask loop: {diff_pd}"
     assert ok_ar, f"arrow grouping diverged from mask loop: {diff_ar}"
-    assert ok_kn, f"kernel reducer diverged beyond rtol={KERNEL_RTOL}: {diff_kn}"
 
-    # Cross-check that count/min/max (the integral / extremum stats) are *exact*
-    # under the kernel path, isolating the divergence to the float reductions.
-    exact = [n for n in get_data_vars(cfg) if n in ("count", "h_min", "h_max")]
-    for child in ref:
-        for name in exact:
-            assert float(ref[child][name]) == float(res_kn[child][name]) or (
-                np.isnan(ref[child][name]) and np.isnan(res_kn[child][name])
-            ), f"kernel {name} not exact for cell {child}"
-
-    print(f"n_obs={args.n_obs:,}  n_cells={args.n_cells:,}  parity: OK (kernel rtol={KERNEL_RTOL})")
+    print(f"n_obs={args.n_obs:,}  n_cells={args.n_cells:,}  parity: OK (pandas == arrow)")
     print(f"{'approach':<16}{'wall_s':>10}{'peak_MB':>12}")
     for name, dt, mem in [
         ("mask-loop", dt_mask, mem_mask),
         ("pandas-group", dt_pd, mem_pd),
         ("arrow-group", dt_ar, mem_ar),
-        ("arrow-kernel", dt_kn, mem_kn),
     ]:
         print(f"{name:<16}{dt:>10.3f}{mem:>12.1f}")
 

--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -86,21 +86,28 @@ rm -rf "$OUTPUT_DIR/python"/xarray* \
        "$OUTPUT_DIR/python"/boto3* \
        "$OUTPUT_DIR/python"/botocore* 2>/dev/null || true
 
-# pyarrow component strip (issue #130): drop the C++ engines zagg never calls --
-# Flight (RPC), Substrait, Gandiva (LLVM expr JIT), and Dataset -- plus their
-# cython modules. KEEP libarrow.so* (core), libarrow_python* (numpy<->arrow),
-# libparquet* (catalog), libarrow_acero*/_acero*.so + _compute*.so (the
-# arrow-kernel hash-aggregate reducer, kept per issue #130). The generic *.so
-# strip below then strips debug symbols from what remains.
+# pyarrow component strip (issue #130): drop the C++ engines the Lambda worker
+# never calls -- Flight (RPC), Substrait, Gandiva (LLVM expr JIT), Dataset, and
+# Parquet -- plus their cython modules. KEEP libarrow.so* (core), libarrow_python*
+# (numpy<->arrow), and libarrow_acero*/_acero*.so + _compute*.so (the arrow-kernel
+# hash-aggregate reducer, kept per issue #130). Parquet is stripped because
+# pyarrow.parquet is used ONLY by zagg.catalog (STAC/geoparquet fetch+build), which
+# runs OFF-Lambda with the ``catalog`` extra and never on the worker -- the layer
+# exists only for the worker, so libparquet is pure dead weight here (and recovers
+# the ~12 MB that put the combined layer+function over the 250 MB gate). The worker
+# parquet path, if any, is fastparquet+cramjam, which stay. The generic *.so strip
+# below then strips debug symbols from what remains.
 echo "Component-stripping pyarrow..."
 rm -f "$OUTPUT_DIR/python/pyarrow"/libarrow_flight* \
       "$OUTPUT_DIR/python/pyarrow"/libarrow_substrait* \
       "$OUTPUT_DIR/python/pyarrow"/libgandiva* \
       "$OUTPUT_DIR/python/pyarrow"/libarrow_dataset* \
+      "$OUTPUT_DIR/python/pyarrow"/libparquet* \
       "$OUTPUT_DIR/python/pyarrow"/_flight*.so \
       "$OUTPUT_DIR/python/pyarrow"/_substrait*.so \
       "$OUTPUT_DIR/python/pyarrow"/_gandiva*.so \
-      "$OUTPUT_DIR/python/pyarrow"/_dataset*.so 2>/dev/null || true
+      "$OUTPUT_DIR/python/pyarrow"/_dataset*.so \
+      "$OUTPUT_DIR/python/pyarrow"/_parquet*.so 2>/dev/null || true
 
 # Clean caches/tests and strip debug symbols.
 find "$OUTPUT_DIR/python" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -59,7 +59,7 @@ fi
 # here -- they are function-level deps installed by build_function.sh.
 echo "Installing processing deps..."
 $PIP install \
-    "pandas==2.2.3" fastparquet cramjam \
+    "pandas==2.2.3" "pyarrow==24.0.0" fastparquet cramjam \
     shapely pyproj odc-geo affine cachetools \
     -c "$CONSTRAINTS" \
     -t "$OUTPUT_DIR/python" \
@@ -76,15 +76,31 @@ if [[ "$NUMPY_VERSION" == *"2.3"* ]]; then
 fi
 
 # Remove bloat. pyproj is intentionally NOT stripped (rectilinear/odc-geo assign
-# needs it); pyarrow stays stripped (catalog fetch/build only, never the
-# processing path).
+# needs it); pyarrow IS kept now -- it is on the vector-write hot path and the
+# experimental arrow-kernel reducer (issue #130), but its unused C++ engines are
+# component-stripped below to stay under the combined size gate.
 echo "Removing bloat..."
-rm -rf "$OUTPUT_DIR/python"/pyarrow* \
-       "$OUTPUT_DIR/python"/xarray* \
+rm -rf "$OUTPUT_DIR/python"/xarray* \
        "$OUTPUT_DIR/python"/matplotlib* \
        "$OUTPUT_DIR/python"/lonboard* \
        "$OUTPUT_DIR/python"/boto3* \
        "$OUTPUT_DIR/python"/botocore* 2>/dev/null || true
+
+# pyarrow component strip (issue #130): drop the C++ engines zagg never calls --
+# Flight (RPC), Substrait, Gandiva (LLVM expr JIT), and Dataset -- plus their
+# cython modules. KEEP libarrow.so* (core), libarrow_python* (numpy<->arrow),
+# libparquet* (catalog), libarrow_acero*/_acero*.so + _compute*.so (the
+# arrow-kernel hash-aggregate reducer, kept per issue #130). The generic *.so
+# strip below then strips debug symbols from what remains.
+echo "Component-stripping pyarrow..."
+rm -f "$OUTPUT_DIR/python/pyarrow"/libarrow_flight* \
+      "$OUTPUT_DIR/python/pyarrow"/libarrow_substrait* \
+      "$OUTPUT_DIR/python/pyarrow"/libgandiva* \
+      "$OUTPUT_DIR/python/pyarrow"/libarrow_dataset* \
+      "$OUTPUT_DIR/python/pyarrow"/_flight*.so \
+      "$OUTPUT_DIR/python/pyarrow"/_substrait*.so \
+      "$OUTPUT_DIR/python/pyarrow"/_gandiva*.so \
+      "$OUTPUT_DIR/python/pyarrow"/_dataset*.so 2>/dev/null || true
 
 # Clean caches/tests and strip debug symbols.
 find "$OUTPUT_DIR/python" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -58,8 +58,13 @@ fi
 # lat/lon -> grid CRS at processing time. zarr/obstore/pydantic-zarr are NOT
 # here -- they are function-level deps installed by build_function.sh.
 echo "Installing processing deps..."
+# arro3-core (issue #130) is the deployed-worker Arrow carrier, replacing pyarrow:
+# ~7 MB, zero required deps, importable (pyarrow's bindings hard-link a ~100 MB
+# unstrippable C++ core that can't fit the gate while importable). pyarrow is NOT
+# installed here -- its only use is off-Lambda zagg.catalog. Keep the pin in sync
+# with the `lambda` extra in pyproject.toml.
 $PIP install \
-    "pandas==2.2.3" "pyarrow==24.0.0" fastparquet cramjam \
+    "pandas==2.2.3" "arro3-core==0.8.1" fastparquet cramjam \
     shapely pyproj odc-geo affine cachetools \
     -c "$CONSTRAINTS" \
     -t "$OUTPUT_DIR/python" \
@@ -76,38 +81,15 @@ if [[ "$NUMPY_VERSION" == *"2.3"* ]]; then
 fi
 
 # Remove bloat. pyproj is intentionally NOT stripped (rectilinear/odc-geo assign
-# needs it); pyarrow IS kept now -- it is on the vector-write hot path and the
-# experimental arrow-kernel reducer (issue #130), but its unused C++ engines are
-# component-stripped below to stay under the combined size gate.
+# needs it). pyarrow is no longer installed (issue #130): the worker's Arrow carrier
+# is arro3-core, which needs no component strip, so the whole pyarrow strip block is
+# gone with it.
 echo "Removing bloat..."
 rm -rf "$OUTPUT_DIR/python"/xarray* \
        "$OUTPUT_DIR/python"/matplotlib* \
        "$OUTPUT_DIR/python"/lonboard* \
        "$OUTPUT_DIR/python"/boto3* \
        "$OUTPUT_DIR/python"/botocore* 2>/dev/null || true
-
-# pyarrow component strip (issue #130): drop the C++ engines the Lambda worker
-# never calls -- Flight (RPC), Substrait, Gandiva (LLVM expr JIT), Dataset, and
-# Parquet -- plus their cython modules. KEEP libarrow.so* (core), libarrow_python*
-# (numpy<->arrow), and libarrow_acero*/_acero*.so + _compute*.so (the arrow-kernel
-# hash-aggregate reducer, kept per issue #130). Parquet is stripped because
-# pyarrow.parquet is used ONLY by zagg.catalog (STAC/geoparquet fetch+build), which
-# runs OFF-Lambda with the ``catalog`` extra and never on the worker -- the layer
-# exists only for the worker, so libparquet is pure dead weight here (and recovers
-# the ~12 MB that put the combined layer+function over the 250 MB gate). The worker
-# parquet path, if any, is fastparquet+cramjam, which stay. The generic *.so strip
-# below then strips debug symbols from what remains.
-echo "Component-stripping pyarrow..."
-rm -f "$OUTPUT_DIR/python/pyarrow"/libarrow_flight* \
-      "$OUTPUT_DIR/python/pyarrow"/libarrow_substrait* \
-      "$OUTPUT_DIR/python/pyarrow"/libgandiva* \
-      "$OUTPUT_DIR/python/pyarrow"/libarrow_dataset* \
-      "$OUTPUT_DIR/python/pyarrow"/libparquet* \
-      "$OUTPUT_DIR/python/pyarrow"/_flight*.so \
-      "$OUTPUT_DIR/python/pyarrow"/_substrait*.so \
-      "$OUTPUT_DIR/python/pyarrow"/_gandiva*.so \
-      "$OUTPUT_DIR/python/pyarrow"/_dataset*.so \
-      "$OUTPUT_DIR/python/pyarrow"/_parquet*.so 2>/dev/null || true
 
 # Clean caches/tests and strip debug symbols.
 find "$OUTPUT_DIR/python" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -271,6 +271,10 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # read/index/aggregate deltas; the write phase runs here, so we bracket it
         # below and merge it in. Default (no key) leaves the worker path unchanged.
         profile = event.get("profile", False)
+        # Per-cell carrier/reducer (issue #130). Absent key -> "pandas", the
+        # byte-identical default worker path; "arrow"/"arrow-kernel" opt into the
+        # Arrow read carrier / experimental pyarrow.compute reducer for benchmarks.
+        handoff = event.get("handoff", "pandas")
         chunk_results: list = []
         _df_out, metadata = process_shard(
             grid,
@@ -279,6 +283,7 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             s3_credentials=s3_creds,
             config=config,
             chunk_results=chunk_results,
+            handoff=handoff,
             profile=profile,
         )
 

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -271,9 +271,9 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # read/index/aggregate deltas; the write phase runs here, so we bracket it
         # below and merge it in. Default (no key) leaves the worker path unchanged.
         profile = event.get("profile", False)
-        # Per-cell carrier/reducer (issue #130). Absent key -> "pandas", the
-        # byte-identical default worker path; "arrow"/"arrow-kernel" opt into the
-        # Arrow read carrier / experimental pyarrow.compute reducer for benchmarks.
+        # Per-cell carrier (issue #130). Absent key -> "pandas", the byte-identical
+        # default worker path; "arrow" opts into the arro3-core read carrier for
+        # benchmarks. (Neither imports pyarrow; pyarrow is not in the layer.)
         handoff = event.get("handoff", "pandas")
         chunk_results: list = []
         _df_out, metadata = process_shard(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
 lambda = [
     "numpy==2.2.6",
     "pandas==2.2.3",
+    "pyarrow==24.0.0",
     "h5coro==1.0.4",
     "cramjam",
     "astropy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,13 @@ dependencies = [
     "earthaccess",
     "boto3",
     "fastparquet",
-    "pyarrow",
+    # arro3-core is the deployed-worker Arrow carrier (issue #130): ~7 MB, zero
+    # required runtime deps, importable inside the 250 MB Lambda gate — unlike
+    # pyarrow, whose bindings hard-link a ~100 MB unstrippable C++ core. pyarrow is
+    # NOT a core dep: after the pivot its only remaining direct use is off-Lambda
+    # zagg.catalog, so it lives in the `catalog` extra (forced anyway by
+    # stac-geoparquet).
+    "arro3-core>=0.8.1",
     "pydantic-zarr>=0.9.1",
     "zarr>=3.1.5",
     "obstore>=0.8.2",
@@ -46,7 +52,9 @@ dependencies = [
 lambda = [
     "numpy==2.2.6",
     "pandas==2.2.3",
-    "pyarrow==24.0.0",
+    # arro3-core replaces pyarrow as the deployed-worker Arrow carrier (issue #130).
+    # Keep this pin in sync with deployment/aws/build_layer.sh.
+    "arro3-core==0.8.1",
     "h5coro==1.0.4",
     "cramjam",
     "astropy",
@@ -59,8 +67,12 @@ lambda = [
 # it separately for the exact-S2 catalog backend; without it, `auto` falls back
 # to mortie (HEALPix) / shapely (rectilinear):
 #   pip install "spherely @ https://github.com/espg/spherely/releases/download/v0.1.1-spatialindex/spherely-0.1.1+spatialindex-cp312-cp312-manylinux_2_28_x86_64.whl"
+# pyarrow lives here (not core): zagg.catalog (STAC/geoparquet build) is the only
+# direct pyarrow user after the issue #130 pivot, and stac-geoparquet hard-requires
+# pyarrow anyway. catalog runs off-Lambda, so pyarrow never reaches the worker/layer.
 catalog = [
     "stac-geoparquet>=0.7.0",
+    "pyarrow",
 ]
 analysis = [
     "cubed>=0.24.0",
@@ -72,9 +84,9 @@ analysis = [
     "matplotlib>=3.10.8",
     "notebook",
 ]
-# Lean extra for the Lambda-benchmark CI plotting step (issue #110). pyarrow is
-# already a core dep; this just pulls in matplotlib (same pin as analysis) so the
-# benchmark workflow doesn't install the heavy analysis stack.
+# Lean extra for the Lambda-benchmark CI plotting step (issue #110): just pulls in
+# matplotlib (same pin as analysis) so the benchmark workflow doesn't install the
+# heavy analysis stack.
 benchmark = [
     "matplotlib>=3.10.8",
 ]

--- a/src/zagg/processing/__init__.py
+++ b/src/zagg/processing/__init__.py
@@ -82,7 +82,6 @@ __all__ = [
     "write_ragged_to_zarr",
     "write_shard_to_zarr",
     # aggregate-stage helpers
-    "_KERNEL_FUNCS",
     "_build_groups",
     "_coerce_field_value",
     "_coerce_ragged_value",
@@ -93,8 +92,6 @@ __all__ = [
     "_group_columns",
     "_has_ragged_fields",
     "_has_vector_fields",
-    "_kernel_able",
-    "_kernel_aggregate",
     # read-stage helpers
     "_COMPARE",
     "_broadcast_segment_to_base",

--- a/src/zagg/processing/__init__.py
+++ b/src/zagg/processing/__init__.py
@@ -8,8 +8,8 @@ It is a package (split out of a single ~2000-line ``processing.py`` for the §4
 size limit) whose stages are:
 
 * :mod:`zagg.processing.read` — read + spatially filter HDF5 groups for a shard.
-* :mod:`zagg.processing.aggregate` — per-cell statistics, grouping, the per-chunk
-  precompute hook, and the EXPERIMENTAL pyarrow kernel reducer.
+* :mod:`zagg.processing.aggregate` — per-cell statistics, grouping, and the
+  per-chunk precompute hook.
 * :mod:`zagg.processing.write` — assemble + write the output carrier to Zarr.
 * :mod:`zagg.processing.worker` — ``process_shard`` orchestration.
 
@@ -23,8 +23,6 @@ This ``__init__`` re-exports every public + previously-importable name, so
 import h5coro
 
 from zagg.processing.aggregate import (
-    _KERNEL_FUNCS,
-    KERNEL_RTOL,
     _build_groups,
     _coerce_field_value,
     _coerce_ragged_value,
@@ -35,8 +33,6 @@ from zagg.processing.aggregate import (
     _group_columns,
     _has_ragged_fields,
     _has_vector_fields,
-    _kernel_able,
-    _kernel_aggregate,
     calculate_cell_statistics,
 )
 from zagg.processing.read import (
@@ -76,8 +72,6 @@ from zagg.processing.write import (
 # across the relocation (mirrors ``zagg.grids.__init__``'s re-export convention,
 # and is what lets ruff accept these as intentional re-exports, not dead F401s).
 __all__ = [
-    # public surface
-    "KERNEL_RTOL",
     # bound on the package so ``zagg.processing.h5coro.H5Coro`` resolves (and
     # stays monkeypatch-able) from the worker
     "h5coro",

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -2,9 +2,9 @@
 monolithic ``processing.py`` for the §4 size limit; pure relocation, no behavior
 change).
 
-Per-cell statistics, grouping, coercion, the per-chunk precompute hook, and the
-EXPERIMENTAL pyarrow kernel reducer. Depends only on ``config`` — never on the
-read or write stages — so the import DAG stays acyclic.
+Per-cell statistics, grouping, coercion, and the per-chunk precompute hook.
+Depends only on ``config`` — never on the read or write stages — so the import
+DAG stays acyclic.
 """
 
 from typing import Any
@@ -17,7 +17,6 @@ from zagg.config import (
     default_config,
     get_agg_fields,
     get_chunk_precompute,
-    get_data_vars,
     get_output_signature,
 )
 
@@ -25,8 +24,8 @@ from zagg.config import (
 def _field_sentinel(meta: dict) -> float:
     """Per-cell fill value for an agg field's empty/unused slots.
 
-    Mirrors how ``process_shard`` / :func:`_kernel_aggregate` seed their output
-    arrays: the schema-declared ``fill_value`` (default ``"NaN"`` -> ``np.nan``,
+    Mirrors how ``process_shard`` seeds its output arrays: the schema-declared
+    ``fill_value`` (default ``"NaN"`` -> ``np.nan``,
     else the literal numeric fill). Used both for scalar empty cells and for the
     padding of ``vector`` fields (issue #29 Option B).
     """
@@ -92,16 +91,20 @@ def _concat_and_group(all_reads, grid, handoff: str):
     """Concat the per-group reads and split observations by cell.
 
     Carrier-agnostic seam shared by :func:`process_shard` and its tests, so the
-    Arrow path is exercised end-to-end (including multi-table ``concat_tables``
-    ordering) rather than re-assembled inline. Both carriers feed identical numpy
-    arrays into :func:`_group_columns`, so the groupings — and the aggregations
-    computed from them — are byte-for-byte identical.
+    Arrow path is exercised end-to-end (including multi-table concat ordering)
+    rather than re-assembled inline. Both carriers feed identical numpy arrays into
+    :func:`_group_columns`, so the groupings — and the aggregations computed from
+    them — are byte-for-byte identical.
+
+    The arrow carrier is ``arro3-core`` (issue #130 path C): pyarrow is no longer a
+    runtime dependency. ``arro3`` has no whole-table concat helper, so the per-group
+    reads are concatenated by collecting their record batches into one table.
 
     Parameters
     ----------
     all_reads : list
         Per-group reads from ``_read_group``: ``pandas.DataFrame`` for the pandas
-        carrier, ``pyarrow.Table`` for the arrow carrier.
+        carrier, ``arro3.core.Table`` for the arrow carrier.
     grid : OutputGrid
         Provides ``cells_of`` to map leaf ids to child cell ids.
     handoff : {"pandas", "arrow"}
@@ -117,21 +120,24 @@ def _concat_and_group(all_reads, grid, handoff: str):
         Total observation count across all reads.
     """
     if handoff == "arrow":
-        import pyarrow as pa
+        from arro3.core import Table
 
-        table = pa.concat_tables(all_reads).combine_chunks()
+        # arro3 has no ``concat_tables``; collect every read's batches into one
+        # table (preserving order), matching pyarrow's concat semantics.
+        batches = [b for tbl in all_reads for b in tbl.to_batches()]
+        table = Table.from_batches(batches, schema=all_reads[0].schema)
         # The arrow handoff requires dense, null-free columns: ``_read_group``
-        # builds tables from raw h5coro reads (no null mask), so
-        # ``to_numpy(zero_copy_only=False)`` is dtype-exact and matches ``.values``
-        # on the pandas side. Guard the precondition so a future nullable source
-        # can't silently diverge the two carriers instead of failing loudly.
+        # builds tables from raw h5coro reads (no null mask), so ``to_numpy`` is
+        # dtype-exact and matches ``.values`` on the pandas side. Guard the
+        # precondition so a future nullable source can't silently diverge the two
+        # carriers instead of failing loudly.
         null_cols = [n for n in table.column_names if table.column(n).null_count]
         if null_cols:
             raise ValueError(f"arrow handoff requires null-free columns; got nulls in {null_cols}")
         n_obs_total = table.num_rows
-        cell_col = grid.cells_of(table.column("leaf_id").to_numpy(zero_copy_only=False))
-        col_dict = {n: table.column(n).to_numpy(zero_copy_only=False) for n in table.column_names}
-        col_arrays, cell_to_slice = _group_columns(col_dict, cell_col)
+        cols = {n: table.column(n).combine_chunks().to_numpy() for n in table.column_names}
+        cell_col = grid.cells_of(cols["leaf_id"])
+        col_arrays, cell_to_slice = _group_columns(cols, cell_col)
     else:
         df_all = pd.concat(all_reads, ignore_index=True)
         n_obs_total = len(df_all)
@@ -307,9 +313,6 @@ def calculate_cell_statistics(
     ``np.nanmin``, ``np.nansum``, ``np.nanstd``, ``np.nanmedian``, … — is
     usable directly from the config template with no special-casing, and is
     reduced with numpy's own NaN semantics (see ``test_numpy_nan_aware_functions``).
-    The experimental ``handoff="arrow-kernel"`` path is an *opt-in* acceleration
-    for the kernel-able subset only; it does not change or narrow this contract
-    (see the EXPERIMENTAL block below).
 
     Parameters
     ----------
@@ -645,224 +648,3 @@ def _aggregate_chunk_cells(
                 stats_arrays[key][i] = value
 
     return stats_arrays, ragged_payloads, ragged_cell_indices, cells_with_data
-
-
-# EXPERIMENTAL (phase 2b of #30) -----------------------------------------------
-# Dual aggregation contract
-# -------------------------
-# The DEFAULT, fully-supported contract is "any aggregation expressible in numpy",
-# including the NaN-aware family (``np.nanmean``/``np.nanvar``/``np.nanmax``/…);
-# the user picks the function in the agg template and it runs through
-# ``calculate_cell_statistics`` with numpy's own semantics (see that docstring and
-# ``test_numpy_nan_aware_functions``). Arrow kernels do NOT replace or narrow that
-# contract — they are an OPT-IN acceleration for the kernel-able subset, and the
-# user chooses numpy vs arrow per run via the ``handoff`` flag.
-#
-# Why arrow kernels aren't drop-in nan-operators: pyarrow compute has
-# ``mean``/``min_max``/``variance`` with ``skip_nulls``, but an Arrow NULL is a
-# distinct missing-value bit, NOT a float NaN — ``skip_nulls`` does not skip NaN.
-# So there is no arrow "nanmean" kernel equivalent; the kernel path instead
-# replicates numpy's NaN behaviour by hand (NaN-propagating min/max, see below)
-# rather than pretending arrow nulls and float NaN are the same thing.
-#
-# Optional pyarrow.compute hash-aggregate ("kernel") reduction path. Unlike the
-# pandas/arrow *carriers* — which feed identical numpy arrays into
-# ``calculate_cell_statistics`` and are therefore byte-for-byte identical — the
-# kernel path computes the kernel-able reductions in a single vectorised C++
-# pass (Acero ``TableGroupBy.aggregate``). pyarrow's float summation differs from
-# numpy's, so its ``mean``/``variance`` outputs are NOT byte-identical to the
-# numpy path; they agree only within ``KERNEL_RTOL`` (validated in tests and in
-# ``benchmarks/handoff_bench.py``). ``count``/``min``/``max`` ARE exact vs numpy,
-# including on NaN input: pyarrow's ``min``/``max`` kernels skip NaN by default
-# (numpy propagates it), so :func:`_kernel_aggregate` detects NaN per group and
-# overwrites those groups' min/max with NaN to restore numpy parity (NaN is a
-# value, not an Arrow null, so ``skip_nulls`` does not cover it). This lever is
-# opt-in via ``handoff="arrow-kernel"`` and exists purely so phase 3 can benchmark
-# it on real ATL03 data; it is kept gated and clearly experimental, and should be
-# dropped if that benchmark shows no material speedup (see PR #33 discussion).
-
-# Documented tolerance for kernel-vs-numpy float agreement. float32 means/variance
-# over millions of obs diverge by ~1 ULP (~1e-6 relative); 1e-5 leaves headroom.
-KERNEL_RTOL = 1e-5
-
-# numpy/config ``function`` name -> pyarrow hash-aggregate function name. Only
-# reductions that are mathematically a pure (unweighted) group reduction appear
-# here; weighted ``average``, ``quantile`` (only approximate via tdigest) and any
-# ``expression`` field fall back to the per-cell numpy path.
-# NOTE: ``"average" -> "mean"`` is currently dead for the shipped atl06 config
-# (its ``h_mean`` is a *weighted* average, which ``_kernel_able`` excludes). It is
-# kept only so an unweighted ``average`` field — if a future config defines one —
-# is kernel-able rather than silently falling back; remove it if that never lands.
-_KERNEL_FUNCS = {
-    "len": "count",
-    "count": "count",
-    "min": "min",
-    "max": "max",
-    "var": "variance",
-    "average": "mean",
-}
-
-
-def _kernel_able(meta: dict) -> bool:
-    """Whether an agg field can be computed by a pyarrow hash-aggregate kernel.
-
-    EXPERIMENTAL. Excludes expression fields, weighted ``average`` (no weighted
-    hash kernel), quantiles (only approximate tdigest), and anything whose
-    function has no pure-reduction kernel equivalent.
-    """
-    if meta.get("expression"):
-        return False
-    func = meta.get("function")
-    if func not in _KERNEL_FUNCS:
-        return False
-    # Weighted average is not a pure hash reduction.
-    if func == "average" and "weights" in (meta.get("params") or {}):
-        return False
-    return True
-
-
-def _kernel_aggregate(
-    table,
-    cell_col: np.ndarray,
-    children,
-    value_col: str,
-    config: PipelineConfig,
-    chunk_scalars: dict[str, Any] | None = None,
-) -> dict:
-    """EXPERIMENTAL pyarrow hash-aggregate reducer (phase 2b of #30).
-
-    Computes the kernel-able stats (count/min/max/variance/unweighted-mean) for
-    every child cell in one vectorised ``TableGroupBy.aggregate`` pass, then fills
-    the remaining (weighted mean, expression, quantile) fields via the per-cell
-    numpy path so output columns match the default reducer exactly in shape.
-
-    ``chunk_scalars`` (issue #30) are the per-chunk precompute values, injected
-    into each cell's namespace in the fallback per-cell loop exactly as the default
-    handoff does, so an ``expression`` field referencing a chunk anchor resolves on
-    the arrow path too. A precompute field is never kernel-able (it is an
-    ``expression``), so it always lands in ``fallback_names`` and sees the scalars.
-
-    ``count``/``min``/``max`` are EXACT vs the numpy reducer, including on NaN
-    input — pyarrow's min/max kernels skip NaN, so this function detects NaN per
-    group and propagates it (numpy semantics). The kernel-reduced float stats
-    (``mean``/``variance``) are NOT byte-identical to numpy; they agree within
-    :data:`KERNEL_RTOL` (and both yield NaN on a NaN-bearing group). Returns
-    ``stats_arrays`` (``name -> ndarray`` over ``children``) plus
-    ``cells_with_data``.
-
-    Parameters
-    ----------
-    table : pyarrow.Table
-        Concatenated, null-free observations (one row per observation). "Null-free"
-        is the Arrow-null sense; float NaN values ARE allowed and are handled with
-        numpy semantics (see above). Callers must enforce the null-free contract
-        (``process_shard`` does); this function does not re-check it.
-    cell_col : np.ndarray
-        Child cell id for each row of ``table`` (already ``grid.cells_of`` mapped,
-        so the group key is the destination cell, not the leaf id).
-    children : sequence of int
-        Child cell ids, in canonical chunk order.
-    value_col : str
-        Default value column for fields without an explicit ``source``.
-    config : PipelineConfig
-        Drives the agg-field metadata.
-    """
-    import pyarrow as pa
-
-    agg_fields = get_agg_fields(config)
-    data_vars = get_data_vars(config)
-    n_cells = len(children)
-    child_index = {int(c): i for i, c in enumerate(children)}
-
-    stats_arrays: dict[str, np.ndarray] = {}
-    for name in data_vars:
-        meta = agg_fields[name]
-        # Ragged fields (issue #48) cannot be dense-preallocated; skip them here.
-        # The kernel path does not support ragged — they have no hash-aggregate
-        # kernel equivalent — so a config mixing ragged + arrow-kernel uses the
-        # fallback for ragged fields. But the dense fallback array assignment
-        # (``stats_arrays[name][i] = value``) would crash for a list payload.
-        # Exclude ragged from both the kernel and fallback lists; the caller is
-        # responsible for collecting ragged payloads via process_shard's own loop.
-        if get_output_signature(meta)["kind"] == "ragged":
-            continue
-        zarr_dtype = np.dtype(meta.get("dtype", "float32"))
-        fill_value = meta.get("fill_value", "NaN")
-        if fill_value == "NaN":
-            stats_arrays[name] = np.full(n_cells, np.nan, dtype=zarr_dtype)
-        else:
-            stats_arrays[name] = np.zeros(n_cells, dtype=zarr_dtype)
-
-    # Ragged fields are excluded from kernel and fallback (see above).
-    dense_names = [n for n in data_vars if get_output_signature(agg_fields[n])["kind"] != "ragged"]
-    kernel_names = [n for n in dense_names if _kernel_able(agg_fields[n])]
-    fallback_names = [n for n in dense_names if n not in kernel_names]
-
-    # Group by the destination cell id (not the raw leaf id): append cell_col and
-    # run one vectorised group-by + reduction pass for all kernel-able fields.
-    keyed = table.append_column("_cell", pa.array(np.asarray(cell_col)))
-    aggregations = [
-        (agg_fields[n].get("source") or value_col, _KERNEL_FUNCS[agg_fields[n]["function"]])
-        for n in kernel_names
-    ]
-    # NaN semantics: pyarrow's ``min``/``max`` hash kernels SKIP NaN, whereas
-    # ``np.min``/``np.max`` PROPAGATE it. To keep count/min/max bit-identical to the
-    # numpy path on NaN-bearing input (ATL06 ``h_li`` can carry fill/invalid values
-    # and ``quality_filter`` is a flag check, not a NaN filter), detect NaN per
-    # group on each min/max source column and overwrite those groups' min/max with
-    # NaN below. (``count`` already matches: NaN is a value, not a null, so it is
-    # counted; ``mean``/``variance`` already propagate NaN like numpy.)
-    extrema_srcs = {
-        src for n, (src, kfunc) in zip(kernel_names, aggregations) if kfunc in ("min", "max")
-    }
-    for src in extrema_srcs:
-        is_nan = np.isnan(table.column(src).to_numpy(zero_copy_only=False))
-        keyed = keyed.append_column(f"_isnan_{src}", pa.array(is_nan))
-    aggregations_nan = [(f"_isnan_{src}", "max") for src in extrema_srcs]
-    gd = keyed.group_by("_cell").aggregate(aggregations + aggregations_nan).to_pydict()
-    group_cells = gd["_cell"]
-    group_has_nan = {src: gd[f"_isnan_{src}_max"] for src in extrema_srcs}
-    # Map each grouped row back to its position in ``children``.
-    row_to_idx = [child_index.get(int(c)) for c in group_cells]
-    for n, (src, kfunc) in zip(kernel_names, aggregations):
-        col = gd[f"{src}_{kfunc}"]
-        nan_flags = group_has_nan.get(src) if kfunc in ("min", "max") else None
-        out = stats_arrays[n]
-        for row, idx in enumerate(row_to_idx):
-            if idx is not None:
-                # Propagate NaN for min/max to match numpy (pyarrow skips NaN).
-                out[idx] = np.nan if (nan_flags is not None and nan_flags[row]) else col[row]
-
-    cells_with_data = sum(1 for idx in row_to_idx if idx is not None)
-
-    # Fallback fields (and only those) via the per-cell numpy reducer. Reuse the
-    # carrier-agnostic grouping so the slices match the default path exactly.
-    # NOTE: ``calculate_cell_statistics`` recomputes the *full* stats dict per cell,
-    # so the kernel-able stats are computed a second time here and discarded — we
-    # only read ``fallback_names`` out of it. Acceptable while experimental (the
-    # fallback set is small: weighted mean, expression, quantiles); revisit if a
-    # config makes the fallback set dominate.
-    if fallback_names:
-        col_dict = {
-            name: table.column(name).to_numpy(zero_copy_only=False) for name in table.column_names
-        }
-        col_arrays, cell_to_slice = _group_columns(col_dict, np.asarray(cell_col))
-        _empty = {col: arr[:0] for col, arr in col_arrays.items()}
-        for i, child in enumerate(children):
-            child = int(child)
-            if child in cell_to_slice:
-                s, e = cell_to_slice[child]
-                cell_data = {col: arr[s:e] for col, arr in col_arrays.items()}
-            else:
-                cell_data = _empty
-            # Inject the chunk-level precompute values (no-op when empty), so an
-            # expression fallback field can reference a chunk anchor (issue #30).
-            cell_namespace = {**cell_data, **chunk_scalars} if chunk_scalars else cell_data
-            stats = calculate_cell_statistics(cell_namespace, value_col=value_col, config=config)
-            for name in fallback_names:
-                stats_arrays[name][i] = stats[name]
-
-    return {"stats_arrays": stats_arrays, "cells_with_data": cells_with_data}
-
-
-# -- end EXPERIMENTAL kernel path ---------------------------------------------

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -7,6 +7,8 @@ Depends only on ``config`` — never on the read or write stages — so the impo
 DAG stays acyclic.
 """
 
+import logging
+import os
 from typing import Any
 
 import numpy as np
@@ -19,6 +21,27 @@ from zagg.config import (
     get_chunk_precompute,
     get_output_signature,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _rss_mb() -> float:
+    """Current process RSS in MB (Linux ``/proc``; peak ``rusage`` fallback)."""
+    try:
+        with open("/proc/self/statm") as f:
+            return int(f.read().split()[1]) * os.sysconf("SC_PAGE_SIZE") / 1e6
+    except (FileNotFoundError, OSError, ValueError):
+        import resource
+        import sys
+
+        m = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        return m / 1e6 if sys.platform == "darwin" else m / 1024  # mac=bytes, linux=KB
+
+
+def _rss_log(stage: str) -> None:
+    """Opt-in per-stage RSS trace (set ``ZAGG_PROFILE_RSS=1``) for #130 diagnostics."""
+    if os.environ.get("ZAGG_PROFILE_RSS"):
+        logger.info(f"  [rss] {stage:34s} {_rss_mb():7.0f} MB")
 
 
 def _field_sentinel(meta: dict) -> float:
@@ -126,6 +149,7 @@ def _concat_and_group(all_reads, grid, handoff: str):
         # table (preserving order), matching pyarrow's concat semantics.
         batches = [b for tbl in all_reads for b in tbl.to_batches()]
         table = Table.from_batches(batches, schema=all_reads[0].schema)
+        _rss_log("arrow: after from_batches")
         # The arrow handoff requires dense, null-free columns: ``_read_group``
         # builds tables from raw h5coro reads (no null mask), so ``to_numpy`` is
         # dtype-exact and matches ``.values`` on the pandas side. Guard the
@@ -135,14 +159,29 @@ def _concat_and_group(all_reads, grid, handoff: str):
         if null_cols:
             raise ValueError(f"arrow handoff requires null-free columns; got nulls in {null_cols}")
         n_obs_total = table.num_rows
+        # ``combine_chunks().to_numpy()`` is the one forced copy: it concatenates
+        # each column's per-read chunks into a fresh contiguous numpy array.
         cols = {n: table.column(n).combine_chunks().to_numpy() for n in table.column_names}
+        _rss_log("arrow: after combine_chunks->numpy")
+        # The pooled data now lives in ``cols`` (numpy). Release EVERY Arrow buffer
+        # before grouping -- the chunked ``table``, its ``batches``, and the per-read
+        # tables in ``all_reads`` (all zero-copy views onto the source read buffers).
+        # Without this the worker holds the pooled data twice through ``_group_columns``,
+        # which doubled peak RSS and OOM'd the densest shard at the 2 GB Lambda cap
+        # (issue #130). ``all_reads`` is not used after this call (worker.py).
+        del table, batches
+        all_reads.clear()
+        _rss_log("arrow: after free Arrow buffers")
         cell_col = grid.cells_of(cols["leaf_id"])
         col_arrays, cell_to_slice = _group_columns(cols, cell_col)
+        _rss_log("arrow: after group")
     else:
         df_all = pd.concat(all_reads, ignore_index=True)
+        _rss_log("pandas: after concat")
         n_obs_total = len(df_all)
         cell_col = grid.cells_of(df_all["leaf_id"].values)
         col_arrays, cell_to_slice = _build_groups(df_all, cell_col)
+        _rss_log("pandas: after group")
     return col_arrays, cell_to_slice, n_obs_total
 
 

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -26,16 +26,23 @@ logger = logging.getLogger(__name__)
 
 
 def _rss_mb() -> float:
-    """Current process RSS in MB (Linux ``/proc``; peak ``rusage`` fallback)."""
+    """Best-effort process RSS in MB; never raises (diagnostic-only).
+
+    Linux current RSS via ``/proc``; peak ``rusage`` fallback elsewhere; ``0.0`` if
+    neither is available (e.g. Windows has no ``/proc`` and may lack ``resource``).
+    """
     try:
         with open("/proc/self/statm") as f:
             return int(f.read().split()[1]) * os.sysconf("SC_PAGE_SIZE") / 1e6
     except (FileNotFoundError, OSError, ValueError):
-        import resource
-        import sys
+        try:
+            import resource
+            import sys
 
-        m = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-        return m / 1e6 if sys.platform == "darwin" else m / 1024  # mac=bytes, linux=KB
+            m = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            return m / 1e6 if sys.platform == "darwin" else m / 1024  # mac=bytes, linux=KB
+        except Exception:
+            return 0.0
 
 
 def _rss_log(stage: str) -> None:
@@ -163,12 +170,13 @@ def _concat_and_group(all_reads, grid, handoff: str):
         # each column's per-read chunks into a fresh contiguous numpy array.
         cols = {n: table.column(n).combine_chunks().to_numpy() for n in table.column_names}
         _rss_log("arrow: after combine_chunks->numpy")
-        # The pooled data now lives in ``cols`` (numpy). Release EVERY Arrow buffer
+        # The pooled data now lives in ``cols`` (independent numpy copies that
+        # ``combine_chunks().to_numpy()`` owns). Release the read-stage Arrow buffers
         # before grouping -- the chunked ``table``, its ``batches``, and the per-read
-        # tables in ``all_reads`` (all zero-copy views onto the source read buffers).
-        # Without this the worker holds the pooled data twice through ``_group_columns``,
-        # which doubled peak RSS and OOM'd the densest shard at the 2 GB Lambda cap
-        # (issue #130). ``all_reads`` is not used after this call (worker.py).
+        # tables in ``all_reads`` -- so the worker doesn't hold the pooled data twice
+        # through ``_group_columns``. Without this the peak RSS doubled and OOM'd the
+        # densest shard at the 2 GB Lambda cap (issue #130). ``all_reads`` is unused
+        # after this call (worker.py).
         del table, batches
         all_reads.clear()
         _rss_log("arrow: after free Arrow buffers")

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -306,7 +306,7 @@ def _planned_read_group(
     - the cell ``signal_conf_ph``-style 2-D structured filter would be re-read
       via the planned slices either way (the helper handles that uniformly).
 
-    Returns the same ``pandas.DataFrame`` / ``pyarrow.Table`` / ``None`` contract
+    Returns the same ``pandas.DataFrame`` / ``arro3.core.Table`` / ``None`` contract
     as :func:`_read_group`. Output rows are in plan-slice / spatial-mask /
     filter order — which matches the full-read path's row ordering because the
     plan's runs are emitted in increasing parent index.
@@ -523,17 +523,20 @@ def _planned_read_group(
         data_dict = {k: v[emask] for k, v in data_dict.items()}
 
     if arrow:
-        import pyarrow as pa
+        from arro3.core import Table
 
-        return pa.table(data_dict)
+        # arro3-core carrier (issue #130): no pyarrow on the worker. ``from_pydict``
+        # accepts the raw numpy column arrays directly (zero-copy for the contiguous
+        # dense reads here), matching the pandas carrier's columns.
+        return Table.from_pydict(data_dict)
     return pd.DataFrame(data_dict)
 
 
 def _read_group(h5obj, group: str, data_source: dict, shard_key: int, grid, arrow: bool = False):
     """Read and spatially filter one HDF5 group.
 
-    Returns a ``pandas.DataFrame`` (default) or, when ``arrow=True``, a
-    ``pyarrow.Table`` carrying the identical columns. Returns ``None`` when the
+    Returns a ``pandas.DataFrame`` (default) or, when ``arrow=True``, an
+    ``arro3.core.Table`` carrying the identical columns. Returns ``None`` when the
     group has no observations in this shard.
 
     Supports three modes (issues #43 Phase A/B/C):
@@ -749,7 +752,10 @@ def _read_group_full(
         data_dict = {k: v[emask] for k, v in data_dict.items()}
 
     if arrow:
-        import pyarrow as pa
+        from arro3.core import Table
 
-        return pa.table(data_dict)
+        # arro3-core carrier (issue #130): no pyarrow on the worker. ``from_pydict``
+        # accepts the raw numpy column arrays directly (zero-copy for the contiguous
+        # dense reads here), matching the pandas carrier's columns.
+        return Table.from_pydict(data_dict)
     return pd.DataFrame(data_dict)

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -33,10 +33,7 @@ from zagg.processing.aggregate import (
     _aggregate_chunk_cells,
     _concat_and_group,
     _eval_chunk_precompute,
-    _group_columns,
-    _has_ragged_fields,
     _has_vector_fields,
-    _kernel_aggregate,
     _pool_chunk_columns,
 )
 from zagg.processing.write import _build_output
@@ -83,16 +80,12 @@ def process_shard(
     driver : str, optional
         ``"s3"`` (default) or ``"https"``.
     handoff : str, optional
-        Per-cell aggregation carrier: ``"pandas"`` (default), ``"arrow"``, or the
-        EXPERIMENTAL ``"arrow-kernel"``. ``"pandas"`` and ``"arrow"`` share
-        :func:`_group_columns` and the same numpy reductions, so scalar outputs
-        are byte-for-byte identical; only the read→concat→extract representation
-        differs. ``"arrow-kernel"`` (phase 2b of #30) instead reduces via
-        ``pyarrow.compute`` hash-aggregate kernels: ``count``/``min``/``max`` stay
-        exact vs numpy (NaN included — see :func:`_kernel_aggregate`), while its
-        float ``mean``/``variance`` differ by ~1 ULP (agree within
-        :data:`KERNEL_RTOL`, not byte identical). All three are opt-in while
-        benchmarked (issue #30).
+        Per-cell aggregation carrier: ``"pandas"`` (default) or ``"arrow"``. Both
+        feed identical numpy arrays into the same numpy reductions, so scalar
+        outputs are byte-for-byte identical; only the read→concat→extract
+        representation differs (pandas DataFrames vs ``arro3.core`` Tables). The
+        ``"arrow"`` carrier is opt-in for benchmarking the carrier cost (issue
+        #130). pyarrow is not used on either path.
     ragged_out : dict, optional
         Out-param sink for ``kind: ragged`` (CSR) fields (issue #48). When a dict
         is passed, it is filled in place with ``{field_name: (values_list,
@@ -138,8 +131,8 @@ def process_shard(
     """
     if config is None:
         config = default_config()
-    if handoff not in ("pandas", "arrow", "arrow-kernel"):
-        raise ValueError(f"handoff must be 'pandas', 'arrow', or 'arrow-kernel', got {handoff!r}")
+    if handoff not in ("pandas", "arrow"):
+        raise ValueError(f"handoff must be 'pandas' or 'arrow', got {handoff!r}")
     data_source = config.data_source
 
     shard_key = int(shard_key)
@@ -195,7 +188,7 @@ def process_shard(
     # Build URL rewriter for the active driver
     _rewrite_url = _processing._make_url_rewriter(driver)
 
-    use_arrow = handoff in ("arrow", "arrow-kernel")
+    use_arrow = handoff == "arrow"
     all_reads = []
     files_processed = 0
     read_errors = 0
@@ -309,33 +302,10 @@ def process_shard(
     # so the gain/offset anchor must be reduced over each chunk's own observations,
     # not the whole pooled shard. At K==1 the lone chunk == the whole shard, so the
     # anchor is identical to the old shard-level reduction (byte-for-byte unchanged).
-    if handoff == "arrow-kernel":
-        # EXPERIMENTAL (phase 2b of #30): reduce via pyarrow hash-aggregate kernels.
-        if _has_ragged_fields(config):
-            raise NotImplementedError(
-                "handoff='arrow-kernel' does not support ragged fields (issue #48); "
-                "use handoff='pandas' or 'arrow' instead"
-            )
-        import pyarrow as pa
-
-        table = pa.concat_tables(all_reads).combine_chunks()
-        null_cols = [n for n in table.column_names if table.column(n).null_count]
-        if null_cols:
-            raise ValueError(f"arrow handoff requires null-free columns; got nulls in {null_cols}")
-        n_obs_total = table.num_rows
-        cell_col = grid.cells_of(table.column("leaf_id").to_numpy(zero_copy_only=False))
-        logger.info(f"  Read {n_obs_total:,} observations")
-        pooled = {n: table.column(n).to_numpy(zero_copy_only=False) for n in table.column_names}
-        # Group the pooled columns by cell ONCE (issue #82 phase 6), exactly as the
-        # default path's ``cell_to_slice`` does, so the per-chunk precompute subset is
-        # a contiguous gather (O(N) total) rather than a shard-wide ``np.isin`` rescan
-        # on every one of the K iterations (O(K·N)).
-        pooled_sorted, pooled_to_slice = _group_columns(pooled, cell_col)
-    else:
-        # Concat the per-group reads and split observations by cell (carrier-
-        # agnostic; both carriers feed identical numpy arrays into _group_columns).
-        col_arrays, cell_to_slice, n_obs_total = _concat_and_group(all_reads, grid, handoff)
-        logger.info(f"  Read {n_obs_total:,} observations")
+    # Concat the per-group reads and split observations by cell (carrier-agnostic;
+    # both carriers feed identical numpy arrays into _group_columns).
+    col_arrays, cell_to_slice, n_obs_total = _concat_and_group(all_reads, grid, handoff)
+    logger.info(f"  Read {n_obs_total:,} observations")
 
     if profile:
         phase_timings["index"] = time.time() - _index_t0
@@ -359,35 +329,20 @@ def process_shard(
     single_ragged: dict = {}
     for block_index, chunk_children in chunk_iter:
         chunk_children = np.asarray(chunk_children)
-        if handoff == "arrow-kernel":
-            # Per-chunk precompute (issue #82 phase 6): reduce the anchor over only
-            # this chunk's observations, gathered from the once-grouped pooled columns
-            # (contiguous slices, not a shard-wide rescan). An empty chunk yields
-            # length-0 columns, which ``_eval_chunk_precompute`` short-circuits to NaN
-            # anchors rather than raising on ``np.min`` of an empty array.
-            chunk_pooled = _pool_chunk_columns(pooled_sorted, pooled_to_slice, chunk_children)
-            chunk_scalars = _eval_chunk_precompute(config, chunk_pooled)
-            kernel = _kernel_aggregate(
-                table, cell_col, chunk_children, "h_li", config, chunk_scalars=chunk_scalars
-            )
-            stats_arrays = kernel["stats_arrays"]
-            cells_with_data += kernel["cells_with_data"]
-            ragged_payloads: dict[str, list] = {}
-        else:
-            # Per-chunk precompute (issue #82 phase 6): pool only this chunk's rows
-            # from the shard's sorted column arrays, then reduce the anchor over them.
-            chunk_pooled = _pool_chunk_columns(col_arrays, cell_to_slice, chunk_children)
-            chunk_scalars = _eval_chunk_precompute(config, chunk_pooled)
-            stats_arrays, ragged_payloads, ragged_idx, cwd = _aggregate_chunk_cells(
-                chunk_children,
-                col_arrays,
-                cell_to_slice,
-                chunk_scalars,
-                config,
-                data_vars,
-                agg_fields,
-            )
-            cells_with_data += cwd
+        # Per-chunk precompute (issue #82 phase 6): pool only this chunk's rows
+        # from the shard's sorted column arrays, then reduce the anchor over them.
+        chunk_pooled = _pool_chunk_columns(col_arrays, cell_to_slice, chunk_children)
+        chunk_scalars = _eval_chunk_precompute(config, chunk_pooled)
+        stats_arrays, ragged_payloads, ragged_idx, cwd = _aggregate_chunk_cells(
+            chunk_children,
+            col_arrays,
+            cell_to_slice,
+            chunk_scalars,
+            config,
+            data_vars,
+            agg_fields,
+        )
+        cells_with_data += cwd
         carrier = _build_output(
             stats_arrays,
             dense_vars,
@@ -397,11 +352,7 @@ def process_shard(
             use_arrow=use_arrow,
             children=(chunk_children if chunks_per_shard > 1 else None),
         )
-        ragged = (
-            {name: (ragged_payloads[name], ragged_idx[name]) for name in ragged_payloads}
-            if handoff != "arrow-kernel"
-            else {}
-        )
+        ragged = {name: (ragged_payloads[name], ragged_idx[name]) for name in ragged_payloads}
         if chunk_results is not None:
             chunk_results.append((block_index, carrier, ragged))
         else:

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -31,14 +31,20 @@ def _arrow_column(block: np.ndarray, sig: dict):
     list. Keeping the vector path a list-carrier (rather than a bespoke 2-D
     column) is what lets the future ragged t-digest slot in as a variable-length
     ``List<FixedSizeList<2>>`` through the same seam (issue #29 Tier 2).
+
+    The carrier is ``arro3-core`` (issue #130 path C): ~7 MB, zero required deps,
+    importable inside the 250 MB Lambda gate — unlike pyarrow, whose Python
+    bindings hard-link a ~100 MB unstrippable C++ core. pyarrow is no longer
+    shipped in the layer; it stays a dep only for off-Lambda ``zagg.catalog`` and
+    the local-only ``handoff='arrow-kernel'`` reducer.
     """
-    import pyarrow as pa
+    from arro3.core import Array, fixed_size_list_array
 
     if sig["kind"] != "vector":
-        return pa.array(block)
+        return Array.from_numpy(np.ascontiguousarray(block))
     width = int(np.prod(sig["trailing_shape"]))
     flat = np.ascontiguousarray(block).reshape(-1)
-    return pa.FixedSizeListArray.from_arrays(pa.array(flat), width)
+    return fixed_size_list_array(Array.from_numpy(flat), width)
 
 
 def _build_output(
@@ -46,9 +52,9 @@ def _build_output(
 ):
     """Assemble the per-shard output carrier from the per-cell stats blocks.
 
-    Returns a ``pandas.DataFrame`` for a pure-scalar config (unchanged) or a
-    ``pyarrow.Table`` when any ``vector`` field is present, in both cases with the
-    data-variable columns followed by the grid's per-cell coord columns.
+    Returns a ``pandas.DataFrame`` for a pure-scalar config (unchanged) or an
+    ``arro3.core.Table`` when any ``vector`` field is present, in both cases with
+    the data-variable columns followed by the grid's per-cell coord columns.
 
     ``children`` (issue #30 item 3): when given, the coord columns are computed
     for that explicit chunk's cells via ``grid.coords_of(children)`` instead of the
@@ -63,7 +69,7 @@ def _build_output(
             df_out[col_name] = vals
         return df_out
 
-    import pyarrow as pa
+    from arro3.core import Array, Table
 
     columns = {
         var: _arrow_column(stats_arrays[var], get_output_signature(agg_fields[var]))
@@ -74,8 +80,8 @@ def _build_output(
         # pandas carrier (#71), so both carriers share one on-disk dtype guarantee
         # rather than relying on MortonIndexArray.__array__ returning uint64.
         arr = morton_words(vals) if is_morton_array(vals) else np.asarray(vals)
-        columns[col_name] = pa.array(arr)
-    return pa.table(columns)
+        columns[col_name] = Array.from_numpy(np.ascontiguousarray(arr))
+    return Table.from_pydict(columns)
 
 
 def _carrier_empty(carrier) -> bool:
@@ -96,8 +102,8 @@ def write_dataframe_to_zarr(
 
     Parameters
     ----------
-    df_out : pandas.DataFrame or pyarrow.Table
-        Coordinate + data-variable columns. A ``pyarrow.Table`` is used when the
+    df_out : pandas.DataFrame or arro3.core.Table
+        Coordinate + data-variable columns. An ``arro3.core.Table`` is used when the
         config declares any ``vector`` field (issue #29): its ``FixedSizeList``
         columns carry the per-cell ``trailing_shape`` payload, written to a
         Zarr array with a trailing dimension. Cell count must equal
@@ -579,14 +585,17 @@ def _iter_carrier_columns(carrier):
             yield name, values
         return
 
-    import pyarrow as pa
+    from arro3.core import list_flatten
 
     n_rows = carrier.num_rows
     for name in carrier.column_names:
         col = carrier.column(name).combine_chunks()
-        if pa.types.is_fixed_size_list(col.type):
-            width = col.type.list_size
-            flat = col.values.to_numpy(zero_copy_only=False)
+        # arro3 marks a FixedSizeList by an integer ``list_size`` (None for scalar
+        # types), so the per-cell width and the 2-D reshape mirror the pyarrow path
+        # exactly — the numpy block written to Zarr is byte-for-byte unchanged.
+        width = col.type.list_size
+        if width is not None:
+            flat = list_flatten(col).to_numpy()
             yield name, flat.reshape(n_rows, width)
         else:
-            yield name, col.to_numpy(zero_copy_only=False)
+            yield name, col.to_numpy()

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -85,7 +85,14 @@ def _build_output(
 
 
 def _carrier_empty(carrier) -> bool:
-    """Whether a process_shard output carrier (DataFrame or Arrow table) is empty."""
+    """Whether a process_shard output carrier (DataFrame or Arrow table) is empty.
+
+    The arro3 carrier is never built with 0 rows in practice — ``_build_output``
+    sizes it to ``prod(chunk_shape) > 0`` cells, and a no-data shard returns an
+    empty pandas DataFrame before any arro3 table is constructed (arro3 cannot build
+    a 0-length array). The ``num_rows == 0`` arm is kept as a defensive parallel to
+    the DataFrame ``.empty`` check, not a path the worker exercises.
+    """
     if isinstance(carrier, pd.DataFrame):
         return carrier.empty
     return carrier.num_rows == 0

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -34,9 +34,9 @@ def _arrow_column(block: np.ndarray, sig: dict):
 
     The carrier is ``arro3-core`` (issue #130 path C): ~7 MB, zero required deps,
     importable inside the 250 MB Lambda gate — unlike pyarrow, whose Python
-    bindings hard-link a ~100 MB unstrippable C++ core. pyarrow is no longer
-    shipped in the layer; it stays a dep only for off-Lambda ``zagg.catalog`` and
-    the local-only ``handoff='arrow-kernel'`` reducer.
+    bindings hard-link a ~100 MB unstrippable C++ core. pyarrow is no longer shipped
+    in the layer or a core dep; it survives only in the off-Lambda ``catalog`` extra
+    (``zagg.catalog``, via stac-geoparquet).
     """
     from arro3.core import Array, fixed_size_list_array
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -86,7 +86,7 @@ def agg(
     region: str = "us-west-2",
     output_credentials: dict | None = None,
     output_endpoint_url: str | None = None,
-    handoff: str = "pandas",
+    handoff: str = "arrow",
     profile: bool = False,
     max_retries: int = 3,
 ) -> dict:
@@ -133,13 +133,14 @@ def agg(
         Custom S3-compatible endpoint for the output store (e.g. R2, MinIO).
         Overrides ``output.endpoint_url`` in the config.
     handoff : str
-        Per-cell aggregation carrier: ``"pandas"`` (default) or ``"arrow"`` (an
-        ``arro3.core`` carrier). Both produce byte-for-byte identical scalar outputs
-        (#30); ``"arrow"`` is opt-in for benchmarking the carrier cost. Honored by
-        both the ``"local"`` and ``"lambda"`` backends (issue #130): the lambda
-        backend forwards it into each cell event, and the default ``"pandas"`` keeps
-        the event payload byte-identical (no key). pyarrow is not used on either
-        path; the experimental ``arrow-kernel`` reducer was dropped with pyarrow.
+        Per-cell aggregation carrier: ``"arrow"`` (default, an ``arro3.core``
+        carrier) or ``"pandas"``. Both produce byte-for-byte identical scalar outputs
+        (#30); ``"arrow"`` is the default because it is faster and lighter on dense
+        shards (issue #130). Honored by both the ``"local"`` and ``"lambda"``
+        backends: the lambda backend forwards it into each cell event, and an
+        explicit ``"pandas"`` keeps that event payload byte-identical (no key).
+        pyarrow is not used on either path; the experimental ``arrow-kernel``
+        reducer was dropped with pyarrow.
     profile : bool
         Opt-in per-phase timing (issue #100). When ``True`` (lambda backend),
         forwards ``profile`` into each cell event so the worker emits a
@@ -351,7 +352,7 @@ def _check_signature(grid, catalog_data: dict) -> None:
 
 
 def _process_and_write(
-    shard_key, chunk_idx, records, grid, s3_creds, zarr_store, config, driver=None, handoff="pandas"
+    shard_key, chunk_idx, records, grid, s3_creds, zarr_store, config, driver=None, handoff="arrow"
 ):
     """Process a single shard and write its K finer chunks to the store.
 
@@ -421,7 +422,7 @@ def _run_local(
     driver="s3",
     output_credentials=None,
     output_endpoint_url=None,
-    handoff="pandas",
+    handoff="arrow",
 ):
     """Run processing locally via the generic dispatch loop on a thread pool.
 
@@ -561,7 +562,7 @@ def _run_lambda(
     function_name,
     output_credentials=None,
     output_endpoint_url=None,
-    handoff="pandas",
+    handoff="arrow",
     profile=False,
     max_retries=3,
 ):
@@ -1036,7 +1037,7 @@ def _invoke_lambda_cell(
     output_creds_event=None,
     max_retries=3,
     max_workers=None,
-    handoff="pandas",
+    handoff="arrow",
     profile=False,
 ):
     """Invoke Lambda for a single cell with retry logic.
@@ -1046,8 +1047,8 @@ def _invoke_lambda_cell(
     ``"profile": true`` event key so the worker emits ``phase_timings``; when
     False the event payload is byte-identical to the pre-profile path (no key).
     ``handoff`` (issue #130) forwards a ``"handoff"`` event key selecting the
-    worker's carrier/reducer; the default ``"pandas"`` omits the key, keeping the
-    event byte-identical to the pre-handoff path.
+    worker's carrier; the default ``"arrow"`` adds the key, while an explicit
+    ``"pandas"`` omits it, keeping that event byte-identical to the pre-handoff path.
     """
     wall_start = time.time()
 
@@ -1074,8 +1075,8 @@ def _invoke_lambda_cell(
     # Only add the key when profiling, so default runs stay byte-identical (#100).
     if profile:
         event["profile"] = True
-    # Only add the key for a non-default carrier, so default (pandas) runs stay
-    # byte-identical to the pre-handoff path (#130).
+    # Add the key for the arrow carrier (the default); an explicit pandas run omits
+    # it, staying byte-identical to the pre-handoff path (#130).
     if handoff and handoff != "pandas":
         event["handoff"] = handoff
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -133,9 +133,13 @@ def agg(
         Custom S3-compatible endpoint for the output store (e.g. R2, MinIO).
         Overrides ``output.endpoint_url`` in the config.
     handoff : str
-        Per-cell aggregation carrier: ``"pandas"`` (default) or ``"arrow"``.
-        Both produce byte-for-byte identical scalar outputs (#30); ``"arrow"``
-        is opt-in for benchmarking. Only honored by the ``"local"`` backend.
+        Per-cell aggregation carrier/reducer: ``"pandas"`` (default), ``"arrow"``,
+        or ``"arrow-kernel"`` (experimental pyarrow.compute reducer). ``"pandas"``
+        and ``"arrow"`` produce byte-for-byte identical scalar outputs (#30);
+        ``"arrow-kernel"`` agrees within ``KERNEL_RTOL`` (#33). Opt-in for
+        benchmarking. Honored by both the ``"local"`` and ``"lambda"`` backends
+        (issue #130): the lambda backend forwards it into each cell event, and the
+        default ``"pandas"`` keeps the event payload byte-identical (no key).
     profile : bool
         Opt-in per-phase timing (issue #100). When ``True`` (lambda backend),
         forwards ``profile`` into each cell event so the worker emits a
@@ -230,6 +234,7 @@ def agg(
             function_name=function_name,
             output_credentials=output_credentials,
             output_endpoint_url=resolved_endpoint,
+            handoff=handoff,
             profile=profile,
             max_retries=max_retries,
         )
@@ -556,6 +561,7 @@ def _run_lambda(
     function_name,
     output_credentials=None,
     output_endpoint_url=None,
+    handoff="pandas",
     profile=False,
     max_retries=3,
 ):
@@ -675,6 +681,7 @@ def _run_lambda(
             output_creds_event=output_creds_event,
             max_retries=max_retries,
             max_workers=state["workers"],
+            handoff=handoff,
             profile=profile,
         )
 
@@ -1029,6 +1036,7 @@ def _invoke_lambda_cell(
     output_creds_event=None,
     max_retries=3,
     max_workers=None,
+    handoff="pandas",
     profile=False,
 ):
     """Invoke Lambda for a single cell with retry logic.
@@ -1037,6 +1045,9 @@ def _invoke_lambda_cell(
     (#28); it does not affect dispatch. ``profile`` (issue #100) forwards a
     ``"profile": true`` event key so the worker emits ``phase_timings``; when
     False the event payload is byte-identical to the pre-profile path (no key).
+    ``handoff`` (issue #130) forwards a ``"handoff"`` event key selecting the
+    worker's carrier/reducer; the default ``"pandas"`` omits the key, keeping the
+    event byte-identical to the pre-handoff path.
     """
     wall_start = time.time()
 
@@ -1063,6 +1074,10 @@ def _invoke_lambda_cell(
     # Only add the key when profiling, so default runs stay byte-identical (#100).
     if profile:
         event["profile"] = True
+    # Only add the key for a non-default carrier, so default (pandas) runs stay
+    # byte-identical to the pre-handoff path (#130).
+    if handoff and handoff != "pandas":
+        event["handoff"] = handoff
 
     last_error = None
     for attempt in range(max_retries):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -133,13 +133,13 @@ def agg(
         Custom S3-compatible endpoint for the output store (e.g. R2, MinIO).
         Overrides ``output.endpoint_url`` in the config.
     handoff : str
-        Per-cell aggregation carrier/reducer: ``"pandas"`` (default), ``"arrow"``,
-        or ``"arrow-kernel"`` (experimental pyarrow.compute reducer). ``"pandas"``
-        and ``"arrow"`` produce byte-for-byte identical scalar outputs (#30);
-        ``"arrow-kernel"`` agrees within ``KERNEL_RTOL`` (#33). Opt-in for
-        benchmarking. Honored by both the ``"local"`` and ``"lambda"`` backends
-        (issue #130): the lambda backend forwards it into each cell event, and the
-        default ``"pandas"`` keeps the event payload byte-identical (no key).
+        Per-cell aggregation carrier: ``"pandas"`` (default) or ``"arrow"`` (an
+        ``arro3.core`` carrier). Both produce byte-for-byte identical scalar outputs
+        (#30); ``"arrow"`` is opt-in for benchmarking the carrier cost. Honored by
+        both the ``"local"`` and ``"lambda"`` backends (issue #130): the lambda
+        backend forwards it into each cell event, and the default ``"pandas"`` keeps
+        the event payload byte-identical (no key). pyarrow is not used on either
+        path; the experimental ``arrow-kernel`` reducer was dropped with pyarrow.
     profile : bool
         Opt-in per-phase timing (issue #100). When ``True`` (lambda backend),
         forwards ``profile`` into each cell event so the worker emits a

--- a/tests/data/benchmark/configs/atl03_scalar_healpix_o11.yaml
+++ b/tests/data/benchmark/configs/atl03_scalar_healpix_o11.yaml
@@ -1,0 +1,81 @@
+# ATL03 photon-height scalar template (HEALPix, multi-chunk-per-worker).
+#
+# Purely SCALAR per-cell stats over photon heights (h_ph): count, min, max, and
+# variance -- no vector and no ragged field. Every field is a pure (unweighted)
+# group reduction in ``_KERNEL_FUNCS`` (len/min/max/var), so this config is the
+# one that the experimental ``handoff="arrow-kernel"`` Acero hash-aggregate
+# reducer can run end-to-end. It exists purely to benchmark the per-cell handoff
+# (issue #130): the SAME config + SAME shard is dispatched three times --
+# pandas / arrow / arrow-kernel -- to isolate the Arrow carrier cost and the
+# kernel reducer's speedup + accuracy (pandas==arrow byte-identical; arrow-kernel
+# within KERNEL_RTOL). See the ``provisional_targets`` block in targets.json.
+#
+# data_source / read_plan / grid match atl03_tdigest_healpix_o11.yaml exactly
+# (the segment->photon planned IO of issue #43 applies here too); only the
+# aggregation differs -- scalar-only so arrow-kernel is applicable.
+data_source:
+  reader: h5coro
+  driver: s3
+  groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]
+  coordinates:
+    latitude: "/{group}/heights/lat_ph"
+    longitude: "/{group}/heights/lon_ph"
+  variables:
+    h_ph: "/{group}/heights/h_ph"
+  filters:
+    - dataset: "/{group}/heights/signal_conf_ph"
+      column: 0                  # land surface type; TEP is uniform across columns
+      op: ne
+      value: -2
+  base_level: photons
+  levels:
+    photons:
+      path: "/{group}/heights"
+      coordinates: {latitude: lat_ph, longitude: lon_ph}
+      link: null
+    segments:
+      path: "/{group}/geolocation"
+      coordinates: {latitude: reference_photon_lat, longitude: reference_photon_lon}
+      link:
+        to: photons
+        index_beg: "/{group}/geolocation/ph_index_beg"
+        count: "/{group}/geolocation/segment_ph_cnt"
+        index_base: 1            # ATL03 ph_index_beg is 1-based per the v3 dict
+  read_plan:
+    spatial_index: segments
+    pad: 1                       # one segment of padding on each side per #43
+
+aggregation:
+  coordinates:
+    cell_ids:
+      dtype: uint64
+      fill_value: 0
+    morton:
+      dtype: uint64
+      fill_value: 0
+  variables:
+    count:
+      function: len
+      source: h_ph
+      dtype: int32
+      fill_value: 0
+    h_min:
+      function: min
+      source: h_ph
+      dtype: float32
+    h_max:
+      function: max
+      source: h_ph
+      dtype: float32
+    h_variance:
+      function: var
+      source: h_ph
+      dtype: float32
+
+output:
+  grid:
+    type: healpix
+    indexing_scheme: nested
+    parent_order: 11             # shard / dispatch unit: 4^(19-11) = 256x256 cells
+    chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=16 per shard)
+    child_order: 19              # leaf cell resolution (~10 m)

--- a/tests/data/benchmark/configs/atl03_scalar_healpix_o11.yaml
+++ b/tests/data/benchmark/configs/atl03_scalar_healpix_o11.yaml
@@ -1,18 +1,16 @@
 # ATL03 photon-height scalar template (HEALPix, multi-chunk-per-worker).
 #
 # Purely SCALAR per-cell stats over photon heights (h_ph): count, min, max, and
-# variance -- no vector and no ragged field. Every field is a pure (unweighted)
-# group reduction in ``_KERNEL_FUNCS`` (len/min/max/var), so this config is the
-# one that the experimental ``handoff="arrow-kernel"`` Acero hash-aggregate
-# reducer can run end-to-end. It exists purely to benchmark the per-cell handoff
-# (issue #130): the SAME config + SAME shard is dispatched three times --
-# pandas / arrow / arrow-kernel -- to isolate the Arrow carrier cost and the
-# kernel reducer's speedup + accuracy (pandas==arrow byte-identical; arrow-kernel
-# within KERNEL_RTOL). See the ``provisional_targets`` block in targets.json.
+# variance -- no vector and no ragged field. It exists purely to benchmark the
+# per-cell carrier handoff (issue #130): the SAME config + SAME shard is dispatched
+# twice -- pandas / arrow -- to isolate the Arrow carrier cost (pandas DataFrame vs
+# an arro3-core Arrow table; both byte-identical, neither imports pyarrow). See the
+# ``provisional_targets`` block in targets.json. (The earlier arrow-kernel reducer
+# was dropped with pyarrow -- arro3 has no hash-aggregate -- per the path-C pivot.)
 #
 # data_source / read_plan / grid match atl03_tdigest_healpix_o11.yaml exactly
 # (the segment->photon planned IO of issue #43 applies here too); only the
-# aggregation differs -- scalar-only so arrow-kernel is applicable.
+# aggregation differs (scalar-only).
 data_source:
   reader: h5coro
   driver: s3

--- a/tests/data/benchmark/targets.json
+++ b/tests/data/benchmark/targets.json
@@ -99,7 +99,7 @@
     }
   },
   "provisional_targets": {
-    "_comment": "PROVISIONAL, PR-TREE-ONLY (issue #130, @espg decision https://github.com/englacial/zagg/issues/130#issuecomment-4838186259). These three scalar targets share ONE config + ONE shard (healpix_o11) and differ only by handoff (pandas / arrow / arrow-kernel) to benchmark the per-cell carrier cost and the experimental kernel reducer. They are deliberately NOT in 'targets' so they do NOT join the committed every-merge matrix until the kernel keep/drop decision is made. run_benchmark.py runs them by explicit --target name (via /benchmark); 'run all' (no --target) skips them.",
+    "_comment": "PROVISIONAL, PR-TREE-ONLY (issue #130). These two scalar targets share ONE config + ONE shard (healpix_o11) and differ only by handoff (pandas / arrow) to benchmark the per-cell carrier cost: pandas DataFrame vs an arro3-core Arrow table. Both produce byte-identical scalar output and neither imports pyarrow. (The experimental arrow-kernel reducer was dropped with pyarrow per @espg's path-C decision https://github.com/englacial/zagg/pull/131#issuecomment-4838785058, since arro3 has no hash-aggregate.) They are deliberately NOT in 'targets' so they do NOT join the committed every-merge matrix until the carrier keep/drop decision is made. run_benchmark.py runs them by explicit --target name (via /benchmark); 'run all' (no --target) skips them.",
     "scalar_pandas_healpix_o11": {
       "config": "configs/atl03_scalar_healpix_o11.yaml",
       "shardmap": "healpix_o11",
@@ -115,14 +115,6 @@
       "grid_type": "healpix",
       "grid_size": "o11",
       "handoff": "arrow"
-    },
-    "scalar_kernel_healpix_o11": {
-      "config": "configs/atl03_scalar_healpix_o11.yaml",
-      "shardmap": "healpix_o11",
-      "aggregator": "scalar",
-      "grid_type": "healpix",
-      "grid_size": "o11",
-      "handoff": "arrow-kernel"
     }
   }
 }

--- a/tests/data/benchmark/targets.json
+++ b/tests/data/benchmark/targets.json
@@ -46,56 +46,64 @@
       "shardmap": "healpix_o11",
       "aggregator": "gain_bias",
       "grid_type": "healpix",
-      "grid_size": "o11"
+      "grid_size": "o11",
+      "handoff": "arrow"
     },
     "tdigest_healpix_o11": {
       "config": "configs/atl03_tdigest_healpix_o11.yaml",
       "shardmap": "healpix_o11",
       "aggregator": "tdigest",
       "grid_type": "healpix",
-      "grid_size": "o11"
+      "grid_size": "o11",
+      "handoff": "arrow"
     },
     "gain_bias_healpix_o10": {
       "config": "configs/atl03_gain_bias_healpix_o10.yaml",
       "shardmap": "healpix_o10",
       "aggregator": "gain_bias",
       "grid_type": "healpix",
-      "grid_size": "o10"
+      "grid_size": "o10",
+      "handoff": "arrow"
     },
     "tdigest_healpix_o10": {
       "config": "configs/atl03_tdigest_healpix_o10.yaml",
       "shardmap": "healpix_o10",
       "aggregator": "tdigest",
       "grid_type": "healpix",
-      "grid_size": "o10"
+      "grid_size": "o10",
+      "handoff": "arrow"
     },
     "gain_bias_rect_3km": {
       "config": "configs/atl03_gain_bias_rect_3km.yaml",
       "shardmap": "rect_3km",
       "aggregator": "gain_bias",
       "grid_type": "rectilinear",
-      "grid_size": "3km"
+      "grid_size": "3km",
+      "handoff": "arrow"
     },
     "tdigest_rect_3km": {
       "config": "configs/atl03_tdigest_rect_3km.yaml",
       "shardmap": "rect_3km",
       "aggregator": "tdigest",
       "grid_type": "rectilinear",
-      "grid_size": "3km"
+      "grid_size": "3km",
+      "handoff": "arrow"
     },
     "gain_bias_rect_6km": {
       "config": "configs/atl03_gain_bias_rect_6km.yaml",
       "shardmap": "rect_6km",
       "aggregator": "gain_bias",
       "grid_type": "rectilinear",
-      "grid_size": "6km"
+      "grid_size": "6km",
+      "handoff": "arrow"
     },
     "tdigest_rect_6km": {
       "config": "configs/atl03_tdigest_rect_6km.yaml",
       "shardmap": "rect_6km",
       "aggregator": "tdigest",
       "grid_type": "rectilinear",
-      "grid_size": "6km"
+      "grid_size": "6km",
+      "handoff": "arrow"
     }
   },
   "provisional_targets": {

--- a/tests/data/benchmark/targets.json
+++ b/tests/data/benchmark/targets.json
@@ -97,5 +97,32 @@
       "grid_type": "rectilinear",
       "grid_size": "6km"
     }
+  },
+  "provisional_targets": {
+    "_comment": "PROVISIONAL, PR-TREE-ONLY (issue #130, @espg decision https://github.com/englacial/zagg/issues/130#issuecomment-4838186259). These three scalar targets share ONE config + ONE shard (healpix_o11) and differ only by handoff (pandas / arrow / arrow-kernel) to benchmark the per-cell carrier cost and the experimental kernel reducer. They are deliberately NOT in 'targets' so they do NOT join the committed every-merge matrix until the kernel keep/drop decision is made. run_benchmark.py runs them by explicit --target name (via /benchmark); 'run all' (no --target) skips them.",
+    "scalar_pandas_healpix_o11": {
+      "config": "configs/atl03_scalar_healpix_o11.yaml",
+      "shardmap": "healpix_o11",
+      "aggregator": "scalar",
+      "grid_type": "healpix",
+      "grid_size": "o11",
+      "handoff": "pandas"
+    },
+    "scalar_arrow_healpix_o11": {
+      "config": "configs/atl03_scalar_healpix_o11.yaml",
+      "shardmap": "healpix_o11",
+      "aggregator": "scalar",
+      "grid_type": "healpix",
+      "grid_size": "o11",
+      "handoff": "arrow"
+    },
+    "scalar_kernel_healpix_o11": {
+      "config": "configs/atl03_scalar_healpix_o11.yaml",
+      "shardmap": "healpix_o11",
+      "aggregator": "scalar",
+      "grid_type": "healpix",
+      "grid_size": "o11",
+      "handoff": "arrow-kernel"
+    }
   }
 }

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -245,6 +245,73 @@ def test_targets_manifest_consistent():
         assert n == sm_meta["n_granules"], f"{t['shardmap']}: stale n_granules"
 
 
+# --- provisional (PR-tree-only) handoff targets (issue #130) ---------------
+
+
+def test_provisional_targets_excluded_from_merge_matrix():
+    # The arrow/arrow-kernel comparison targets are PR-tree-only: "run all"
+    # (no --target) must not iterate them, so they never join the merge matrix.
+    manifest = json.loads((BENCH / "targets.json").read_text())
+    all_names = run_benchmark.all_target_names(manifest)
+    provisional = set(manifest["provisional_targets"]) - {"_comment"}
+    assert provisional, "expected provisional targets"
+    assert provisional.isdisjoint(all_names)
+    assert set(manifest["targets"]).issubset(all_names)
+
+
+def test_provisional_targets_consistent_and_carry_handoff():
+    manifest = json.loads((BENCH / "targets.json").read_text())
+    expected = {
+        "scalar_pandas_healpix_o11": "pandas",
+        "scalar_arrow_healpix_o11": "arrow",
+        "scalar_kernel_healpix_o11": "arrow-kernel",
+    }
+    for tname, handoff in expected.items():
+        t = manifest["provisional_targets"][tname]
+        assert (BENCH / t["config"]).exists(), f"{tname}: missing config"
+        assert manifest["shardmaps"][t["shardmap"]]  # shardmap is reused/known
+        assert t["handoff"] == handoff
+
+
+def test_provisional_target_resolves_and_threads_handoff(monkeypatch):
+    # /benchmark --target <provisional> must resolve and thread its handoff into agg.
+    manifest, base = run_benchmark.load_targets(str(BENCH / "targets.json"))
+    captured = {}
+
+    import zagg.runner as runner
+
+    def fake_agg(config, **kwargs):
+        captured["handoff"] = kwargs.get("handoff")
+        return {}
+
+    monkeypatch.setattr(runner, "agg", fake_agg)
+    run_benchmark.run_target(
+        "scalar_kernel_healpix_o11",
+        manifest,
+        base,
+        store="s3://b/x.zarr",
+        region="us-west-2",
+        function_name="process-shard",
+        context={"commit": "deadbee", "event": "pr"},
+        dry_run=False,
+    )
+    assert captured["handoff"] == "arrow-kernel"
+
+
+def test_scalar_config_is_kernel_able():
+    # The new scalar config must be GENUINELY scalar -- every field a pure group
+    # reduction -- so handoff="arrow-kernel" can run it end-to-end (issue #130).
+    from zagg.config import get_agg_fields, get_output_signature, load_config
+    from zagg.processing import _kernel_able
+
+    config = load_config(str(BENCH / "configs" / "atl03_scalar_healpix_o11.yaml"))
+    fields = get_agg_fields(config)
+    assert fields, "expected aggregation fields"
+    for name, meta in fields.items():
+        assert get_output_signature(meta)["kind"] == "scalar", f"{name} is not scalar"
+        assert _kernel_able(meta), f"{name} is not kernel-able"
+
+
 # --- per-target AOI override resolution (issue #121) -----------------------
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -249,7 +249,7 @@ def test_targets_manifest_consistent():
 
 
 def test_provisional_targets_excluded_from_merge_matrix():
-    # The arrow/arrow-kernel comparison targets are PR-tree-only: "run all"
+    # The pandas/arrow carrier-comparison targets are PR-tree-only: "run all"
     # (no --target) must not iterate them, so they never join the merge matrix.
     manifest = json.loads((BENCH / "targets.json").read_text())
     all_names = run_benchmark.all_target_names(manifest)
@@ -264,7 +264,6 @@ def test_provisional_targets_consistent_and_carry_handoff():
     expected = {
         "scalar_pandas_healpix_o11": "pandas",
         "scalar_arrow_healpix_o11": "arrow",
-        "scalar_kernel_healpix_o11": "arrow-kernel",
     }
     for tname, handoff in expected.items():
         t = manifest["provisional_targets"][tname]
@@ -286,7 +285,7 @@ def test_provisional_target_resolves_and_threads_handoff(monkeypatch):
 
     monkeypatch.setattr(runner, "agg", fake_agg)
     run_benchmark.run_target(
-        "scalar_kernel_healpix_o11",
+        "scalar_arrow_healpix_o11",
         manifest,
         base,
         store="s3://b/x.zarr",
@@ -295,21 +294,20 @@ def test_provisional_target_resolves_and_threads_handoff(monkeypatch):
         context={"commit": "deadbee", "event": "pr"},
         dry_run=False,
     )
-    assert captured["handoff"] == "arrow-kernel"
+    assert captured["handoff"] == "arrow"
 
 
-def test_scalar_config_is_kernel_able():
-    # The new scalar config must be GENUINELY scalar -- every field a pure group
-    # reduction -- so handoff="arrow-kernel" can run it end-to-end (issue #130).
+def test_scalar_config_is_genuinely_scalar():
+    # The scalar benchmark config must be GENUINELY scalar -- every field a plain
+    # per-cell stat (no vector/ragged) -- so the pandas/arrow carrier comparison
+    # isolates carrier cost, not output shape (issue #130).
     from zagg.config import get_agg_fields, get_output_signature, load_config
-    from zagg.processing import _kernel_able
 
     config = load_config(str(BENCH / "configs" / "atl03_scalar_healpix_o11.yaml"))
     fields = get_agg_fields(config)
     assert fields, "expected aggregation fields"
     for name, meta in fields.items():
         assert get_output_signature(meta)["kind"] == "scalar", f"{name} is not scalar"
-        assert _kernel_able(meta), f"{name} is not kernel-able"
 
 
 # --- per-target AOI override resolution (issue #121) -----------------------

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -129,13 +129,13 @@ class TestProcessEventDispatch:
 
     def test_handoff_event_key_forwarded_to_worker(self, handler_mod, monkeypatch):
         # issue #130: an explicit handoff event key reaches process_shard so the
-        # deployed worker selects the arrow/arrow-kernel carrier/reducer.
+        # deployed worker selects the arro3 arrow carrier.
         event = _base_event(_healpix_config_dict())
         event["child_order"] = 12
-        event["handoff"] = "arrow-kernel"
+        event["handoff"] = "arrow"
         resp, captured = self._run(handler_mod, monkeypatch, event)
         assert resp["statusCode"] == 200
-        assert captured["handoff"] == "arrow-kernel"
+        assert captured["handoff"] == "arrow"
 
     def test_default_handoff_is_pandas(self, handler_mod, monkeypatch):
         # No handoff key -> the worker runs the byte-identical default ("pandas").

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -103,6 +103,7 @@ class TestProcessEventDispatch:
 
         def fake_process_shard(grid, shard_key, granule_urls, **kwargs):
             captured["shard_key"] = shard_key
+            captured["handoff"] = kwargs.get("handoff")
             meta = {
                 "shard_key": shard_key,
                 "cells_with_data": 0,
@@ -125,6 +126,25 @@ class TestProcessEventDispatch:
         resp, captured = self._run(handler_mod, monkeypatch, event)
         assert resp["statusCode"] == 200
         assert captured["shard_key"] == 12345
+
+    def test_handoff_event_key_forwarded_to_worker(self, handler_mod, monkeypatch):
+        # issue #130: an explicit handoff event key reaches process_shard so the
+        # deployed worker selects the arrow/arrow-kernel carrier/reducer.
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        event["handoff"] = "arrow-kernel"
+        resp, captured = self._run(handler_mod, monkeypatch, event)
+        assert resp["statusCode"] == 200
+        assert captured["handoff"] == "arrow-kernel"
+
+    def test_default_handoff_is_pandas(self, handler_mod, monkeypatch):
+        # No handoff key -> the worker runs the byte-identical default ("pandas").
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        assert "handoff" not in event
+        resp, captured = self._run(handler_mod, monkeypatch, event)
+        assert resp["statusCode"] == 200
+        assert captured["handoff"] == "pandas"
 
     def test_rectilinear_dispatch_without_child_order(self, handler_mod, monkeypatch):
         event = _base_event(_rectilinear_config_dict())

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -7,7 +7,6 @@ from zarr.storage import MemoryStore
 from zagg.config import default_config, get_agg_fields, get_coords, get_data_vars
 from zagg.grids import HEALPIX_BASE_CELLS, HealpixGrid
 from zagg.processing import (
-    KERNEL_RTOL,
     _arrow_column,
     _broadcast_segment_to_base,
     _build_groups,
@@ -21,8 +20,6 @@ from zagg.processing import (
     _has_ragged_fields,
     _has_vector_fields,
     _iter_carrier_columns,
-    _kernel_able,
-    _kernel_aggregate,
     _predicate_mask,
     _read_group,
     _read_segment_broadcasts,
@@ -1237,81 +1234,6 @@ class TestMultiChunkWorker:
                 # Empty chunk -> NaN anchor (the n_obs==0 short-circuit), not a raise.
                 assert np.isnan(anchor)
 
-    def test_chunk_precompute_empty_inner_chunk_arrow_kernel(self, monkeypatch):
-        """Issue #82 phase 6 (review fold): the arrow-kernel path also short-circuits
-        an empty inner chunk to a NaN anchor instead of raising on ``np.min`` of an
-        empty subset. Mirrors the default-path empty-chunk test on
-        ``handoff='arrow-kernel'`` (the once-grouped O(N) per-chunk subset path)."""
-        pa = pytest.importorskip("pyarrow")
-        import zarr
-        from mortie import geo2mort
-        from zarr.storage import MemoryStore
-
-        from zagg.config import default_config
-        from zagg.grids import from_config
-        from zagg.processing import write_dataframe_to_zarr
-
-        cfg = default_config("atl06")
-        cfg.output["grid"] = {
-            "type": "healpix",
-            "parent_order": 6,
-            "chunk_inner": 7,
-            "child_order": 8,
-        }
-        cfg.aggregation["chunk_precompute"] = {
-            "anchor": {"expression": "np.float32(np.min(h_li))", "source": "h_li"}
-        }
-        cfg.aggregation["variables"] = {
-            "h_min": {"function": "min", "source": "h_li", "dtype": "float32"},
-            "offset_h": {"expression": "anchor", "resolution": "chunk", "dtype": "float32"},
-        }
-        grid = from_config(cfg)
-        assert grid.chunks_per_shard == 4
-        shard_key = int(geo2mort(-78.5, -132.0, order=6)[0])
-        chunks = list(grid.iter_chunks(shard_key))
-        populated = {0, 1}
-        leaf, h = [], []
-        for k, (_b, cc) in enumerate(chunks):
-            if k not in populated:
-                continue
-            base = 100.0 * (k + 1)
-            leaf += [int(cc[0]), int(cc[0])]
-            h += [base + 5.0, base]
-        table = pa.table(
-            {
-                "h_li": pa.array(np.array(h, dtype=np.float32)),
-                "s_li": pa.array(np.full(len(h), 0.1, dtype=np.float32)),
-                "leaf_id": pa.array(np.array(leaf, dtype=np.uint64)),
-            }
-        )
-        it = iter([table])
-        monkeypatch.setattr("zagg.processing._read_group", lambda *a, **k: next(it, None))
-        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
-        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
-
-        store = MemoryStore()
-        grid.emit_template(store)
-        results: list = []
-        process_shard(
-            grid,
-            shard_key,
-            ["s3://x"],
-            s3_credentials={},
-            config=cfg,
-            chunk_results=results,
-            handoff="arrow-kernel",
-        )
-        assert len(results) == 4
-        for block_index, carrier, _ragged in results:
-            write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=block_index)
-        offset = zarr.open_array(store, path="8/offset_h", mode="r")
-        for k, (block_index, _c, _r) in enumerate(results):
-            anchor = float(offset[block_index])
-            if k in populated:
-                assert anchor == 100.0 * (k + 1)
-            else:
-                assert np.isnan(anchor)
-
 
 class TestChunkCompanionWorkedExample:
     """Issue #82 phase 5: a worked example exercising a chunk_precompute value
@@ -1502,7 +1424,7 @@ class TestArrowHandoff:
 
     def test_arrow_grouping_matches_pandas(self):
         """Arrow-carrier grouping yields byte-for-byte identical stats to pandas."""
-        pa = pytest.importorskip("pyarrow")
+        ac = pytest.importorskip("arro3.core")
         rng = np.random.default_rng(11)
         n = 500
         child_ids = np.array([100, 200, 300, 400, 500], dtype=np.int64)
@@ -1516,12 +1438,12 @@ class TestArrowHandoff:
         df = pd.DataFrame(col_dict)
         p_arrays, p_slices = _build_groups(df, cells)
 
-        # arrow carrier: read the columns back as numpy and group identically
-        table = pa.table(col_dict).combine_chunks()
+        # arrow (arro3) carrier: read the columns back as numpy and group identically
+        table = ac.Table.from_pydict({k: ac.Array.from_numpy(v) for k, v in col_dict.items()})
         a_carrier = {
-            name: table.column(name).to_numpy(zero_copy_only=False) for name in table.column_names
+            name: table.column(name).combine_chunks().to_numpy() for name in table.column_names
         }
-        a_leaf = table.column("leaf_id").to_numpy(zero_copy_only=False)
+        a_leaf = a_carrier["leaf_id"]
         a_arrays, a_slices = _group_columns(a_carrier, a_leaf)
 
         assert p_slices == a_slices
@@ -1544,7 +1466,7 @@ class TestArrowHandoff:
 
     def test_concat_and_group_arrow_matches_pandas(self):
         """_concat_and_group drives the real carrier path (incl. multi-table concat)."""
-        pa = pytest.importorskip("pyarrow")
+        ac = pytest.importorskip("arro3.core")
 
         grid = _IdentityGrid()
         cfg = default_config()
@@ -1563,7 +1485,9 @@ class TestArrowHandoff:
                 }
             )
         pandas_reads = [pd.DataFrame(r) for r in reads]
-        arrow_reads = [pa.table(r) for r in reads]
+        arrow_reads = [
+            ac.Table.from_pydict({k: ac.Array.from_numpy(v) for k, v in r.items()}) for r in reads
+        ]
 
         p_arrays, p_slices, p_n = _concat_and_group(pandas_reads, grid, "pandas")
         a_arrays, a_slices, a_n = _concat_and_group(arrow_reads, grid, "arrow")
@@ -1596,162 +1520,24 @@ class TestArrowHandoff:
         exists to catch: a null there would corrupt the cell assignment under
         ``to_numpy``, not just a single stat.
         """
-        pa = pytest.importorskip("pyarrow")
+        ac = pytest.importorskip("arro3.core")
 
-        table = pa.table(
+        table = ac.Table.from_pydict(
             {
-                "h_li": pa.array([1.0, 2.0, 3.0], type=pa.float32()),
-                "s_li": pa.array([0.1, 0.2, 0.3], type=pa.float32()),
-                "leaf_id": pa.array([100, None, 100], type=pa.int64()),
+                "h_li": ac.Array.from_numpy(np.array([1.0, 2.0, 3.0], dtype=np.float32)),
+                "s_li": ac.Array.from_numpy(np.array([0.1, 0.2, 0.3], dtype=np.float32)),
+                "leaf_id": ac.Array([100, None, 100], ac.DataType.int64()),
             }
         )
         with pytest.raises(ValueError, match="null-free"):
             _concat_and_group([table], _IdentityGrid(), "arrow")
-
-
-class TestKernelHandoff:
-    """Phase 2b of #30 (EXPERIMENTAL): the pyarrow hash-aggregate kernel reducer.
-
-    Unlike the pandas<->arrow *carrier* equivalence (byte-for-byte identical), the
-    kernel path's float mean/variance diverge from numpy by ~1 ULP, so it is
-    validated within :data:`KERNEL_RTOL`, not by exact equality.
-    """
-
-    def _numpy_reference(self, col_dict, cell_col, children, cfg):
-        """Default per-cell numpy stats, as ``name -> ndarray`` over ``children``."""
-        col_arrays, cell_to_slice = _group_columns(col_dict, cell_col)
-        empty = {c: a[:0] for c, a in col_arrays.items()}
-        out = {v: np.full(len(children), np.nan, dtype=np.float64) for v in get_data_vars(cfg)}
-        for i, child in enumerate(children):
-            child = int(child)
-            if child in cell_to_slice:
-                s, e = cell_to_slice[child]
-                cell_data = {c: a[s:e] for c, a in col_arrays.items()}
-            else:
-                cell_data = empty
-            stats = calculate_cell_statistics(cell_data, config=cfg)
-            for k, v in stats.items():
-                out[k][i] = v
-        return out
-
-    def test_kernel_able_classification(self):
-        """count/min/max/var and unweighted average are kernel-able; the rest fall back."""
-        cfg = default_config()
-        fields = get_agg_fields(cfg)
-        # Default atl06 config: count/h_min/h_max/h_variance are pure reductions;
-        # h_mean is weighted, h_sigma is an expression, the quantiles are tdigest.
-        assert _kernel_able(fields["count"])
-        assert _kernel_able(fields["h_min"])
-        assert _kernel_able(fields["h_max"])
-        assert _kernel_able(fields["h_variance"])
-        assert not _kernel_able(fields["h_mean"])  # weighted average
-        assert not _kernel_able(fields["h_sigma"])  # expression
-        assert not _kernel_able(fields["h_q50"])  # quantile
-        # Unweighted average would be kernel-able.
-        assert _kernel_able({"function": "average", "source": "h_li"})
-
-    def test_kernel_matches_numpy_within_tolerance(self):
-        """Kernel stats match the numpy reducer within KERNEL_RTOL (exact where integral)."""
-        pa = pytest.importorskip("pyarrow")
-        cfg = default_config()
-        rng = np.random.default_rng(3)
-        children = np.array([100, 200, 300, 400, 500], dtype=np.int64)
-        n = 2000
-        cells = rng.choice(children, size=n)
-        h = (rng.standard_normal(n) * 30.0).astype(np.float32)
-        s = (np.abs(rng.standard_normal(n)) + 0.01).astype(np.float32)
-        col_dict = {"h_li": h, "s_li": s, "leaf_id": cells}
-
-        ref = self._numpy_reference(col_dict, cells, children, cfg)
-        table = pa.table(col_dict)
-        kernel = _kernel_aggregate(table, cells, children, "h_li", cfg)
-        ks = kernel["stats_arrays"]
-
-        assert kernel["cells_with_data"] == len(children)
-        # count/min/max are integral or order-independent extrema: exact.
-        for name in ("count", "h_min", "h_max"):
-            np.testing.assert_array_equal(
-                np.asarray(ks[name], dtype=np.float64), ref[name], err_msg=name
-            )
-        # variance is the kernel-reduced float stat: close, not identical.
-        np.testing.assert_allclose(
-            np.asarray(ks["h_variance"], dtype=np.float64),
-            ref["h_variance"],
-            rtol=KERNEL_RTOL,
-            equal_nan=True,
-        )
-        # Fallback fields (weighted mean, expression, quantiles) stay byte-identical
-        # to numpy because the kernel path routes them through the same reducer.
-        for name in ("h_mean", "h_sigma", "h_q25", "h_q50", "h_q75"):
-            np.testing.assert_array_equal(
-                np.asarray(ks[name], dtype=np.float64), ref[name], err_msg=name
-            )
-
-    def test_kernel_empty_cells_get_fill_values(self):
-        """Cells with no observations get count=0 and NaN floats, like the default path."""
-        pa = pytest.importorskip("pyarrow")
-        cfg = default_config()
-        children = np.array([1, 2, 3], dtype=np.int64)
-        # Only cell 2 has data.
-        cells = np.array([2, 2, 2], dtype=np.int64)
-        col_dict = {
-            "h_li": np.array([1.0, 2.0, 3.0], dtype=np.float32),
-            "s_li": np.array([0.1, 0.1, 0.1], dtype=np.float32),
-            "leaf_id": cells,
-        }
-        kernel = _kernel_aggregate(pa.table(col_dict), cells, children, "h_li", cfg)
-        ks = kernel["stats_arrays"]
-        assert kernel["cells_with_data"] == 1
-        assert list(ks["count"]) == [0, 3, 0]
-        assert np.isnan(ks["h_min"][0]) and np.isnan(ks["h_min"][2])
-        assert ks["h_min"][1] == 1.0
-
-    def test_kernel_nan_matches_numpy_semantics(self):
-        """NaN-bearing cells: count/min/max stay EXACT vs numpy (NaN-propagating).
-
-        pyarrow's min/max kernels skip NaN; numpy's propagate it. _kernel_aggregate
-        must restore numpy semantics so the "count/min/max exact" contract holds on
-        the NaN-bearing ``h_li`` values ATL06 can carry (the quality_filter is a
-        flag check, not a NaN/fill filter). count is unaffected (NaN is a value, not
-        a null) and mean/variance already propagate NaN like numpy.
-        """
-        pa = pytest.importorskip("pyarrow")
-        cfg = default_config()
-        children = np.array([10, 20, 30], dtype=np.int64)
-        # cell 10: clean; cell 20: one NaN; cell 30: all NaN.
-        cells = np.array([10, 10, 10, 20, 20, 20, 30, 30], dtype=np.int64)
-        h = np.array([1.0, 2.0, 4.0, 1.0, np.nan, 3.0, np.nan, np.nan], dtype=np.float32)
-        s = np.full(len(cells), 0.1, dtype=np.float32)
-        col_dict = {"h_li": h, "s_li": s, "leaf_id": cells}
-
-        ref = self._numpy_reference(col_dict, cells, children, cfg)
-        ks = _kernel_aggregate(pa.table(col_dict), cells, children, "h_li", cfg)["stats_arrays"]
-
-        # count: exact everywhere (NaN counts as a value).
-        np.testing.assert_array_equal(np.asarray(ks["count"], dtype=np.float64), ref["count"])
-        # min/max: bit-identical to numpy, including the NaN cells (10 clean, 20/30
-        # propagate NaN). assert_array_equal treats NaN==NaN here.
-        for name in ("h_min", "h_max"):
-            np.testing.assert_array_equal(
-                np.asarray(ks[name], dtype=np.float64), ref[name], err_msg=name
-            )
-        # Clean cell 10 is finite; NaN cells 20/30 propagate to NaN.
-        assert ks["h_min"][0] == 1.0 and ks["h_max"][0] == 4.0
-        assert np.isnan(ks["h_min"][1]) and np.isnan(ks["h_max"][1])
-        assert np.isnan(ks["h_min"][2]) and np.isnan(ks["h_max"][2])
-        # mean/variance already propagate NaN in both paths -> NaN on cells 20/30.
-        for name in ("h_variance",):
-            assert np.isnan(ks[name][1]) and np.isnan(ref[name][1])
-            assert np.isnan(ks[name][2]) and np.isnan(ref[name][2])
-
-
 class _KernelShardGrid:
-    """Minimal grid stub driving the ``process_shard`` kernel branch.
+    """Minimal grid stub driving ``process_shard`` over canned reads.
 
-    Exposes only what the ``handoff="arrow-kernel"`` path post-read needs:
-    ``children``/``cells_of``/``chunk_coords`` (and ``chunk_shape`` is unused by
-    process_shard itself). Spatial read methods are bypassed because the test
-    monkeypatches ``_read_group`` to return canned tables.
+    Exposes only what the post-read path needs: ``children``/``cells_of``/
+    ``chunk_coords`` (and ``chunk_shape`` is unused by process_shard itself).
+    Spatial read methods are bypassed because the test monkeypatches
+    ``_read_group`` to return canned tables.
     """
 
     def __init__(self, children, leaf_to_cell):
@@ -1772,10 +1558,8 @@ class _KernelShardGrid:
 
 
 class TestProcessShardKernelBranch:
-    """HIGH-2 of PR #33 review: exercise the production ``process_shard`` kernel
-    branch (null guard, ``cells_of``, ``concat_tables().combine_chunks()``, and the
-    ``handoff`` validation), including NaN-bearing input so the NaN-semantics fix is
-    covered end-to-end, not only in ``_kernel_aggregate``."""
+    """Shared canned-read harness (``_patch_reads``) for ``process_shard`` tests,
+    plus the ``handoff`` validation guard."""
 
     def _patch_reads(self, monkeypatch, tables):
         """Make ``_read_group`` yield the canned tables once, then None.
@@ -1792,88 +1576,6 @@ class TestProcessShardKernelBranch:
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         # Avoid resolving a real h5coro driver (s3driver import / creds plumbing).
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
-
-    def test_kernel_branch_matches_default_path(self, monkeypatch):
-        """process_shard(handoff="arrow-kernel") agrees with the default path on the
-        kernel-able stats (count/min/max exact, variance within KERNEL_RTOL),
-        running the real concat + null guard + cells_of."""
-        pa = pytest.importorskip("pyarrow")
-
-        cfg = default_config()
-        leaf_to_cell = {1: 10, 2: 10, 3: 20, 4: 30}
-        children = [10, 20, 30]
-        grid = _KernelShardGrid(children, leaf_to_cell)
-
-        rng = np.random.default_rng(5)
-
-        def make_table(n):
-            leaf = rng.choice([1, 2, 3, 4], size=n).astype(np.int64)
-            h = (rng.standard_normal(n) * 10.0).astype(np.float32)
-            s = (np.abs(rng.standard_normal(n)) + 0.01).astype(np.float32)
-            return pa.table({"h_li": h, "s_li": s, "leaf_id": leaf})
-
-        # Two reads -> exercises pa.concat_tables(...).combine_chunks().
-        tables = [make_table(60), make_table(25)]
-        # Reuse the same data for the default path via a copy of the iterator.
-        kernel_tables = [t for t in tables]
-        default_tables = [t for t in tables]
-
-        self._patch_reads(monkeypatch, kernel_tables)
-        df_k, meta_k = process_shard(
-            grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
-        )
-
-        self._patch_reads(monkeypatch, default_tables)
-        df_d, meta_d = process_shard(
-            grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow"
-        )
-
-        assert meta_k["cells_with_data"] == meta_d["cells_with_data"]
-        assert meta_k["total_obs"] == meta_d["total_obs"] == 85
-        for name in ("count", "h_min", "h_max"):
-            np.testing.assert_array_equal(
-                df_k[name].to_numpy(), df_d[name].to_numpy(), err_msg=name
-            )
-        np.testing.assert_allclose(
-            df_k["h_variance"].to_numpy(),
-            df_d["h_variance"].to_numpy(),
-            rtol=KERNEL_RTOL,
-            equal_nan=True,
-        )
-
-    def test_kernel_branch_nan_input(self, monkeypatch):
-        """End-to-end NaN handling through process_shard's kernel branch: a NaN in
-        ``h_li`` propagates to that cell's min/max (numpy semantics), count is
-        unaffected, and the null guard does NOT trip (NaN is not an Arrow null)."""
-        pa = pytest.importorskip("pyarrow")
-
-        cfg = default_config()
-        leaf_to_cell = {1: 10, 2: 20}
-        children = [10, 20]
-        grid = _KernelShardGrid(children, leaf_to_cell)
-
-        # cell 10 clean, cell 20 has a NaN.
-        table = pa.table(
-            {
-                "h_li": pa.array([1.0, 2.0, 4.0, 5.0, np.nan], type=pa.float32()),
-                "s_li": pa.array([0.1, 0.1, 0.1, 0.1, 0.1], type=pa.float32()),
-                "leaf_id": pa.array([1, 1, 1, 2, 2], type=pa.int64()),
-            }
-        )
-        self._patch_reads(monkeypatch, [table])
-        df, meta = process_shard(
-            grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
-        )
-
-        idx = {c: i for i, c in enumerate(children)}
-        # Clean cell 10: finite extrema.
-        assert df["h_min"].to_numpy()[idx[10]] == 1.0
-        assert df["h_max"].to_numpy()[idx[10]] == 4.0
-        # NaN cell 20: min/max propagate NaN (numpy semantics), count still 2.
-        assert np.isnan(df["h_min"].to_numpy()[idx[20]])
-        assert np.isnan(df["h_max"].to_numpy()[idx[20]])
-        assert df["count"].to_numpy()[idx[20]] == 2
-        assert meta["total_obs"] == 5
 
     def test_invalid_handoff_rejected(self):
         """The ``handoff`` validation rejects unknown carriers before any read."""
@@ -4040,29 +3742,6 @@ class TestChunkPrecompute:
         np.testing.assert_array_equal(offsets, np.array([1.0, 101.0], dtype=np.float32))
         assert offsets[0] != offsets[1]
 
-    def test_arrow_kernel_runs_chunk_precompute(self, monkeypatch):
-        """The kernel path now evaluates chunk_precompute over the pooled arrow
-        table and threads the scalar through the fallback per-cell loop (issue #30,
-        item ii): the per-cell ``offset`` resolves to the pooled chunk anchor,
-        uniform across cells — same result the pandas/arrow carriers produce."""
-        pa = pytest.importorskip("pyarrow")
-        cfg = self._cfg(with_precompute=True)
-        grid = _KernelShardGrid([10, 20], {1: 10, 2: 20})
-        table = pa.table(
-            {
-                "h_ph": np.array([0.0, 2.0, 100.0, 102.0], dtype=np.float32),
-                "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
-            }
-        )
-        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [table])
-        df_out, _ = process_shard(
-            grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
-        )
-        offsets = df_out["offset"].to_numpy()
-        pooled_median = np.median([0.0, 2.0, 100.0, 102.0])
-        np.testing.assert_array_equal(offsets, np.full(2, pooled_median, dtype=np.float32))
-        assert offsets[0] == offsets[1]
-
     def test_worked_template_uniform_offset_and_gain(self, monkeypatch):
         """The shipped atl03_waveform_chunk template runs end-to-end through the
         worker and emits a chunk-uniform offset_h/gain_h across two cells whose own
@@ -4191,9 +3870,11 @@ class TestChunkPrecompute:
         )
         TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
         # vector field -> arrow table carrier.
+        import arro3.core as ac
+
         tbl, _ = process_shard(grid, 0, ["s3://x"], s3_credentials={}, config=cfg)
         anchored = tbl.column("anchored").combine_chunks()
-        block = anchored.values.to_numpy(zero_copy_only=False).reshape(2, 3)
+        block = ac.list_flatten(anchored).to_numpy().reshape(2, 3)
         chunk_vec = np.percentile([0.0, 2.0, 100.0, 102.0], [25, 50, 75]).astype(np.float32)
         # cell 10 mean = 1.0, cell 20 mean = 101.0.
         np.testing.assert_allclose(block[0], chunk_vec + np.float32(1.0), rtol=1e-5)
@@ -4254,62 +3935,6 @@ class TestChunkPrecompute:
         # Pooled dict only carries h_ph (e.g. 'other' was not read).
         with pytest.raises(ValueError, match="source column 'other' is not present"):
             _eval_chunk_precompute(cfg, {"h_ph": np.array([1.0, 2.0])})
-
-    def test_arrow_kernel_runs_non_scalar_chunk_precompute(self, monkeypatch):
-        """A NON-scalar chunk_precompute result also works on the kernel path: the
-        pooled arrow table is reduced once to a 3-vector, injected into the kernel
-        fallback namespace, and a per-cell scalar expression reduces over it (issue
-        #30, item ii). (A kind: vector OUTPUT is a separate kernel-path gap — the
-        experimental kernel reducer dense-preallocates scalars only — so the
-        per-cell field reduces the chunk array rather than emitting it whole.)"""
-        pa = pytest.importorskip("pyarrow")
-        from zagg.config import PipelineConfig
-
-        cfg = PipelineConfig(
-            data_source={"groups": ["gt1l"], "variables": {"h_ph": "/{group}/h_ph"}},
-            aggregation={
-                "chunk_precompute": {
-                    "chunk_vec": {
-                        "expression": "np.percentile(h_ph, [25, 50, 75])",
-                        "source": "h_ph",
-                        "dtype": "float32",
-                    }
-                },
-                "variables": {
-                    # per-cell scalar reduces over the injected chunk 3-vector.
-                    "anchored": {
-                        "expression": "float(np.sum(chunk_vec)) + float(np.mean(h_ph))",
-                        "source": "h_ph",
-                        "dtype": "float32",
-                    },
-                    "count": {
-                        "function": "len",
-                        "source": "h_ph",
-                        "dtype": "int32",
-                        "fill_value": 0,
-                    },
-                },
-            },
-            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
-        )
-        grid = _KernelShardGrid([10, 20], {1: 10, 2: 20})
-        table = pa.table(
-            {
-                "h_ph": np.array([0.0, 2.0, 100.0, 102.0], dtype=np.float32),
-                "leaf_id": np.array([1, 1, 2, 2], dtype=np.int64),
-            }
-        )
-        TestProcessShardKernelBranch()._patch_reads(monkeypatch, [table])
-        df_out, _ = process_shard(
-            grid, 0, ["s3://x"], s3_credentials={}, config=cfg, handoff="arrow-kernel"
-        )
-        anchored = df_out["anchored"].to_numpy()
-        chunk_sum = float(
-            np.sum(np.percentile([0.0, 2.0, 100.0, 102.0], [25, 50, 75]).astype(np.float32))
-        )
-        # cell 10 mean = 1.0, cell 20 mean = 101.0.
-        np.testing.assert_allclose(anchored[0], chunk_sum + 1.0, rtol=1e-5)
-        np.testing.assert_allclose(anchored[1], chunk_sum + 101.0, rtol=1e-5)
 
     def test_degenerate_single_photon_chunk_gain_floor(self, monkeypatch):
         """The worked template's chunk_gain floors to 0.5 on a degenerate pooled

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1531,6 +1531,8 @@ class TestArrowHandoff:
         )
         with pytest.raises(ValueError, match="null-free"):
             _concat_and_group([table], _IdentityGrid(), "arrow")
+
+
 class _KernelShardGrid:
     """Minimal grid stub driving ``process_shard`` over canned reads.
 
@@ -1708,6 +1710,72 @@ class TestVectorCarrier:
         )
         assert isinstance(out, pd.DataFrame)
         np.testing.assert_array_equal(out["count"].to_numpy(), [2, 1])
+
+    def test_default_and_vector_write_path_works_without_pyarrow(self):
+        """The deployed-worker contract (issue #130 path C): the default (scalar
+        pandas) AND the vector arro3 write carrier must run with pyarrow absent —
+        the Lambda layer ships arro3-core, not pyarrow.
+
+        Run in a fresh interpreter that blocks every ``pyarrow`` import via a
+        meta-path finder, reproducing the layer's pyarrow-free closure. (A plain
+        ``sys.modules`` check is unreliable here because the test env installs
+        pyarrow transitively for the off-Lambda ``catalog`` extra, and pandas
+        eagerly imports it when present — neither of which holds on the layer.)
+        """
+        import subprocess
+        import sys
+        import textwrap
+
+        pytest.importorskip("arro3.core")
+        script = textwrap.dedent(
+            """
+            import sys
+
+            class _Blocker:
+                def find_spec(self, name, path, target=None):
+                    if name == "pyarrow" or name.startswith("pyarrow."):
+                        raise ImportError("pyarrow is blocked (deployed-layer guard)")
+                    return None
+
+            sys.meta_path.insert(0, _Blocker())
+
+            import numpy as np
+            from zagg.config import PipelineConfig, get_agg_fields, get_data_vars
+            from zagg.processing.write import _build_output, _iter_carrier_columns
+
+            class _G:
+                group_path = "g"
+                def coords_of(self, children):
+                    return {"morton": np.asarray(children, dtype=np.uint64)}
+                def chunk_coords(self, shard_key):
+                    return {"morton": np.array([0, 1], dtype=np.uint64)}
+
+            cfg = PipelineConfig(
+                data_source={"groups": ["g"]},
+                aggregation={"variables": {
+                    "count": {"function": "len"},
+                    "hist": {"function": "np.bincount", "source": "b", "kind": "vector",
+                             "trailing_shape": 3, "dtype": "int64", "fill_value": 0},
+                }},
+            )
+            stats = {"count": np.array([2, 1], dtype="int64"),
+                     "hist": np.array([[1, 0, 1], [0, 1, 0]], dtype="int64")}
+            # vector (arro3) carrier round-trips with pyarrow blocked
+            tbl = _build_output(stats, get_data_vars(cfg), get_agg_fields(cfg), _G(), 0,
+                                use_arrow=True)
+            assert dict(_iter_carrier_columns(tbl))["hist"].shape == (2, 3)
+            # default (pandas) carrier
+            scfg = PipelineConfig(data_source={"groups": ["g"]},
+                                  aggregation={"variables": {"count": {"function": "len"}}})
+            _build_output({"count": np.array([2, 1])}, ["count"],
+                          get_agg_fields(scfg), _G(), 0, use_arrow=False)
+            assert "pyarrow" not in sys.modules
+            print("OK")
+            """
+        )
+        result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "OK" in result.stdout
 
 
 class TestDataSource:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1935,7 +1935,7 @@ class TestVectorCarrier:
         """Drive process_shard on a canned read via the default (pandas) handoff;
         the output carrier (pandas vs Arrow) is chosen by the config's field kinds,
         independent of the input handoff."""
-        pytest.importorskip("pyarrow")
+        pytest.importorskip("arro3.core")
         leaf_to_cell = {1: 10, 2: 10, 3: 20}
         children = [10, 20]
         grid = _KernelShardGrid(children, leaf_to_cell)
@@ -1954,10 +1954,10 @@ class TestVectorCarrier:
         assert isinstance(df, pd.DataFrame)
 
     def test_vector_config_returns_arrow_table(self, monkeypatch):
-        pa = pytest.importorskip("pyarrow")
+        ac = pytest.importorskip("arro3.core")
         (tbl, _meta), _children = self._run(monkeypatch, self._vector_cfg())
-        assert isinstance(tbl, pa.Table)
-        assert pa.types.is_fixed_size_list(tbl.column("hist").type)
+        assert isinstance(tbl, ac.Table)
+        # arro3 marks a FixedSizeList by an integer ``list_size`` (None for scalar).
         assert tbl.column("hist").type.list_size == 3
 
     def test_scalar_columns_byte_identical_with_and_without_vector(self, monkeypatch):
@@ -1969,16 +1969,17 @@ class TestVectorCarrier:
         for name in ("count", "h_min"):
             np.testing.assert_array_equal(
                 df[name].to_numpy(),
-                tbl.column(name).to_numpy(zero_copy_only=False),
+                tbl.column(name).combine_chunks().to_numpy(),
                 err_msg=name,
             )
 
     def test_vector_column_values(self, monkeypatch):
         """The FixedSizeList payload holds each cell's per-cell vector. cell 10 has
         b=[0,2] -> bincount(minlength=3)=[1,0,1]; cell 20 has b=[1] -> [0,1,0]."""
+        ac = pytest.importorskip("arro3.core")
         (tbl, _meta), children = self._run(monkeypatch, self._vector_cfg())
         hist = tbl.column("hist").combine_chunks()
-        block = hist.values.to_numpy(zero_copy_only=False).reshape(len(children), 3)
+        block = ac.list_flatten(hist).to_numpy().reshape(len(children), 3)
         idx = {c: i for i, c in enumerate(children)}
         np.testing.assert_array_equal(block[idx[10]], [1, 0, 1])
         np.testing.assert_array_equal(block[idx[20]], [0, 1, 0])
@@ -1986,12 +1987,12 @@ class TestVectorCarrier:
     def test_arrow_column_roundtrips_through_iter(self):
         """_arrow_column -> _iter_carrier_columns recovers the (n_cells, C) block,
         the seam the dense vector writer consumes (phase 5)."""
-        pa = pytest.importorskip("pyarrow")
+        ac = pytest.importorskip("arro3.core")
         sig = {"kind": "vector", "trailing_shape": (3,), "dtype": "int64"}
         block = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int64)
         col = _arrow_column(block, sig)
-        assert pa.types.is_fixed_size_list(col.type)
-        tbl = pa.table({"hist": col})
+        assert col.type.list_size == 3
+        tbl = ac.Table.from_pydict({"hist": col})
         recovered = dict(_iter_carrier_columns(tbl))["hist"]
         np.testing.assert_array_equal(recovered, block)
 
@@ -2064,7 +2065,7 @@ class TestVectorRoundTrip:
         return PipelineConfig(data_source=cfg.data_source, aggregation=agg, output=cfg.output)
 
     def test_vector_leaf_to_zarr_to_read(self):
-        pytest.importorskip("pyarrow")
+        pytest.importorskip("arro3.core")
         from mortie import geo2mort
 
         cfg = self._vector_cfg()
@@ -2121,7 +2122,7 @@ class TestVectorRoundTrip:
         """The writer enforces the single-trailing-chunk invariant: if the target
         array chunks the trailing payload dim, ``set_block_selection`` at block 0
         would drop the rest, so the write must raise instead (issue #29)."""
-        pa = pytest.importorskip("pyarrow")
+        ac = pytest.importorskip("arro3.core")
         from zarr import create_array
 
         class _OneChunkGrid:
@@ -2138,8 +2139,8 @@ class TestVectorRoundTrip:
             dtype="float32",
             fill_value=np.float32("nan"),
         )
-        edges = pa.FixedSizeListArray.from_arrays(pa.array(np.arange(8.0, dtype="float32")), 4)
-        table = pa.table({"edges": edges})
+        edges = ac.fixed_size_list_array(ac.Array.from_numpy(np.arange(8.0, dtype="float32")), 4)
+        table = ac.Table.from_pydict({"edges": edges})
         with pytest.raises(ValueError, match="one whole chunk"):
             write_dataframe_to_zarr(table, store, grid=_OneChunkGrid(), chunk_idx=(0,))
 
@@ -2292,7 +2293,7 @@ class TestChunkResolutionCompanion:
         worker and written to a real Zarr store, stores offset_h/gain_h as
         chunk-resolution companions (one value per chunk), while waveform_counts
         stays a per-cell vector array (issue #30 items 1+2)."""
-        pytest.importorskip("pyarrow")
+        pytest.importorskip("arro3.core")
         from zagg.grids import RectilinearGrid
 
         cfg = default_config("atl03_waveform_chunk")
@@ -4067,7 +4068,7 @@ class TestChunkPrecompute:
         worker and emits a chunk-uniform offset_h/gain_h across two cells whose own
         photon distributions differ (low vs high), proving the bin-28 window is set
         once over the pooled shard, not per cell."""
-        pytest.importorskip("pyarrow")
+        pytest.importorskip("arro3.core")
         cfg = default_config("atl03_waveform_chunk")
         leaf_to_cell = {1: 10, 2: 20}
         children = [10, 20]
@@ -4085,8 +4086,8 @@ class TestChunkPrecompute:
         TestProcessShardKernelBranch()._patch_reads(monkeypatch, [df])
         tbl, _meta = process_shard(grid, 0, ["s3://x"], s3_credentials={}, config=cfg)
         # vector waveform field -> arrow table carrier.
-        offset = tbl.column("offset_h").to_numpy(zero_copy_only=False)
-        gain = tbl.column("gain_h").to_numpy(zero_copy_only=False)
+        offset = tbl.column("offset_h").combine_chunks().to_numpy()
+        gain = tbl.column("gain_h").combine_chunks().to_numpy()
         assert offset[0] == offset[1]
         assert gain[0] == gain[1]
         # chunk_offset is now the DEM anchor: floor(min(pooled dem_h)).
@@ -4314,7 +4315,7 @@ class TestChunkPrecompute:
         """The worked template's chunk_gain floors to 0.5 on a degenerate pooled
         range (single photon / all-equal heights) WITHOUT a log2(0) divide-by-zero
         warning — the range is clamped before log2 and the 0.5 m floor applies."""
-        pytest.importorskip("pyarrow")
+        pytest.importorskip("arro3.core")
         cfg = default_config("atl03_waveform_chunk")
         children = [10, 20]
         grid = _KernelShardGrid(children, {1: 10, 2: 20})
@@ -4333,7 +4334,7 @@ class TestChunkPrecompute:
         with warnings.catch_warnings():
             warnings.simplefilter("error")  # any RuntimeWarning would fail the test
             tbl, _meta = process_shard(grid, 0, ["s3://x"], s3_credentials={}, config=cfg)
-        gain = tbl.column("gain_h").to_numpy(zero_copy_only=False)
+        gain = tbl.column("gain_h").combine_chunks().to_numpy()
         np.testing.assert_array_equal(gain, np.full(2, np.float32(0.5)))
 
     def test_absent_block_matches_plain_path_values(self, monkeypatch):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -327,7 +327,7 @@ class TestInvokeLambdaCellEvent:
 
     _CREDS = {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"}
 
-    def _captured_event(self, *, child_order, profile=False):
+    def _captured_event(self, *, child_order, profile=False, handoff="pandas"):
         from unittest.mock import MagicMock
 
         from zagg.runner import _invoke_lambda_cell
@@ -342,7 +342,7 @@ class TestInvokeLambdaCellEvent:
             client, (0,), 12345, 6, child_order,
             ["s3://b/g.h5"], "s3://out/x.zarr", self._CREDS,
             function_name="process-shard", config_dict=None, max_workers=4,
-            profile=profile,
+            handoff=handoff, profile=profile,
         )
         return json.loads(client.invoke.call_args.kwargs["Payload"])
 
@@ -370,6 +370,19 @@ class TestInvokeLambdaCellEvent:
         # no "profile" key is added.
         event = self._captured_event(child_order=12, profile=False)
         assert "profile" not in event
+
+    def test_handoff_adds_event_key(self):
+        # issue #130: a non-default handoff forwards "handoff" into the event so
+        # the deployed worker selects the arrow/arrow-kernel carrier/reducer.
+        for h in ("arrow", "arrow-kernel"):
+            event = self._captured_event(child_order=12, handoff=h)
+            assert event["handoff"] == h
+
+    def test_default_handoff_event_has_no_handoff_key(self):
+        # Default (pandas): event payload is byte-identical to the pre-handoff
+        # path; no "handoff" key is added (#130).
+        event = self._captured_event(child_order=12, handoff="pandas")
+        assert "handoff" not in event
 
 
 class TestInvokeLambdaCellRetry:
@@ -971,6 +984,34 @@ class TestProfilePlumbing:
         )
         runner.agg(atl06_config, catalog="ignored", store="s3://out/x.zarr", backend="lambda")
         assert captured["profile"] is False
+
+    def test_agg_threads_handoff_into_run_lambda(self, monkeypatch, atl06_config):
+        # issue #130: agg(handoff=...) reaches the lambda backend (it was local-only).
+        from zagg import runner
+
+        captured = {}
+        monkeypatch.setattr(runner, "_load_catalog", lambda p: _run_catalog())
+        monkeypatch.setattr(
+            runner, "_run_lambda",
+            lambda *a, **k: captured.update(handoff=k.get("handoff")) or {},
+        )
+        runner.agg(
+            atl06_config, catalog="ignored", store="s3://out/x.zarr",
+            backend="lambda", handoff="arrow-kernel",
+        )
+        assert captured["handoff"] == "arrow-kernel"
+
+    def test_agg_default_handoff_is_pandas_on_lambda(self, monkeypatch, atl06_config):
+        from zagg import runner
+
+        captured = {}
+        monkeypatch.setattr(runner, "_load_catalog", lambda p: _run_catalog())
+        monkeypatch.setattr(
+            runner, "_run_lambda",
+            lambda *a, **k: captured.update(handoff=k.get("handoff")) or {},
+        )
+        runner.agg(atl06_config, catalog="ignored", store="s3://out/x.zarr", backend="lambda")
+        assert captured["handoff"] == "pandas"
 
 
 class TestWorkerPhaseTimings:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -373,10 +373,10 @@ class TestInvokeLambdaCellEvent:
 
     def test_handoff_adds_event_key(self):
         # issue #130: a non-default handoff forwards "handoff" into the event so
-        # the deployed worker selects the arrow/arrow-kernel carrier/reducer.
-        for h in ("arrow", "arrow-kernel"):
-            event = self._captured_event(child_order=12, handoff=h)
-            assert event["handoff"] == h
+        # the deployed worker selects the arro3 arrow carrier. (The runner forwards
+        # the string opaquely; the worker validates it.)
+        event = self._captured_event(child_order=12, handoff="arrow")
+        assert event["handoff"] == "arrow"
 
     def test_default_handoff_event_has_no_handoff_key(self):
         # Default (pandas): event payload is byte-identical to the pre-handoff
@@ -997,9 +997,9 @@ class TestProfilePlumbing:
         )
         runner.agg(
             atl06_config, catalog="ignored", store="s3://out/x.zarr",
-            backend="lambda", handoff="arrow-kernel",
+            backend="lambda", handoff="arrow",
         )
-        assert captured["handoff"] == "arrow-kernel"
+        assert captured["handoff"] == "arrow"
 
     def test_agg_default_handoff_is_pandas_on_lambda(self, monkeypatch, atl06_config):
         from zagg import runner

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -567,7 +567,9 @@ class TestHandoffPassthrough:
         )
         assert captured["handoff"] == "arrow"
 
-    def test_default_handoff_is_pandas(self, monkeypatch, atl06_config):
+    def test_default_handoff_is_arrow(self, monkeypatch, atl06_config):
+        # issue #130: arro3/arrow is the default carrier (faster + lighter on dense
+        # shards); pandas remains available via an explicit handoff="pandas".
         from zagg import runner
 
         captured = {}
@@ -582,7 +584,7 @@ class TestHandoffPassthrough:
             0, (0,), [_rec(1)], grid=None, s3_creds={}, zarr_store=None,
             config=atl06_config, driver="s3",
         )
-        assert captured["handoff"] == "pandas"
+        assert captured["handoff"] == "arrow"
 
 
 def _stub_grid():
@@ -1001,7 +1003,8 @@ class TestProfilePlumbing:
         )
         assert captured["handoff"] == "arrow"
 
-    def test_agg_default_handoff_is_pandas_on_lambda(self, monkeypatch, atl06_config):
+    def test_agg_default_handoff_is_arrow_on_lambda(self, monkeypatch, atl06_config):
+        # issue #130: agg() defaults to the arro3/arrow carrier on the lambda backend.
         from zagg import runner
 
         captured = {}
@@ -1011,7 +1014,7 @@ class TestProfilePlumbing:
             lambda *a, **k: captured.update(handoff=k.get("handoff")) or {},
         )
         runner.agg(atl06_config, catalog="ignored", store="s3://out/x.zarr", backend="lambda")
-        assert captured["handoff"] == "pandas"
+        assert captured["handoff"] == "arrow"
 
 
 class TestWorkerPhaseTimings:


### PR DESCRIPTION
Closes #130

## What this does

Migrates the deployed Lambda worker's Arrow carrier from **pyarrow** to **arro3-core** (path C, per @espg's [Do (C) decision](https://github.com/englacial/zagg/pull/131#issuecomment-4838785058)), and makes the **arro3 / `arrow` carrier the default** for production *and* the benchmark matrix.

pyarrow 24.0.0's bindings hard-link a ~100 MB unstrippable C++ core that can't fit the 250 MB combined Lambda gate while remaining importable; `arro3-core` is ~7 MB, zero required runtime deps, importable inside the gate. **The deployed worker + layer are now pyarrow-free** — pyarrow survives only in the off-Lambda `catalog` extra (`stac-geoparquet` hard-requires it), which never runs on the worker.

## The carriers

- **Vector WRITE carrier → arro3-core** — verified live (`gain_bias` → 200,676 obs on `process-shard-test`). On-disk numpy blocks are **byte-for-byte identical** to the prior pyarrow output (FixedSizeList via `fixed_size_list_array` + `list_flatten(col).to_numpy().reshape(n, width)`).
- **Read handoff carrier (`handoff="arrow"`) → arro3-core — diagnosed, fixed, and now the default.** (Story below.)
- **`arrow-kernel` reducer DROPPED** — arro3 has no hash-aggregate. Removed `_kernel_*`/`KERNEL_RTOL`, the worker branch, the `scalar_kernel` target, and the kernel tests.

## The read-carrier failure: not a native crash — a memory-lifetime bug (fixed)

The arro3 read carrier first *appeared* to crash the Lambda worker (`scalar_arrow`), so it was dropped (`96dfa09`). Re-investigating with the actual **CloudWatch logs** showed it was **not** a native crash — it was **memory exhaustion**:

| carrier (same dense o11 shard, 200,676 photons) | result | max mem |
|---|---|---|
| `gain_bias` (arro3 vector write) | ✅ | 1278 MB |
| `scalar_pandas` | ✅ | 1725 MB |
| `scalar_arrow` (arro3 read handoff, **unfixed**) | ❌ timeout | **2048 MB (cap)** |

`REPORT … Duration: 720000 ms  Max Memory Used: 2048 MB  Status: timeout` — the worker pegged the 2 GB cap and thrashed to the 720 s wall, surfacing to the orchestrator as `ConnectionClosedError` ("connection closed, no response").

**Root cause (measured, not inferred).** `Array.from_numpy`/`from_pydict`/`from_batches` are zero-copy; the single forced copy is `combine_chunks().to_numpy()`. `_concat_and_group` kept the chunked Arrow `table` (and the per-read tables in `all_reads`) **alive through `_group_columns`**, so the pooled data was held **twice**. **Fix** — free the Arrow buffers the instant the columns are numpy:

```python
cols = {n: table.column(n).combine_chunks().to_numpy() for n in table.column_names}
del table, batches
all_reads.clear()        # unused after this call (worker.py)
```

**Proof:** peak RSS 1004 → 524 MB; under a 2 GB cap the unfixed run OOMs (exit 137) and the fixed run survives (exit 0) with byte-identical output; on the real NEON median shard `handoff=arrow` is byte-identical to pandas through `process_shard`; at matched scale fixed-arro3 (1019 MB) is **lighter** than pandas (1456 MB, which holds 3× vs arrow's 2×). Full diagnosis: [#130 comment](https://github.com/englacial/zagg/issues/130#issuecomment-4839451197); fresh-context adversarial review (no blocking issues): [#131 review](https://github.com/englacial/zagg/pull/131#issuecomment-4839665178).

## Default switch → arro3 / `arrow`

- **Production:** `agg()` and the runner dispatch layer default `handoff="arrow"`. The **wire protocol is unchanged** ("absent event key = pandas"): arrow runs inject the key; an explicit `handoff="pandas"` omits it (byte-identical legacy path). `process_shard`'s library default and the handler's absent-default stay `"pandas"` (legacy-safe — explicit pandas keeps working).
- **Benchmarks:** all 8 committed matrix targets set `"handoff": "arrow"`, so the retained series tracks the carrier production actually runs.
- **Follow-on (#132):** a cleaner, config-driven `handoff` (an aggregation-YAML field, so other sensors / nullable sources can choose pandas) — the read carrier requires dense, null-free columns, so a global default isn't right for every sensor. Not blocking this PR.

## Phases

- [x] **Phase 1** — vector carrier → arro3-core (`processing/write.py`); byte-identical output.
- [x] **Phase 2** — drop arrow-kernel reducer (arro3 has no hash-aggregate).
- [x] **Phase 3** — deps + layer: pyarrow core→`catalog` (out of `lambda`); `arro3-core` in core + `lambda`; `build_layer.sh` swap + strip-block removal.
- [x] **Phase 4** — benchmark matrix (`scalar_pandas`/`scalar_arrow` A/B baseline) + pyarrow-free worker guard test.
- [x] **Phase 5** — read carrier `handoff="arrow"`: diagnosed (CloudWatch: OOM→timeout), **fixed** (free Arrow buffers before grouping), revived; opt-in `ZAGG_PROFILE_RSS` per-stage RSS trace added.
- [x] **Phase 6** — `arrow` made the **default** carrier (production `agg()`/runner + the 8 benchmark targets); docstrings/comments + the two default-assertion tests updated to `arrow`.

## How tested

- Full suite green locally (incl. `test_runner`/`test_lambda_handler`/`test_benchmark` after the default flip; the two `test_default_handoff_is_*` tests updated to assert `arrow`); ruff + `ruff format` clean.
- **Carrier byte-identity:** vector + scalar columns round-trip through arro3 identically to the prior pyarrow blocks; `handoff=arrow` output == pandas on the real median shard.
- **Memory fix A/B:** unfixed read carrier OOM-kills under a 2 GB cap, fixed survives, identical checksum (see above).
- **pyarrow-free guard:** the default + vector write carrier run in a subinterpreter that blocks every `pyarrow` import, asserting `pyarrow` never enters `sys.modules`.
- **Live Lambda (`process-shard-test`):** gain_bias (arro3 write) ✅ 200,676 obs; scalar_pandas ✅ 200,676 obs. The fixed arro3 read carrier will be exercised by the next merge's arrow benchmark across all 8 targets.

## Questions for review

- **Validate the fixed read carrier on the dense shard on real Lambda** before fully trusting the default — the next merge runs the 8-target arrow matrix; watch the dense o11/o10 `REPORT` mem stays well under 2048 MB.
- The read carrier requires **dense, null-free columns** (guard raises on nulls). Per-sensor pandas/arrow choice belongs in the config-driven follow-on (#132).
- **arro3 pin** is `==0.8.1` (lambda) / `>=0.8.1` (core) — bump policy is yours.
