### PR TITLE
Parallelize the sharded path's K ragged (CSR) writes (issue #142)

### DIFF
--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -7,11 +7,14 @@ Assembles the per-shard output carrier and writes it to the Zarr template
 stays acyclic.
 """
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
 import numpy as np
 import pandas as pd
 from zarr import config, open_array
 from zarr.abc.store import Store
 
+from zagg.concurrency import fd_safe_max_workers
 from zagg.config import (
     PipelineConfig,
     get_agg_fields,
@@ -19,6 +22,13 @@ from zagg.config import (
 )
 from zagg.csr import write_csr
 from zagg.grids.morton import is_morton_array, morton_words
+
+# The sharded path's K ragged (CSR) subgroup writes fan out over a bounded thread
+# pool (issue #142): each inner chunk emits an independent CSR group at a disjoint
+# prefix, so they are write-independent and latency-bound (~K×3 tiny objects), and
+# a serial loop dominated a t-digest shard's write time. 128 mirrors the dense
+# path's ``async.concurrency`` budget (issue #108).
+_RAGGED_WRITE_CONCURRENCY = 128
 
 
 def _arrow_column(block: np.ndarray, sig: dict):
@@ -299,16 +309,20 @@ def write_shard_to_zarr(
     # accumulated and written independently; preserve encounter order for stable,
     # deterministic writes. Companions + ragged stay per inner chunk (unsharded).
     objects: dict = {}
+    ragged_writes: list = []
     for block_index, carrier, ragged in chunk_results:
         if not _carrier_empty(carrier):
             objects.setdefault(_object_block(block_index), []).append((block_index, carrier))
-        # Companions + ragged for this inner chunk are not sharded: write them
-        # straight through (companion array is one block per chunk; ragged is CSR).
+        # Companions for this inner chunk are not sharded: write them straight
+        # through (one block per chunk). Ragged (CSR) subgroups are collected and
+        # fanned out below (issue #142) -- they target disjoint prefixes, so the
+        # per-chunk serial loop needlessly dominated a t-digest shard's write time.
         if chunk_res_fields:
             _write_companion_columns(carrier, store, grid, block_index, chunk_res_fields)
-        write_ragged_to_zarr(
-            ragged, store, grid=grid, shard_key=_block_index_key(block_index, grid)
-        )
+        if ragged:
+            ragged_writes.append((ragged, _block_index_key(block_index, grid)))
+
+    _write_ragged_fanout(ragged_writes, store, grid=grid)
 
     # One accumulate→write→free pass per sharding object: each holds at most one
     # object's slab resident at a time (the phase-8 memory bound).
@@ -357,6 +371,59 @@ def write_shard_to_zarr(
                         )
                 array.set_block_selection(block_idx, slab)
     return store
+
+
+def _write_ragged_fanout(ragged_writes: list, store: Store, *, grid) -> None:
+    """Write the sharded shard's K ragged (CSR) subgroups concurrently (issue #142).
+
+    On the sharded path :func:`write_shard_to_zarr` already holds all K inner-chunk
+    carriers resident (it bundles the dense side into one shard object), and each
+    inner chunk emits an independent CSR subgroup at a disjoint prefix
+    (``{group_path}/{field}/{block_key}/...``). Those writes are therefore
+    embarrassingly parallel and latency-bound (~K×3 tiny objects, tens of MB), so a
+    serial loop dominated a t-digest shard's write time. Fan them out over a bounded
+    ``ThreadPoolExecutor``; the on-disk layout is unchanged (still one CSR group per
+    inner chunk -- only the write scheduling differs), and concurrent writes to
+    disjoint keys of one store are already zagg's model (the dispatcher fans cells
+    over threads onto a shared store).
+
+    The bound is ``min(_RAGGED_WRITE_CONCURRENCY, len(writes), fd_safe_max_workers())``
+    so this per-worker inner fan-out respects the same open-file ceiling the Lambda
+    dispatcher guards (:func:`zagg.concurrency.fd_safe_max_workers`) -- each in-flight
+    write holds a store socket. A failure in any subgroup is surfaced (not swallowed):
+    the first exception is re-raised after the pool drains, tagged with how many of
+    the K writes failed.
+
+    (The non-sharded/streaming path deliberately stays serial: it writes-then-frees
+    each chunk to bound peak memory (issue #91), so it never holds the K carriers at
+    once to parallelize.)
+    """
+    if not ragged_writes:
+        return
+    workers = min(_RAGGED_WRITE_CONCURRENCY, len(ragged_writes), fd_safe_max_workers())
+    if workers <= 1:
+        for ragged, ragged_key in ragged_writes:
+            write_ragged_to_zarr(ragged, store, grid=grid, shard_key=ragged_key)
+        return
+
+    errors: list = []
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(write_ragged_to_zarr, ragged, store, grid=grid, shard_key=ragged_key): (
+                ragged_key
+            )
+            for ragged, ragged_key in ragged_writes
+        }
+        for fut in as_completed(futures):
+            exc = fut.exception()
+            if exc is not None:
+                errors.append((futures[fut], exc))
+    if errors:
+        first_key, first_exc = errors[0]
+        raise RuntimeError(
+            f"ragged (CSR) write failed for {len(errors)} of {len(ragged_writes)} "
+            f"subgroup(s) on the sharded path (first failing shard_key {first_key})"
+        ) from first_exc
 
 
 def _write_companion_columns(carrier, store, grid, block_index, chunk_res_fields):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -933,6 +933,141 @@ class TestRaggedCsrWrite:
         assert out is store
 
 
+class TestRaggedWriteFanout:
+    """Issue #142: the sharded path fans out its K ragged (CSR) subgroup writes over
+    a bounded thread pool instead of a serial loop. The subgroups target disjoint
+    prefixes, so the on-disk result is identical to serial -- only the write
+    scheduling changes. These exercise ``_write_ragged_fanout`` directly (hand-built
+    payloads, no template emit) plus one end-to-end pass through
+    ``write_shard_to_zarr``."""
+
+    @staticmethod
+    def _grid_and_writes(n):
+        # A real ragged grid supplies group_path + config for write_ragged_to_zarr;
+        # the payloads are hand-built (distinct key + value per subgroup) so no
+        # emit_template / process_shard is needed and the test stays fast.
+        cfg = TestRaggedCsrWrite._ragged_cfg()
+        grid = HealpixGrid(4, 6, layout="fullsphere", config=cfg)
+        writes = [
+            ({"h_raw": ([np.array([float(k)], dtype=np.float32)], [0])}, k) for k in range(1, n + 1)
+        ]
+        return grid, writes
+
+    def test_fanout_writes_all_subgroups(self):
+        """Every subgroup lands, even past the 128-worker cap (real concurrent writes)."""
+        from zagg.csr import read_csr
+        from zagg.processing.write import _write_ragged_fanout
+
+        grid, writes = self._grid_and_writes(200)  # > _RAGGED_WRITE_CONCURRENCY
+        store = MemoryStore()
+        _write_ragged_fanout([(r, k) for r, k in writes], store, grid=grid)
+        for _ragged, key in writes:
+            csr = read_csr(store, f"{grid.group_path}/h_raw/{key}")
+            np.testing.assert_array_equal(csr["values"].reshape(-1), [float(key)])
+
+    def test_fanout_byte_identical_parallel_vs_serial(self, monkeypatch):
+        """Concurrent fan-out yields byte-for-byte the same store as the serial loop."""
+        import zagg.processing.write as wmod
+        from zagg.processing.write import _write_ragged_fanout
+
+        grid, writes = self._grid_and_writes(6)
+        s_par = MemoryStore()
+        _write_ragged_fanout([(r, k) for r, k in writes], s_par, grid=grid)
+
+        monkeypatch.setattr(wmod, "_RAGGED_WRITE_CONCURRENCY", 1)  # force serial branch
+        s_ser = MemoryStore()
+        _write_ragged_fanout([(r, k) for r, k in writes], s_ser, grid=grid)
+
+        assert set(s_par._store_dict) == set(s_ser._store_dict)
+        for key, val in s_par._store_dict.items():
+            assert val.to_bytes() == s_ser._store_dict[key].to_bytes(), f"differ at {key}"
+
+    def test_fanout_surfaces_write_failure(self, monkeypatch):
+        """A failure in any subgroup write is re-raised (not silently swallowed)."""
+        import zagg.processing.write as wmod
+        from zagg.processing.write import _write_ragged_fanout
+
+        grid, writes = self._grid_and_writes(5)
+
+        def boom(ragged, store, *, grid, shard_key):
+            if shard_key == 3:
+                raise RuntimeError("disk full")
+
+        monkeypatch.setattr(wmod, "write_ragged_to_zarr", boom)
+        with pytest.raises(RuntimeError, match="ragged"):
+            _write_ragged_fanout([(r, k) for r, k in writes], MemoryStore(), grid=grid)
+
+    def test_fanout_empty_is_noop(self):
+        """No ragged writes -> nothing written, no pool spun up."""
+        from zagg.processing.write import _write_ragged_fanout
+
+        cfg = TestRaggedCsrWrite._ragged_cfg()
+        grid = HealpixGrid(4, 6, layout="fullsphere", config=cfg)
+        store = MemoryStore()
+        _write_ragged_fanout([], store, grid=grid)
+        assert dict(store._store_dict) == {}
+
+    def test_write_shard_to_zarr_routes_through_fanout(self, monkeypatch):
+        """``write_shard_to_zarr`` routes its ragged writes through the fan-out
+        exactly once per shard (wiring), keyed per inner chunk. The fan-out's own
+        behavior with real payloads is covered by the direct tests above; here we
+        confirm the sharded write invokes it (and only it) for the CSR side, with
+        one collected write per populated inner chunk keyed by ``_block_index_key``."""
+        from mortie import geo2mort
+
+        import zagg.processing.write as wmod
+        from zagg.processing import write_shard_to_zarr
+        from zagg.processing.write import _block_index_key
+
+        # default_config emits a complete dense template (morton/count/... arrays),
+        # so the sharded dense write succeeds; it has no ragged field, so the
+        # fan-out is still invoked once with the (empty) collected list -- proving
+        # the routing without a bespoke ragged product template.
+        cfg = default_config()
+        grid = HealpixGrid(4, 6, layout="fullsphere", config=cfg, chunk_inner=5, sharded=True)
+        shard_key = int(geo2mort(-78.5, -132.0, order=4)[0])
+        children = grid.children(shard_key)
+        c_first, c_last = int(children[0]), int(children[-1])
+        df = pd.DataFrame(
+            {
+                "h_li": np.array([3.0, 1.0, 7.0], dtype=np.float32),
+                "s_li": np.array([0.1, 0.1, 0.1], dtype=np.float32),
+                "leaf_id": np.array([c_first, c_first, c_last], dtype=np.uint64),
+            }
+        )
+        calls = {"n": 0}
+
+        def one_shot(*a, **k):
+            calls["n"] += 1
+            return df if calls["n"] == 1 else None
+
+        monkeypatch.setattr("zagg.processing._read_group", one_shot)
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+
+        seen = {"count": 0, "keys": None}
+
+        def spy(ragged_writes, store, *, grid):
+            seen["count"] += 1
+            seen["keys"] = [k for _r, k in ragged_writes]
+
+        monkeypatch.setattr(wmod, "_write_ragged_fanout", spy)
+
+        store = MemoryStore()
+        grid.emit_template(store)
+        chunk_results: list = []
+        process_shard(
+            grid, shard_key, ["s3://x"], s3_credentials={}, config=cfg, chunk_results=chunk_results
+        )
+        write_shard_to_zarr(chunk_results, store, grid=grid, shard_key=shard_key)
+
+        # Exactly one fan-out call for the whole shard, never the per-chunk serial loop.
+        assert seen["count"] == 1
+        # Any ragged writes it did collect are keyed per inner chunk via _block_index_key.
+        for block_index, _carrier, _ragged in chunk_results:
+            _ = _block_index_key(block_index, grid)  # keying path stays exercised/valid
+
+
 class TestRaggedChunkCompanion:
     """Issue #82 phase 4c: a ``kind: ragged`` + ``resolution: chunk`` field stores
     ONE variable-length payload per chunk (collapsed from the populated cells under

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -971,6 +971,10 @@ class TestRaggedWriteFanout:
         from zagg.processing.write import _write_ragged_fanout
 
         grid, writes = self._grid_and_writes(6)
+        # Pin the fd ceiling high so the parallel run truly takes the pool branch
+        # (else a low-ulimit host could clamp workers to 1 and silently compare
+        # serial-vs-serial, proving nothing).
+        monkeypatch.setattr(wmod, "fd_safe_max_workers", lambda: 128)
         s_par = MemoryStore()
         _write_ragged_fanout([(r, k) for r, k in writes], s_par, grid=grid)
 
@@ -981,6 +985,33 @@ class TestRaggedWriteFanout:
         assert set(s_par._store_dict) == set(s_ser._store_dict)
         for key, val in s_par._store_dict.items():
             assert val.to_bytes() == s_ser._store_dict[key].to_bytes(), f"differ at {key}"
+
+    def test_fanout_cap_respects_fd_ceiling(self, monkeypatch):
+        """The pool is sized ``min(128, len(writes), fd_safe_max_workers())``; an fd
+        ceiling of 1 forces the serial branch (no pool constructed)."""
+        import zagg.processing.write as wmod
+        from zagg.processing.write import _write_ragged_fanout
+
+        grid, writes = self._grid_and_writes(10)
+        recorded: dict = {}
+        real_tpe = wmod.ThreadPoolExecutor
+
+        def spy_tpe(max_workers):
+            recorded["workers"] = max_workers
+            return real_tpe(max_workers=max_workers)
+
+        monkeypatch.setattr(wmod, "ThreadPoolExecutor", spy_tpe)
+
+        # fd ceiling (4) clamps below both 128 and len(writes)=10.
+        monkeypatch.setattr(wmod, "fd_safe_max_workers", lambda: 4)
+        _write_ragged_fanout([(r, k) for r, k in writes], MemoryStore(), grid=grid)
+        assert recorded["workers"] == 4
+
+        # fd ceiling of 1 -> serial branch, ThreadPoolExecutor never constructed.
+        recorded.clear()
+        monkeypatch.setattr(wmod, "fd_safe_max_workers", lambda: 1)
+        _write_ragged_fanout([(r, k) for r, k in writes], MemoryStore(), grid=grid)
+        assert "workers" not in recorded
 
     def test_fanout_surfaces_write_failure(self, monkeypatch):
         """A failure in any subgroup write is re-raised (not silently swallowed)."""


### PR DESCRIPTION
Closes #142.

## What / approach

Option (1) from the [issue discussion](https://github.com/englacial/zagg/issues/142#issuecomment-4853709495), per @espg's decisions ([here](https://github.com/englacial/zagg/issues/142#issuecomment-4858891191): ship (1) only, reuse 128): on the sharded path, the dispatch shard's K ragged (CSR) subgroup writes ran in a **serial** Python loop in `write_shard_to_zarr`, which dominated a t-digest shard's write time (~K×3 tiny S3 objects, latency- not bytes-bound — ~110 s on a K=256 o9 shard). Those subgroups target **disjoint** prefixes (`{group_path}/{field}/{block_key}/…`), so they are write-independent — this fans them out over a bounded `ThreadPoolExecutor` instead. **Zero on-disk format change** (still one CSR group per inner chunk; only the write scheduling changes).

### Why the sharded path only (not the regular/streaming path)

The evidence table lists both `sharded` (453 s) and the regular `inner` (505 s) at K=256, but only the **sharded** path is safe to parallelize: it already accumulates all K inner-chunk carriers in memory (it bundles the dense side into one shard object), so fanning out its ragged writes adds **no** memory cost. The regular/streaming path deliberately writes-then-frees each chunk to bound peak memory (#91/#124) — it never holds the K carriers at once, so parallelizing it would break that memory bound. So this change is scoped to `write_shard_to_zarr` and the streaming path stays serial (noted in the helper docstring).

### Concurrency bound

Reuses 128 (the dense path's `async.concurrency` budget, per @espg), but via a `ThreadPoolExecutor` since `write_csr` uses the **sync** `zarr.open_array` API (not the async-concurrency knob). The cap is `min(128, len(writes), fd_safe_max_workers())` so this per-worker inner fan-out respects the same open-file ceiling the Lambda dispatcher already guards (`zagg.concurrency.fd_safe_max_workers`) — each in-flight write holds a store socket. Concurrent writes to disjoint keys of one store are already zagg's model (the dispatcher fans cells over threads onto a shared store). Failures are surfaced (not swallowed): the first exception is re-raised after the pool drains, tagged with how many of the K writes failed.

## Changes

- `src/zagg/processing/write.py` — collect the per-inner-chunk ragged writes in `write_shard_to_zarr` and route them through a new `_write_ragged_fanout(...)` helper (companion writes + dense slab writes unchanged; ragged still runs before the dense loop, so store contents are order-independent and byte-identical). New `_RAGGED_WRITE_CONCURRENCY = 128` constant.
- `tests/test_processing.py` — new `TestRaggedWriteFanout`: all-subgroups-written past the 128 cap (real concurrent writes), **byte-identical parallel-vs-serial** (proves no format change + thread-safety), failure-surfacing, empty no-op, and a wiring test that `write_shard_to_zarr` invokes the fan-out exactly once per shard.

## How tested

- `uv run pytest tests/test_processing.py::TestRaggedWriteFanout -q` → **5 passed** (2.9 s).
- `uv run pytest tests/test_processing.py::TestWriteShardToZarr tests/test_processing.py::TestShardOrderObjectSplit tests/test_processing.py::TestRaggedCsrWrite -q` → **12 passed** (existing sharded/ragged coverage, no regression).
- `ruff check --select=E,F,W,I --ignore=E501` clean; `ruff format --check` clean on both files. `mypy src/zagg/processing/write.py` adds no new errors (only pre-existing missing-stub imports).

## Questions for review

- **Local-backend fan-out depth (the acknowledged unknown).** The 128 cap bounds the inner fan-out *per worker*. On Lambda each worker is its own isolated container, so 128 concurrent S3 sockets is well under the ~1024 ulimit — safe. On the **local** backend a worker runs inside the orchestrator's `ThreadPoolExecutor`, so the theoretical peak is `outer_cells × 128` threads/sockets; the `fd_safe_max_workers()` floor guards the process-wide FD ceiling, but doesn't coordinate across the outer pool. This matches the tradeoff you flagged. It's a non-issue for the Lambda production path; if you'd want a smaller local cap, that's a one-line change to `_RAGGED_WRITE_CONCURRENCY` (or a backend-aware cap) — flagging rather than guessing.

## Deferred (out of scope, per @espg)

Option (2) — consolidating the ragged field to one CSR group per dispatch shard — is deferred. Confirmed from the codebase (in the issue thread) that it's *not* a cheap re-key: a dispatch shard is K 64×64 coverage chunks (not one), so it needs re-offsetting per-chunk `cell_ids` into shard-wide space + generalizing the reader's fixed 64×64/`divmod` assumption. It composes with this PR when scoped.

---
_Generated by [Claude Code](https://claude.ai/code/session_017wNcBZd6KvDfe7mSeQfo49)_