### PR TITLE
Make the worker carrier (handoff) a config-driven aggregation-YAML field

### DIFF
--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -34,7 +34,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import bench_metrics  # noqa: E402
 
-from zagg.config import load_config  # noqa: E402
+from zagg.config import get_handoff, load_config  # noqa: E402
 from zagg.grids import from_config  # noqa: E402
 
 
@@ -98,11 +98,11 @@ def run_target(
     shard_key = int(shardmap_meta["shard_key"])
     n_granules = shardmap_meta.get("n_granules")
 
-    # Per-cell carrier (issue #130). Default "pandas" keeps the dispatched event
-    # byte-identical to a pre-handoff run; the arrow (arro3) target sets it.
-    handoff = target.get("handoff", "pandas")
-
     config = load_config(str(config_path))
+    # Per-cell carrier (issues #130/#132). Inherit from the config
+    # (``aggregation.handoff``, default ``"arrow"``) unless the target pins an
+    # explicit override for a pandas-vs-arrow A/B; the override still wins.
+    handoff = target.get("handoff") or get_handoff(config)
     # parent_order lives in the config grid for HEALPix; the kwarg is just a
     # legacy fallback. Rect grids ignore it. ``from_config`` gives us the grid
     # object the area/cost derivation needs.

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -61,7 +61,7 @@ from zarr import open_group
 from zarr.errors import GroupNotFoundError
 
 # Import cloud-agnostic processing
-from zagg.config import load_config_from_dict
+from zagg.config import get_handoff, load_config_from_dict
 from zagg.processing import (
     write_dataframe_to_zarr,
     write_ragged_to_zarr,
@@ -274,10 +274,14 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # read/index/aggregate deltas; the write phase runs in the callback below and
         # is accumulated into the same sub-dict. Default (no key) leaves it unchanged.
         profile = event.get("profile", False)
-        # Per-cell carrier (issue #130). Absent key -> "pandas", the byte-identical
-        # default worker path; "arrow" opts into the arro3-core read carrier for
-        # benchmarks. (Neither imports pyarrow; pyarrow is not in the layer.)
-        handoff = event.get("handoff", "pandas")
+        # Per-cell carrier (issues #130/#132). Wire protocol (A): the orchestrator
+        # injects the ``handoff`` event key only for an explicit non-default
+        # override, so an absent key means "derive from the forwarded config" via
+        # ``get_handoff(config)`` (``aggregation.handoff``, default ``"arrow"``).
+        # This keeps existing event payloads byte-identical while making the config
+        # the single source of truth. (Neither carrier imports pyarrow; pyarrow is
+        # not in the layer.)
+        handoff = event.get("handoff") or get_handoff(config)
         sharded = getattr(grid, "sharded", False)
         store_path = event["store_path"]
         shard_key = event["shard_key"]

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -208,6 +208,13 @@ def validate_config(config: PipelineConfig) -> None:
         if layout is not None and layout not in ("dense", "fullsphere"):
             raise ValueError(f"output.grid.layout must be 'dense' or 'fullsphere' (got {layout!r})")
 
+    # Validate the optional per-cell carrier (issue #132). Mirrors the worker's
+    # ``{"pandas", "arrow"}`` guard (worker.py) so a typo in the aggregation YAML
+    # fails at load, not deep in a worker.
+    handoff = config.aggregation.get("handoff")
+    if handoff is not None and handoff not in ("pandas", "arrow"):
+        raise ValueError(f"aggregation.handoff must be 'pandas' or 'arrow' (got {handoff!r})")
+
     # Validate bounds structure (optional)
     if config.bounds is not None:
         allowed_keys = {"temporal", "spatial"}
@@ -1107,6 +1114,30 @@ def get_driver(config: PipelineConfig) -> str:
         ``"s3"`` or ``"https"``. Defaults to ``"s3"``.
     """
     return config.data_source.get("driver", "s3")
+
+
+def get_handoff(config: PipelineConfig) -> str:
+    """Return the per-cell aggregation carrier from the aggregation config (issue #132).
+
+    The ``handoff`` knob lives on the ``aggregation`` block, default ``"arrow"``,
+    and selects the per-cell read->concat->extract carrier: ``"arrow"`` (an
+    ``arro3.core`` Table, faster + lighter on dense shards) or ``"pandas"`` (a
+    DataFrame, which tolerates nullable columns natively). Both feed identical
+    numpy arrays into the same reductions, so scalar outputs are byte-for-byte
+    identical (issues #130/#131). A pipeline declares its carrier next to the rest
+    of its aggregation settings rather than relying on a global default; the
+    explicit ``handoff=`` kwarg still overrides this value.
+
+    Parameters
+    ----------
+    config : PipelineConfig
+
+    Returns
+    -------
+    str
+        ``"arrow"`` (default) or ``"pandas"``.
+    """
+    return config.aggregation.get("handoff", "arrow")
 
 
 def get_child_order(config: PipelineConfig) -> int:

--- a/src/zagg/configs/atl06.yaml
+++ b/src/zagg/configs/atl06.yaml
@@ -13,6 +13,11 @@ data_source:
     value: 0
 
 aggregation:
+  # Per-cell carrier (issue #132): "arrow" (arro3 Table, faster + lighter on dense
+  # shards) or "pandas" (DataFrame, tolerates nullable columns). Default "arrow";
+  # declared here so the carrier travels with the rest of the aggregation settings.
+  # A nullable/sparse source should set "pandas" (see atl06_nullable.yaml).
+  handoff: arrow
   coordinates:
     cell_ids:
       dtype: uint64

--- a/src/zagg/configs/atl06_nullable.yaml
+++ b/src/zagg/configs/atl06_nullable.yaml
@@ -1,0 +1,51 @@
+# ATL06 land-ice height, nullable-source example selecting the pandas carrier.
+#
+# This mirrors atl06.yaml but declares ``aggregation.handoff: pandas`` (issue #132):
+# the arro3/arrow read carrier requires dense, null-free columns (its null_cols
+# guard raises on nulls), so a source that can carry nulls -- here h_li is kept
+# WITHOUT the atl06_quality_summary filter that atl06.yaml uses to drop invalid
+# returns, so masked/invalid h_li values survive into the per-cell columns -- must
+# use the pandas carrier, which tolerates nulls natively. The carrier travels with
+# the config; everything else is identical to atl06.yaml.
+data_source:
+  reader: h5coro
+  driver: s3
+  groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]
+  coordinates:
+    latitude: "/{group}/land_ice_segments/latitude"
+    longitude: "/{group}/land_ice_segments/longitude"
+  variables:
+    h_li: "/{group}/land_ice_segments/h_li"
+    s_li: "/{group}/land_ice_segments/h_li_sigma"
+
+aggregation:
+  # Nullable source -> pandas carrier (arrow's null_cols guard would raise).
+  handoff: pandas
+  coordinates:
+    cell_ids:
+      dtype: uint64
+      fill_value: 0
+    morton:
+      dtype: uint64
+      fill_value: 0
+  variables:
+    count:
+      function: len
+      source: h_li
+      dtype: int32
+      fill_value: 0
+    h_min:
+      function: min
+      source: h_li
+      dtype: float32
+    h_max:
+      function: max
+      source: h_li
+      dtype: float32
+
+output:
+  grid:
+    type: healpix
+    indexing_scheme: nested
+    parent_order: 6
+    child_order: 12

--- a/src/zagg/configs/atl06_nullable.yaml
+++ b/src/zagg/configs/atl06_nullable.yaml
@@ -2,11 +2,11 @@
 #
 # This mirrors atl06.yaml but declares ``aggregation.handoff: pandas`` (issue #132):
 # the arro3/arrow read carrier requires dense, null-free columns (its null_cols
-# guard raises on nulls), so a source that can carry nulls -- here h_li is kept
-# WITHOUT the atl06_quality_summary filter that atl06.yaml uses to drop invalid
-# returns, so masked/invalid h_li values survive into the per-cell columns -- must
-# use the pandas carrier, which tolerates nulls natively. The carrier travels with
-# the config; everything else is identical to atl06.yaml.
+# guard raises on nulls), so a source whose columns may carry nulls must use the
+# pandas carrier, which tolerates nulls natively. (Here the quality_filter is also
+# omitted vs atl06.yaml so invalid returns aren't pre-dropped, but nullability is a
+# property of the source data, not of that filter.) The carrier travels with the
+# config; everything else is identical to atl06.yaml.
 data_source:
   reader: h5coro
   driver: s3

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -81,12 +81,16 @@ def process_shard(
     driver : str, optional
         ``"s3"`` (default) or ``"https"``.
     handoff : str, optional
-        Per-cell aggregation carrier: ``"pandas"`` (default) or ``"arrow"``. Both
-        feed identical numpy arrays into the same numpy reductions, so scalar
-        outputs are byte-for-byte identical; only the read→concat→extract
-        representation differs (pandas DataFrames vs ``arro3.core`` Tables). The
-        ``"arrow"`` carrier is opt-in for benchmarking the carrier cost (issue
-        #130). pyarrow is not used on either path.
+        Per-cell aggregation carrier: ``"pandas"`` or ``"arrow"``. Both feed
+        identical numpy arrays into the same numpy reductions, so scalar outputs
+        are byte-for-byte identical; only the read→concat→extract representation
+        differs (pandas DataFrames vs ``arro3.core`` Tables). The carrier is
+        normally declared per-pipeline in the aggregation config
+        (``aggregation.handoff``, default ``"arrow"`` — issue #132) and resolved by
+        the caller (``agg`` / the Lambda handler) via
+        :func:`zagg.config.get_handoff`; this parameter's own ``"pandas"`` default
+        is only a no-config safety net for direct callers. pyarrow is not used on
+        either path.
     ragged_out : dict, optional
         Out-param sink for ``kind: ragged`` (CSR) fields (issue #48). When a dict
         is passed, it is filled in place with ``{field_name: (values_list,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -31,6 +31,7 @@ from zagg.config import (
     PipelineConfig,
     get_child_order,
     get_driver,
+    get_handoff,
     get_layout,
     get_output_endpoint_url,
     get_output_region,
@@ -86,7 +87,7 @@ def agg(
     region: str = "us-west-2",
     output_credentials: dict | None = None,
     output_endpoint_url: str | None = None,
-    handoff: str = "arrow",
+    handoff: str | None = None,
     profile: bool = False,
     max_retries: int = 3,
 ) -> dict:
@@ -132,15 +133,18 @@ def agg(
     output_endpoint_url : str, optional
         Custom S3-compatible endpoint for the output store (e.g. R2, MinIO).
         Overrides ``output.endpoint_url`` in the config.
-    handoff : str
-        Per-cell aggregation carrier: ``"arrow"`` (default, an ``arro3.core``
-        carrier) or ``"pandas"``. Both produce byte-for-byte identical scalar outputs
-        (#30); ``"arrow"`` is the default because it is faster and lighter on dense
-        shards (issue #130). Honored by both the ``"local"`` and ``"lambda"``
-        backends: the lambda backend forwards it into each cell event, and an
-        explicit ``"pandas"`` keeps that event payload byte-identical (no key).
-        pyarrow is not used on either path; the experimental ``arrow-kernel``
-        reducer was dropped with pyarrow.
+    handoff : str, optional
+        Per-cell aggregation carrier: ``"arrow"`` (an ``arro3.core`` carrier) or
+        ``"pandas"``. Both produce byte-for-byte identical scalar outputs (#30);
+        ``"arrow"`` is faster and lighter on dense shards (issue #130). Default
+        ``None`` reads the carrier from the config (``aggregation.handoff``, itself
+        defaulting to ``"arrow"`` — issue #132) via :func:`get_handoff`; an explicit
+        kwarg overrides the config, mirroring the ``driver`` precedence. Honored by
+        both the ``"local"`` and ``"lambda"`` backends: the lambda backend forwards
+        a non-default carrier into each cell event, and an absent key keeps that
+        event payload byte-identical (the worker then derives the carrier from the
+        forwarded config). pyarrow is not used on either path; the experimental
+        ``arrow-kernel`` reducer was dropped with pyarrow.
     profile : bool
         Opt-in per-phase timing (issue #100). When ``True`` (lambda backend),
         forwards ``profile`` into each cell event so the worker emits a
@@ -177,6 +181,10 @@ def agg(
     # Resolve driver: kwarg > config > default
     resolved_driver = driver or get_driver(config)
 
+    # Resolve carrier: explicit kwarg > config (aggregation.handoff > "arrow").
+    # Mirrors the driver precedence above (issue #132).
+    resolved_handoff = handoff if handoff is not None else get_handoff(config)
+
     # Output endpoint/region are non-secret: runtime kwarg > config.
     resolved_endpoint = output_endpoint_url or get_output_endpoint_url(config)
     config_region = get_output_region(config)
@@ -211,7 +219,7 @@ def agg(
             driver=resolved_driver,
             output_credentials=output_credentials,
             output_endpoint_url=resolved_endpoint,
-            handoff=handoff,
+            handoff=resolved_handoff,
         )
     elif backend == "lambda":
         if max_workers is None:
@@ -235,7 +243,7 @@ def agg(
             function_name=function_name,
             output_credentials=output_credentials,
             output_endpoint_url=resolved_endpoint,
-            handoff=handoff,
+            handoff=resolved_handoff,
             profile=profile,
             max_retries=max_retries,
         )

--- a/tests/data/benchmark/targets.json
+++ b/tests/data/benchmark/targets.json
@@ -46,64 +46,56 @@
       "shardmap": "healpix_o11",
       "aggregator": "gain_bias",
       "grid_type": "healpix",
-      "grid_size": "o11",
-      "handoff": "arrow"
+      "grid_size": "o11"
     },
     "tdigest_healpix_o11": {
       "config": "configs/atl03_tdigest_healpix_o11.yaml",
       "shardmap": "healpix_o11",
       "aggregator": "tdigest",
       "grid_type": "healpix",
-      "grid_size": "o11",
-      "handoff": "arrow"
+      "grid_size": "o11"
     },
     "gain_bias_healpix_o10": {
       "config": "configs/atl03_gain_bias_healpix_o10.yaml",
       "shardmap": "healpix_o10",
       "aggregator": "gain_bias",
       "grid_type": "healpix",
-      "grid_size": "o10",
-      "handoff": "arrow"
+      "grid_size": "o10"
     },
     "tdigest_healpix_o10": {
       "config": "configs/atl03_tdigest_healpix_o10.yaml",
       "shardmap": "healpix_o10",
       "aggregator": "tdigest",
       "grid_type": "healpix",
-      "grid_size": "o10",
-      "handoff": "arrow"
+      "grid_size": "o10"
     },
     "gain_bias_rect_3km": {
       "config": "configs/atl03_gain_bias_rect_3km.yaml",
       "shardmap": "rect_3km",
       "aggregator": "gain_bias",
       "grid_type": "rectilinear",
-      "grid_size": "3km",
-      "handoff": "arrow"
+      "grid_size": "3km"
     },
     "tdigest_rect_3km": {
       "config": "configs/atl03_tdigest_rect_3km.yaml",
       "shardmap": "rect_3km",
       "aggregator": "tdigest",
       "grid_type": "rectilinear",
-      "grid_size": "3km",
-      "handoff": "arrow"
+      "grid_size": "3km"
     },
     "gain_bias_rect_6km": {
       "config": "configs/atl03_gain_bias_rect_6km.yaml",
       "shardmap": "rect_6km",
       "aggregator": "gain_bias",
       "grid_type": "rectilinear",
-      "grid_size": "6km",
-      "handoff": "arrow"
+      "grid_size": "6km"
     },
     "tdigest_rect_6km": {
       "config": "configs/atl03_tdigest_rect_6km.yaml",
       "shardmap": "rect_6km",
       "aggregator": "tdigest",
       "grid_type": "rectilinear",
-      "grid_size": "6km",
-      "handoff": "arrow"
+      "grid_size": "6km"
     }
   },
   "provisional_targets": {

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -343,6 +343,40 @@ def test_provisional_target_resolves_and_threads_handoff(monkeypatch):
     assert captured["handoff"] == "arrow"
 
 
+def test_committed_targets_drop_redundant_handoff(monkeypatch):
+    # issue #132: the merge-matrix targets no longer restate the carrier; they
+    # inherit it from each config. Only the provisional A/B targets pin handoff.
+    manifest = json.loads((BENCH / "targets.json").read_text())
+    for tname, t in manifest["targets"].items():
+        assert "handoff" not in t, f"{tname}: handoff should be inherited from the config"
+
+
+def test_committed_target_inherits_handoff_from_config(monkeypatch):
+    # issue #132: a committed target with no handoff key inherits the config carrier
+    # (get_handoff -> "arrow" for the benchmark configs, which set no handoff).
+    manifest, base = run_benchmark.load_targets(str(BENCH / "targets.json"))
+    captured = {}
+
+    import zagg.runner as runner
+
+    def fake_agg(config, **kwargs):
+        captured["handoff"] = kwargs.get("handoff")
+        return {}
+
+    monkeypatch.setattr(runner, "agg", fake_agg)
+    run_benchmark.run_target(
+        "gain_bias_healpix_o11",
+        manifest,
+        base,
+        store="s3://b/x.zarr",
+        region="us-west-2",
+        function_name="process-shard",
+        context={"commit": "deadbee", "event": "pr"},
+        dry_run=False,
+    )
+    assert captured["handoff"] == "arrow"
+
+
 def test_scalar_config_is_genuinely_scalar():
     # The scalar benchmark config must be GENUINELY scalar -- every field a plain
     # per-cell stat (no vector/ragged) -- so the pandas/arrow carrier comparison

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ from zagg.config import (
     get_coords,
     get_data_vars,
     get_filters,
+    get_handoff,
     get_levels,
     get_output_signature,
     get_sharded,
@@ -1088,6 +1089,45 @@ class TestOutputHelpers:
             }
         )
         assert get_store_path(cfg) == "s3://bucket/prefix.zarr"
+
+
+# ---------------------------------------------------------------------------
+# Carrier handoff config helper + validation (issue #132)
+# ---------------------------------------------------------------------------
+
+
+def _cfg_with_handoff(handoff=None) -> PipelineConfig:
+    """Minimal valid config; sets aggregation.handoff only when given."""
+    aggregation = {"variables": {"c": {"function": "len", "source": "h_li", "dtype": "int32"}}}
+    if handoff is not None:
+        aggregation["handoff"] = handoff
+    return PipelineConfig(
+        data_source={"variables": {"h_li": "/path"}},
+        aggregation=aggregation,
+        output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+    )
+
+
+class TestHandoff:
+    def test_default_is_arrow(self, atl06_config):
+        assert get_handoff(atl06_config) == "arrow"
+
+    def test_explicit_pandas(self):
+        assert get_handoff(_cfg_with_handoff("pandas")) == "pandas"
+
+    def test_explicit_arrow(self):
+        assert get_handoff(_cfg_with_handoff("arrow")) == "arrow"
+
+    def test_valid_handoff_validates(self):
+        validate_config(_cfg_with_handoff("pandas"))  # should not raise
+        validate_config(_cfg_with_handoff("arrow"))
+
+    def test_absent_handoff_validates(self):
+        validate_config(_cfg_with_handoff())  # should not raise
+
+    def test_invalid_handoff_rejected_at_load(self):
+        with pytest.raises(ValueError, match="aggregation.handoff must be 'pandas' or 'arrow'"):
+            validate_config(_cfg_with_handoff("bogus"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1126,7 +1126,7 @@ class TestHandoff:
         validate_config(_cfg_with_handoff())  # should not raise
 
     def test_invalid_handoff_rejected_at_load(self):
-        with pytest.raises(ValueError, match="aggregation.handoff must be 'pandas' or 'arrow'"):
+        with pytest.raises(ValueError, match=r"aggregation\.handoff must be 'pandas' or 'arrow'"):
             validate_config(_cfg_with_handoff("bogus"))
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1129,6 +1129,15 @@ class TestHandoff:
         with pytest.raises(ValueError, match=r"aggregation\.handoff must be 'pandas' or 'arrow'"):
             validate_config(_cfg_with_handoff("bogus"))
 
+    def test_shipped_atl06_declares_arrow(self):
+        # The shipped atl06 config now declares its carrier explicitly (issue #132).
+        assert get_handoff(default_config("atl06")) == "arrow"
+
+    def test_shipped_nullable_example_selects_pandas(self):
+        # The nullable-source example ships with the pandas carrier and validates.
+        cfg = default_config("atl06_nullable")  # default_config runs validate_config
+        assert get_handoff(cfg) == "pandas"
+
 
 # ---------------------------------------------------------------------------
 # Output grid validation

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -129,17 +129,31 @@ class TestProcessEventDispatch:
 
     def test_handoff_event_key_forwarded_to_worker(self, handler_mod, monkeypatch):
         # issue #130: an explicit handoff event key reaches process_shard so the
-        # deployed worker selects the arro3 arrow carrier.
+        # deployed worker selects the named carrier (the key still wins, #132 wire (A)).
         event = _base_event(_healpix_config_dict())
         event["child_order"] = 12
-        event["handoff"] = "arrow"
+        event["handoff"] = "pandas"
+        resp, captured = self._run(handler_mod, monkeypatch, event)
+        assert resp["statusCode"] == 200
+        assert captured["handoff"] == "pandas"
+
+    def test_absent_handoff_key_derives_from_config(self, handler_mod, monkeypatch):
+        # issue #132 wire (A): an absent handoff key means "derive from the
+        # forwarded config". The default atl06 config sets no aggregation.handoff,
+        # so get_handoff -> the "arrow" default (the pandas->arrow flip is on record).
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        assert "handoff" not in event
         resp, captured = self._run(handler_mod, monkeypatch, event)
         assert resp["statusCode"] == 200
         assert captured["handoff"] == "arrow"
 
-    def test_default_handoff_is_pandas(self, handler_mod, monkeypatch):
-        # No handoff key -> the worker runs the byte-identical default ("pandas").
-        event = _base_event(_healpix_config_dict())
+    def test_absent_handoff_key_honors_config_pandas(self, handler_mod, monkeypatch):
+        # issue #132: a config declaring aggregation.handoff="pandas" (e.g. a
+        # nullable-source pipeline) is honored on the absent-key path.
+        config_dict = _healpix_config_dict()
+        config_dict["aggregation"]["handoff"] = "pandas"
+        event = _base_event(config_dict)
         event["child_order"] = 12
         assert "handoff" not in event
         resp, captured = self._run(handler_mod, monkeypatch, event)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1344,6 +1344,22 @@ class TestProfilePlumbing:
         )
         assert captured["handoff"] == "arrow"
 
+    def test_agg_reads_handoff_from_config_on_local(self, monkeypatch, atl06_config):
+        # issue #132: the config-derived carrier reaches the local backend too
+        # (resolution is backend-agnostic, before the local/lambda split).
+        from zagg import runner
+
+        atl06_config.aggregation["handoff"] = "pandas"
+        captured = {}
+        monkeypatch.setattr(runner, "_load_catalog", lambda p: _run_catalog())
+        monkeypatch.setattr(
+            runner,
+            "_run_local",
+            lambda *a, **k: captured.update(handoff=k.get("handoff")) or {},
+        )
+        runner.agg(atl06_config, catalog="ignored", store="./out.zarr", backend="local")
+        assert captured["handoff"] == "pandas"
+
 
 class TestWorkerPhaseTimings:
     """``process_shard(profile=...)`` emits ``phase_timings`` only when set, and

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -450,9 +450,17 @@ class TestInvokeLambdaCellRetry:
         from zagg.runner import _invoke_lambda_cell
 
         return _invoke_lambda_cell(
-            client, (0,), 12345, 6, 12,
-            ["s3://b/g.h5"], "s3://out/x.zarr", self._CREDS,
-            function_name="process-shard", config_dict=None, max_workers=4,
+            client,
+            (0,),
+            12345,
+            6,
+            12,
+            ["s3://b/g.h5"],
+            "s3://out/x.zarr",
+            self._CREDS,
+            function_name="process-shard",
+            config_dict=None,
+            max_workers=4,
             max_retries=max_retries,
         )
 
@@ -563,32 +571,51 @@ class TestMaxRetriesPassthrough:
 
         captured = {}
 
-        monkeypatch.setattr(runner, "get_nsidc_s3_credentials",
-                            lambda: {"accessKeyId": "a", "secretAccessKey": "s",
-                                     "sessionToken": "t"})
+        monkeypatch.setattr(
+            runner,
+            "get_nsidc_s3_credentials",
+            lambda: {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
+        )
         monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
         from unittest.mock import MagicMock
+
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
         monkeypatch.setattr(
-            runner, "compute_available_workers",
+            runner,
+            "compute_available_workers",
             lambda requested, *a, **k: (
                 1,
-                ConcurrencyReport(account_limit=1000, current_concurrent=0,
-                                  padding=100, available=900, function_reserved=None),
+                ConcurrencyReport(
+                    account_limit=1000,
+                    current_concurrent=0,
+                    padding=100,
+                    available=900,
+                    function_reserved=None,
+                ),
             ),
         )
 
         def _fake_cell(*a, **k):
             captured["max_retries"] = k.get("max_retries")
-            return {"status_code": 200, "body": {"total_obs": 1}, "error": None,
-                    "lambda_duration": 1.0, "shard_key": 0}
+            return {
+                "status_code": 200,
+                "body": {"total_obs": 1},
+                "error": None,
+                "lambda_duration": 1.0,
+                "shard_key": 0,
+            }
 
         monkeypatch.setattr(runner, "_invoke_lambda_cell", _fake_cell)
-        agg(atl06_config, catalog=catalog_file, store="s3://out/x.zarr",
-            backend="lambda", **agg_kwargs)
+        agg(
+            atl06_config,
+            catalog=catalog_file,
+            store="s3://out/x.zarr",
+            backend="lambda",
+            **agg_kwargs,
+        )
         return captured
 
     def test_max_retries_threaded_end_to_end(self, monkeypatch, atl06_config, catalog_file):
@@ -1251,26 +1278,70 @@ class TestProfilePlumbing:
         captured = {}
         monkeypatch.setattr(runner, "_load_catalog", lambda p: _run_catalog())
         monkeypatch.setattr(
-            runner, "_run_lambda",
+            runner,
+            "_run_lambda",
             lambda *a, **k: captured.update(handoff=k.get("handoff")) or {},
         )
         runner.agg(
-            atl06_config, catalog="ignored", store="s3://out/x.zarr",
-            backend="lambda", handoff="arrow",
+            atl06_config,
+            catalog="ignored",
+            store="s3://out/x.zarr",
+            backend="lambda",
+            handoff="arrow",
         )
         assert captured["handoff"] == "arrow"
 
     def test_agg_default_handoff_is_arrow_on_lambda(self, monkeypatch, atl06_config):
-        # issue #130: agg() defaults to the arro3/arrow carrier on the lambda backend.
+        # issue #132: with no kwarg and no config field, agg() resolves the carrier
+        # from get_handoff(config), which defaults to arrow.
         from zagg import runner
 
         captured = {}
         monkeypatch.setattr(runner, "_load_catalog", lambda p: _run_catalog())
         monkeypatch.setattr(
-            runner, "_run_lambda",
+            runner,
+            "_run_lambda",
             lambda *a, **k: captured.update(handoff=k.get("handoff")) or {},
         )
         runner.agg(atl06_config, catalog="ignored", store="s3://out/x.zarr", backend="lambda")
+        assert captured["handoff"] == "arrow"
+
+    def test_agg_reads_handoff_from_config(self, monkeypatch, atl06_config):
+        # issue #132: with no kwarg, the carrier comes from aggregation.handoff so a
+        # nullable-source pipeline can declare pandas in its YAML.
+        from zagg import runner
+
+        atl06_config.aggregation["handoff"] = "pandas"
+        captured = {}
+        monkeypatch.setattr(runner, "_load_catalog", lambda p: _run_catalog())
+        monkeypatch.setattr(
+            runner,
+            "_run_lambda",
+            lambda *a, **k: captured.update(handoff=k.get("handoff")) or {},
+        )
+        runner.agg(atl06_config, catalog="ignored", store="s3://out/x.zarr", backend="lambda")
+        assert captured["handoff"] == "pandas"
+
+    def test_agg_handoff_kwarg_overrides_config(self, monkeypatch, atl06_config):
+        # issue #132: an explicit handoff= kwarg wins over aggregation.handoff,
+        # mirroring the driver precedence.
+        from zagg import runner
+
+        atl06_config.aggregation["handoff"] = "pandas"
+        captured = {}
+        monkeypatch.setattr(runner, "_load_catalog", lambda p: _run_catalog())
+        monkeypatch.setattr(
+            runner,
+            "_run_lambda",
+            lambda *a, **k: captured.update(handoff=k.get("handoff")) or {},
+        )
+        runner.agg(
+            atl06_config,
+            catalog="ignored",
+            store="s3://out/x.zarr",
+            backend="lambda",
+            handoff="arrow",
+        )
         assert captured["handoff"] == "arrow"
 
 


### PR DESCRIPTION
Closes #132

## What this does

Makes the per-cell worker carrier (`handoff`, `"pandas"` vs `"arrow"`/arro3) a **config-driven field of the aggregation YAML** instead of a string default hard-coded in ~7 call sites that disagreed with each other (runner stack defaulted `"arrow"`, worker/Lambda stack defaulted `"pandas"`). The single source of truth becomes `get_handoff(config)` (default `"arrow"`); the explicit `handoff=` kwarg still overrides it. A nullable-source pipeline can declare `handoff: pandas` next to the rest of its aggregation settings.

Design is fully locked on #132 (plan comment + @espg's answers): field is `aggregation.handoff`, default `"arrow"`; wire protocol is **option (A) minimal injection** (orchestrator injects the `handoff` event key only for an explicit non-default override, Lambda derives from forwarded `config` on an absent key, so existing event payloads stay byte-identical); the pandas->arrow default flip on the worker/Lambda side is approved; the `deployment/aws/lambda_handler.py` edit is explicitly authorized for this issue.

## Phases

- [x] **Phase 1 — Schema + accessor + validation.** `get_handoff(config)` in `config.py` returning `aggregation.get("handoff", "arrow")`; `validate_config` guard against `{"pandas","arrow"}` so a typo fails at load; config-validation tests.
- [x] **Phase 2 — Resolve config in `agg()`; kwarg overrides.** `agg`'s `handoff` default -> `None`, resolved `handoff if handoff is not None else get_handoff(config)` (mirroring `driver = driver or get_driver(config)`); threaded through `_run_local`/`_run_lambda`. Runner tests for config-derived selection (local + lambda) + kwarg-override-wins.
- [x] **Phase 3 — Lambda worker reads from config when event key absent.** `deployment/aws/lambda_handler.py` now `event.get("handoff") or get_handoff(config)`, preserving the (A) wire contract. `process_shard`'s `"pandas"` stays a no-config safety net. Lambda-handler tests (absent->config-arrow; absent+config-pandas->pandas; explicit key wins).
- [x] **Phase 4 — Benchmark + configs + docs.** `.github/scripts/run_benchmark.py` inherits from the loaded config (`target.get("handoff") or get_handoff(config)`); `tests/data/benchmark/targets.json` drops the redundant per-target `handoff` from the 8 committed targets (keeps the 2 provisional A/B overrides); `src/zagg/configs/atl06.yaml` declares `handoff: arrow`; new `src/zagg/configs/atl06_nullable.yaml` is a `pandas` example; `worker.py` docstring updated. Benchmark + config tests.

## How tested

Per phase: `uv run ruff check --select=E,F,W,I --ignore=E501 src tests deployment .github/scripts/run_benchmark.py` (clean), `uv run ruff format --check` on touched files (clean), and `uv run pytest -q`. The touched modules (`test_config`, `test_runner`, `test_lambda_handler`, `test_benchmark`, `test_processing`) all pass; the full suite was green at 874 passed / 15 skipped excluding two pre-existing collection errors (see below).

### Pre-existing, unrelated (flagged not fixed, per §4)

`tests/test_shardmap.py` and `tests/test_viz.py` fail at collection with `ModuleNotFoundError: No module named 'pyarrow'` — they `import pyarrow` at module level, and this is unchanged on `main` (not in any file this PR touches). Left as-is.

## Questions for review

None — all design decisions are locked on #132.

---
Authored by an automated Claude routine run for issue #132; see the issue thread for the approved plan and locked decisions.