### PR TITLE
Fix Lambda Benchmark Earthdata IPv6 no-route + parallelize + per-invocation RSS (#137)

### DIFF
--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -200,6 +200,15 @@ def main(argv: list[str] | None = None) -> int:
         help="One-line banner for the PR comment when the benchmarked worker is "
         "the stable deploy, not this PR's code (issue #25).",
     )
+    parser.add_argument(
+        "--fail-on-empty",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Exit non-zero if any real target comes back with zero observations "
+        "or null peak memory -- the signature of a silent OOM that would "
+        "otherwise keep the job green (issue #145). Skipped under --dry-run, "
+        "which emits empty metrics by design; --no-fail-on-empty opts out.",
+    )
     args = parser.parse_args(argv)
 
     manifest, base = load_targets(args.targets)
@@ -247,6 +256,22 @@ def main(argv: list[str] | None = None) -> int:
         Path(args.out_comment).write_text(
             bench_metrics.comment_markdown(records, worker_note=args.worker_note)
         )
+
+    # A silently OOM'd target records obs=0 / max_memory_mb=None but the job
+    # otherwise stays green, so a memory regression can merge (and land a junk
+    # series row) unnoticed (issue #145). Fail loudly on any real target that
+    # came back empty; --dry-run emits empty metrics by design, so it's exempt.
+    if args.fail_on_empty and not args.dry_run:
+        empty = [
+            r["target"] for r in records if not r.get("total_obs") or r.get("max_memory_mb") is None
+        ]
+        if empty:
+            print(
+                "benchmark target(s) returned empty metrics (obs=0 / "
+                f"max_memory_mb=None), likely a silent OOM: {', '.join(empty)}",
+                file=sys.stderr,
+            )
+            return 1
     return 0
 
 

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -28,7 +28,14 @@ import datetime as dt
 import json
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+
+# Benchmark targets are launched concurrently (issue #137). Each target is one
+# independent single-shard Lambda dispatch, so this bounds how many run at once;
+# the matrix is small (~single digits), so the cap only guards a pathological
+# manifest.
+_MAX_TARGET_CONCURRENCY = 16
 
 # Allow ``import bench_metrics`` whether run as a script or imported by tests.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -226,14 +233,17 @@ def main(argv: list[str] | None = None) -> int:
         "pr_number": pr_number,
     }
 
-    records = []
+    # Validate every requested target up front so an unknown name fails before any
+    # dispatch (and before the pool spins up).
     for name in names:
         if name not in known:
             raise SystemExit(f"unknown target '{name}'; have {sorted(known)}")
+
+    def _dispatch(name: str) -> dict:
         store = None
         if args.store_prefix:
             store = f"{args.store_prefix.rstrip('/')}/{name}.zarr"
-        record = run_target(
+        return run_target(
             name,
             manifest,
             base,
@@ -243,9 +253,24 @@ def main(argv: list[str] | None = None) -> int:
             context=context,
             dry_run=args.dry_run,
         )
-        records.append(record)
+
+    # Launch all targets concurrently (issue #137). Each is an independent
+    # single-shard Lambda dispatch, so fanning them out is cold-favoring (a fresh
+    # container per concurrent invoke) and cuts wall-clock ~N x; the runtime metric
+    # is billable worker-seconds (init-independent), so en-masse launch doesn't bias
+    # it. Results are collected then re-ordered back to ``names`` for deterministic
+    # output/series rows; a target that raises propagates (aborting the run) exactly
+    # as the prior serial loop did.
+    records_by_name: dict = {}
+    max_workers = min(len(names), _MAX_TARGET_CONCURRENCY) or 1
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_dispatch, name): name for name in names}
+        for fut in as_completed(futures):
+            records_by_name[futures[fut]] = fut.result()
+    records = [records_by_name[name] for name in names]
+    for record in records:
         print(
-            f"[{name}] obs={record['total_obs']} runtime_s={record['runtime_s']} "
+            f"[{record['target']}] obs={record['total_obs']} runtime_s={record['runtime_s']} "
             f"cost/shard=${record['cost_per_shard_usd']} "
             f"cost/100km2=${record['cost_per_100km2_usd']} "
             f"max_memory_mb={record['max_memory_mb']}"

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -239,6 +239,15 @@ def main(argv: list[str] | None = None) -> int:
         if name not in known:
             raise SystemExit(f"unknown target '{name}'; have {sorted(known)}")
 
+    # Authenticate once up front so the concurrent targets below don't race to
+    # initialize earthaccess's process-global auth singleton (issue #137). Skipped
+    # under --dry-run (no dispatch, no auth) and pointless for a single target (no
+    # fan-out); each agg() still logs in, but now hits the warmed singleton.
+    if not args.dry_run and len(names) > 1:
+        from zagg.auth import ensure_logged_in
+
+        ensure_logged_in()
+
     def _dispatch(name: str) -> dict:
         store = None
         if args.store_prefix:

--- a/.github/workflows/lambda-benchmark-command.yml
+++ b/.github/workflows/lambda-benchmark-command.yml
@@ -139,6 +139,16 @@ jobs:
           rm -rf src/zagg
           cp -r _fork/src/zagg src/zagg
 
+      # The runner resolves urs.earthdata.nasa.gov to an AAAA record but has no
+      # usable IPv6 route, so earthaccess.login() (inside run_benchmark.py) dies
+      # immediately with `[Errno 101] Network is unreachable` (issue #137).
+      # Raising the getaddrinfo precedence of IPv4-mapped addresses makes glibc
+      # return+try the A record first, so the login handshake takes the routable
+      # IPv4 path. Runner-only config -- the shipped package and user auth are
+      # untouched.
+      - name: Prefer IPv4 for Earthdata login (issue #137)
+        run: echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
+
       - name: Run benchmark (base harness, fork package)
         uses: ./.github/actions/run-benchmark
         with:

--- a/.github/workflows/lambda-benchmark-command.yml
+++ b/.github/workflows/lambda-benchmark-command.yml
@@ -163,11 +163,20 @@ jobs:
           pr-number: ${{ needs.check.outputs.pr_number }}
           worker-note: ${{ needs.check.outputs.worker_note }}
 
+      # always(): a silent-OOM target now fails the benchmark step (--fail-on-empty,
+      # issue #145), but the maintainer who ran /benchmark should still see WHY --
+      # the just-written comment.md carries the obs=0 row. Skip cleanly if the run
+      # died before writing it (e.g. login failure -> no comment to post).
       - name: Upsert PR comment
+        if: always()
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
+            if (!fs.existsSync('comment.md')) {
+              core.info('no comment.md (benchmark did not get far enough); skipping');
+              return;
+            }
             const body = fs.readFileSync('comment.md', 'utf8');
             const marker = '<!-- zagg-benchmark -->';
             const { owner, repo } = context.repo;

--- a/.github/workflows/lambda-benchmark.yml
+++ b/.github/workflows/lambda-benchmark.yml
@@ -168,6 +168,16 @@ jobs:
       - name: Checkout merge commit
         uses: actions/checkout@v5
 
+      # The runner resolves urs.earthdata.nasa.gov to an AAAA record but has no
+      # usable IPv6 route, so earthaccess.login() (inside run_benchmark.py) dies
+      # immediately with `[Errno 101] Network is unreachable` (issue #137).
+      # Raising the getaddrinfo precedence of IPv4-mapped addresses makes glibc
+      # return+try the A record first, so the login handshake takes the routable
+      # IPv4 path. Runner-only config -- the shipped package and user auth are
+      # untouched.
+      - name: Prefer IPv4 for Earthdata login (issue #137)
+        run: echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
+
       - name: Run benchmark
         uses: ./.github/actions/run-benchmark
         with:

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -61,8 +61,9 @@ import json
 import logging
 import os
 import resource
+import threading
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from zarr import open_group
 from zarr.errors import GroupNotFoundError
@@ -91,6 +92,75 @@ def _max_memory_mb() -> float:
     Memory Used" closely.
     """
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+
+
+def _read_vmrss_kib() -> Optional[int]:
+    """Current resident set size in KiB from ``/proc/self/status``, or None off Linux.
+
+    ``VmRSS`` is the process's *current* RSS (not a high-water mark), reported in
+    KiB. Returns None when ``/proc/self/status`` is absent/unreadable (macOS/dev),
+    so callers fall back to ``ru_maxrss``.
+    """
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])  # "VmRSS:\t   12345 kB"
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+class _PeakRSSSampler:
+    """Sample THIS invocation's peak current RSS on a daemon thread (issue #141).
+
+    ``ru_maxrss`` is a per-*process* high-water mark, so on a warm/reused Lambda
+    container it reports the max over every prior invocation, not this one --
+    making ``max_memory_mb`` untrustworthy on warm containers (it can only ever
+    rise, so it also can't reflect #140's teardown reclaim). This polls the
+    *current* RSS (``VmRSS``) at a fixed interval and records the max while it
+    runs, so the reported peak reflects the current invocation. #140's teardown
+    ``malloc_trim`` returns current RSS to ~baseline between invokes, so a warm
+    container starts each invocation low and the sampled peak is clean.
+
+    Off Linux (no ``/proc/self/status``) it degrades to a no-op and ``peak_mb`` is
+    None, so the caller falls back to ``ru_maxrss``. Sampling overhead is one small
+    file read per tick -- negligible next to read/aggregate/write.
+    """
+
+    def __init__(self, interval_s: float = 0.05):
+        self._interval_s = interval_s
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._peak_kib = 0
+        self._available = _read_vmrss_kib() is not None
+
+    def start(self) -> "_PeakRSSSampler":
+        if self._available:
+            self._thread = threading.Thread(target=self._run, name="peak-rss", daemon=True)
+            self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+
+    def _run(self) -> None:
+        # Sample immediately, then every interval until stopped.
+        while True:
+            cur = _read_vmrss_kib()
+            if cur is not None and cur > self._peak_kib:
+                self._peak_kib = cur
+            if self._stop.wait(self._interval_s):
+                return
+
+    @property
+    def peak_mb(self) -> Optional[float]:
+        """Peak sampled RSS in MB, or None if unavailable (fall back to ru_maxrss)."""
+        if not self._available or self._peak_kib == 0:
+            return None
+        return self._peak_kib / 1024.0
 
 
 def _reclaim_memory() -> None:
@@ -241,6 +311,11 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             }
         )
     )
+
+    # Per-invocation peak-RSS sampler (issue #141): sample current VmRSS on a
+    # daemon thread for the whole invocation so ``max_memory_mb`` reflects THIS
+    # run, not the warm container's lifetime high-water. Stopped in ``finally``.
+    rss_sampler = _PeakRSSSampler().start()
 
     try:
         # Validate required parameters. ``child_order`` is HEALPix-specific and
@@ -434,10 +509,18 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         if profile and not metadata.get("error") and "phase_timings" in metadata and store_box:
             metadata["phase_timings"]["write"] = _write_elapsed
 
-        # Peak worker RSS (issue #120): captured here, after the write phase, so
-        # it covers the full invocation. Threaded back via the result body so the
-        # orchestrator can surface OOM-proximity without CloudWatch access.
-        metadata["max_memory_mb"] = _max_memory_mb()
+        # Peak worker RSS (issues #120, #141): captured here, after the write phase,
+        # so it covers the full invocation. ``max_memory_mb`` is the per-invocation
+        # sampled peak (``VmRSS``), trustworthy on warm containers; ``ru_maxrss`` is
+        # kept as ``container_hwm_mb`` (the container-lifetime high-water) so the
+        # distinction is explicit. Off Linux the sampler is a no-op, so fall back to
+        # ``ru_maxrss``. Threaded back via the result body so the orchestrator can
+        # surface OOM-proximity without CloudWatch access.
+        metadata["container_hwm_mb"] = _max_memory_mb()
+        sampled_peak = rss_sampler.peak_mb
+        metadata["max_memory_mb"] = (
+            sampled_peak if sampled_peak is not None else metadata["container_hwm_mb"]
+        )
 
         # Log structured result
         logger.info(
@@ -485,6 +568,9 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             ),
         }
     finally:
+        # Stop the per-invocation RSS sampler (issue #141) before the teardown
+        # reclaim, so its thread isn't sampling while ``malloc_trim`` runs.
+        rss_sampler.stop()
         # Warm-container memory reclaim (issue #139): once per invocation, after
         # the write completes and the buffers above are dropped, hand freed heap
         # back to the OS so the next invoke on this warm container starts near

--- a/src/zagg/auth.py
+++ b/src/zagg/auth.py
@@ -33,11 +33,13 @@ def _login_with_retry():
     """Return an authenticated ``earthaccess`` session, retrying transient failures.
 
     Retries ``earthaccess.login()`` up to ``_LOGIN_MAX_ATTEMPTS`` with exponential
-    backoff (2s, 4s, ...) on ``OSError``. That base class covers both the bare
-    ``OSError: [Errno 101]`` no-route *and* ``requests.exceptions.ConnectionError``
-    (which subclasses ``IOError``/``OSError``), i.e. the connection/timeout family
-    the login can raise. The final attempt's exception propagates unchanged, so a
-    genuine, persistent auth failure still surfaces rather than being masked.
+    backoff (2s, 4s, ...) on ``OSError``. That base class is the whole ``requests``
+    IO/HTTP-error family -- every ``requests.exceptions.RequestException`` subclasses
+    ``IOError``/``OSError`` -- so it covers the bare ``OSError: [Errno 101]`` no-route,
+    ``ConnectionError``, and ``Timeout`` that the login can raise transiently. A
+    genuinely-rejected credential surfaces as ``earthaccess``'s own
+    ``LoginAttemptFailure`` (not an ``OSError``), so it fails fast rather than being
+    retried; and the final attempt's exception propagates unchanged either way.
     """
     last_exc: OSError | None = None
     for attempt in range(1, _LOGIN_MAX_ATTEMPTS + 1):
@@ -58,6 +60,20 @@ def _login_with_retry():
             time.sleep(backoff)
     assert last_exc is not None  # loop ran >=1 time and every attempt failed
     raise last_exc
+
+
+def ensure_logged_in() -> None:
+    """Warm the ``earthaccess`` auth singleton once, up front (issue #137).
+
+    ``earthaccess.login()`` mutates process-global auth/store singletons, so a
+    caller that fans work out across threads (e.g. the parallel benchmark) should
+    authenticate ONCE before the fan-out -- otherwise the concurrent workers race
+    to initialize that shared singleton. Calling this first populates it serially,
+    so the in-worker logins become cheap hits. Uses the same bounded retry as the
+    credential helpers; honors this module's "call once in the orchestrator"
+    contract.
+    """
+    _login_with_retry()
 
 
 def get_edl_token() -> str:

--- a/src/zagg/auth.py
+++ b/src/zagg/auth.py
@@ -12,7 +12,52 @@ Call ONCE in the orchestrator before processing. Credentials are valid
 for approximately 1 hour.
 """
 
+import logging
+import time
+
 import earthaccess
+
+logger = logging.getLogger(__name__)
+
+# ``earthaccess.login()`` makes an HTTPS call to ``urs.earthdata.nasa.gov`` to
+# validate/mint credentials, and that call fails transiently on CI runners -- an
+# IPv6 no-route (``OSError: [Errno 101] Network is unreachable``, addressed at the
+# resolver level in the benchmark workflow, issue #137) or a brief network blip.
+# A bounded retry/backoff lets a genuinely transient failure self-heal instead of
+# taking down the whole run/benchmark on the first attempt (issue #137).
+_LOGIN_MAX_ATTEMPTS = 3
+_LOGIN_BACKOFF_BASE_S = 2.0
+
+
+def _login_with_retry():
+    """Return an authenticated ``earthaccess`` session, retrying transient failures.
+
+    Retries ``earthaccess.login()`` up to ``_LOGIN_MAX_ATTEMPTS`` with exponential
+    backoff (2s, 4s, ...) on ``OSError``. That base class covers both the bare
+    ``OSError: [Errno 101]`` no-route *and* ``requests.exceptions.ConnectionError``
+    (which subclasses ``IOError``/``OSError``), i.e. the connection/timeout family
+    the login can raise. The final attempt's exception propagates unchanged, so a
+    genuine, persistent auth failure still surfaces rather than being masked.
+    """
+    last_exc: OSError | None = None
+    for attempt in range(1, _LOGIN_MAX_ATTEMPTS + 1):
+        try:
+            return earthaccess.login()
+        except OSError as exc:
+            last_exc = exc
+            if attempt == _LOGIN_MAX_ATTEMPTS:
+                break
+            backoff = _LOGIN_BACKOFF_BASE_S * (2 ** (attempt - 1))
+            logger.warning(
+                "earthaccess.login() failed (attempt %d/%d): %s; retrying in %.0fs",
+                attempt,
+                _LOGIN_MAX_ATTEMPTS,
+                exc,
+                backoff,
+            )
+            time.sleep(backoff)
+    assert last_exc is not None  # loop ran >=1 time and every attempt failed
+    raise last_exc
 
 
 def get_edl_token() -> str:
@@ -26,7 +71,7 @@ def get_edl_token() -> str:
     str
         Bearer token string.
     """
-    auth = earthaccess.login()
+    auth = _login_with_retry()
     return auth.token["access_token"]
 
 
@@ -62,5 +107,5 @@ def get_nsidc_s3_credentials() -> dict:
     }
     ```
     """
-    auth = earthaccess.login()
+    auth = _login_with_retry()
     return auth.get_s3_credentials(daac="NSIDC")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -103,3 +103,10 @@ def test_get_nsidc_s3_credentials_uses_retry(monkeypatch):
     creds = auth.get_nsidc_s3_credentials()
     assert creds["accessKeyId"] == "AK"
     assert creds["daac"] == "NSIDC"  # login().get_s3_credentials(daac="NSIDC")
+
+
+def test_ensure_logged_in_warms_singleton_with_retry(monkeypatch):
+    """The pre-fan-out warm-up authenticates once and rides the same retry."""
+    calls = _login_seq(monkeypatch, OSError(101, "unreachable"), _FakeAuth())
+    auth.ensure_logged_in()  # returns None; must not raise
+    assert calls["n"] == 2  # transient failure retried, then succeeded

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,105 @@
+"""Tests for the orchestrator Earthdata auth helpers (issue #137).
+
+The login retry/backoff wraps ``earthaccess.login()`` so a transient network
+failure on the orchestrator/CI (an IPv6 no-route ``OSError: [Errno 101]`` or a
+``requests.exceptions.ConnectionError``, which subclasses ``OSError``) self-heals
+instead of failing the whole run on the first attempt.
+"""
+
+import pytest
+
+import zagg.auth as auth
+
+
+class _FakeAuth:
+    """Stand-in for the object ``earthaccess.login()`` returns."""
+
+    def __init__(self):
+        self.token = {"access_token": "tok-123"}
+
+    def get_s3_credentials(self, daac):
+        return {"accessKeyId": "AK", "secretAccessKey": "SK", "daac": daac}
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Never actually sleep during the backoff (keeps the tests instant)."""
+    monkeypatch.setattr(auth.time, "sleep", lambda _s: None)
+
+
+def _login_seq(monkeypatch, *outcomes):
+    """Patch ``earthaccess.login`` to yield ``outcomes`` (exception -> raise,
+    else -> return) in order, recording the call count."""
+    calls = {"n": 0}
+
+    def fake_login():
+        calls["n"] += 1
+        result = outcomes[calls["n"] - 1]
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr(auth.earthaccess, "login", fake_login)
+    return calls
+
+
+def test_login_retries_then_succeeds(monkeypatch):
+    """A transient OSError on the first attempt is retried and the second wins."""
+    fake = _FakeAuth()
+    calls = _login_seq(monkeypatch, OSError(101, "Network is unreachable"), fake)
+    sleeps = []
+    monkeypatch.setattr(auth.time, "sleep", lambda s: sleeps.append(s))
+
+    assert auth._login_with_retry() is fake
+    assert calls["n"] == 2  # failed once, then succeeded
+    assert sleeps == [auth._LOGIN_BACKOFF_BASE_S]  # one backoff, base delay
+
+
+def test_login_gives_up_after_max_attempts(monkeypatch):
+    """All attempts failing -> the last exception propagates, after N tries."""
+    err = OSError(101, "Network is unreachable")
+    calls = _login_seq(monkeypatch, *([err] * auth._LOGIN_MAX_ATTEMPTS))
+    sleeps = []
+    monkeypatch.setattr(auth.time, "sleep", lambda s: sleeps.append(s))
+
+    with pytest.raises(OSError, match="Network is unreachable"):
+        auth._login_with_retry()
+    assert calls["n"] == auth._LOGIN_MAX_ATTEMPTS
+    # Backoff between attempts only (not after the final failure): 2s, 4s, ...
+    assert sleeps == [
+        auth._LOGIN_BACKOFF_BASE_S * (2**i) for i in range(auth._LOGIN_MAX_ATTEMPTS - 1)
+    ]
+
+
+def test_login_does_not_retry_non_oserror(monkeypatch):
+    """A non-transient error (e.g. bad credentials) is not retried -- fail fast."""
+    calls = _login_seq(monkeypatch, ValueError("bad token"))
+    with pytest.raises(ValueError, match="bad token"):
+        auth._login_with_retry()
+    assert calls["n"] == 1  # no retry
+
+
+def test_connection_error_is_retried(monkeypatch):
+    """``requests.exceptions.ConnectionError`` (an OSError subclass) is retried too."""
+    requests_exceptions = pytest.importorskip("requests.exceptions")
+    assert issubclass(requests_exceptions.ConnectionError, OSError)
+    fake = _FakeAuth()
+    calls = _login_seq(monkeypatch, requests_exceptions.ConnectionError("no route"), fake)
+    assert auth._login_with_retry() is fake
+    assert calls["n"] == 2
+
+
+def test_get_edl_token_uses_retry(monkeypatch):
+    """The public HTTPS-token helper routes through the retry wrapper."""
+    fake = _FakeAuth()
+    _login_seq(monkeypatch, OSError(101, "unreachable"), fake)
+    assert auth.get_edl_token() == "tok-123"
+
+
+def test_get_nsidc_s3_credentials_uses_retry(monkeypatch):
+    """The public S3-creds helper routes through the retry wrapper."""
+    fake = _FakeAuth()
+    _login_seq(monkeypatch, OSError(101, "unreachable"), fake)
+    creds = auth.get_nsidc_s3_credentials()
+    assert creds["accessKeyId"] == "AK"
+    assert creds["daac"] == "NSIDC"  # login().get_s3_credentials(daac="NSIDC")

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -432,6 +432,9 @@ def test_main_dispatches_targets_concurrently(tmp_path, monkeypatch):
     # even though completion order is nondeterministic (issue #137).
     import threading
 
+    import zagg.auth as zauth
+
+    monkeypatch.setattr(zauth, "ensure_logged_in", lambda: None)  # no real login
     barrier = threading.Barrier(2, timeout=10)
 
     def fake(name, *a, **k):
@@ -460,6 +463,67 @@ def test_main_dispatches_targets_concurrently(tmp_path, monkeypatch):
         "tdigest_healpix_o10_inner",
         "tdigest_healpix_o10_sharded",
     ]
+
+
+def test_main_warms_auth_once_before_parallel_dispatch(tmp_path, monkeypatch):
+    # With >1 target and a real (non-dry-run) dispatch, main() authenticates ONCE
+    # up front so the concurrent targets don't race earthaccess's global auth
+    # singleton (issue #137). run_target is stubbed so no real AWS/agg is touched.
+    import zagg.auth as zauth
+
+    calls = {"login": 0, "targets": []}
+    monkeypatch.setattr(
+        zauth, "ensure_logged_in", lambda: calls.__setitem__("login", calls["login"] + 1)
+    )
+    monkeypatch.setattr(
+        run_benchmark,
+        "run_target",
+        lambda name, *a, **k: (
+            calls["targets"].append(name) or _fake_record(name, total_obs=1, max_memory_mb=100.0)
+        ),
+    )
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o10_inner",
+            "--target",
+            "tdigest_healpix_o10_sharded",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(tmp_path / "metrics.json"),
+        ]
+    )
+    assert rc == 0
+    assert calls["login"] == 1  # exactly one warm-up, before the fan-out
+    assert len(calls["targets"]) == 2
+
+
+def test_main_skips_auth_warmup_on_dry_run(tmp_path, monkeypatch):
+    # --dry-run does no dispatch, so it must not authenticate (no creds in CI dry
+    # runs / local wiring checks).
+    import zagg.auth as zauth
+
+    warmed = {"n": 0}
+    monkeypatch.setattr(zauth, "ensure_logged_in", lambda: warmed.__setitem__("n", warmed["n"] + 1))
+    run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o10_inner",
+            "--target",
+            "tdigest_healpix_o10_sharded",
+            "--dry-run",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(tmp_path / "metrics.json"),
+        ]
+    )
+    assert warmed["n"] == 0
 
 
 def test_main_unknown_target_fails_before_any_dispatch(tmp_path, monkeypatch):

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -316,6 +316,30 @@ def test_main_fails_on_empty_target(tmp_path, monkeypatch):
     assert rc == 1
 
 
+def test_main_fails_on_null_memory_alone(tmp_path, monkeypatch):
+    # The guard is `not total_obs OR max_memory_mb is None`: a target that recorded
+    # observations but no memory reading must still fail, so the `max_memory_mb is
+    # None` clause is exercised independently of the obs=0 clause (issue #145).
+    monkeypatch.setattr(
+        run_benchmark,
+        "run_target",
+        lambda name, *a, **k: _fake_record(name, total_obs=999, max_memory_mb=None),
+    )
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o10_inner",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(tmp_path / "metrics.json"),
+        ]
+    )
+    assert rc == 1
+
+
 def test_main_no_fail_on_empty_opts_out(tmp_path, monkeypatch):
     monkeypatch.setattr(
         run_benchmark,
@@ -380,6 +404,25 @@ def test_main_dry_run_writes_outputs(tmp_path):
     records = json.loads(out_json.read_text())
     assert len(records) == 1 and records[0]["target"] == "tdigest_healpix_o10_inner"
     assert "tdigest_healpix_o10_inner" in out_md.read_text()
+
+
+def test_main_dry_run_exempt_from_fail_on_empty(tmp_path):
+    # --dry-run emits empty metrics by design, so --fail-on-empty (default on) must
+    # NOT trip on it -- main() returns 0 even though total_obs is null (issue #145).
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o10_inner",
+            "--dry-run",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(tmp_path / "metrics.json"),
+        ]
+    )
+    assert rc == 0
 
 
 # --- manifest integrity (the pin is internally consistent) ----------------

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -280,6 +280,85 @@ def test_run_target_dry_run():
     assert rec["total_obs"] is None  # no dispatch in dry-run
 
 
+def _fake_record(target, *, total_obs, max_memory_mb):
+    # Minimal record with the fields main()'s per-target print + the empty-metrics
+    # guard read (issue #145). Enough to drive main() without a real dispatch.
+    return {
+        "target": target,
+        "total_obs": total_obs,
+        "runtime_s": None,
+        "cost_per_shard_usd": None,
+        "cost_per_100km2_usd": None,
+        "max_memory_mb": max_memory_mb,
+    }
+
+
+def test_main_fails_on_empty_target(tmp_path, monkeypatch):
+    # A silent OOM comes back as obs=0 / max_memory_mb=None; main() must exit
+    # non-zero so the job goes red instead of retaining a junk row (issue #145).
+    monkeypatch.setattr(
+        run_benchmark,
+        "run_target",
+        lambda name, *a, **k: _fake_record(name, total_obs=0, max_memory_mb=None),
+    )
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o10_inner",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(tmp_path / "metrics.json"),
+        ]
+    )
+    assert rc == 1
+
+
+def test_main_no_fail_on_empty_opts_out(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        run_benchmark,
+        "run_target",
+        lambda name, *a, **k: _fake_record(name, total_obs=0, max_memory_mb=None),
+    )
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o10_inner",
+            "--no-fail-on-empty",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(tmp_path / "metrics.json"),
+        ]
+    )
+    assert rc == 0
+
+
+def test_main_passes_on_populated_target(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        run_benchmark,
+        "run_target",
+        lambda name, *a, **k: _fake_record(name, total_obs=12345, max_memory_mb=800.0),
+    )
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o10_inner",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(tmp_path / "metrics.json"),
+        ]
+    )
+    assert rc == 0
+
+
 def test_main_dry_run_writes_outputs(tmp_path):
     out_json = tmp_path / "metrics.json"
     out_md = tmp_path / "comment.md"

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -425,6 +425,71 @@ def test_main_dry_run_exempt_from_fail_on_empty(tmp_path):
     assert rc == 0
 
 
+def test_main_dispatches_targets_concurrently(tmp_path, monkeypatch):
+    # Two targets must be in-flight at once for a Barrier(2) to release; a serial
+    # loop would block forever on the first wait() and the timeout would trip it.
+    # Also asserts the output records are re-ordered back to the requested order
+    # even though completion order is nondeterministic (issue #137).
+    import threading
+
+    barrier = threading.Barrier(2, timeout=10)
+
+    def fake(name, *a, **k):
+        barrier.wait()  # rendezvous: only clears if both targets run concurrently
+        return _fake_record(name, total_obs=1, max_memory_mb=100.0)
+
+    monkeypatch.setattr(run_benchmark, "run_target", fake)
+    out_json = tmp_path / "metrics.json"
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o10_inner",
+            "--target",
+            "tdigest_healpix_o10_sharded",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(out_json),
+        ]
+    )
+    assert rc == 0
+    recs = json.loads(out_json.read_text())
+    assert [r["target"] for r in recs] == [
+        "tdigest_healpix_o10_inner",
+        "tdigest_healpix_o10_sharded",
+    ]
+
+
+def test_main_unknown_target_fails_before_any_dispatch(tmp_path, monkeypatch):
+    # An unknown target name aborts before the pool spins up -- no target is
+    # dispatched (so we never pay for a partial run on a typo'd matrix).
+    called = {"n": 0}
+
+    def fake(name, *a, **k):
+        called["n"] += 1
+        return _fake_record(name, total_obs=1, max_memory_mb=100.0)
+
+    monkeypatch.setattr(run_benchmark, "run_target", fake)
+    with pytest.raises(SystemExit, match="unknown target"):
+        run_benchmark.main(
+            [
+                "--targets",
+                str(BENCH / "targets.json"),
+                "--target",
+                "tdigest_healpix_o10_inner",
+                "--target",
+                "does_not_exist",
+                "--commit",
+                "cafe123",
+                "--out-json",
+                str(tmp_path / "metrics.json"),
+            ]
+        )
+    assert called["n"] == 0  # no dispatch happened
+
+
 # --- manifest integrity (the pin is internally consistent) ----------------
 
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -9,6 +9,7 @@ other grids.
 
 import importlib.util
 import json
+import time
 import warnings
 from dataclasses import asdict
 from pathlib import Path
@@ -842,3 +843,72 @@ class TestSetupTemplate:
         n_chunks = self._template_chunk_count(store, worker_grid)
         assert (n_chunks,) == worker_grid.chunk_grid_shape
         assert n_chunks == 5
+
+
+class TestPeakRSSSampler:
+    """Issue #141: per-invocation peak-RSS sampling. ``max_memory_mb`` must reflect
+    the CURRENT invocation's peak (sampled ``VmRSS``), not the warm container's
+    lifetime ``ru_maxrss`` high-water. Uses a controlled ``_read_vmrss_kib`` feed so
+    the assertions don't depend on real RSS or thread timing."""
+
+    @staticmethod
+    def _feeder(values_kib):
+        """A ``_read_vmrss_kib`` stub that yields ``values_kib`` in order then holds
+        the last value (so late samples keep reading the tail, not None)."""
+        it = iter(values_kib)
+        last = [values_kib[-1]]
+
+        def read():
+            try:
+                last[0] = next(it)
+            except StopIteration:
+                pass
+            return last[0]
+
+        return read
+
+    def test_read_vmrss_kib_reads_current_rss(self, handler_mod):
+        val = handler_mod._read_vmrss_kib()
+        if val is None:
+            pytest.skip("no /proc/self/status (non-Linux dev host)")
+        assert isinstance(val, int) and val > 0
+
+    def test_sampler_reports_peak_not_last(self, handler_mod, monkeypatch):
+        # Feed 100 -> 300 -> 150 MB; the sampler must report the PEAK (300), not
+        # the first or last sample.
+        monkeypatch.setattr(
+            handler_mod,
+            "_read_vmrss_kib",
+            self._feeder([100 * 1024, 300 * 1024, 150 * 1024]),
+        )
+        s = handler_mod._PeakRSSSampler(interval_s=0.001).start()
+        time.sleep(0.05)
+        s.stop()
+        assert s.peak_mb == pytest.approx(300.0)
+
+    def test_two_samplers_report_independent_peaks(self, handler_mod, monkeypatch):
+        # The crux of #141: a light invocation after a heavy one on the same warm
+        # process reads its OWN (smaller) peak -- unlike ru_maxrss, which would stay
+        # stuck at the heavy high-water.
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", self._feeder([100 * 1024, 900 * 1024]))
+        heavy = handler_mod._PeakRSSSampler(interval_s=0.001).start()
+        time.sleep(0.03)
+        heavy.stop()
+
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", self._feeder([90 * 1024, 120 * 1024]))
+        light = handler_mod._PeakRSSSampler(interval_s=0.001).start()
+        time.sleep(0.03)
+        light.stop()
+
+        assert heavy.peak_mb == pytest.approx(900.0)
+        assert light.peak_mb == pytest.approx(120.0)
+        assert light.peak_mb < heavy.peak_mb  # the whole point of #141
+
+    def test_sampler_unavailable_off_linux_returns_none(self, handler_mod, monkeypatch):
+        # No /proc/self/status -> the sampler is a no-op and peak_mb is None, so the
+        # caller falls back to ru_maxrss.
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: None)
+        s = handler_mod._PeakRSSSampler().start()
+        s.stop()
+        assert s.peak_mb is None
+        assert s._thread is None  # never spawned


### PR DESCRIPTION
Closes #137. Closes #145. Refs #141.

## What this does

The **Lambda Benchmark** workflows intermittently — and lately consistently — fail at the Earthdata login step with `OSError: [Errno 101] Network is unreachable` when reaching `urs.earthdata.nasa.gov:443`. That signature is an origin-side IPv6 no-route: the GitHub runner resolves the host's AAAA record, has no usable IPv6 path, and the connect fails immediately (before any packet reaches NASA) instead of falling back to IPv4.

Per the approved plan on #137, this PR lands the fix plus the related benchmark-reliability work in phases:

1. **IPv4 for the Earthdata login (option 2, workflow-level)** + **fold #145** (fail the benchmark on a silent OOM).
2. **Login retry/backoff** (app-level in `src/zagg/auth.py`) so a genuinely transient blip self-heals.
3. **Parallelize the benchmark target launch** — fan out all targets concurrently (cold-favoring + faster wall-clock; the runtime metric is billable-worker-seconds, init-independent, so en-masse launch doesn't bias it).
4. **Per-invocation peak RSS** (rolls in #141) — sample current `VmRSS` scoped to `_handle_process` so warm-container `max_memory_mb` numbers are trustworthy.

## Phases checklist

- [x] **Phase 1 — force IPv4 for the Earthdata login (workflow-level, option 2)** + **fold #145** (fail benchmark on silent OOM)
- [x] **Phase 2 — login retry/backoff in `src/zagg/auth.py`** (+ new `tests/test_auth.py`)
- [x] **Phase 3 — parallelize the benchmark target launch** in `.github/scripts/run_benchmark.py` (+ harness tests)
- [x] **Phase 4 — per-invocation peak RSS** in `deployment/aws/lambda_handler.py` (+ tests), rolls in #141

## Phase 1 detail

**IPv4 (option 2).** Both `lambda-benchmark.yml` (the `merge-publish` job) and the on-demand `lambda-benchmark-command.yml` (the `run` job) dispatch through the shared `./.github/actions/run-benchmark` composite action. A step immediately before each invocation raises the `getaddrinfo` precedence of IPv4-mapped addresses so glibc returns/tries the A record first:

```yaml
- name: Prefer IPv4 for Earthdata login (issue #137)
  run: echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
```

Runner-only config for the CI job's process tree — it does not touch the shipped package or any user's `agg(backend="lambda")` auth (the concern that drove option (2) over the app-level `HAS_IPV6` mutation on #137). Issue #137 names `lambda-benchmark.yml` explicitly, so this infra edit is authorized.

**Fold #145 — fail on silent OOM.** A `--fail-on-empty` flag (default on, `BooleanOptionalAction`) on `run_benchmark.py`: after the target loop, any **real** target whose `total_obs` is falsy or `max_memory_mb` is `None` makes `main()` return non-zero. `--dry-run` is exempt; `--no-fail-on-empty` opts out.

## Phase 2 detail — login retry/backoff

`src/zagg/auth.py` gains `_login_with_retry()` — retries `earthaccess.login()` up to 3× with exponential backoff (2s, 4s) on `OSError`. That base class is the whole requests IO/HTTP-error family (every `requests.exceptions.RequestException` subclasses `IOError`/`OSError`), so it covers the bare `[Errno 101]` no-route, `ConnectionError`, and `Timeout`; a genuinely-rejected credential surfaces as `earthaccess`'s own `LoginAttemptFailure` (not an `OSError`) and so fails fast rather than being retried. Both `get_edl_token` and `get_nsidc_s3_credentials` route through it. New `tests/test_auth.py` pins retry-then-succeed, give-up-after-N (with the exact backoff sequence, no trailing sleep), fail-fast-on-non-`OSError`, the `ConnectionError`-is-an-`OSError` claim, and both public helpers routing through the wrapper.

## Phase 3 detail — parallelize the target launch

`run_benchmark.py`'s serial target loop becomes a `ThreadPoolExecutor` fan-out (cap `min(len, _MAX_TARGET_CONCURRENCY=16)`). Each target is an independent single-shard Lambda dispatch, so this is cold-favoring and cuts wall-clock ~N×; the runtime metric is billable worker-seconds (init-independent), so en-masse launch doesn't bias it. Unknown target names are validated **up front** (before any dispatch), results are re-ordered back to the requested `names` for deterministic output/series rows, and a raising target propagates (aborting the run) as the serial loop did.

**Auth warm-up (folded from self-review).** Because each concurrent `agg()` calls `earthaccess.login()` — which mutates process-global auth/store singletons — N concurrent logins would race to initialize them, contradicting `auth.py`'s "call once" contract. So `main()` calls the new `zagg.auth.ensure_logged_in()` **once before** the pool (guarded by `not dry_run and len(names) > 1`); the in-worker logins then hit the warmed singleton. Tests: the `threading.Barrier(2)` concurrency proof (a serial impl deadlocks → timeout → fails), output-order preservation, up-front unknown-target validation (no dispatch), and the warm-once / skip-on-dry-run wiring.

## Phase 4 detail — per-invocation peak RSS (#141)

`ru_maxrss` is a per-*process* high-water, so on a warm container it reports the max over every prior invocation — untrustworthy, and it can't reflect #140's teardown reclaim. `lambda_handler.py` adds `_PeakRSSSampler`: a daemon thread that samples current `VmRSS` (`/proc/self/status`) every 50 ms while `_handle_process` runs, reported as `max_memory_mb`; `ru_maxrss` is kept as `container_hwm_mb` so the distinction is explicit. Off Linux (no `/proc`) the sampler is a no-op and it falls back to `ru_maxrss`. Sampler is started before the `try`, its peak read after the write phase, stopped in `finally` before the teardown reclaim. Tests (`TestPeakRSSSampler`, controlled `_read_vmrss_kib` feed so they're timing-deterministic): reads current RSS on Linux, reports peak-not-last, two samplers report independent peaks (the #141 acceptance criterion — a light invoke after a heavy one reads its own smaller peak), and the off-Linux no-op fallback.

## How it was tested

- `pytest tests/test_auth.py tests/test_benchmark.py tests/test_lambda_handler.py` — green (auth 7, benchmark harness incl. 4 new parallel/warm-up tests, lambda-handler incl. 4 new sampler tests). Full `tests/test_lambda_handler.py` 35 passed with the `_handle_process` change.
- `ruff check --select=E,F,W,I --ignore=E501` + `ruff format --check` clean on every touched file. Both workflow YAMLs parse.
- IPv4 step is runner config, not unit-testable; acceptance is empirical (consecutive `main` benchmarks green).

## Notes

- Merged up to current `main` (picks up #143/#144). No `main` push, no force-push.
- **Pre-existing, not fixed (§4):** `mypy` flags `_write_elapsed += time.time() - _write_t0` (the #100 profiling block, untouched by this PR) as `float - None`; it exists on `main`, unrelated to this diff.

## Questions for review

- None blocking. Two non-blocking nits noted in the self-review: on a manifest exceeding the 16-way cap a raising target lets already-queued targets finish before the abort (equivalent to serial for the real ≤16 matrix); per-target progress lines now print after all targets complete rather than streaming.