### PR TITLE
Set glibc allocator tunables on the process Lambda (issue #143)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -94,16 +94,19 @@ def _max_memory_mb() -> float:
 
 
 def _reclaim_memory() -> None:
-    """Return freed heap to the OS at invocation teardown (issue #139).
+    """Reclaim Python objects at invocation teardown (issues #139, #143).
 
-    Lambda reuses warm containers, and neither CPython's pymalloc arenas nor
-    glibc's malloc heap hand freed memory back to the OS on their own, so a
-    subsequent invocation on a warm container starts near the *previous*
-    invocation's RSS high-water and can OOM (``Max Memory Used`` is
-    per-container-lifetime). A ``gc.collect()`` reclaims unreachable Python
-    objects but does NOT drop RSS by itself; glibc's ``malloc_trim(0)`` releases
-    the freed top-of-heap back to the OS, so the next invocation on the same
-    container starts near baseline.
+    Lambda reuses warm containers, so a subsequent invocation on a warm
+    container starts near the *previous* invocation's RSS and can OOM
+    (``Max Memory Used`` is per-container-lifetime). The reliable fix for the
+    glibc-arena retention that drives this is the allocator env vars set on the
+    function itself (``MALLOC_ARENA_MAX``/``MALLOC_TRIM_THRESHOLD_`` in
+    ``template.yaml``, issue #143) -- those take effect at libc init and flatten
+    warm-container growth to ~0. The ``malloc_trim(0)`` below is retained as a
+    harmless secondary: it only trims the top of the main arena, so on its own
+    it does *not* reliably return the retained secondary-arena numpy blocks
+    (hence the env-var fix supersedes it as the primary mechanism), but the
+    ``gc.collect()`` still reclaims unreachable Python objects.
 
     Called once per invocation (O(heap) -- negligible next to read/aggregate/
     write) and behavior-neutral: it only frees memory the invocation is done

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -80,6 +80,24 @@ Parameters:
     Default: 720
     Description: Function timeout in seconds.
 
+  MallocArenaMax:
+    Type: String
+    Default: "2"
+    Description: >-
+      glibc MALLOC_ARENA_MAX for the process function (issue #143). Caps the
+      number of per-thread malloc arenas so freed numpy/glibc heap is returned
+      to the OS between warm invocations instead of accumulating toward the
+      memory cap. Must be set as an env var (it takes effect at libc init; a
+      runtime mallopt/malloc_trim from Python does not). Set empty to unset.
+
+  MallocTrimThreshold:
+    Type: String
+    Default: "0"
+    Description: >-
+      glibc MALLOC_TRIM_THRESHOLD_ for the process function (issue #143). 0
+      trims freed top-of-heap back to the OS immediately, independently
+      flattening warm-container memory growth. Set empty to unset.
+
 Conditions:
   ShouldCreateBucket: !Equals [!Ref CreateOutputBucket, "true"]
   ShouldCreateRole: !Equals [!Ref CreateExecutionRole, "true"]
@@ -145,6 +163,10 @@ Resources:
       Timeout: !Ref Timeout
       Role: !If [ShouldCreateRole, !GetAtt ExecutionRole.Arn, !Ref ExecutionRoleArn]
       Layers: [!Ref DepsLayer]
+      Environment:
+        Variables:
+          MALLOC_ARENA_MAX: !Ref MallocArenaMax
+          MALLOC_TRIM_THRESHOLD_: !Ref MallocTrimThreshold
       Code:
         S3Bucket: !Ref ArtifactBucket
         S3Key: !Ref FunctionS3Key

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -88,7 +88,7 @@ Parameters:
       number of per-thread malloc arenas so freed numpy/glibc heap is returned
       to the OS between warm invocations instead of accumulating toward the
       memory cap. Must be set as an env var (it takes effect at libc init; a
-      runtime mallopt/malloc_trim from Python does not). Set empty to unset.
+      runtime mallopt/malloc_trim from Python does not). Set empty to fall back to the glibc default (the key is still emitted, just empty).
 
   MallocTrimThreshold:
     Type: String
@@ -96,7 +96,7 @@ Parameters:
     Description: >-
       glibc MALLOC_TRIM_THRESHOLD_ for the process function (issue #143). 0
       trims freed top-of-heap back to the OS immediately, independently
-      flattening warm-container memory growth. Set empty to unset.
+      flattening warm-container memory growth. Set empty to fall back to the glibc default (the key is still emitted, just empty).
 
 Conditions:
   ShouldCreateBucket: !Equals [!Ref CreateOutputBucket, "true"]

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -152,6 +152,47 @@ class TestLambdaHandlerSyntax:
         compile(invoker.read_text(), str(invoker), "exec")
 
 
+class TestTemplateEnvironment:
+    """The CloudFormation template must wire the glibc allocator tunables (#143).
+
+    Set as Lambda ``Environment`` variables (they take effect at libc init, so a
+    runtime ``mallopt``/``malloc_trim`` from Python is not enough), driven by
+    CloudFormation Parameters so they stay tunable without a template edit.
+    """
+
+    @staticmethod
+    def _load_template():
+        import yaml
+
+        class _CfnLoader(yaml.SafeLoader):
+            pass
+
+        def _cfn_multi(loader, tag_suffix, node):
+            # Treat CloudFormation short-form intrinsics (!Ref, !Sub, !GetAtt,
+            # !If, ...) as generic {TagSuffix: value} mappings so PyYAML can
+            # parse the template without choking on the unknown tags.
+            if isinstance(node, yaml.ScalarNode):
+                return {tag_suffix: loader.construct_scalar(node)}
+            if isinstance(node, yaml.SequenceNode):
+                return {tag_suffix: loader.construct_sequence(node)}
+            return {tag_suffix: loader.construct_mapping(node)}
+
+        _CfnLoader.add_multi_constructor("!", _cfn_multi)
+        template = REPO_ROOT / "deployment" / "aws" / "template.yaml"
+        return yaml.load(template.read_text(), Loader=_CfnLoader)
+
+    def test_process_fn_carries_malloc_tunables(self):
+        tpl = self._load_template()
+        env = tpl["Resources"]["ProcessFn"]["Properties"]["Environment"]["Variables"]
+        assert env["MALLOC_ARENA_MAX"] == {"Ref": "MallocArenaMax"}
+        assert env["MALLOC_TRIM_THRESHOLD_"] == {"Ref": "MallocTrimThreshold"}
+
+    def test_malloc_parameters_have_expected_defaults(self):
+        params = self._load_template()["Parameters"]
+        assert params["MallocArenaMax"]["Default"] == "2"
+        assert params["MallocTrimThreshold"]["Default"] == "0"
+
+
 class TestPackageConsistency:
     """Verify dependency specifications are consistent across build scripts."""
 


### PR DESCRIPTION
Closes #143.

## What / approach

Warm `process-shard` containers accumulate retained glibc-arena memory across invokes and OOM by the o9 target (the `808 → 1354` climb in #143). The [root-cause probe](https://github.com/englacial/zagg/issues/143#issuecomment-4852348594) showed this is **glibc arena retention** of freed numpy blocks — not an Arrow pool (the carrier is `arro3-core`, plain glibc `malloc`), and #140's `malloc_trim(0)` recovers only ~23 MB of it. The reliable, carrier-agnostic fix is glibc allocator tunables set **as Lambda `Environment` variables** (they must be present at libc init — a runtime `mallopt`/`malloc_trim` from Python does not take effect). In the probe `MALLOC_ARENA_MAX=2` flattened warm accumulation from +320 MB to **+0.0 MB**.

Decisions taken per @espg's answers on the [plan](https://github.com/englacial/zagg/issues/143#issuecomment-4859068444): tunables `MALLOC_ARENA_MAX=2` + `MALLOC_TRIM_THRESHOLD_=0`; keep the harmless `gc.collect()` in `_reclaim_memory` for now; the benchmark silent-OOM hardening splits to its own `small-fix` (not this PR).

Issue #143 names `deployment/aws/template.yaml`, so editing that infra file is authorized here. **No live-AWS run** — see "Pre-merge Lambda proof" below.

## Phases

- [x] **Phase 1 — allocator env vars on the process function.** Two new CloudFormation Parameters (`MallocArenaMax` default `"2"`, `MallocTrimThreshold` default `"0"`) wired into a new `ProcessFn.Environment.Variables` block (`MALLOC_ARENA_MAX` / `MALLOC_TRIM_THRESHOLD_`), matching the template's existing `MemorySize`/`Timeout` parameter style so the values stay tunable without a template edit. A template-shape test (`tests/test_lambda_build.py::TestTemplateEnvironment`) asserts `ProcessFn` carries both env vars and the parameters carry the expected defaults, so a future template edit can't silently drop them.
- [x] **Phase 2 — keep the harmless `gc.collect()`, document supersession.** Per @espg's lean, `_reclaim_memory` is retained (the `gc.collect()` still reclaims unreachable Python objects); its docstring now records that the env-var tunables are the *primary/reliable* fix for the glibc-arena retention and that `malloc_trim(0)` is an unreliable secondary. No behavioral change (docstring only).

## Pre-merge Lambda proof — answering @espg's `/benchmark`-label question

> can you do this via /benchmark label on the PR, or does it need to be manual run?

**It needs a manual env-var update — the `/benchmark` PR command cannot validate this fix.** The on-demand benchmark (`.github/workflows/lambda-benchmark-command.yml`) overlays only the PR's `src/zagg` onto the base harness and runs against the **already-deployed** `process-shard-test` function (`vars.BENCHMARK_FUNCTION_NAME`); it never applies a CloudFormation update, so the new `Environment` block in `template.yaml` is not in effect during that run. A `/benchmark` here would therefore measure the *old* function config (no `MALLOC_ARENA_MAX`) and show no change.

To confirm end-to-end, the tunables have to be present on the running function. The reversible way (no full CFN deploy) is a Lambda **env-var update** on `process-shard-test` — `MALLOC_ARENA_MAX=2` + `MALLOC_TRIM_THRESHOLD_=0` — then re-run the 6 benchmark targets sequentially and check o10/o9 pass instead of OOM. That is a live-AWS action, so per §1 I'm **not** doing it here — leaving it for @espg (or confirmation that the deployed test function should get the env vars via the normal deploy path).

## How tested

- `uv run pytest tests/test_lambda_build.py tests/test_lambda_handler.py -q` → **53 passed** (incl. the 2 new `TestTemplateEnvironment` cases).
- `uv run ruff check --select=E,F,W,I --ignore=E501 deployment tests/test_lambda_build.py` → clean. Touched Python files are `ruff format`-clean.
- No behavioral Python change (Phase 1 is template + a shape test; Phase 2 is a docstring), so no runtime test beyond the template assertion.

## Questions for review

- **None blocking.** Confirm whether the deployed `process-shard-test` should receive the env vars manually for the pre-merge proof, or whether you'll take that as a normal deploy after merge.

## Follow-up (out of scope, per @espg)

Phase 3 from the plan — the benchmark recording an OOM'd target as `obs=0, max_memory_mb=None` while the CI job stays green — is split to its own `small-fix` so this memory fix lands unblocked.

---
_Generated by [Claude Code](https://claude.ai/code/session_017wNcBZd6KvDfe7mSeQfo49)_