### PR TITLE
Fix coarse-level filter KeyError on missing hyperslice key (issue #157)

### DIFF
--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -646,9 +646,10 @@ def _read_group_full(
             level_key = f["level"]
             lvl = levels[level_key]
             flag_path = f["dataset"].format(group=group)
-            # Read the coarse flag array (full level, no hyperslice — we need all parents
-            # to align with link arrays which are also full-length).
-            coarse_data = h5obj.readDatasets([{"dataset": flag_path}])
+            # Read the coarse flag array in full ("hyperslice": [] is h5coro's
+            # full-read form; the key is required on dict entries — issue #157).
+            # We need all parents to align with the full-length link arrays.
+            coarse_data = h5obj.readDatasets([{"dataset": flag_path, "hyperslice": []}])
             coarse_arr = coarse_data[flag_path]
             coarse_fmask = _predicate_mask(coarse_arr, f)
             # Read the link arrays from this level.
@@ -658,8 +659,8 @@ def _read_group_full(
             cnt_path = link["count"].format(group=group)
             link_data = h5obj.readDatasets(
                 [
-                    {"dataset": ibeg_path},
-                    {"dataset": cnt_path},
+                    {"dataset": ibeg_path, "hyperslice": []},
+                    {"dataset": cnt_path, "hyperslice": []},
                 ]
             )
             ibeg_arr = link_data[ibeg_path]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2989,7 +2989,11 @@ class TestVectorChunkResolutionCompanion:
 class _FakeH5:
     """Stub h5coro object: ``readDatasets`` returns canned arrays by path.
 
-    Honors the ``hyperslice`` bound so sliced reads mirror the real driver.
+    Honors the ``hyperslice`` bound so sliced reads mirror the real driver,
+    including h5coro's strict dict contract: only *string* entries are
+    normalized to ``{"dataset": ..., "hyperslice": []}``; dict entries must
+    carry ``"hyperslice"`` themselves (``H5Promise`` indexes it
+    unconditionally — issue #157), and ``[]`` means a full read.
     """
 
     def __init__(self, arrays):
@@ -3003,8 +3007,8 @@ class _FakeH5:
                 continue
             path = d["dataset"]
             arr = self._arrays[path]
-            hs = d.get("hyperslice")
-            if hs is not None:
+            hs = d["hyperslice"]  # KeyError on missing key, as in real h5coro
+            if hs:
                 lo, hi = hs[0]
                 arr = arr[lo:hi]
             out[path] = arr
@@ -3482,6 +3486,36 @@ class TestReadGroupCrossLevel:
         }
         df = _read_group(h5, "gt1l", ds, 0, _ShardGrid())
         assert df["h"].tolist() == [1.0, 3.0]
+
+
+class TestCoarseFilterHypersliceKey:
+    """Issue #157: coarse-filter reads must pass dict entries WITH ``"hyperslice"``.
+
+    h5coro 1.0.4 normalizes only *string* entries to ``{"dataset": ...,
+    "hyperslice": []}``; dict entries pass through unchanged and ``H5Promise``
+    indexes ``dataset["hyperslice"]`` unconditionally, so a dict without the
+    key raises ``KeyError`` (swallowed by the worker's per-group except into a
+    silent 0-obs shard). The stubs here replicate that strict contract, so the
+    :class:`TestReadGroupCrossLevel` cases above regression-guard the fix;
+    these tests pin the stubs' strictness so a tolerant ``.get`` can't creep
+    back in and re-hide the bug behind mocked reads.
+    """
+
+    def test_fake_h5_rejects_dict_without_hyperslice(self):
+        h5 = _FakeH5({"/x": np.arange(3.0)})
+        with pytest.raises(KeyError, match="hyperslice"):
+            h5.readDatasets([{"dataset": "/x"}])
+
+    def test_serve_datasets_rejects_dict_without_hyperslice(self):
+        with pytest.raises(KeyError, match="hyperslice"):
+            _serve_datasets({"/x": np.arange(3.0)}, [{"dataset": "/x"}])
+
+    def test_empty_hyperslice_is_full_read(self):
+        # "hyperslice": [] is h5coro's own normalization of a full read —
+        # exactly what the coarse flag + link-array reads now pass.
+        h5 = _FakeH5({"/x": np.arange(3.0)})
+        out = h5.readDatasets([{"dataset": "/x", "hyperslice": []}])
+        np.testing.assert_array_equal(out["/x"], np.arange(3.0))
 
 
 # ---------------------------------------------------------------------------
@@ -4688,7 +4722,8 @@ def _release_cfg():
 
 def _serve_datasets(arrays, datasets):
     """Shared ``readDatasets`` body: honor the same path/hyperslice contract as
-    :class:`_FakeH5` (mirrors the real h5coro driver)."""
+    :class:`_FakeH5` (mirrors the real h5coro driver, including the strict
+    dict-entry ``"hyperslice"`` requirement — issue #157)."""
     out = {}
     for d in datasets:
         if isinstance(d, str):
@@ -4696,8 +4731,8 @@ def _serve_datasets(arrays, datasets):
             continue
         path = d["dataset"]
         arr = arrays[path]
-        hs = d.get("hyperslice")
-        if hs is not None:
+        hs = d["hyperslice"]  # KeyError on missing key, as in real h5coro
+        if hs:
             lo, hi = hs[0]
             arr = arr[lo:hi]
         out[path] = arr
@@ -4830,7 +4865,7 @@ class TestProcessShardCacheRelease:
                     path = d if isinstance(d, str) else d["dataset"]
                     buf = self._buffers[path]
                     arr = np.frombuffer(buf, dtype=self._dtypes[path])  # view into buffer
-                    if not isinstance(d, str) and d.get("hyperslice") is not None:
+                    if not isinstance(d, str) and d["hyperslice"]:
                         lo, hi = d["hyperslice"][0]
                         arr = arr[lo:hi]
                     out[path] = arr

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,3 +1,5 @@
+import gc
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -3516,6 +3518,31 @@ class TestCoarseFilterHypersliceKey:
         h5 = _FakeH5({"/x": np.arange(3.0)})
         out = h5.readDatasets([{"dataset": "/x", "hyperslice": []}])
         np.testing.assert_array_equal(out["/x"], np.arange(3.0))
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+    def test_real_h5promise_requires_hyperslice_on_dict_entries(self):
+        # Monkeypatch-free check against the INSTALLED h5coro: ``H5Promise``
+        # indexes ``dataset["hyperslice"]`` unconditionally (1.0.4,
+        # h5promise.py:80) — synchronously, before any resource access, which
+        # is why a ``None`` resource suffices. Pins the stubs' contract on the
+        # real driver so an upstream normalization change surfaces here.
+        h5promise = pytest.importorskip("h5coro.h5promise")
+        kwargs = {"earlyExit": True, "metaOnly": False, "enableAttributes": False}
+        # Bare dict — the pre-fix zagg shape (issue #157): KeyError.
+        with pytest.raises(KeyError, match="hyperslice"):
+            h5promise.H5Promise(None, {"x": {"dataset": "x"}}, True, **kwargs)
+        # Fixed shape: entry handling passes. The None resource fails further
+        # down (there is no real file), but never with the missing-key KeyError.
+        try:
+            h5promise.H5Promise(None, {"x": {"dataset": "x", "hyperslice": []}}, True, **kwargs)
+        except KeyError:
+            pytest.fail('dict entry with "hyperslice": [] must pass H5Promise entry handling')
+        except Exception:
+            pass  # downstream of entry handling — expected with a None resource
+        # h5coro's half-constructed H5Dataset raises in ``__del__`` when the
+        # failed promise is collected; collect it here so the unraisable stays
+        # confined to this test (and is filtered by the mark above).
+        gc.collect()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #157.

## Small-fix checklist

- [x] #157 — coarse-level filter reads `KeyError` on missing `'hyperslice'` key, silently swallowed into a 0-obs shard.

## What / approach

h5coro 1.0.4's `readDatasets` normalizes only *string* entries to `{"dataset": ..., "hyperslice": []}`; dict entries pass through unchanged, and `H5Promise.__init__` indexes `dataset["hyperslice"]` unconditionally. The coarse-level structured-filter branch of `_read_group_full` passed three dicts without the key — the coarse flag read and the two link-array reads in `src/zagg/processing/read.py` — so any config filtering at a non-base level raised `KeyError: 'hyperslice'`, which the worker's per-group `except Exception` swallowed into a WARNING and a silent zero-observation shard (same failure signature class as #116).

Fix, per the issue's proposal (1): add `"hyperslice": []` to the three dict literals — `[]` is h5coro's own normalization of a full read:

```python
coarse_data = h5obj.readDatasets([{"dataset": flag_path, "hyperslice": []}])
...
link_data = h5obj.readDatasets(
    [
        {"dataset": ibeg_path, "hyperslice": []},
        {"dataset": cnt_path, "hyperslice": []},
    ]
)
```

These were the only bare-dict `readDatasets` call sites in `src/` (all other sites pass strings or dicts that already carry `hyperslice`).

## Closing the test gap

The bug survived because the test stubs used a tolerant `d.get("hyperslice")`, so mocked reads never exercised h5coro's real entry normalization. This PR makes the stubs replicate the strict contract (verified against installed h5coro 1.0.4 source):

- `_FakeH5.readDatasets`, `_serve_datasets`, and `_ViewBackedH5.readDatasets` in `tests/test_processing.py` now index `d["hyperslice"]` unconditionally on dict entries (`KeyError` on a missing key, `[]` = full read), mirroring `H5Promise`.
- With the strict stubs, the existing `TestReadGroupCrossLevel` cases become live regression guards for this fix — before the src change they fail with `KeyError: 'hyperslice'` on exactly the three reads the issue identified (reproduced locally).
- New `TestCoarseFilterHypersliceKey` pins the stubs' strictness (dict-without-key raises for both stub bodies; `"hyperslice": []` is a full read), so a tolerant `.get` can't creep back in and re-hide the bug.

The optional upstream hardening (`setdefault("hyperslice", [])` in h5coro's `readDatasets`) is out of scope here per the issue — it stays a candidate one-liner for a future SlideRuleEarth/h5coro PR.

## How tested

- Reproduced first: with the strict stubs and the src fix reverted, `TestReadGroupCrossLevel` fails with `KeyError: 'hyperslice'` (3 failures, matching the issue's read sites); green with the fix.
- Full suite: `uv run pytest -v` — **1100 passed, 24 skipped, 0 failed** (Python 3.12, h5coro 1.0.4).
- `uv run ruff check --select=E,F,W,I --ignore=E501 src tests` (the PR lint-bot gate) — clean.
- `uv run ruff format --check` — both touched files clean. Pre-existing on `main` and untouched here: one `N818` in `src/zagg/registry.py` under the full local select (already flagged in PR #152), and format drift in 6 unrelated files (identical result with this diff stashed).

## Questions for review

- None blocking. One judgment call: the stub strictness change also applies to `_ViewBackedH5` (the issue #66 cache-eviction test), not just the coarse-path stubs — done for a uniform stub contract so no `readDatasets` stub in the file tolerates a missing key.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pvu3umLej7woxRE8uKUu2a)_