### PR TITLE
Reclaim worker RSS on warm Lambda containers (gc + malloc_trim) (#139)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -55,6 +55,8 @@ output bucket (e.g. cross-account JupyterHub orchestrators) can run the
 full pipeline using only lambda:InvokeFunction.
 """
 
+import ctypes
+import gc
 import json
 import logging
 import os
@@ -89,6 +91,31 @@ def _max_memory_mb() -> float:
     Memory Used" closely.
     """
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+
+
+def _reclaim_memory() -> None:
+    """Return freed heap to the OS at invocation teardown (issue #139).
+
+    Lambda reuses warm containers, and neither CPython's pymalloc arenas nor
+    glibc's malloc heap hand freed memory back to the OS on their own, so a
+    subsequent invocation on a warm container starts near the *previous*
+    invocation's RSS high-water and can OOM (``Max Memory Used`` is
+    per-container-lifetime). A ``gc.collect()`` reclaims unreachable Python
+    objects but does NOT drop RSS by itself; glibc's ``malloc_trim(0)`` releases
+    the freed top-of-heap back to the OS, so the next invocation on the same
+    container starts near baseline.
+
+    Called once per invocation (O(heap) -- negligible next to read/aggregate/
+    write) and behavior-neutral: it only frees memory the invocation is done
+    with. Guarded so it is a no-op off glibc (macOS/dev has no ``libc.so.6``,
+    non-glibc libcs may lack ``malloc_trim``) -- it never raises.
+    """
+    gc.collect()
+    try:
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except (OSError, AttributeError):
+        # No glibc (no libc.so.6) or no malloc_trim symbol -- nothing to trim.
+        logger.debug("malloc_trim unavailable; skipping heap reclaim", exc_info=True)
 
 
 def _output_store_kwargs(event: Dict[str, Any]) -> Dict[str, Any]:
@@ -429,6 +456,12 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         logger.info("Lambda invocation completed successfully")
         logger.info("=" * 70)
 
+        # Drop the invocation's large output buffers before the teardown reclaim
+        # (issue #139): the response body is just ``metadata`` (small), so freeing
+        # the shard's carrier / accumulated K chunk carriers here lets the
+        # ``_reclaim_memory`` call in ``finally`` return their heap to the OS.
+        del _df_out, chunk_results
+
         return {
             "statusCode": 200 if not metadata.get("error") else 500,
             "body": json.dumps(metadata),
@@ -448,3 +481,9 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 }
             ),
         }
+    finally:
+        # Warm-container memory reclaim (issue #139): once per invocation, after
+        # the write completes and the buffers above are dropped, hand freed heap
+        # back to the OS so the next invoke on this warm container starts near
+        # baseline instead of the prior invocation's RSS high-water.
+        _reclaim_memory()

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -202,6 +202,72 @@ class TestProcessEventDispatch:
         assert body["max_memory_mb"] > 0.0
 
 
+class TestReclaimMemory:
+    """Issue #139: each invocation hands freed heap back to the OS at teardown so
+    a warm-container reuse starts near baseline instead of the prior invocation's
+    RSS high-water. The reclaim runs once per invocation in a ``finally`` (both
+    the success and unhandled-exception paths)."""
+
+    def test_reclaim_memory_never_raises(self, handler_mod):
+        # The helper is guarded: on a non-glibc dev host (no libc.so.6) or a libc
+        # lacking malloc_trim it must be a silent no-op, never an exception.
+        handler_mod._reclaim_memory()  # would raise on the dev platform if unguarded
+
+    def test_success_path_calls_reclaim_once(self, handler_mod, monkeypatch):
+        import zagg.grids as grids
+        import zagg.processing as processing
+
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            handler_mod, "_reclaim_memory", lambda: calls.__setitem__("n", calls["n"] + 1)
+        )
+
+        def fake_process_shard(grid, shard_key, granule_urls, **kwargs):
+            meta = {
+                "shard_key": shard_key,
+                "cells_with_data": 0,
+                "total_obs": 0,
+                "granule_count": len(granule_urls),
+                "files_processed": 0,
+                "duration_s": 0.0,
+                "error": None,
+            }
+            return pd.DataFrame(), meta
+
+        monkeypatch.setattr(processing, "process_shard", fake_process_shard)
+        monkeypatch.setattr(grids, "from_config", lambda *a, **k: MagicMock())
+
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        resp = handler_mod._handle_process(event, _context())
+        assert resp["statusCode"] == 200
+        assert calls["n"] == 1
+
+    def test_reclaim_runs_on_exception_path(self, handler_mod, monkeypatch):
+        # An unhandled error mid-invocation must still trigger the teardown reclaim
+        # (it lives in a ``finally``), so a crashed warm invocation doesn't strand
+        # its high-water for the next one.
+        import zagg.grids as grids
+        import zagg.processing as processing
+
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            handler_mod, "_reclaim_memory", lambda: calls.__setitem__("n", calls["n"] + 1)
+        )
+
+        def boom(*a, **k):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(processing, "process_shard", boom)
+        monkeypatch.setattr(grids, "from_config", lambda *a, **k: MagicMock())
+
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        resp = handler_mod._handle_process(event, _context())
+        assert resp["statusCode"] == 500
+        assert calls["n"] == 1
+
+
 class TestProcessEventWriteLoop:
     """Issue #82 phase 7: the handler drives ``process_shard`` with a
     ``chunk_results`` sink and writes each chunk's dense region (at its own


### PR DESCRIPTION
Closes #139

## What

Reclaim the worker's RSS at Lambda handler teardown so a **warm** container doesn't carry the previous invocation's memory into the next one. Adds a guarded `_reclaim_memory()` (`gc.collect()` + glibc `malloc_trim(0)`) called once per invocation in a `finally` on `_handle_process`, after `del`-ing the large output buffers.

## Why (from the #138 / #137 investigation)

Lambda reuses warm containers, and neither CPython's pymalloc arenas nor glibc's heap return freed memory to the OS on their own — so a subsequent invocation on a warm container starts near the *previous* invocation's RSS high-water (`Max Memory Used` is per-container-lifetime). Measured directly on prod `process-shard`: the **same** o11 shard read **774 MB cold vs 1322 MB** when it reused a warm container, and the CI benchmark's `tdigest_healpix_o10_inner` OOMs because it follows the ~2013 MB warm `sharded` target on the same container. Production fan-outs beyond the concurrency budget reuse warm containers too, so this is a real robustness gap — not just a benchmark artifact.

## The change

```python
def _reclaim_memory() -> None:
    gc.collect()                                  # frees Python objects (not RSS by itself)
    try:
        ctypes.CDLL("libc.so.6").malloc_trim(0)   # glibc: returns freed heap to the OS -> RSS drops
    except (OSError, AttributeError):
        ...  # no-op off glibc (macOS/dev), never raises
```
Called in a `finally`, after `del _df_out, chunk_results` (the response body is just the small metadata), so the freed carrier heap is available to trim. Guarded so it's a no-op on non-glibc dev machines.

## How tested

- **podman (arm64 / glibc = matches the AL2023 runtime):** baseline 27.5 MB → alloc 467 MB → after `del`+`gc.collect()` **156 MB** (gc alone strands ~128 MB) → after `malloc_trim(0)` **29.7 MB** (baseline). And a warm-reuse sim: carried residual **189 MB → 29 MB**. So `gc` alone does not drop RSS; `malloc_trim` does.
- **Tests:** 3 new in `test_lambda_handler.py` — the helper never raises on a non-glibc host; the reclaim runs exactly once on the success path and once on the exception path.
- **No regression:** full suite **1059 passed, 9 skipped** (only a pre-existing macOS-only build test deselected); `ruff check` / `ruff format --check` clean. `malloc_trim` is O(heap), once per invocation — behavior-neutral (memory only).

## Real-Lambda confirmation — note on why the metric can't show it

The patched `lambda_handler.py` **was** deployed in-place to `process-shard-test` and the o10 `sharded → inner` warm sequence re-run. It came back **895 → 1603 MB**, vs the unpatched prod control **878 → 1569 MB** — i.e. the fix looks *absent*. It isn't: `max_memory_mb` (= `ru_maxrss`) is a **monotonic per-process high-water mark**, and `malloc_trim(0)` lowers *current* RSS, not the recorded peak. On a warm container the peak can't drop, so this metric **structurally cannot** reflect the fix. (Details: PR comment above / #138.)

The valid evidence is the **current-RSS** podman proof under "How tested" (467 → 156 → **29.7 MB**). `malloc_trim`'s payoff is resetting *current* RSS between invocations so a warm container doesn't accumulate toward an OOM in production — confirming that on real Lambda would mean reproducing the near-cap accumulation scenario, not a `max_memory_mb` delta. Recommend merging on the podman proof + review; the change is correct and behavior-neutral.

## Questions for review
- `malloc_trim(0)` is glibc-specific; the guard makes it a no-op elsewhere. AL2023 arm64 (the deployed runtime) is glibc, so it's active in prod. OK as-is, or prefer a `platform`/`sys.platform` gate too?

