### PR TITLE
async Lambda dispatch with S3-polled worker results (issue #151)

### DIFF
--- a/.github/scripts/deploy_lambda.sh
+++ b/.github/scripts/deploy_lambda.sh
@@ -48,13 +48,15 @@ aws lambda update-function-code \
 # Async-invoke hygiene (issue #151): the runner dispatches with
 # InvocationType=Event and polls for worker-written results; Lambda's async
 # defaults would re-run a timed-out/OOM'd shard twice with delays, so pin
-# retries to 0 and bound queued-event age to the runner's poll window
-# (mirrors ProcessFnAsyncConfig in deployment/aws/template.yaml). Warn-only:
-# the deploy role may not yet carry lambda:PutFunctionEventInvokeConfig, and
-# the pipeline still works (just noisier on worker crashes) without it.
+# retries to 0, and keep event age under the runner's 90 s poll margin so no
+# delivery starts after the runner stops listening (mirrors
+# ProcessFnAsyncConfig in deployment/aws/template.yaml -- keep in sync).
+# Warn-only: the deploy role may not yet carry
+# lambda:PutFunctionEventInvokeConfig, and the pipeline still works (just
+# noisier on worker crashes) without it.
 aws lambda put-function-event-invoke-config \
   --function-name "$FUNCTION" --maximum-retry-attempts 0 \
-  --maximum-event-age-in-seconds 900 --region "$REGION" \
+  --maximum-event-age-in-seconds 60 --region "$REGION" \
   || echo "WARN: could not set event-invoke config on $FUNCTION (needs lambda:PutFunctionEventInvokeConfig); async service retries stay at the default" >&2
 
 echo "deployed $FUNCTION (layer $LAYER_ARN)"

--- a/.github/scripts/deploy_lambda.sh
+++ b/.github/scripts/deploy_lambda.sh
@@ -45,4 +45,16 @@ aws lambda wait function-updated --function-name "$FUNCTION" --region "$REGION"
 aws lambda update-function-code \
   --function-name "$FUNCTION" --zip-file "fileb://${FUNCTION_ZIP}" --publish --region "$REGION"
 
+# Async-invoke hygiene (issue #151): the runner dispatches with
+# InvocationType=Event and polls for worker-written results; Lambda's async
+# defaults would re-run a timed-out/OOM'd shard twice with delays, so pin
+# retries to 0 and bound queued-event age to the runner's poll window
+# (mirrors ProcessFnAsyncConfig in deployment/aws/template.yaml). Warn-only:
+# the deploy role may not yet carry lambda:PutFunctionEventInvokeConfig, and
+# the pipeline still works (just noisier on worker crashes) without it.
+aws lambda put-function-event-invoke-config \
+  --function-name "$FUNCTION" --maximum-retry-attempts 0 \
+  --maximum-event-age-in-seconds 900 --region "$REGION" \
+  || echo "WARN: could not set event-invoke config on $FUNCTION (needs lambda:PutFunctionEventInvokeConfig); async service retries stay at the default" >&2
+
 echo "deployed $FUNCTION (layer $LAYER_ARN)"

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -124,9 +124,10 @@ Resources:
                 "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
               StringLike:
                 "token.actions.githubusercontent.com:sub": !Sub "repo:${GitHubRepo}:*"
-      # No S3: the Zarr template write happens INSIDE the Lambda (runner.py
-      # "the orchestrator only needs lambda:InvokeFunction; no direct S3 access"),
-      # so the orchestrator never touches the output bucket directly.
+      # S3 writes still happen INSIDE the Lambda (runner.py: the Zarr template /
+      # data writes need no orchestrator S3 access). The one orchestrator read
+      # is the async result poll (issue #151): workers mirror per-shard result
+      # JSON to <store>.status/<run_id>/ and the runner GETs it.
       Policies:
         - PolicyName: invoke-and-probe
           PolicyDocument:
@@ -148,6 +149,13 @@ Resources:
                 Effect: Allow
                 Action: [lambda:GetAccountSettings, cloudwatch:GetMetricStatistics]
                 Resource: "*"
+              # Async-dispatch result polling (issue #151): read the per-shard
+              # result objects the workers write next to the benchmark output
+              # store (BENCHMARK_STORE_PREFIX lives in this bucket).
+              - Sid: PollAsyncResults
+                Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub "arn:aws:s3:::${BenchmarkStoreBucket}/*"
 
   # --- tier-2 test-deploy role (issue #25 §9) --------------------------------
   DeployRole:
@@ -176,6 +184,8 @@ Resources:
                 Action:
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
+                  # deploy_lambda.sh pins async retries to 0 (issue #151).
+                  - lambda:PutFunctionEventInvokeConfig
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
                 Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}"
@@ -219,6 +229,8 @@ Resources:
                 Action:
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
+                  # deploy_lambda.sh pins async retries to 0 (issue #151).
+                  - lambda:PutFunctionEventInvokeConfig
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
                 Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}"

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -29,6 +29,14 @@ Event payload (default / process mode):
         Forwarded to ``process_shard`` so the worker fills the ``aoi_mask``
         column; absent when ``output.aoi_mask`` is off (the column is not
         allocated), keeping the flag-off event and outputs byte-identical.
+    "result_url": str (optional, issue #151) -- where to ALSO write this
+        invocation's response envelope as JSON (e.g.
+        "s3://bucket/out.zarr.status/<run_id>/<shard_key>.json"). Set by the
+        orchestrator's async dispatch (InvocationType="Event", which discards
+        the return value); the orchestrator polls this object instead of
+        holding a synchronous connection open while the shard runs. Written
+        with the output-store credentials. Absent -> no write, and the event
+        and behavior are byte-identical to the synchronous path.
 }
 
 Setup mode (creates the zarr template once before per-cell fan-out):
@@ -237,7 +245,34 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         return _handle_setup(event)
     if mode == "finalize":
         return _handle_finalize(event)
-    return _handle_process(event, context)
+    response = _handle_process(event, context)
+    # Async result channel (issue #151): on an Event invoke the return value is
+    # discarded, so mirror the response envelope to the orchestrator-supplied
+    # result_url for it to poll. Covers every branch (200 / 400 / 500) because
+    # it wraps the whole process handler.
+    if event.get("result_url"):
+        _write_result(event["result_url"], response, event)
+    return response
+
+
+def _write_result(result_url: str, response: Dict[str, Any], event: Dict[str, Any]) -> None:
+    """Write the response envelope to ``result_url`` as JSON (issue #151).
+
+    Uses the same credentials/endpoint resolution as the output store. Never
+    raises: on failure the orchestrator's poll times out and records the shard
+    as failed, and the cause lands here in CloudWatch.
+    """
+    import obstore
+
+    from zagg.store import open_object_store
+
+    try:
+        prefix, key = result_url.rsplit("/", 1)
+        store = open_object_store(prefix, **_output_store_kwargs(event))
+        obstore.put(store, key, json.dumps(response).encode())
+        logger.info(f"Wrote async result to {result_url}")
+    except Exception as e:
+        logger.error(f"Failed to write async result to {result_url}: {e}")
 
 
 def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -172,18 +172,23 @@ Resources:
         S3Key: !Ref FunctionS3Key
 
   # Async-invoke hygiene (issue #151): the runner dispatches per-cell events
-  # with InvocationType=Event and polls for the worker-written result object.
-  # Lambda's async defaults would re-run a timed-out/OOM'd shard twice with
-  # delays -- re-failing deterministic failures at extra cost and risking late
-  # writes into a store the caller has moved on from -- so pin retries to 0 and
-  # bound queued-event age to the runner's poll window (Timeout + margin).
+  # with InvocationType=Event and polls for the worker-written result object
+  # until Timeout + a 90 s margin. Lambda's async defaults would re-run a
+  # timed-out/OOM'd shard twice with delays -- re-failing deterministic
+  # failures at extra cost and risking late writes into a store the caller has
+  # moved on from -- so pin retries to 0. Event age must stay UNDER the poll
+  # margin so no first delivery can start after the runner stops listening (a
+  # late run would write into the store post-finalize); 60 is the API minimum
+  # and leaves >=30 s of the margin for the result write. A delivery delayed
+  # past it is dropped and the runner records the shard failed at its
+  # deadline -- strictly better than a zombie write.
   ProcessFnAsyncConfig:
     Type: AWS::Lambda::EventInvokeConfig
     Properties:
       FunctionName: !Ref ProcessFn
       Qualifier: "$LATEST"
       MaximumRetryAttempts: 0
-      MaximumEventAgeInSeconds: 900
+      MaximumEventAgeInSeconds: 60
 
 Outputs:
   FunctionArn:

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -171,6 +171,20 @@ Resources:
         S3Bucket: !Ref ArtifactBucket
         S3Key: !Ref FunctionS3Key
 
+  # Async-invoke hygiene (issue #151): the runner dispatches per-cell events
+  # with InvocationType=Event and polls for the worker-written result object.
+  # Lambda's async defaults would re-run a timed-out/OOM'd shard twice with
+  # delays -- re-failing deterministic failures at extra cost and risking late
+  # writes into a store the caller has moved on from -- so pin retries to 0 and
+  # bound queued-event age to the runner's poll window (Timeout + margin).
+  ProcessFnAsyncConfig:
+    Type: AWS::Lambda::EventInvokeConfig
+    Properties:
+      FunctionName: !Ref ProcessFn
+      Qualifier: "$LATEST"
+      MaximumRetryAttempts: 0
+      MaximumEventAgeInSeconds: 900
+
 Outputs:
   FunctionArn:
     Description: ARN of the deployed Lambda function.

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -16,6 +16,7 @@ import logging
 import os
 import statistics
 import time
+import uuid
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 
@@ -55,7 +56,7 @@ from zagg.processing import (
     write_shard_to_zarr,
 )
 from zagg.processing.write import _block_index_key
-from zagg.store import open_store
+from zagg.store import open_object_store, open_store
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,7 @@ def agg(
     handoff: str | None = None,
     profile: bool = False,
     max_retries: int = 3,
+    invocation: str = "async",
 ) -> dict:
     """Run the aggregation pipeline.
 
@@ -158,6 +160,20 @@ def agg(
         exception) are never retried regardless. Default ``3``. Ignored by the
         ``"local"`` backend. Set to ``1`` (e.g. the CI benchmark) to measure one
         clean invocation and record a failure as a failure.
+    invocation : str
+        Lambda-only (issue #151). ``"async"`` (default) dispatches each cell
+        with ``InvocationType="Event"`` and polls a per-shard result object the
+        worker writes next to the output store
+        (``<store>.status/<run_id>/<shard_key>.json``), so no synchronous
+        connection sits idle while the shard runs -- shards longer than a NAT
+        idle window (~4 min on GitHub-hosted runners) complete reliably, and
+        the 6 MB synchronous response cap no longer applies. Requires (a) a
+        deployed worker that honors the ``result_url`` event key and (b) the
+        caller to have read access to the output bucket for the poll. Note the
+        async request payload cap is 256 KB (vs 6 MB synchronous); pass
+        ``"sync"`` for older deployed workers or extreme per-cell payloads
+        (granule-dense shards with large AOI masks). Ignored by the
+        ``"local"`` backend.
 
     Returns
     -------
@@ -227,6 +243,8 @@ def agg(
         max_workers = min(max_workers, n_cells)
         if not store_path.startswith("s3://"):
             raise ValueError(f"Lambda backend requires s3:// store path, got: {store_path}")
+        if invocation not in ("async", "sync"):
+            raise ValueError(f"Unknown invocation: {invocation!r} (expected 'async' or 'sync')")
         if function_name is None:
             function_name = os.environ.get("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard")
         return _run_lambda(
@@ -246,6 +264,7 @@ def agg(
             handoff=resolved_handoff,
             profile=profile,
             max_retries=max_retries,
+            invocation=invocation,
         )
     else:
         raise ValueError(f"Unknown backend: {backend!r} (expected 'local' or 'lambda')")
@@ -603,6 +622,7 @@ def _run_lambda(
     handoff="arrow",
     profile=False,
     max_retries=3,
+    invocation="async",
 ):
     """Run processing via AWS Lambda invocation.
 
@@ -664,6 +684,19 @@ def _run_lambda(
         region,
     )
 
+    # Async result channel (issue #151): a per-run unique status prefix next to
+    # the output store. Each worker mirrors its response envelope to
+    # <prefix>/<shard_key>.json and the dispatch threads poll for it instead of
+    # holding a synchronous invoke connection open -- GitHub-hosted runners sit
+    # behind a ~4 min NAT idle timeout that severed every >250 s benchmark
+    # target. The run_id keeps reruns into the same store from reading stale
+    # results. ``invocation="sync"`` skips the channel (legacy RequestResponse).
+    result_prefix = None
+    result_box: dict = {}
+    if invocation == "async":
+        result_prefix = f"{store_path.rstrip('/')}.status/{uuid.uuid4().hex}"
+        logger.info(f"Async worker results at {result_prefix}")
+
     # The dispatch lambda_client is built inside preflight() (once the probe
     # has clamped the worker count, which sizes its connection pool), so the
     # per-cell / finalize closures read it from this holder rather than closing
@@ -704,6 +737,9 @@ def _run_lambda(
             region_name=region,
             config=boto_config,
         )
+        # Read the function Timeout once, pre-fan-out: the async poll deadline
+        # is keyed to it (issue #151), and the summary reports it (#100).
+        state["function_timeout_s"] = _get_function_timeout_s(state["lambda_client"], function_name)
         return PreflightReport(workers=clamped, detail=concurrency_report)
 
     # Per-cell invoke, bound to everything but the (shard_key, records) pair so
@@ -717,6 +753,17 @@ def _run_lambda(
         extra = {}
         if aoi_by_shard:
             extra["aoi_payload"] = aoi_by_shard.get(int(shard_key))
+        # Async dispatch (issue #151): where the worker writes this shard's
+        # result, how to poll for it, and how long before giving up (function
+        # timeout + queue/write margin). Sync runs pass none of these, keeping
+        # the invoke byte-identical to the legacy path.
+        if result_prefix is not None:
+            key = f"{int(shard_key)}.json"
+            extra["result_url"] = f"{result_prefix}/{key}"
+            extra["result_fetch"] = _result_fetcher(
+                result_box, result_prefix, output_creds_event, region, key
+            )
+            extra["poll_timeout_s"] = state["function_timeout_s"] + _ASYNC_POLL_MARGIN_S
         return _invoke_lambda_cell(
             state["lambda_client"],
             grid.block_index(int(shard_key)),
@@ -831,7 +878,7 @@ def _run_lambda(
     # the billed per-cell durations plus the max's share of the function
     # Timeout -- the safety margin that flags a skewed shardmap (one fat cell
     # dominating wall time). Raw material already lives in report.results.
-    function_timeout_s = _get_function_timeout_s(state.get("lambda_client"), function_name)
+    function_timeout_s = state.get("function_timeout_s", _DEFAULT_FUNCTION_TIMEOUT_S)
     durations = [r["lambda_duration"] for r in report.results if r.get("lambda_duration")]
     if durations:
         worker_max_s = max(durations)
@@ -1001,6 +1048,110 @@ def _log_concurrency_report(report: ConcurrencyReport, max_workers: int) -> None
 # deployment/aws/template.yaml (Timeout Default: 720).
 _DEFAULT_FUNCTION_TIMEOUT_S = 720
 
+# Async-dispatch polling (issue #151). The poll deadline is the function
+# Timeout plus this margin (async queue latency + the worker's result write);
+# past it the worker either timed out, was OOM-killed, or crashed before
+# writing -- all deterministic, so the shard is recorded failed, not retried.
+# The interval keeps a full 1700-worker fan-out to ~a few hundred S3 GETs/s.
+_ASYNC_POLL_MARGIN_S = 90.0
+_ASYNC_POLL_INTERVAL_S = 5.0
+
+
+def _result_fetcher(box, prefix, output_creds_event, region, key):
+    """Zero-arg fetch closure for one shard's async result object (#151).
+
+    The obstore store is built lazily on the first poll and shared across all
+    cells via ``box`` (a plain dict; a benign first-poll race just builds it
+    twice), so runs whose dispatch is fully mocked (tests) never touch
+    obstore/S3. Credential resolution mirrors the worker's
+    ``_output_store_kwargs``: the explicit output-credentials block when
+    supplied, else the ambient chain.
+    """
+
+    def fetch():
+        store = box.get("store")
+        if store is None:
+            kwargs = {"region": region}
+            if output_creds_event:
+                kwargs["region"] = output_creds_event.get("region", region)
+                kwargs["credentials"] = output_creds_event
+                if output_creds_event.get("endpointUrl"):
+                    kwargs["endpoint_url"] = output_creds_event["endpointUrl"]
+            store = open_object_store(prefix, **kwargs)
+            box["store"] = store
+        return _fetch_result(store, key)
+
+    return fetch
+
+
+def _fetch_result(result_store, key):
+    """Read one worker-written result envelope; None while it hasn't landed."""
+    import obstore
+    from obstore.exceptions import NotFoundError
+
+    try:
+        data = obstore.get(result_store, key).bytes()
+    except (FileNotFoundError, NotFoundError):
+        return None
+    return json.loads(bytes(data))
+
+
+def _poll_lambda_result(
+    result_fetch,
+    shard_key,
+    granule_count,
+    wall_start,
+    retries,
+    poll_timeout_s,
+    poll_interval_s=_ASYNC_POLL_INTERVAL_S,
+):
+    """Poll for one async invoke's worker-written result object (issue #151).
+
+    Returns the same result-dict shape as the synchronous path so the dispatch
+    accumulator and summary are unchanged. A result missing at the deadline
+    means the worker timed out, was OOM-killed, or crashed before its write --
+    deterministic outcomes, so (like sync FunctionErrors, #119) it is recorded
+    as the shard's failure rather than re-invoked.
+    """
+    if poll_timeout_s is None:
+        poll_timeout_s = _DEFAULT_FUNCTION_TIMEOUT_S + _ASYNC_POLL_MARGIN_S
+    deadline = wall_start + poll_timeout_s
+    while True:
+        result = result_fetch()
+        if result is not None:
+            try:
+                body = json.loads(result.get("body", "{}"))
+            except (json.JSONDecodeError, TypeError):
+                body = {}
+            return {
+                "shard_key": shard_key,
+                "status_code": result.get("statusCode"),
+                "body": body,
+                "wall_time": time.time() - wall_start,
+                "lambda_duration": body.get("duration_s", 0),
+                "error": body.get("error"),
+                "retries": retries,
+                "timeout": False,
+                "granule_count": granule_count,
+            }
+        if time.time() >= deadline:
+            return {
+                "shard_key": shard_key,
+                "status_code": None,
+                "body": {},
+                "wall_time": time.time() - wall_start,
+                "lambda_duration": 0,
+                "error": (
+                    f"no worker result within {poll_timeout_s:.0f}s (worker "
+                    "timeout, OOM, or crash before writing its result -- "
+                    "check CloudWatch)"
+                ),
+                "retries": retries,
+                "granule_count": granule_count,
+            }
+        # Sub-second jitter de-synchronizes the fan-out's poll bursts.
+        time.sleep(poll_interval_s + (time.time() % 1))
+
 
 def _get_function_timeout_s(lambda_client, function_name):
     """Read the function's configured Timeout (seconds), once.
@@ -1090,6 +1241,9 @@ def _invoke_lambda_cell(
     handoff="arrow",
     profile=False,
     aoi_payload=None,
+    result_url=None,
+    result_fetch=None,
+    poll_timeout_s=None,
 ):
     """Invoke Lambda for a single cell with retry logic.
 
@@ -1104,6 +1258,13 @@ def _invoke_lambda_cell(
     ``handoff`` (issue #130) forwards a ``"handoff"`` event key selecting the
     worker's carrier; the default ``"arrow"`` adds the key, while an explicit
     ``"pandas"`` omits it, keeping that event byte-identical to the pre-handoff path.
+    ``result_url`` (issue #151) switches the invoke to fire-and-forget
+    (``InvocationType="Event"``): the worker mirrors its response envelope to
+    that object and ``result_fetch`` (a zero-arg callable returning the parsed
+    envelope, or None while absent) polls for it until ``poll_timeout_s``. No
+    connection sits idle while the shard runs, so long shards survive NAT idle
+    timeouts (GitHub-hosted runners sever synchronous invokes at ~4 min). When
+    ``None`` (legacy sync path) the invoke is byte-identical to before.
     """
     wall_start = time.time()
 
@@ -1138,6 +1299,12 @@ def _invoke_lambda_cell(
     # it, staying byte-identical to the pre-handoff path (#130).
     if handoff and handoff != "pandas":
         event["handoff"] = handoff
+    # Async dispatch (issue #151): tell the worker where to mirror its response
+    # envelope and fire-and-forget. Absent -> the legacy synchronous invoke.
+    invocation_type = "RequestResponse"
+    if result_url is not None:
+        event["result_url"] = result_url
+        invocation_type = "Event"
 
     last_error = None
     for attempt in range(max_retries):
@@ -1147,9 +1314,20 @@ def _invoke_lambda_cell(
             # cross-account callers. The tail data was unused anyway.
             response = lambda_client.invoke(
                 FunctionName=function_name,
-                InvocationType="RequestResponse",
+                InvocationType=invocation_type,
                 Payload=json.dumps(event),
             )
+            if result_url is not None:
+                # 202 accepted -- an Event invoke returns no payload; the
+                # worker's envelope lands at result_url instead. Poll for it.
+                return _poll_lambda_result(
+                    result_fetch,
+                    shard_key,
+                    len(granule_urls),
+                    wall_start,
+                    attempt,
+                    poll_timeout_s,
+                )
 
             function_error = response.get("FunctionError")
             is_timeout = False

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1116,8 +1116,19 @@ def _poll_lambda_result(
     if poll_timeout_s is None:
         poll_timeout_s = _DEFAULT_FUNCTION_TIMEOUT_S + _ASYNC_POLL_MARGIN_S
     deadline = wall_start + poll_timeout_s
+    fetch_error = None
     while True:
-        result = result_fetch()
+        # A fetch fault (S3 blip, throttled GET) must NOT escape into the
+        # invoke retry classifier -- re-dispatching a still-running shard
+        # duplicates work and cost. Treat it as a miss and keep polling; a
+        # *persistent* fault (e.g. missing s3:GetObject) surfaces in the
+        # deadline error below instead of masquerading as a worker crash.
+        try:
+            result = result_fetch()
+            fetch_error = None
+        except Exception as e:
+            fetch_error = e
+            result = None
         if result is not None:
             try:
                 body = json.loads(result.get("body", "{}"))
@@ -1135,17 +1146,18 @@ def _poll_lambda_result(
                 "granule_count": granule_count,
             }
         if time.time() >= deadline:
+            cause = (
+                f"result fetch failing: {fetch_error}"
+                if fetch_error is not None
+                else "worker timeout, OOM, or crash before writing its result -- check CloudWatch"
+            )
             return {
                 "shard_key": shard_key,
                 "status_code": None,
                 "body": {},
                 "wall_time": time.time() - wall_start,
                 "lambda_duration": 0,
-                "error": (
-                    f"no worker result within {poll_timeout_s:.0f}s (worker "
-                    "timeout, OOM, or crash before writing its result -- "
-                    "check CloudWatch)"
-                ),
+                "error": f"no worker result within {poll_timeout_s:.0f}s ({cause})",
                 "retries": retries,
                 "granule_count": granule_count,
             }

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1056,6 +1056,12 @@ _DEFAULT_FUNCTION_TIMEOUT_S = 720
 _ASYNC_POLL_MARGIN_S = 90.0
 _ASYNC_POLL_INTERVAL_S = 5.0
 
+# Async (Event) invoke requests cap at 256 KB (vs 6 MB synchronous). Budget a
+# little under it so the dispatch pre-flight fails with a remedy before
+# Lambda's raw RequestEntityTooLargeException does; the realistic trigger is a
+# large strict-AOI ``aoi_payload`` (issue #101).
+_ASYNC_PAYLOAD_CAP_BYTES = 250 * 1024
+
 
 def _result_fetcher(box, prefix, output_creds_event, region, key):
     """Zero-arg fetch closure for one shard's async result object (#151).
@@ -1149,7 +1155,12 @@ def _poll_lambda_result(
             cause = (
                 f"result fetch failing: {fetch_error}"
                 if fetch_error is not None
-                else "worker timeout, OOM, or crash before writing its result -- check CloudWatch"
+                else (
+                    "worker timed out, was OOM-killed, or crashed before "
+                    "writing its result (check CloudWatch) -- or the deployed "
+                    "worker predates result_url support: redeploy the "
+                    'function, or pass invocation="sync"'
+                )
             )
             return {
                 "shard_key": shard_key,
@@ -1318,6 +1329,19 @@ def _invoke_lambda_cell(
         event["result_url"] = result_url
         invocation_type = "Event"
 
+    # json.dumps is ASCII by default, so len() is the request byte size. Gate
+    # async payloads against the 256 KB Event cap with a remedy, up front,
+    # rather than letting every attempt fail on Lambda's raw
+    # RequestEntityTooLargeException (issue #151).
+    payload = json.dumps(event)
+    if invocation_type == "Event" and len(payload) > _ASYNC_PAYLOAD_CAP_BYTES:
+        raise ValueError(
+            f"cell {shard_key} event payload is {len(payload):,} bytes, over the "
+            f"{_ASYNC_PAYLOAD_CAP_BYTES:,}-byte async dispatch budget (Lambda caps "
+            'Event invokes at 256 KB): pass invocation="sync" for this run, or '
+            "shrink the per-cell payload (e.g. the strict-AOI aoi_payload)"
+        )
+
     last_error = None
     for attempt in range(max_retries):
         try:
@@ -1327,7 +1351,7 @@ def _invoke_lambda_cell(
             response = lambda_client.invoke(
                 FunctionName=function_name,
                 InvocationType=invocation_type,
-                Payload=json.dumps(event),
+                Payload=payload,
             )
             if result_url is not None:
                 # 202 accepted -- an Event invoke returns no payload; the

--- a/src/zagg/store.py
+++ b/src/zagg/store.py
@@ -48,6 +48,34 @@ def open_store(
     return LocalStore(Path(path).resolve(), read_only=read_only)
 
 
+def open_object_store(
+    path: str,
+    credentials: dict | None = None,
+    endpoint_url: str | None = None,
+    **kwargs,
+):
+    """Open a raw obstore store for small side-channel objects (issue #151).
+
+    Unlike :func:`open_store` (which wraps the backend in a Zarr ``Store``),
+    this returns the bare obstore store for plain byte get/put of non-Zarr
+    objects -- e.g. the per-shard async result JSON a Lambda worker writes next
+    to the output store for the orchestrator to poll. Path forms and credential
+    handling match ``open_store``; a local directory is created if absent.
+    """
+    if path.startswith("s3://"):
+        return _s3_object_store(
+            path,
+            credentials=credentials,
+            endpoint_url=endpoint_url,
+            **kwargs,
+        )
+    from obstore.store import LocalStore as ObstoreLocalStore
+
+    local = Path(path).resolve()
+    local.mkdir(parents=True, exist_ok=True)
+    return ObstoreLocalStore(local)
+
+
 def _open_s3_store(
     path: str,
     read_only: bool = False,
@@ -64,8 +92,20 @@ def _open_s3_store(
     path-style addressing is enabled (so dotted bucket names and
     S3-compatible endpoints work over TLS).
     """
-    from obstore.store import S3Store
     from zarr.storage import ObjectStore
+
+    s3 = _s3_object_store(path, credentials=credentials, endpoint_url=endpoint_url, **kwargs)
+    return ObjectStore(store=s3, read_only=read_only)
+
+
+def _s3_object_store(
+    path: str,
+    credentials: dict | None = None,
+    endpoint_url: str | None = None,
+    **kwargs,
+):
+    """Build the raw obstore ``S3Store`` for ``path`` (credential rules above)."""
+    from obstore.store import S3Store
 
     bucket, prefix = parse_s3_path(path)
     region = kwargs.pop("region", "us-west-2")
@@ -97,7 +137,7 @@ def _open_s3_store(
             credential_provider=Boto3CredentialProvider(),
             **kwargs,
         )
-    return ObjectStore(store=s3, read_only=read_only)
+    return s3
 
 
 def parse_s3_path(path: str) -> tuple[str, str]:
@@ -125,4 +165,4 @@ def parse_s3_path(path: str) -> tuple[str, str]:
     return bucket, prefix
 
 
-__all__ = ["open_store", "parse_s3_path"]
+__all__ = ["open_object_store", "open_store", "parse_s3_path"]

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -71,10 +71,11 @@ def test_deploy_sequence(tmp_path):
     assert "lambda wait function-updated" in log[2]  # settle before code update
     assert "lambda update-function-code" in log[3]
     assert f"fileb://{fn_zip}" in log[3]
-    # Async-invoke hygiene (issue #151): retries pinned to 0, bounded event age.
+    # Async-invoke hygiene (issue #151): retries pinned to 0, event age under
+    # the runner's poll margin (see ProcessFnAsyncConfig in template.yaml).
     assert "lambda put-function-event-invoke-config" in log[4]
     assert "--maximum-retry-attempts 0" in log[4]
-    assert "--maximum-event-age-in-seconds 900" in log[4]
+    assert "--maximum-event-age-in-seconds 60" in log[4]
 
 
 def test_event_invoke_config_failure_is_nonfatal(tmp_path):

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -62,7 +62,7 @@ def test_deploy_sequence(tmp_path):
         env=env,
     )
     log = (tmp_path / "aws.log").read_text().splitlines()
-    # Four calls, in order.
+    # Five calls, in order.
     assert "lambda publish-layer-version" in log[0]
     assert "process-shard-test-deps" in log[0]  # layer named after the function
     assert "S3Key=lambda-test/abc/lambda_layer_arm64.zip" in log[0]
@@ -71,6 +71,45 @@ def test_deploy_sequence(tmp_path):
     assert "lambda wait function-updated" in log[2]  # settle before code update
     assert "lambda update-function-code" in log[3]
     assert f"fileb://{fn_zip}" in log[3]
+    # Async-invoke hygiene (issue #151): retries pinned to 0, bounded event age.
+    assert "lambda put-function-event-invoke-config" in log[4]
+    assert "--maximum-retry-attempts 0" in log[4]
+    assert "--maximum-event-age-in-seconds 900" in log[4]
+
+
+def test_event_invoke_config_failure_is_nonfatal(tmp_path):
+    # issue #151: the deploy role may not yet carry
+    # lambda:PutFunctionEventInvokeConfig; a denied config call must warn, not
+    # fail the deploy (the pipeline works without it, just with default async
+    # service retries).
+    if shutil.which("bash") is None:
+        pytest.skip("bash unavailable")
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "aws").write_text(
+        STUB_AWS.replace(
+            "exit 0",
+            'if [ "$2" = "put-function-event-invoke-config" ]; then exit 1; fi\nexit 0',
+        )
+    )
+    (bindir / "aws").chmod(0o755)
+    fn_zip = tmp_path / "fn.zip"
+    fn_zip.write_bytes(b"zip")
+
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "AWS_LOG": str(tmp_path / "aws.log"),
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--function", "f", "--layer-bucket", "b", "--layer-key", "k"]
+        + ["--function-zip", str(fn_zip), "--region", "us-west-2"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "WARN: could not set event-invoke config" in result.stderr
 
 
 def test_missing_required_arg_errors(tmp_path):

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -195,12 +195,17 @@ class TestTemplateEnvironment:
     def test_async_event_invoke_config_pins_retries(self):
         # issue #151: the runner's async dispatch relies on service retries
         # being 0 (a re-run of a deterministic failure re-fails at extra cost
-        # and can write into a store the caller has moved on from) and on
-        # queued events not outliving the runner's poll window.
+        # and can write into a store the caller has moved on from) and on the
+        # event age staying UNDER the runner's poll margin, so no first
+        # delivery can start after the runner stops listening (a late run
+        # would write into the store post-finalize).
+        from zagg.runner import _ASYNC_POLL_MARGIN_S
+
         props = self._load_template()["Resources"]["ProcessFnAsyncConfig"]["Properties"]
         assert props["FunctionName"] == {"Ref": "ProcessFn"}
         assert props["MaximumRetryAttempts"] == 0
-        assert props["MaximumEventAgeInSeconds"] == 900
+        assert props["MaximumEventAgeInSeconds"] == 60  # API minimum
+        assert props["MaximumEventAgeInSeconds"] < _ASYNC_POLL_MARGIN_S
 
 
 class TestPackageConsistency:

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -192,6 +192,16 @@ class TestTemplateEnvironment:
         assert params["MallocArenaMax"]["Default"] == "2"
         assert params["MallocTrimThreshold"]["Default"] == "0"
 
+    def test_async_event_invoke_config_pins_retries(self):
+        # issue #151: the runner's async dispatch relies on service retries
+        # being 0 (a re-run of a deterministic failure re-fails at extra cost
+        # and can write into a store the caller has moved on from) and on
+        # queued events not outliving the runner's poll window.
+        props = self._load_template()["Resources"]["ProcessFnAsyncConfig"]["Properties"]
+        assert props["FunctionName"] == {"Ref": "ProcessFn"}
+        assert props["MaximumRetryAttempts"] == 0
+        assert props["MaximumEventAgeInSeconds"] == 900
+
 
 class TestPackageConsistency:
     """Verify dependency specifications are consistent across build scripts."""

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -912,3 +912,83 @@ class TestPeakRSSSampler:
         s.stop()
         assert s.peak_mb is None
         assert s._thread is None  # never spawned
+
+
+class TestAsyncResultWrite:
+    """``result_url`` (issue #151): ``lambda_handler`` mirrors the process
+    response envelope to the orchestrator-supplied object so an async (Event)
+    invoke -- whose return value Lambda discards -- has a pollable result.
+    Absent key -> no write, byte-identical to the synchronous path."""
+
+    def _ok_event(self, monkeypatch, result_url=None):
+        import zagg.grids as grids
+        import zagg.processing as processing
+
+        def fake_process_shard(grid, shard_key, granule_urls, **kwargs):
+            meta = {
+                "shard_key": shard_key,
+                "cells_with_data": 0,
+                "total_obs": 7,
+                "granule_count": len(granule_urls),
+                "files_processed": 0,
+                "duration_s": 0.5,
+                "error": None,
+            }
+            return pd.DataFrame(), meta
+
+        monkeypatch.setattr(processing, "process_shard", fake_process_shard)
+        monkeypatch.setattr(grids, "from_config", lambda *a, **k: MagicMock())
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        if result_url is not None:
+            event["result_url"] = result_url
+        return event
+
+    def test_result_url_writes_response_envelope(self, handler_mod, monkeypatch, tmp_path):
+        url = str(tmp_path / "status" / "12345.json")
+        event = self._ok_event(monkeypatch, result_url=url)
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200
+        written = json.loads(Path(url).read_text())
+        assert written == resp
+        assert json.loads(written["body"])["total_obs"] == 7
+
+    def test_gate_failure_envelope_also_written(self, handler_mod, monkeypatch, tmp_path):
+        # A 400 (bad event) is mirrored too, so the poller learns fast instead
+        # of waiting out the whole deadline.
+        url = str(tmp_path / "status" / "bad.json")
+        event = self._ok_event(monkeypatch, result_url=url)
+        del event["shard_key"]
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 400
+        assert json.loads(Path(url).read_text()) == resp
+
+    def test_no_result_url_no_write(self, handler_mod, monkeypatch, tmp_path):
+        event = self._ok_event(monkeypatch)
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200
+        assert list(tmp_path.iterdir()) == []  # nothing written anywhere
+
+    def test_write_failure_never_raises(self, handler_mod, monkeypatch, tmp_path):
+        import obstore
+
+        def boom(*a, **k):
+            raise RuntimeError("s3 down")
+
+        monkeypatch.setattr(obstore, "put", boom)
+        url = str(tmp_path / "status" / "12345.json")
+        event = self._ok_event(monkeypatch, result_url=url)
+        resp = handler_mod.lambda_handler(event, _context())
+        # The invocation result is unaffected; the failure is CloudWatch-only.
+        assert resp["statusCode"] == 200
+        assert not Path(url).exists()
+
+    def test_setup_mode_ignores_result_url(self, handler_mod, monkeypatch, tmp_path):
+        # The result channel is per-cell (process mode) only.
+        monkeypatch.setattr(
+            handler_mod, "_handle_setup", lambda event: {"statusCode": 200, "body": "{}"}
+        )
+        url = str(tmp_path / "status" / "setup.json")
+        resp = handler_mod.lambda_handler({"mode": "setup", "result_url": url}, _context())
+        assert resp["statusCode"] == 200
+        assert not Path(url).exists()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -673,6 +673,24 @@ class TestInvokeLambdaCellAsync:
         assert result["status_code"] == 500
         assert result["error"] == "Failed to write zarr"
 
+    def test_fetch_fault_is_contained_not_reinvoked(self):
+        # A poll-side fault (S3 blip / missing s3:GetObject) must never escape
+        # into the invoke retry classifier -- that would re-dispatch a shard
+        # that is still running. It's treated as a miss; at the deadline the
+        # persistent cause is surfaced instead of a phantom "worker crash".
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        client.invoke.return_value = {"StatusCode": 202}
+
+        def denied():
+            raise Exception("PermissionDenied: s3:GetObject")
+
+        result = self._invoke(client, denied, max_retries=5, poll_timeout_s=0.0)
+        assert client.invoke.call_count == 1  # never re-dispatched
+        assert "no worker result within" in result["error"]
+        assert "PermissionDenied" in result["error"]
+
     def test_transient_dispatch_error_still_retried(self, monkeypatch):
         from unittest.mock import MagicMock
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -571,6 +571,146 @@ class TestInvokeLambdaCellRetry:
         assert result["error"] == "AccessDeniedException"
 
 
+class TestInvokeLambdaCellAsync:
+    """Async dispatch (issue #151): ``result_url`` switches the invoke to
+    ``InvocationType="Event"`` and the result comes from polling the
+    worker-written envelope instead of the (discarded) response payload."""
+
+    _CREDS = {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"}
+
+    def _invoke(self, client, result_fetch, *, max_retries=3, poll_timeout_s=10.0):
+        from zagg.runner import _invoke_lambda_cell
+
+        return _invoke_lambda_cell(
+            client,
+            (0,),
+            12345,
+            6,
+            12,
+            ["s3://b/g.h5"],
+            "s3://out/x.zarr",
+            self._CREDS,
+            function_name="process-shard",
+            config_dict=None,
+            max_workers=4,
+            max_retries=max_retries,
+            result_url="s3://out/x.zarr.status/run1/12345.json",
+            result_fetch=result_fetch,
+            poll_timeout_s=poll_timeout_s,
+        )
+
+    @staticmethod
+    def _envelope(body):
+        return {"statusCode": 200, "body": json.dumps(body)}
+
+    def test_event_invoke_carries_result_url(self):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        client.invoke.return_value = {"StatusCode": 202}
+        self._invoke(client, lambda: self._envelope({"total_obs": 1, "duration_s": 1.0}))
+        kwargs = client.invoke.call_args.kwargs
+        assert kwargs["InvocationType"] == "Event"
+        event = json.loads(kwargs["Payload"])
+        assert event["result_url"] == "s3://out/x.zarr.status/run1/12345.json"
+
+    def test_result_envelope_maps_to_sync_result_shape(self):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        client.invoke.return_value = {"StatusCode": 202}
+        result = self._invoke(
+            client,
+            lambda: self._envelope({"total_obs": 7, "duration_s": 3.5, "max_memory_mb": 800.0}),
+        )
+        assert result["status_code"] == 200
+        assert result["body"]["total_obs"] == 7
+        assert result["lambda_duration"] == 3.5
+        assert result["error"] is None
+        assert result["timeout"] is False
+        assert result["retries"] == 0
+        assert result["granule_count"] == 1
+
+    def test_polls_until_result_lands(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        import zagg.runner as runner
+
+        sleeps = []
+        monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
+        client = MagicMock()
+        client.invoke.return_value = {"StatusCode": 202}
+        fetch = MagicMock(
+            side_effect=[None, None, self._envelope({"total_obs": 1, "duration_s": 1.0})]
+        )
+        result = self._invoke(client, fetch)
+        assert fetch.call_count == 3
+        assert len(sleeps) == 2  # slept between the misses
+        assert result["status_code"] == 200
+
+    def test_missing_result_at_deadline_records_error_without_retry(self):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        client.invoke.return_value = {"StatusCode": 202}
+        # poll_timeout_s=0 -> the first miss is already past the deadline.
+        result = self._invoke(client, lambda: None, max_retries=5, poll_timeout_s=0.0)
+        # One Event invoke, no re-invoke: a missing result is deterministic
+        # (worker timeout / OOM / crash), mirroring the sync FunctionError rule.
+        assert client.invoke.call_count == 1
+        assert result["status_code"] is None
+        assert "no worker result within" in result["error"]
+
+    def test_worker_error_envelope_surfaces_body_error(self):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        client.invoke.return_value = {"StatusCode": 202}
+        result = self._invoke(
+            client,
+            lambda: {"statusCode": 500, "body": json.dumps({"error": "Failed to write zarr"})},
+        )
+        assert result["status_code"] == 500
+        assert result["error"] == "Failed to write zarr"
+
+    def test_transient_dispatch_error_still_retried(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        import zagg.runner as runner
+
+        sleeps = []
+        monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
+        client = MagicMock()
+        client.invoke.side_effect = [
+            Exception("TooManyRequestsException: Rate exceeded"),
+            {"StatusCode": 202},
+        ]
+        result = self._invoke(client, lambda: self._envelope({"total_obs": 1, "duration_s": 1.0}))
+        # The throttled *dispatch* is transient and retried; the poll then runs.
+        assert client.invoke.call_count == 2
+        assert result["status_code"] == 200
+        assert result["retries"] == 1
+
+
+class TestResultFetcher:
+    """The lazy per-run result store + fetch closure (issue #151)."""
+
+    def test_fetch_reads_written_envelope_and_none_when_absent(self, tmp_path):
+        import obstore
+
+        from zagg.runner import _result_fetcher
+        from zagg.store import open_object_store
+
+        prefix = str(tmp_path / "x.zarr.status" / "run1")
+        box: dict = {}
+        fetch = _result_fetcher(box, prefix, None, "us-west-2", "12345.json")
+        assert fetch() is None  # nothing written yet
+        writer = open_object_store(prefix)
+        obstore.put(writer, "12345.json", json.dumps({"statusCode": 200, "body": "{}"}).encode())
+        assert fetch() == {"statusCode": 200, "body": "{}"}
+        assert "store" in box  # built lazily, cached for subsequent cells
+
+
 class TestMaxRetriesPassthrough:
     """`agg(max_retries=...)` threads the per-cell retry budget down to
     ``_invoke_lambda_cell`` on the lambda backend (#119), default 3."""
@@ -638,6 +778,99 @@ class TestMaxRetriesPassthrough:
     def test_default_max_retries_is_three(self, monkeypatch, atl06_config, catalog_file):
         captured = self._drive(monkeypatch, atl06_config, catalog_file)
         assert captured["max_retries"] == 3
+
+
+class TestInvocationPassthrough:
+    """`agg(invocation=...)` selects async (default) vs legacy sync dispatch
+    (issue #151); async threads the per-shard result channel into the cell
+    invoke. Same mocked drive as ``TestMaxRetriesPassthrough``."""
+
+    def _drive(self, monkeypatch, atl06_config, catalog_file, **agg_kwargs):
+        from unittest.mock import MagicMock
+
+        import boto3
+
+        import zagg.grids as grids_mod
+        from zagg import runner
+        from zagg.concurrency import ConcurrencyReport
+
+        captured = {}
+
+        monkeypatch.setattr(
+            runner,
+            "get_nsidc_s3_credentials",
+            lambda: {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
+        )
+        monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
+        monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(
+            runner,
+            "compute_available_workers",
+            lambda requested, *a, **k: (
+                1,
+                ConcurrencyReport(
+                    account_limit=1000,
+                    current_concurrent=0,
+                    padding=100,
+                    available=900,
+                    function_reserved=None,
+                ),
+            ),
+        )
+
+        def _fake_cell(*a, **k):
+            captured.update(
+                result_url=k.get("result_url"),
+                result_fetch=k.get("result_fetch"),
+                poll_timeout_s=k.get("poll_timeout_s"),
+            )
+            return {
+                "status_code": 200,
+                "body": {"total_obs": 1},
+                "error": None,
+                "lambda_duration": 1.0,
+                "shard_key": 0,
+            }
+
+        monkeypatch.setattr(runner, "_invoke_lambda_cell", _fake_cell)
+        agg(
+            atl06_config,
+            catalog=catalog_file,
+            store="s3://out/x.zarr",
+            backend="lambda",
+            **agg_kwargs,
+        )
+        return captured
+
+    def test_default_async_threads_result_channel(self, monkeypatch, atl06_config, catalog_file):
+        captured = self._drive(monkeypatch, atl06_config, catalog_file)
+        # <store>.status/<run_id>/<shard_key>.json, run_id unique per run.
+        assert captured["result_url"].startswith("s3://out/x.zarr.status/")
+        assert captured["result_url"].endswith(".json")
+        assert callable(captured["result_fetch"])
+        # _drive pins the function timeout at 720 -> deadline 720 + margin.
+        from zagg.runner import _ASYNC_POLL_MARGIN_S
+
+        assert captured["poll_timeout_s"] == 720 + _ASYNC_POLL_MARGIN_S
+
+    def test_sync_invocation_omits_result_channel(self, monkeypatch, atl06_config, catalog_file):
+        captured = self._drive(monkeypatch, atl06_config, catalog_file, invocation="sync")
+        assert captured["result_url"] is None
+        assert captured["result_fetch"] is None
+        assert captured["poll_timeout_s"] is None
+
+    def test_unknown_invocation_raises(self, atl06_config, catalog_file):
+        with pytest.raises(ValueError, match="Unknown invocation"):
+            agg(
+                atl06_config,
+                catalog=catalog_file,
+                store="s3://out/x.zarr",
+                backend="lambda",
+                invocation="poll",
+            )
 
 
 class TestHandoffPassthrough:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -660,6 +660,10 @@ class TestInvokeLambdaCellAsync:
         assert client.invoke.call_count == 1
         assert result["status_code"] is None
         assert "no worker result within" in result["error"]
+        # Self-diagnosing against a deployed worker that predates result_url
+        # support: the error names the remedies (redeploy / invocation="sync").
+        assert "predates result_url support" in result["error"]
+        assert 'invocation="sync"' in result["error"]
 
     def test_worker_error_envelope_surfaces_body_error(self):
         from unittest.mock import MagicMock
@@ -708,6 +712,68 @@ class TestInvokeLambdaCellAsync:
         assert client.invoke.call_count == 2
         assert result["status_code"] == 200
         assert result["retries"] == 1
+
+    def test_oversized_async_payload_raises_before_dispatch(self):
+        # Event invokes cap at 256 KB (vs 6 MB sync); the pre-flight fails with
+        # a remedy instead of surfacing Lambda's raw
+        # RequestEntityTooLargeException. Realistic trigger: a large strict-AOI
+        # aoi_payload (issue #101).
+        from unittest.mock import MagicMock
+
+        from zagg.runner import _ASYNC_PAYLOAD_CAP_BYTES, _invoke_lambda_cell
+
+        client = MagicMock()
+        big_aoi = list(range(_ASYNC_PAYLOAD_CAP_BYTES // 4))  # >250 KB serialized
+        with pytest.raises(ValueError, match='pass invocation="sync"'):
+            _invoke_lambda_cell(
+                client,
+                (0,),
+                12345,
+                6,
+                12,
+                ["s3://b/g.h5"],
+                "s3://out/x.zarr",
+                self._CREDS,
+                function_name="process-shard",
+                config_dict=None,
+                max_workers=4,
+                aoi_payload=big_aoi,
+                result_url="s3://out/x.zarr.status/run1/12345.json",
+                result_fetch=lambda: None,
+                poll_timeout_s=10.0,
+            )
+        client.invoke.assert_not_called()
+
+    def test_oversized_payload_allowed_on_sync_path(self):
+        # The same event is fine synchronously (6 MB request cap) -- the gate
+        # applies only to Event dispatch, so invocation="sync" is a real remedy.
+        from unittest.mock import MagicMock
+
+        from zagg.runner import _ASYNC_PAYLOAD_CAP_BYTES, _invoke_lambda_cell
+
+        payload = MagicMock()
+        payload.read.return_value = json.dumps(
+            {"statusCode": 200, "body": json.dumps({"total_obs": 0, "duration_s": 0.0})}
+        ).encode()
+        client = MagicMock()
+        client.invoke.return_value = {"Payload": payload, "FunctionError": None}
+        big_aoi = list(range(_ASYNC_PAYLOAD_CAP_BYTES // 4))
+        result = _invoke_lambda_cell(
+            client,
+            (0,),
+            12345,
+            6,
+            12,
+            ["s3://b/g.h5"],
+            "s3://out/x.zarr",
+            self._CREDS,
+            function_name="process-shard",
+            config_dict=None,
+            max_workers=4,
+            aoi_payload=big_aoi,
+        )
+        assert client.invoke.call_count == 1
+        assert result["status_code"] == 200
 
 
 class TestResultFetcher:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 from zarr.storage import LocalStore
 
-from zagg.store import open_store, parse_s3_path
+from zagg.store import open_object_store, open_store, parse_s3_path
 
 
 @pytest.fixture
@@ -103,6 +103,49 @@ class TestOpenS3Store:
         assert kwargs["endpoint"] == "https://minio.local"
         assert kwargs["virtual_hosted_style_request"] is False
         assert "credential_provider" not in kwargs
+
+
+class TestOpenObjectStore:
+    """Raw obstore store for side-channel objects (issue #151): same path and
+    credential handling as ``open_store``, but no Zarr wrapper."""
+
+    def test_local_roundtrip_creates_dir(self, tmp_path):
+        import obstore
+
+        store = open_object_store(str(tmp_path / "x.zarr.status" / "run1"))
+        obstore.put(store, "12345.json", b'{"statusCode": 200}')
+        got = bytes(obstore.get(store, "12345.json").bytes())
+        assert got == b'{"statusCode": 200}'
+
+    def test_local_missing_object_raises_not_found(self, tmp_path):
+        import obstore
+        from obstore.exceptions import NotFoundError
+
+        store = open_object_store(str(tmp_path / "status"))
+        with pytest.raises((FileNotFoundError, NotFoundError)):
+            obstore.get(store, "nope.json")
+
+    def test_s3_returns_bare_store_with_ambient_creds(self, mock_s3):
+        s3_cls, prov_cls = mock_s3
+        store = open_object_store("s3://bucket/prefix.zarr.status/run1")
+        # The raw S3Store, not wrapped in zarr's ObjectStore.
+        assert store is s3_cls.return_value
+        _, kwargs = s3_cls.call_args
+        assert kwargs["credential_provider"] is prov_cls.return_value
+
+    def test_s3_explicit_creds_and_endpoint(self, mock_s3):
+        s3_cls, prov_cls = mock_s3
+        creds = {"accessKeyId": "AKIA", "secretAccessKey": "secret", "sessionToken": "tok"}
+        open_object_store(
+            "s3://bucket/foo.zarr.status/run1",
+            credentials=creds,
+            endpoint_url="https://minio.local",
+        )
+        _, kwargs = s3_cls.call_args
+        assert kwargs["access_key_id"] == "AKIA"
+        assert kwargs["endpoint"] == "https://minio.local"
+        assert kwargs["virtual_hosted_style_request"] is False
+        prov_cls.assert_not_called()
 
 
 class TestParseS3Path:


### PR DESCRIPTION
Closes #151.

Implements the durable fix directed on the issue ([espg's comment](https://github.com/englacial/zagg/issues/151#issuecomment-4860468469), item (3) of [the analysis](https://github.com/englacial/zagg/issues/151#issuecomment-4860426861)): stop holding a synchronous Lambda connection open for minutes. The lambda backend now dispatches each cell with `InvocationType="Event"` and polls for a per-shard result object the worker writes next to the output store, so no connection sits idle while a shard runs — the ~4-minute NAT/SNAT idle kill on GitHub-hosted runners (the cause of every o10_inner/o9 benchmark failure) can no longer sever a result, and the 6 MB synchronous response cap no longer applies.

## Mechanism confirmed in CloudWatch before implementing

`/aws/lambda/process-shard-test`, failing window of run [28549136504](https://github.com/englacial/zagg/actions/runs/28549136504) (Jul 1 ~21:36–21:50 UTC): every "failed" target **completed cleanly server-side, with data, far under both caps**:

| REPORT | duration | max memory | worker `processing_complete` |
|---|---|---|---|
| `a0863fb3` (o10_inner) | 258.0 s | 985 MB | shard 5347405532456026122, **obs=939,217** |
| `f4e9c58f` (o9_sharded) | 330.8 s | 1290 MB | shard 5347395636851376137, **obs=3,112,138** |
| `2125ddc9` (o9_inner) | 475.5 s | 1250 MB | shard 5347395636851376137, **obs=3,112,138** |

No `Task timed out`, no `Runtime.OutOfMemory`. The client recorded `obs=0` for shards whose data was on S3 — transport, not memory. (Bonus: o9's true worst-case duration is ~476 s, comfortably inside the 720 s function timeout.)

## What the change does

**Worker** (`deployment/aws/lambda_handler.py`): new optional `result_url` event key. When present, `lambda_handler` mirrors the process-mode response envelope (`{statusCode, body}`) as JSON to that object — `s3://…/out.zarr.status/<run_id>/<shard_key>.json` — using the same credential/endpoint resolution as the output store (`_output_store_kwargs`). Covers the 200/400/500 branches (it wraps `_handle_process`); never raises. Absent key → byte-identical behavior.

**Runner** (`src/zagg/runner.py`): new `agg(..., invocation="async")` kwarg (default `"async"`):
- `_run_lambda` mints a per-run status prefix `<store>.status/<uuid>` (the run id keeps reruns into the same store from reading stale results) and threads `result_url` / a lazily-built `result_fetch` closure / `poll_timeout_s` into each cell invoke.
- `_invoke_lambda_cell` invokes with `InvocationType="Event"`; `_poll_lambda_result` polls the result object (5 s + sub-second jitter) and maps the envelope into the **same result-dict shape** as the sync path, so the accumulator, cost math, and summary are unchanged. Transient dispatch faults (throttle) keep the existing retry/backoff; a result missing at the deadline (function `Timeout` + 90 s margin) is recorded as the shard's failure and **not retried** (deterministic, mirroring the #119 FunctionError rule).
- The function `Timeout` read moves into `preflight` (it now feeds the poll deadline as well as the existing `worker_pct_timeout` summary field) — still exactly one `GetFunctionConfiguration` call.
- `invocation="sync"` keeps the legacy `RequestResponse` path byte-identical — the escape hatch for older deployed workers or per-cell events above the 256 KB async payload cap.

**Store** (`src/zagg/store.py`): `open_object_store()` — the raw obstore store (same path/credential handling as `open_store`, no Zarr wrapper) used by both sides of the channel.

**Infra riding in this PR for you to deploy (nothing was deployed from this session):**
- `deployment/aws/template.yaml`: `AWS::Lambda::EventInvokeConfig` with `MaximumRetryAttempts: 0` / `MaximumEventAgeInSeconds: 900`. Without it, Lambda's async defaults re-run a timed-out/OOM'd shard twice with delays — violating the benchmark's "measure one clean invocation" contract (#119) and risking late zombie writes into a store the caller has moved on from.
- `.github/scripts/deploy_lambda.sh`: applies the same event-invoke config on the in-place deploy path (which is how `process-shard-test` actually gets updated — the tier-2 deploy never re-runs the CFN stack). Warn-don't-fail until the deploy roles gain the new IAM action.
- `deployment/aws/benchmark_cicd.yaml`: `BenchmarkInvokeRole` gains `s3:GetObject` on the benchmark store bucket (the orchestrator must now *read* the result objects; previously it needed only `lambda:InvokeFunction`); Deploy/Release roles gain `lambda:PutFunctionEventInvokeConfig`.

## Phases

- [x] Phase 1 — worker-side result channel: `open_object_store` + handler `result_url` write, tests
- [x] Phase 2 — runner async dispatch (default) + poll + `invocation="sync"` fallback, tests
- [x] Phase 3 — infra: EventInvokeConfig (template + deploy script), benchmark-role IAM, template/deploy tests

## How it was tested

- `pytest` green locally: 1089 passed. One pre-existing environment failure (`test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`: the local `pip` resolves py3.10 wheels; fails identically on a clean `origin/main` checkout — unrelated).
- `pre-commit run` (pinned ruff check/format, codespell, mypy) clean on all touched files; the mypy failures it reports are pre-existing in untouched modules under local tool versions.
- New tests: handler mirrors the envelope on 200/400 paths, skips absent-key/setup-mode, never raises on write failure; runner async event carries `result_url`, envelope→result-dict mapping, poll-until-lands, deadline-expiry-not-retried, throttle-retry-then-accept; `agg` threads the channel by default, omits it for `invocation="sync"`, rejects unknown values; `open_object_store` local roundtrip + S3 credential branches.

## Questions for review

1. **Deployment ordering / default choice.** The default flipped to async, so a new runner against a not-yet-redeployed worker records every shard as `no worker result within …s`. The benchmark is safe (tier-2 redeploys `process-shard-test` from the PR tree before invoking), but production `process-shard` needs a redeploy before anyone upgrades the client — or callers pass `invocation="sync"` in the interim. Option: flip the default to `"sync"` and let the benchmark opt in, if you'd rather stage it.
2. **IAM/stack updates needed before this PR's benchmark can pass**: apply the `benchmark_cicd.yaml` changes. The poll hard-requires the benchmark role's `s3:GetObject` grant (unless `sliderule-public` is anonymously readable — the explicit grant is correct either way); the event-invoke config is warn-only until the deploy roles gain `PutFunctionEventInvokeConfig`.
3. **Async payload cap**: `InvocationType="Event"` caps the request at 256 KB (vs 6 MB sync). Benchmark shard events are well under it; an extreme granule-dense shard with a large `aoi_payload` could exceed it and will surface as a per-cell dispatch error. Documented in the `agg` docstring with `invocation="sync"` as the workaround; a pointer-to-S3 event scheme is a possible follow-up if it ever bites.
4. `runner.py` was already past the ~1000-line note in CLAUDE.md §4 (1222 lines before this PR, ~1360 after). Happy to split the Lambda invoke/poll helpers into their own module as a follow-up if you want.
5. Status objects are left in place after the run (`<store>.status/<run_id>/`) as a debugging artifact rather than deleted — cheap, and the run id prevents stale reads. Say the word if you'd rather the runner best-effort delete them.
