### PR TITLE
Typed morton_index Arrow surface over the arro3 carrier

### DIFF
--- a/docs/morton_arrow.md
+++ b/docs/morton_arrow.md
@@ -54,6 +54,13 @@ output:
 
 The default (key absent or `nested`) is byte-identical to a pre-flag run.
 
+Note the grid's `spatial_signature()` (recorded in ShardMap manifests) stays
+`nested` regardless of the flag — deliberately, so shard maps remain reusable
+across encodings: the flag changes coordinate *values*, not the spatial layout.
+Only the store's `dggs.indexing_scheme` attribute tracks the active encoding.
+(The pre-existing `output.grid.indexing_scheme` config key is descriptive only
+and must stay `nested`; `cell_ids_encoding` is the knob.)
+
 ## Shardmap parquet manifests
 
 `ShardMap.to_parquet` / `ShardMap.from_parquet` are the Arrow-native siblings

--- a/docs/morton_arrow.md
+++ b/docs/morton_arrow.md
@@ -1,0 +1,63 @@
+# Typed morton boundary
+
+zagg's `morton` output coordinate is a real datatype, not an anonymous integer
+column. mortie defines the `morton_index` type once, and zagg carries it typed
+across every surface it crosses (issue
+[#135](https://github.com/englacial/zagg/issues/135)):
+
+| Surface | Carrier | Form |
+| --- | --- | --- |
+| pandas carrier (worker) | `pandas.DataFrame` | `mortie.MortonIndexArray` extension array (#71) |
+| arro3 carrier (worker) | `arro3.core.Table` | `morton_index` Arrow **extension type** over the PyCapsule C Data Interface (mortie ≥ 0.8.4) |
+| catalog / shardmap parquet | `pyarrow.Table` | `morton_index` pyarrow extension type (registered by mortie on import) |
+| Zarr store (on disk) | Zarr v3 array | plain `uint64` — the packed words, byte-for-byte |
+
+## Who owns what
+
+**mortie owns the interchange type; zagg stores `uint64`.** The extension
+metadata (`ARROW:extension:name == "mortie.morton_index"`) lives at the
+interchange layer only. The write boundary
+(`zagg.processing.write._iter_carrier_columns`) extracts the packed `uint64`
+words from a typed column — on either carrier — so the on-disk output is
+identical to a plain-`uint64` write. Reads reconstruct the typed array via
+`zagg.grids.morton.to_morton_array`.
+
+The adapter lives in `zagg.grids.morton`:
+
+- `morton_to_arrow(values)` — `MortonIndexArray` (or raw words) →
+  `arro3.core.Array` carrying the extension type, zero-copy via
+  `__arrow_c_array__`;
+- `morton_from_arrow(col)` — any Arrow C-Data source (array, chunked column, or
+  capsule pair) → `MortonIndexArray`;
+- `is_morton_arrow(col)` — detects the extension type from field metadata.
+
+No pyarrow is needed on any worker path: the arro3 carrier and mortie's
+PyCapsule surface speak the Arrow C Data Interface directly (pyarrow stays in
+the off-Lambda `catalog` extra). Arrow nulls map to mortie's all-zero empty
+sentinel word in both directions, so missing values round-trip.
+
+## `cell_ids` encoding
+
+`cell_ids` stays the standardized **NESTED HEALPix** id (`uint64`) by default.
+For test and prototyping flows, `output.grid.cell_ids_encoding: morton` emits
+the packed morton words as `cell_ids` instead (HEALPix grids only; the store's
+`dggs.indexing_scheme` attribute records the active encoding):
+
+```yaml
+output:
+  grid:
+    type: healpix
+    parent_order: 6
+    child_order: 12
+    cell_ids_encoding: morton   # default: nested
+```
+
+The default (key absent or `nested`) is byte-identical to a pre-flag run.
+
+## Shardmap parquet manifests
+
+`ShardMap.to_parquet` / `ShardMap.from_parquet` are the Arrow-native siblings
+of the JSON manifest: `shard_keys` is a typed `morton_index` column, granule
+and AOI payloads ride as per-shard JSON strings, and provenance lives in the
+schema metadata (mirroring the `Catalog` geoparquet convention). This path
+requires pyarrow (`pip install zagg[catalog]`) and runs off-worker.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - "Architecture": "design/architecture.md"
       - "Schema": "design/schema.md"
       - "Sharded output": "sharding.md"
+      - "Typed morton boundary": "morton_arrow.md"
   - "Deployment":
       - "Standing Up the Backend": "deployment/standup.md"
       - "AWS Lambda": "deployment/lambda.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy>=2.0",
     "pandas>=2.2",
     "h5coro>=1.0.3",
-    "mortie>=0.8.3",
+    "mortie>=0.8.4",
     "earthaccess",
     "boto3",
     "fastparquet",

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -584,5 +584,64 @@ class ShardMap:
             d.get("aoi_mask"),
         )
 
+    # Schema-metadata key for the manifest's non-columnar payload (parquet form).
+    _PARQUET_META_KEY = b"zagg:shardmap_meta"
+
+    def to_parquet(self, path: str) -> None:
+        """Write the manifest as parquet with a TYPED morton ``shard_keys`` column.
+
+        The Arrow-native sibling of :meth:`to_json` (issue #135): ``shard_keys``
+        carries mortie's ``morton_index`` pyarrow extension type (registered by
+        mortie on import), so any Arrow-aware consumer sees morton words, not
+        anonymous ints. ``granules`` (and ``aoi_mask`` when present) ride as
+        per-shard JSON strings — the same self-contained payloads the JSON form
+        stores — and ``metadata``/``grid_signature`` live in the schema metadata,
+        mirroring the ``Catalog`` geoparquet convention (``sources.py``).
+
+        Requires pyarrow (the off-Lambda ``catalog`` extra); the worker path
+        never calls this — the runner dispatches from the JSON manifest.
+        """
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+        from mortie.arrow import from_morton_index
+
+        words = np.asarray(self.shard_keys, dtype=np.uint64)
+        columns: dict = {
+            "shard_keys": from_morton_index(words),
+            "granules": pa.array([json.dumps(g) for g in self.granules]),
+        }
+        if self.aoi_mask is not None:
+            columns["aoi_mask"] = pa.array([json.dumps(m) for m in self.aoi_mask])
+        meta = json.dumps({"metadata": self.metadata, "grid_signature": self.grid_signature})
+        table = pa.table(columns).replace_schema_metadata({self._PARQUET_META_KEY: meta.encode()})
+        pq.write_table(table, path)
+
+    @classmethod
+    def from_parquet(cls, path: str) -> "ShardMap":
+        """Load a manifest from the parquet form written by :meth:`to_parquet`.
+
+        Importing :mod:`mortie.arrow` first registers the ``morton_index``
+        extension type, so the ``shard_keys`` column rehydrates typed; the words
+        are pulled over the C Data Interface (``import_c_array``) regardless.
+        """
+        import pyarrow.parquet as pq
+        from mortie.arrow import import_c_array
+
+        table = pq.read_table(path)
+        raw = (table.schema.metadata or {}).get(cls._PARQUET_META_KEY)
+        if raw is None or "granules" not in table.column_names:
+            raise ValueError(f"{path}: not a zagg ShardMap parquet manifest")
+        d = json.loads(raw)
+        if "grid_signature" not in d:
+            raise ValueError(f"{path}: missing required key 'grid_signature'")
+        shard_keys = [int(w) for w in import_c_array(table.column("shard_keys"))]
+        granules = [json.loads(g) for g in table.column("granules").to_pylist()]
+        aoi_mask = (
+            [json.loads(m) for m in table.column("aoi_mask").to_pylist()]
+            if "aoi_mask" in table.column_names
+            else None
+        )
+        return cls(d["grid_signature"], shard_keys, granules, d.get("metadata", {}), aoi_mask)
+
 
 __all__ = ["ShardMap"]

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -629,7 +629,7 @@ class ShardMap:
 
         table = pq.read_table(path)
         raw = (table.schema.metadata or {}).get(cls._PARQUET_META_KEY)
-        if raw is None or "granules" not in table.column_names:
+        if raw is None or not {"shard_keys", "granules"}.issubset(table.column_names):
             raise ValueError(f"{path}: not a zagg ShardMap parquet manifest")
         d = json.loads(raw)
         if "grid_signature" not in d:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -222,6 +222,17 @@ def validate_config(config: PipelineConfig) -> None:
                     "output.grid.cell_ids_encoding only applies to healpix grids "
                     f"(grid type is {grid['type']!r})"
                 )
+        # The legacy output.grid.indexing_scheme key is descriptive only (the
+        # shipped configs carry "nested"); it does NOT select the cell_ids
+        # encoding. Reject any other value so a user reaching for it lands on the
+        # real knob instead of a silently-NESTED store.
+        legacy_scheme = grid.get("indexing_scheme")
+        if legacy_scheme is not None and legacy_scheme != "nested":
+            raise ValueError(
+                f"output.grid.indexing_scheme is descriptive and must be 'nested' "
+                f"(got {legacy_scheme!r}); to emit morton words as cell_ids set "
+                f"output.grid.cell_ids_encoding: morton"
+            )
 
     # Validate the optional per-cell carrier (issue #132). Mirrors the worker's
     # ``{"pandas", "arrow"}`` guard (worker.py) so a typo in the aggregation YAML
@@ -1256,8 +1267,8 @@ def get_cell_ids_encoding(config: PipelineConfig) -> str:
     ``"nested"`` (default) stores the standardized NESTED HEALPix cell IDs.
     ``"morton"`` stores the packed morton words instead — the same ``uint64``
     words the ``morton`` coordinate carries — opening test/prototype flows that
-    index by morton directly. Default behavior (key absent or ``"nested"``) is
-    byte-identical to a pre-flag run.
+    index by morton directly. Default behavior (key absent, explicit ``null``,
+    or ``"nested"``) is byte-identical to a pre-flag run.
 
     Parameters
     ----------
@@ -1268,7 +1279,9 @@ def get_cell_ids_encoding(config: PipelineConfig) -> str:
     str
         ``"nested"`` (default) or ``"morton"``.
     """
-    return config.output.get("grid", {}).get("cell_ids_encoding", "nested")
+    # A present-but-null key (YAML ``cell_ids_encoding:``) must fall back to the
+    # default too — the same treatment ``from_config`` gives a null ``layout``.
+    return config.output.get("grid", {}).get("cell_ids_encoding") or "nested"
 
 
 def get_store_path(config: PipelineConfig) -> str | None:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -207,6 +207,21 @@ def validate_config(config: PipelineConfig) -> None:
         layout = grid.get("layout")
         if layout is not None and layout not in ("dense", "fullsphere"):
             raise ValueError(f"output.grid.layout must be 'dense' or 'fullsphere' (got {layout!r})")
+        # Optional cell_ids encoding (issue #135): "nested" (default, the DGGS
+        # standard) or "morton" (emit the packed morton words as cell_ids — a
+        # test/prototype capability). HEALPix-only: rectilinear grids have no
+        # cell_ids coordinate, so the knob would silently do nothing there.
+        encoding = grid.get("cell_ids_encoding")
+        if encoding is not None:
+            if encoding not in ("nested", "morton"):
+                raise ValueError(
+                    f"output.grid.cell_ids_encoding must be 'nested' or 'morton' (got {encoding!r})"
+                )
+            if grid["type"] != "healpix":
+                raise ValueError(
+                    "output.grid.cell_ids_encoding only applies to healpix grids "
+                    f"(grid type is {grid['type']!r})"
+                )
 
     # Validate the optional per-cell carrier (issue #132). Mirrors the worker's
     # ``{"pandas", "arrow"}`` guard (worker.py) so a typo in the aggregation YAML
@@ -1233,6 +1248,27 @@ def get_shard_order(config: PipelineConfig) -> int | None:
     """
     val = config.output.get("grid", {}).get("shard_order")
     return None if val is None else int(val)
+
+
+def get_cell_ids_encoding(config: PipelineConfig) -> str:
+    """Return the HEALPix ``cell_ids`` coordinate encoding (issue #135).
+
+    ``"nested"`` (default) stores the standardized NESTED HEALPix cell IDs.
+    ``"morton"`` stores the packed morton words instead — the same ``uint64``
+    words the ``morton`` coordinate carries — opening test/prototype flows that
+    index by morton directly. Default behavior (key absent or ``"nested"``) is
+    byte-identical to a pre-flag run.
+
+    Parameters
+    ----------
+    config : PipelineConfig
+
+    Returns
+    -------
+    str
+        ``"nested"`` (default) or ``"morton"``.
+    """
+    return config.output.get("grid", {}).get("cell_ids_encoding", "nested")
 
 
 def get_store_path(config: PipelineConfig) -> str | None:

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -172,7 +172,16 @@ class HealpixGrid:
         # cell_ids coordinate encoding (issue #135): "nested" (default, the DGGS
         # standard) or "morton" (emit the packed morton words as cell_ids — a
         # test/prototype capability). Default is byte-identical to a pre-flag run.
+        # Re-validated here (not only in validate_config) because both coords_of
+        # (the cell_ids values) and _dggs_attrs (the recorded indexing_scheme)
+        # interpret this string: an unvalidated third value would write NESTED
+        # values while recording a different scheme — a mis-decode for consumers.
         self.cell_ids_encoding = get_cell_ids_encoding(self.config)
+        if self.cell_ids_encoding not in ("nested", "morton"):
+            raise ValueError(
+                f"Unknown cell_ids_encoding: {self.cell_ids_encoding!r} "
+                "(expected 'nested' or 'morton')"
+            )
         self._position_map: dict[int, int] | None = None
         if populated_shards is not None:
             self.set_populated_shards(populated_shards)

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -524,12 +524,15 @@ class HealpixGrid:
         """Canonical fingerprint of the grid's defining parameters.
 
         The full fingerprint: the spatial layout (:meth:`spatial_signature`)
-        plus the Option-B output-field set. ``nests_with`` (#29) keys on the
-        latter; the shard-map reuse guard keys on the former (#89).
+        plus the Option-B output-field set and the ``cell_ids_encoding``
+        (issue #135 — mixed encodings must never co-aggregate; ``nests_with``
+        keys on both). The shard-map reuse guard keys on the spatial part
+        only (#89).
         """
         return {
             **self.spatial_signature(),
             "output_fields": output_field_signature(self.config),
+            "cell_ids_encoding": self.cell_ids_encoding,
         }
 
     def nests_with(self, other) -> bool:
@@ -538,9 +541,14 @@ class HealpixGrid:
         Any two HEALPix grids nest (the nested hierarchy subdivides 4-for-1 at
         every order), provided they declare the same Option-B output-field set
         (issue #29) — co-aggregated grids must produce the same scalar/vector
-        schema. Cross-family (e.g. rectilinear) never nests.
+        schema — and the same ``cell_ids_encoding`` (issue #135): NESTED ids
+        and morton words are different id spaces, so a consumer joining
+        co-aggregated products on ``cell_ids`` would silently mismatch.
+        Cross-family (e.g. rectilinear) never nests.
         """
         if not isinstance(other, HealpixGrid):
+            return False
+        if self.cell_ids_encoding != other.cell_ids_encoding:
             return False
         return output_field_signature(self.config) == output_field_signature(other.config)
 

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -14,6 +14,7 @@ from zagg.config import (
     default_config,
     get_agg_fields,
     get_aoi_mask,
+    get_cell_ids_encoding,
     get_output_signature,
     output_field_signature,
 )
@@ -168,6 +169,10 @@ class HealpixGrid:
         self.shard_objects_per_shard = 4 ** (shard_obj_order - parent_order)
         self.layout = layout
         self.config = config or default_config("atl06")
+        # cell_ids coordinate encoding (issue #135): "nested" (default, the DGGS
+        # standard) or "morton" (emit the packed morton words as cell_ids — a
+        # test/prototype capability). Default is byte-identical to a pre-flag run.
+        self.cell_ids_encoding = get_cell_ids_encoding(self.config)
         self._position_map: dict[int, int] | None = None
         if populated_shards is not None:
             self.set_populated_shards(populated_shards)
@@ -464,7 +469,9 @@ class HealpixGrid:
 
         ``morton`` is a mortie ``MortonIndexArray`` (the typed coordinate; #71);
         it is stored as ``uint64`` on disk via :mod:`zagg.grids.morton`. ``cell_ids``
-        stays NESTED ``uint64`` (the DGGS coordinate, unchanged).
+        is NESTED ``uint64`` (the DGGS coordinate) by default; the
+        ``output.grid.cell_ids_encoding: morton`` flag (issue #135) emits the
+        packed morton words instead.
         """
         return self.coords_of(self.children(shard_key))
 
@@ -477,9 +484,13 @@ class HealpixGrid:
         ``chunk_coords`` is just ``coords_of(children(shard_key))``.
         """
         children = np.asarray(children)
+        if self.cell_ids_encoding == "morton":
+            cell_ids = np.asarray(children, dtype=np.uint64)
+        else:
+            cell_ids = self.encode_cell_ids(children)
         return {
             "morton": to_morton_array(children),
-            "cell_ids": self.encode_cell_ids(children),
+            "cell_ids": cell_ids,
         }
 
     # ── identity / nesting ───────────────────────────────────────────────
@@ -650,7 +661,12 @@ class HealpixGrid:
             "dggs": {
                 "name": "healpix",
                 "refinement_level": self.child_order,
-                "indexing_scheme": "nested",
+                # cell_ids_encoding: morton (issue #135) stores packed morton words
+                # as cell_ids, so the recorded scheme must not claim "nested" — a
+                # consumer decoding morton words as NESTED ids would mis-place every
+                # cell. "morton" is outside the DGGS convention's standard schemes;
+                # the flag is a test/prototype capability.
+                "indexing_scheme": self.cell_ids_encoding,
                 "spatial_dimension": "cells",
                 "ellipsoid": {
                     "name": "WGS84",

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -2,14 +2,19 @@
 
 The ``morton`` output coordinate is carried in memory as a mortie
 :class:`~mortie.morton_index.MortonIndexArray` (a pandas ExtensionArray over the
-packed ``uint64`` Morton words). On disk it is stored as plain ``uint64`` — Zarr
-stores numpy dtypes, not pandas extension dtypes — and reconstructed as a
-``MortonIndexArray`` on read.
+packed ``uint64`` Morton words), and crosses the Arrow carrier boundary as
+mortie's ``morton_index`` Arrow **extension type** over the PyCapsule C Data
+Interface (:func:`morton_to_arrow` / :func:`morton_from_arrow`; mortie >= 0.8.4,
+issue #135) — typed on both the pandas and arro3 surfaces, no pyarrow on the
+worker path. On disk it is stored as plain ``uint64`` — Zarr stores numpy
+dtypes, and the extension metadata lives at the interchange layer only — and
+reconstructed as a ``MortonIndexArray`` on read.
 
 This is the contained #71 migration: only the ``morton`` coordinate adopts the
-type. ``cell_ids`` stays NESTED ``uint64`` (the DGGS coordinate, unchanged), and
-the internal leaf/cell/shard morton arithmetic (``cells_of`` / ``shards_of`` /
-``children``) stays on plain ``uint64`` ndarrays.
+type. ``cell_ids`` stays NESTED ``uint64`` by default (the DGGS coordinate;
+``output.grid.cell_ids_encoding: morton`` optionally emits the morton words
+instead — issue #135), and the internal leaf/cell/shard morton arithmetic
+(``cells_of`` / ``shards_of`` / ``children``) stays on plain ``uint64`` ndarrays.
 
 Storing the raw ``uint64`` words (rather than a reinterpreted ``int64``) is what
 removes the sign hazard: the packed word's prefix is ``base+1``, so base cells

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -108,7 +108,8 @@ def is_morton_arrow(col) -> bool:
     field = getattr(col, "field", None)
     if field is None:
         return False
-    return dict(field.metadata_str).get(_EXTENSION_NAME_KEY) == MORTON_EXTENSION_NAME
+    # metadata_str is already a plain dict on arro3 — no copy on the write path.
+    return field.metadata_str.get(_EXTENSION_NAME_KEY) == MORTON_EXTENSION_NAME
 
 
 __all__ = [

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -21,6 +21,13 @@ from __future__ import annotations
 
 import numpy as np
 
+# Wire name of mortie's Arrow extension type (``mortie.arrow.EXTENSION_NAME``),
+# carried as ``ARROW:extension:name`` field metadata over the PyCapsule C Data
+# Interface (issue #135). Mirrored here so the hot-path metadata check needs no
+# import; a test pins it against mortie's constant.
+MORTON_EXTENSION_NAME = "mortie.morton_index"
+_EXTENSION_NAME_KEY = "ARROW:extension:name"
+
 
 def is_morton_array(values) -> bool:
     """True if ``values`` is a mortie ``MortonIndexArray``."""
@@ -55,4 +62,56 @@ def to_morton_array(words):
     return MortonIndexArray.from_words(np.asarray(words, dtype=np.uint64))
 
 
-__all__ = ["is_morton_array", "morton_words", "to_morton_array"]
+def morton_to_arrow(values):
+    """Export ``values`` as a typed ``arro3.core.Array`` (issue #135).
+
+    The Arrow leg of the boundary: the returned array carries mortie's
+    ``morton_index`` extension type in its field metadata
+    (:data:`MORTON_EXTENSION_NAME`), pulled zero-copy over the PyCapsule C Data
+    Interface (``MortonIndexArray.__arrow_c_array__``; mortie >= 0.8.4) — no
+    pyarrow on the path. Accepts a ``MortonIndexArray`` or any
+    ``uint64``-coercible array-like of packed words; the all-zero empty sentinel
+    is exported as an Arrow null.
+    """
+    from arro3.core import Array
+
+    if not is_morton_array(values):
+        values = to_morton_array(values)
+    return Array.from_arrow(values)
+
+
+def morton_from_arrow(col):
+    """Reconstruct a ``MortonIndexArray`` from a typed Arrow column.
+
+    The inverse of :func:`morton_to_arrow`: ``col`` is any Arrow C-Data source
+    (an ``arro3.core.Array``, a chunked ``ChunkedArray`` column, or a
+    ``(schema, array)`` capsule pair). Arrow nulls come back as the all-zero
+    empty sentinel word, so ``isna`` round-trips.
+    """
+    from mortie import MortonIndexArray
+
+    return MortonIndexArray.from_arrow(col)
+
+
+def is_morton_arrow(col) -> bool:
+    """True if ``col`` is an Arrow array/column carrying the morton extension type.
+
+    Reads the ``ARROW:extension:name`` field metadata (present on both an
+    ``arro3.core.Array`` and a table column's ``ChunkedArray``); anything
+    without field metadata is not a typed morton column.
+    """
+    field = getattr(col, "field", None)
+    if field is None:
+        return False
+    return dict(field.metadata_str).get(_EXTENSION_NAME_KEY) == MORTON_EXTENSION_NAME
+
+
+__all__ = [
+    "MORTON_EXTENSION_NAME",
+    "is_morton_array",
+    "is_morton_arrow",
+    "morton_from_arrow",
+    "morton_to_arrow",
+    "morton_words",
+    "to_morton_array",
+]

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -21,7 +21,7 @@ from zagg.config import (
     get_output_signature,
 )
 from zagg.csr import write_csr
-from zagg.grids.morton import is_morton_array, morton_words
+from zagg.grids.morton import is_morton_array, is_morton_arrow, morton_to_arrow, morton_words
 
 # The sharded path's K ragged (CSR) subgroup writes fan out over a bounded thread
 # pool (issue #142): each inner chunk emits an independent CSR group at a disjoint
@@ -103,11 +103,15 @@ def _build_output(
         for var in data_vars
     }
     for col_name, vals in coords.items():
-        # Route the morton coordinate through the same uint64 boundary as the
-        # pandas carrier (#71), so both carriers share one on-disk dtype guarantee
-        # rather than relying on MortonIndexArray.__array__ returning uint64.
-        arr = morton_words(vals) if is_morton_array(vals) else np.asarray(vals)
-        columns[col_name] = Array.from_numpy(np.ascontiguousarray(arr))
+        # The typed morton coordinate crosses into the arro3 carrier as mortie's
+        # ``morton_index`` extension column (issue #135) — zero-copy over the
+        # PyCapsule interface, no pyarrow. The extension metadata lives at the
+        # interchange layer only: the write boundary (``_iter_carrier_columns``)
+        # extracts the packed uint64 words, so on-disk stays plain uint64 (#71).
+        if is_morton_array(vals):
+            columns[col_name] = morton_to_arrow(vals)
+        else:
+            columns[col_name] = Array.from_numpy(np.ascontiguousarray(np.asarray(vals)))
     return Table.from_pydict(columns)
 
 
@@ -715,6 +719,16 @@ def _iter_carrier_columns(carrier):
     n_rows = carrier.num_rows
     for name in carrier.column_names:
         col = carrier.column(name).combine_chunks()
+        # A typed morton column (mortie's ``morton_index`` extension type; issue
+        # #135) is the arro3 mirror of the pandas MortonIndexArray branch above:
+        # pull the packed uint64 words over the C Data Interface for the on-disk
+        # write (Arrow nulls -> the all-zero sentinel), keeping the stored dtype
+        # plain uint64 (#71).
+        if is_morton_arrow(col):
+            from mortie.arrow import import_c_array
+
+            yield name, import_c_array(col)
+            continue
         # arro3 marks a FixedSizeList by an integer ``list_size`` (None for scalar
         # types), so the per-cell width and the 2-D reshape mirror the pyarrow path
         # exactly — the numpy block written to Zarr is byte-for-byte unchanged.

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -726,6 +726,7 @@ def _iter_carrier_columns(carrier):
         return
 
     from arro3.core import list_flatten
+    from mortie.arrow import import_c_array
 
     n_rows = carrier.num_rows
     for name in carrier.column_names:
@@ -736,8 +737,6 @@ def _iter_carrier_columns(carrier):
         # write (Arrow nulls -> the all-zero sentinel), keeping the stored dtype
         # plain uint64 (#71).
         if is_morton_arrow(col):
-            from mortie.arrow import import_c_array
-
             yield name, import_c_array(col)
             continue
         # arro3 marks a FixedSizeList by an integer ``list_size`` (None for scalar

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -74,6 +74,14 @@ def _build_output(
     ``arro3.core.Table`` when any ``vector`` field is present, in both cases with
     the data-variable columns followed by the grid's per-cell coord columns.
 
+    On both carriers the ``morton`` coordinate is TYPED (issue #135): the pandas
+    carrier holds the mortie ``MortonIndexArray`` (#71), and the arro3 carrier
+    holds mortie's ``morton_index`` Arrow extension column
+    (:func:`zagg.grids.morton.morton_to_arrow`). The type lives at the
+    interchange layer only — ``_iter_carrier_columns`` extracts the packed
+    ``uint64`` words at the write boundary, so the on-disk dtype is plain
+    ``uint64`` either way.
+
     ``children`` (issue #30 item 3): when given, the coord columns are computed
     for that explicit chunk's cells via ``grid.coords_of(children)`` instead of the
     whole shard's ``grid.chunk_coords(shard_key)``. This is what lets the K>1 worker
@@ -701,7 +709,10 @@ def _iter_carrier_columns(carrier):
 
     Scalar columns yield a 1-D array; a ``FixedSizeList<C>`` Arrow column yields a
     2-D ``(n_cells, C)`` array (the per-cell vector block), so the writer can map
-    it onto the Zarr trailing payload dimension (issue #29).
+    it onto the Zarr trailing payload dimension (issue #29). A typed morton
+    column — ``MortonIndexArray`` on the pandas carrier (#71), the
+    ``morton_index`` Arrow extension column on the arro3 carrier (issue #135) —
+    yields its packed ``uint64`` words, the on-disk form.
     """
     if isinstance(carrier, pd.DataFrame):
         for name, series in carrier.items():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1247,6 +1247,28 @@ class TestCellIdsEncoding:
     def test_rectilinear_without_encoding_still_validates(self):
         validate_config(_cfg_with_cell_ids_encoding(grid_type="rectilinear"))
 
+    def test_present_but_null_key_falls_back_to_nested(self):
+        # YAML `cell_ids_encoding:` (explicit null) must behave like an absent
+        # key: the accessor returns "nested" (never None) and validation passes,
+        # so the store attrs stay byte-identical to a pre-flag run.
+        from zagg.config import get_cell_ids_encoding
+
+        cfg = _cfg_with_cell_ids_encoding()
+        cfg.output["grid"]["cell_ids_encoding"] = None
+        assert get_cell_ids_encoding(cfg) == "nested"
+        validate_config(cfg)
+
+    def test_legacy_indexing_scheme_key_is_descriptive_only(self):
+        # The shipped configs carry output.grid.indexing_scheme: nested, which no
+        # code reads; setting it to "morton" would otherwise silently do nothing.
+        # It must fail loudly and point at the real knob.
+        cfg = _cfg_with_cell_ids_encoding()
+        cfg.output["grid"]["indexing_scheme"] = "nested"
+        validate_config(cfg)  # the shipped value stays valid
+        cfg.output["grid"]["indexing_scheme"] = "morton"
+        with pytest.raises(ValueError, match="cell_ids_encoding: morton"):
+            validate_config(cfg)
+
 
 # ---------------------------------------------------------------------------
 # Bounds validation

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1190,6 +1190,59 @@ class TestOutputGridValidation:
             validate_config(cfg)
 
 
+def _cfg_with_cell_ids_encoding(encoding=None, grid_type="healpix") -> PipelineConfig:
+    """Minimal valid config; sets output.grid.cell_ids_encoding only when given."""
+    grid: dict = {"type": grid_type, "parent_order": 6, "child_order": 12}
+    if grid_type == "rectilinear":
+        grid = {
+            "type": "rectilinear",
+            "crs": "EPSG:3031",
+            "resolution": 100,
+            "bounds": [0, 0, 1000, 1000],
+        }
+    if encoding is not None:
+        grid["cell_ids_encoding"] = encoding
+    return PipelineConfig(
+        data_source={"variables": {"h_li": "/path"}},
+        aggregation={"variables": {"c": {"function": "len", "source": "h_li", "dtype": "int32"}}},
+        output={"grid": grid},
+    )
+
+
+class TestCellIdsEncoding:
+    """Issue #135: optional output.grid.cell_ids_encoding — "nested" (default,
+    the DGGS standard) or "morton" (emit packed morton words as cell_ids)."""
+
+    def test_default_is_nested(self):
+        from zagg.config import get_cell_ids_encoding
+
+        assert get_cell_ids_encoding(_cfg_with_cell_ids_encoding()) == "nested"
+
+    def test_explicit_values_accessor(self):
+        from zagg.config import get_cell_ids_encoding
+
+        assert get_cell_ids_encoding(_cfg_with_cell_ids_encoding("nested")) == "nested"
+        assert get_cell_ids_encoding(_cfg_with_cell_ids_encoding("morton")) == "morton"
+
+    def test_valid_values_validate(self):
+        validate_config(_cfg_with_cell_ids_encoding())  # absent
+        validate_config(_cfg_with_cell_ids_encoding("nested"))
+        validate_config(_cfg_with_cell_ids_encoding("morton"))
+
+    def test_invalid_value_rejected_at_load(self):
+        with pytest.raises(ValueError, match="cell_ids_encoding must be 'nested' or 'morton'"):
+            validate_config(_cfg_with_cell_ids_encoding("bogus"))
+
+    def test_rejected_on_rectilinear(self):
+        # Rectilinear grids have no cell_ids coordinate; the knob would silently
+        # do nothing, so it is rejected at load.
+        with pytest.raises(ValueError, match="only applies to healpix"):
+            validate_config(_cfg_with_cell_ids_encoding("morton", grid_type="rectilinear"))
+
+    def test_rectilinear_without_encoding_still_validates(self):
+        validate_config(_cfg_with_cell_ids_encoding(grid_type="rectilinear"))
+
+
 # ---------------------------------------------------------------------------
 # Bounds validation
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1203,7 +1203,12 @@ def _cfg_with_cell_ids_encoding(encoding=None, grid_type="healpix") -> PipelineC
     if encoding is not None:
         grid["cell_ids_encoding"] = encoding
     return PipelineConfig(
-        data_source={"variables": {"h_li": "/path"}},
+        data_source={
+            "reader": "h5coro",
+            "groups": ["gt1l"],
+            "coordinates": {"latitude": "/lat", "longitude": "/lon"},
+            "variables": {"h_li": "/path"},
+        },
         aggregation={"variables": {"c": {"function": "len", "source": "h_li", "dtype": "int32"}}},
         output={"grid": grid},
     )

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -645,6 +645,95 @@ class TestMortonCoordinate:
         np.testing.assert_array_equal(morton_words(to_morton_array(stored)), expected)
 
 
+class TestMortonArrowAdapter:
+    """The typed Arrow legs of the morton boundary (issue #135): morton_to_arrow /
+    morton_from_arrow / is_morton_arrow carry mortie's ``morton_index`` extension
+    type over the PyCapsule interface, mirroring the uint64 round-trip suite above."""
+
+    def test_extension_name_pins_mortie_constant(self):
+        import mortie.arrow
+
+        from zagg.grids.morton import MORTON_EXTENSION_NAME
+
+        assert MORTON_EXTENSION_NAME == mortie.arrow.EXTENSION_NAME
+
+    def test_to_arrow_carries_extension_type(self, cfg):
+        from zagg.grids.morton import is_morton_arrow, morton_to_arrow
+
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        coords = g.chunk_coords(_valid_parents(1)[0])
+        arr = morton_to_arrow(coords["morton"])
+        assert is_morton_arrow(arr)
+
+    def test_to_arrow_accepts_raw_words(self):
+        from zagg.grids.morton import is_morton_arrow, morton_from_arrow, morton_to_arrow
+
+        words = np.array([123456789, (1 << 63) | 42], dtype=np.uint64)
+        arr = morton_to_arrow(words)
+        assert is_morton_arrow(arr)
+        np.testing.assert_array_equal(np.asarray(morton_from_arrow(arr)._data), words)
+
+    def test_words_roundtrip_through_arrow(self, cfg):
+        """to_arrow -> from_arrow reconstructs the same packed words the typed
+        coordinate carries — the Arrow legs are a skin, not a re-encoding."""
+        from mortie import generate_morton_children
+
+        from zagg.grids.morton import morton_from_arrow, morton_to_arrow, morton_words
+
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        parent = _valid_parents(1)[0]
+        coords = g.chunk_coords(parent)
+        back = morton_from_arrow(morton_to_arrow(coords["morton"]))
+        np.testing.assert_array_equal(morton_words(back), generate_morton_children(int(parent), 8))
+
+    def test_southern_bit63_words_roundtrip(self):
+        """Southern (base 7-11) words set bit 63; the Arrow legs keep them intact
+        as uint64 — the same #71 sign hazard the storage round-trip guards."""
+        from mortie import clip2order, geo2mort
+
+        from zagg.grids.morton import morton_from_arrow, morton_to_arrow, morton_words
+
+        leaf = geo2mort(np.array([-78.5]), np.array([-132.0]), order=18)
+        cells = np.asarray(clip2order(8, leaf), dtype=np.uint64)
+        words = morton_words(morton_from_arrow(morton_to_arrow(cells)))
+        np.testing.assert_array_equal(words, cells)
+        assert words.dtype == np.uint64
+        assert (words.view(np.int64) < 0).any()
+
+    def test_sentinel_null_roundtrip(self):
+        """The all-zero empty sentinel crosses the boundary as an Arrow null and
+        comes back as the sentinel, so isna() round-trips."""
+        from zagg.grids.morton import morton_from_arrow, morton_to_arrow, to_morton_array
+
+        words = np.array([123456789, 0, 42], dtype=np.uint64)
+        back = morton_from_arrow(morton_to_arrow(to_morton_array(words)))
+        np.testing.assert_array_equal(np.asarray(back._data), words)
+        np.testing.assert_array_equal(back.isna(), [False, True, False])
+
+    def test_from_arrow_accepts_chunked_column(self):
+        """A table column (ChunkedArray) round-trips too — the write path hands
+        columns, not bare arrays."""
+        from arro3.core import Table
+
+        from zagg.grids.morton import is_morton_arrow, morton_from_arrow, morton_to_arrow
+
+        words = np.array([7, 11, 13], dtype=np.uint64)
+        tbl = Table.from_pydict({"morton": morton_to_arrow(words)})
+        col = tbl.column("morton")
+        assert is_morton_arrow(col)
+        np.testing.assert_array_equal(np.asarray(morton_from_arrow(col)._data), words)
+
+    def test_is_morton_arrow_false_for_plain_columns(self):
+        from arro3.core import Array, Table
+
+        from zagg.grids.morton import is_morton_arrow
+
+        tbl = Table.from_pydict({"x": Array.from_numpy(np.arange(3, dtype=np.uint64))})
+        assert not is_morton_arrow(tbl.column("x"))
+        assert not is_morton_arrow(tbl.column("x").combine_chunks())
+        assert not is_morton_arrow(np.arange(3))  # no Arrow field at all
+
+
 class TestChunkInnerMultiChunk:
     """Issue #30 item 3: an optional finer ``chunk_inner`` level between shard and
     cell, native units per grid (HEALPix order, rectilinear shape). One shard owns

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -811,6 +811,14 @@ class TestCellIdsEncoding:
         # shard maps stay reusable across the flag (#89).
         assert self._grid("morton").spatial_signature() == self._grid().spatial_signature()
 
+    def test_unknown_encoding_rejected_at_grid_construction(self):
+        # coords_of (values) and _dggs_attrs (recorded scheme) both interpret the
+        # string, so a grid built from an UNVALIDATED config must reject a third
+        # value here — otherwise NESTED values would be recorded under a foreign
+        # scheme name and consumers would mis-decode every cell.
+        with pytest.raises(ValueError, match="Unknown cell_ids_encoding"):
+            self._grid("ring")
+
 
 class TestChunkInnerMultiChunk:
     """Issue #30 item 3: an optional finer ``chunk_inner`` level between shard and

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -734,6 +734,84 @@ class TestMortonArrowAdapter:
         assert not is_morton_arrow(np.arange(3))  # no Arrow field at all
 
 
+class TestCellIdsEncoding:
+    """Issue #135: ``output.grid.cell_ids_encoding`` — ``cell_ids`` stays NESTED
+    HEALPix uint64 by default; ``morton`` emits the packed morton words instead
+    (a test/prototype capability). Default behavior is byte-identical."""
+
+    @staticmethod
+    def _cfg(encoding=None):
+        cfg = default_config("atl06")
+        if encoding is not None:
+            cfg.output["grid"]["cell_ids_encoding"] = encoding
+        return cfg
+
+    def _grid(self, encoding=None):
+        return HealpixGrid(
+            parent_order=6, child_order=8, layout="fullsphere", config=self._cfg(encoding)
+        )
+
+    def test_default_and_explicit_nested_identical(self):
+        parent = _valid_parents(1)[0]
+        default = self._grid().chunk_coords(parent)
+        nested = self._grid("nested").chunk_coords(parent)
+        np.testing.assert_array_equal(default["cell_ids"], nested["cell_ids"])
+        np.testing.assert_array_equal(
+            np.asarray(default["morton"]._data), np.asarray(nested["morton"]._data)
+        )
+        # Default stays the NESTED encode, unchanged.
+        g = self._grid()
+        np.testing.assert_array_equal(default["cell_ids"], g.encode_cell_ids(g.children(parent)))
+
+    def test_morton_encoding_emits_words(self):
+        from zagg.grids.morton import morton_words
+
+        g = self._grid("morton")
+        parent = _valid_parents(1)[0]
+        coords = g.chunk_coords(parent)
+        children = np.asarray(g.children(parent), dtype=np.uint64)
+        assert coords["cell_ids"].dtype == np.uint64
+        np.testing.assert_array_equal(coords["cell_ids"], children)
+        # The morton coordinate itself is unchanged (still the typed array).
+        np.testing.assert_array_equal(morton_words(coords["morton"]), children)
+
+    def test_morton_encoding_roundtrips_through_zarr(self):
+        import pandas as pd
+
+        from zagg.processing import write_dataframe_to_zarr
+
+        cfg = self._cfg("morton")
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        store = MemoryStore()
+        g.emit_template(store)
+
+        parent = _valid_parents(1)[0]
+        coords = g.chunk_coords(parent)
+        n = len(coords["cell_ids"])
+        df = pd.DataFrame({"cell_ids": coords["cell_ids"]})
+        df["morton"] = coords["morton"]
+        for var in get_data_vars(cfg):
+            df[var] = np.zeros(n, dtype=np.int32 if var == "count" else np.float32)
+        chunk_idx = g.block_index(parent)
+        write_dataframe_to_zarr(df, store, grid=g, chunk_idx=chunk_idx)
+
+        grp = open_group(store, path="8", mode="r")
+        start = chunk_idx[0] * n
+        stored = grp["cell_ids"][start : start + n]
+        np.testing.assert_array_equal(stored, np.asarray(g.children(parent), dtype=np.uint64))
+        assert stored.dtype == np.uint64
+
+    def test_dggs_attrs_record_encoding(self):
+        assert self._grid()._dggs_attrs()["dggs"]["indexing_scheme"] == "nested"
+        assert self._grid("nested")._dggs_attrs()["dggs"]["indexing_scheme"] == "nested"
+        assert self._grid("morton")._dggs_attrs()["dggs"]["indexing_scheme"] == "morton"
+
+    def test_spatial_signature_unchanged_by_encoding(self):
+        # The encoding changes coordinate VALUES, not the spatial layout, so
+        # shard maps stay reusable across the flag (#89).
+        assert self._grid("morton").spatial_signature() == self._grid().spatial_signature()
+
+
 class TestChunkInnerMultiChunk:
     """Issue #30 item 3: an optional finer ``chunk_inner`` level between shard and
     cell, native units per grid (HEALPix order, rectilinear shape). One shard owns

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -819,6 +819,25 @@ class TestCellIdsEncoding:
         with pytest.raises(ValueError, match="Unknown cell_ids_encoding"):
             self._grid("ring")
 
+    def test_signature_records_encoding(self):
+        # The full fingerprint carries the encoding (issue #135) so the
+        # validate_compatible rejection message names the actual mismatch;
+        # spatial_signature (shard-map reuse) deliberately does not.
+        assert self._grid().signature()["cell_ids_encoding"] == "nested"
+        assert self._grid("morton").signature()["cell_ids_encoding"] == "morton"
+        assert "cell_ids_encoding" not in self._grid("morton").spatial_signature()
+
+    def test_mixed_encodings_do_not_nest(self):
+        # NESTED ids and morton words are different id spaces: co-aggregating
+        # them would let a consumer join on cell_ids and silently mismatch.
+        nested, morton = self._grid(), self._grid("morton")
+        assert not nested.nests_with(morton)
+        assert not morton.nests_with(nested)
+        # Same encoding still nests — including default vs explicit "nested",
+        # so the gate changes nothing for anyone not using the flag.
+        assert nested.nests_with(self._grid("nested"))
+        assert morton.nests_with(self._grid("morton"))
+
 
 class TestChunkInnerMultiChunk:
     """Issue #30 item 3: an optional finer ``chunk_inner`` level between shard and

--- a/tests/test_morton_arrow.py
+++ b/tests/test_morton_arrow.py
@@ -1,0 +1,114 @@
+"""arro3 interop gates for mortie's typed ``morton_index`` Arrow surface (issue #135).
+
+mortie 0.8.4 (espg/mortie#94) exports the ``morton_index`` extension type over
+the Arrow PyCapsule C Data Interface — no pyarrow required. These tests gate the
+design before the carrier adopts it: the extension metadata must survive exactly
+the arro3-core ops the write path uses (``Array.from_arrow``,
+``Table.from_pydict`` → ``column(name)`` → ``combine_chunks()``), the words must
+round-trip byte-equal with the null↔sentinel mapping intact, and none of it may
+import pyarrow.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import numpy as np
+import pytest
+
+EXT_KEY = "ARROW:extension:name"
+EXT_NAME = "mortie.morton_index"
+
+
+@pytest.fixture
+def words():
+    """Packed uint64 words incl. the all-zero empty sentinel (an Arrow null) and
+    a southern-hemisphere word with bit 63 set (the #71 sign hazard)."""
+    leaf = np.array([123456789, 0, 42], dtype=np.uint64)
+    leaf[2] = np.uint64(1) << np.uint64(63) | np.uint64(42)
+    return leaf
+
+
+def _typed_array(words):
+    from arro3.core import Array
+    from mortie import MortonIndexArray
+
+    return Array.from_arrow(MortonIndexArray.from_words(words))
+
+
+class TestArro3InteropGates:
+    """The four phase-1 gates from the issue #135 plan."""
+
+    def test_array_from_arrow_carries_extension_name(self, words):
+        # Gate (a): MortonIndexArray -> arro3 Array keeps the extension type.
+        arr = _typed_array(words)
+        assert dict(arr.field.metadata_str).get(EXT_KEY) == EXT_NAME
+
+    def test_metadata_survives_table_plumbing(self, words):
+        # Gate (b): the exact ops _build_output/_iter_carrier_columns use —
+        # Table.from_pydict -> column(name) -> combine_chunks().
+        from arro3.core import Array, Table
+
+        tbl = Table.from_pydict(
+            {"morton": _typed_array(words), "x": Array.from_numpy(np.zeros(len(words)))}
+        )
+        col = tbl.column("morton").combine_chunks()
+        assert dict(col.field.metadata_str).get(EXT_KEY) == EXT_NAME
+        # The sibling plain column carries no extension metadata.
+        plain = tbl.column("x").combine_chunks()
+        assert EXT_KEY not in dict(plain.field.metadata_str)
+
+    def test_import_c_array_roundtrips_words(self, words):
+        # Gate (c): words come back byte-equal; the all-zero sentinel survives
+        # its trip through an Arrow null (the mortie null<->sentinel mapping).
+        import mortie.arrow as ma
+        from arro3.core import Array, Table
+
+        tbl = Table.from_pydict(
+            {"morton": _typed_array(words), "x": Array.from_numpy(np.zeros(len(words)))}
+        )
+        col = tbl.column("morton").combine_chunks()
+        back = ma.import_c_array(col)
+        assert back.dtype == np.uint64
+        np.testing.assert_array_equal(back, words)
+        # bit-63 word stored intact (non-negative as uint64; #71).
+        assert (back.view(np.int64) < 0).any()
+
+    def test_path_needs_no_pyarrow(self):
+        # Gate (d): the whole typed path runs with pyarrow unimportable. Must be
+        # a subprocess — in this env pyarrow is installed and mortie registers
+        # its pyarrow extension type eagerly at import, so blocking after the
+        # fact would prove nothing.
+        script = textwrap.dedent(
+            """
+            import sys
+
+            class _BlockPyarrow:
+                def find_spec(self, name, path=None, target=None):
+                    if name == "pyarrow" or name.startswith("pyarrow."):
+                        raise ModuleNotFoundError("pyarrow blocked for this test")
+                    return None
+
+            sys.meta_path.insert(0, _BlockPyarrow())
+
+            import numpy as np
+            import mortie.arrow as ma
+            from arro3.core import Array, Table
+            from mortie import MortonIndexArray
+
+            words = np.array([123456789, 0, (1 << 63) | 42], dtype=np.uint64)
+            arr = Array.from_arrow(MortonIndexArray.from_words(words))
+            tbl = Table.from_pydict({"morton": arr})
+            col = tbl.column("morton").combine_chunks()
+            assert dict(col.field.metadata_str).get("ARROW:extension:name") == (
+                "mortie.morton_index"
+            )
+            back = ma.import_c_array(col)
+            assert np.array_equal(back, words)
+            assert "pyarrow" not in sys.modules, "pyarrow leaked onto the typed path"
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=120
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2600,6 +2600,42 @@ class TestTypedMortonCarrier:
         assert isinstance(df, pd.DataFrame)
         assert is_morton_array(df["morton"].values)
 
+    def test_store_bytes_identical_with_sentinel_nulls(self):
+        """A morton column bearing the all-zero empty sentinel crosses the arro3
+        carrier as an Arrow null; the write boundary must still land a literal
+        uint64 0 on disk — byte-identical to the pandas carrier and the pre-#135
+        strip (which wrote the 0 with no validity bitmap in play)."""
+        ac = pytest.importorskip("arro3.core")
+        from zagg.grids.morton import morton_to_arrow, to_morton_array
+
+        cfg, grid, parent, stats = self._setup()
+        # Fabricate the coordinate columns directly: real children with the first
+        # word replaced by the sentinel (0), so the typed column carries a null.
+        words = np.asarray(grid.children(parent), dtype=np.uint64).copy()
+        words[0] = 0
+        cell_ids = grid.encode_cell_ids(grid.children(parent))
+        mia = to_morton_array(words)
+        assert mia.isna()[0]  # the sentinel really is a missing entry
+
+        typed_cols = {var: ac.Array.from_numpy(stats[var]) for var in get_data_vars(cfg)}
+        typed_cols["morton"] = morton_to_arrow(mia)
+        typed_cols["cell_ids"] = ac.Array.from_numpy(np.asarray(cell_ids))
+        typed = self._store_bytes(ac.Table.from_pydict(typed_cols), grid, parent)
+
+        strip_cols = dict(typed_cols)
+        strip_cols["morton"] = ac.Array.from_numpy(words)  # the pre-#135 strip
+        stripped = self._store_bytes(ac.Table.from_pydict(strip_cols), grid, parent)
+
+        df = pd.DataFrame({var: stats[var] for var in get_data_vars(cfg)})
+        df["morton"] = mia
+        df["cell_ids"] = cell_ids
+        via_pandas = self._store_bytes(df, grid, parent)
+
+        assert typed.keys() == via_pandas.keys() == stripped.keys()
+        for key in typed:
+            assert typed[key] == via_pandas[key], f"arrow vs pandas differ at {key}"
+            assert typed[key] == stripped[key], f"typed vs strip differ at {key}"
+
 
 class TestChunkResolutionCompanion:
     """Issue #30 item 2: a ``resolution: chunk`` field is written ONCE per chunk to

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2502,6 +2502,105 @@ class TestVectorRoundTrip:
             write_dataframe_to_zarr(table, store, grid=_OneChunkGrid(), chunk_idx=(0,))
 
 
+class TestTypedMortonCarrier:
+    """Issue #135: the arrow carrier keeps the ``morton`` coordinate as mortie's
+    ``morton_index`` extension column end-to-end; the write boundary extracts the
+    packed uint64 words, so on-disk output stays byte-identical to the pandas
+    carrier AND to the pre-#135 uint64-strip carrier. The pandas path is untouched."""
+
+    @staticmethod
+    def _setup():
+        from mortie import geo2mort
+
+        cfg = default_config("atl06")
+        grid = HealpixGrid(2, 4, layout="fullsphere", config=cfg)
+        # Southern parent: its order-4 children set bit 63 (the #71 sign hazard).
+        parent = int(geo2mort(-78.5, -132.0, order=2)[0])
+        n = len(grid.children(parent))
+        rng = np.random.default_rng(135)
+        stats = {
+            var: (
+                rng.integers(0, 9, n).astype(np.int32)
+                if var == "count"
+                else rng.random(n).astype(np.float32)
+            )
+            for var in get_data_vars(cfg)
+        }
+        return cfg, grid, parent, stats
+
+    def _carrier(self, cfg, grid, parent, stats, use_arrow):
+        return _build_output(
+            stats, get_data_vars(cfg), get_agg_fields(cfg), grid, parent, use_arrow=use_arrow
+        )
+
+    def test_arrow_carrier_morton_is_extension_typed(self):
+        pytest.importorskip("arro3.core")
+        from zagg.grids.morton import is_morton_arrow
+
+        cfg, grid, parent, stats = self._setup()
+        carrier = self._carrier(cfg, grid, parent, stats, use_arrow=True)
+        assert is_morton_arrow(carrier.column("morton"))
+        # cell_ids stays a plain NESTED uint64 column, no extension metadata.
+        assert not is_morton_arrow(carrier.column("cell_ids"))
+
+    def test_extraction_yields_uint64_words(self):
+        pytest.importorskip("arro3.core")
+        cfg, grid, parent, stats = self._setup()
+        carrier = self._carrier(cfg, grid, parent, stats, use_arrow=True)
+        cols = dict(_iter_carrier_columns(carrier))
+        words = cols["morton"]
+        assert words.dtype == np.uint64
+        np.testing.assert_array_equal(words, np.asarray(grid.children(parent), dtype=np.uint64))
+        # Southern children set bit 63: intact as uint64 (#71).
+        assert (words.view(np.int64) < 0).any()
+
+    @staticmethod
+    def _store_bytes(carrier, grid, parent):
+        store = MemoryStore()
+        grid.emit_template(store)
+        write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=grid.block_index(parent))
+        return {k: v.to_bytes() for k, v in store._store_dict.items()}
+
+    def test_store_bytes_identical_across_carriers(self):
+        """Typed-arrow, pandas, and the pre-#135 uint64-strip carrier all write the
+        same bytes — the extension type lives at the interchange layer only."""
+        ac = pytest.importorskip("arro3.core")
+        from zagg.config import get_output_signature
+        from zagg.grids.morton import is_morton_array, morton_words
+
+        cfg, grid, parent, stats = self._setup()
+        agg_fields = get_agg_fields(cfg)
+
+        typed = self._store_bytes(
+            self._carrier(cfg, grid, parent, stats, use_arrow=True), grid, parent
+        )
+        via_pandas = self._store_bytes(
+            self._carrier(cfg, grid, parent, stats, use_arrow=False), grid, parent
+        )
+        # Reproduce the pre-#135 carrier exactly: the deliberate uint64 strip.
+        columns = {
+            var: _arrow_column(stats[var], get_output_signature(agg_fields[var]))
+            for var in get_data_vars(cfg)
+        }
+        for name, vals in grid.chunk_coords(parent).items():
+            arr = morton_words(vals) if is_morton_array(vals) else np.asarray(vals)
+            columns[name] = ac.Array.from_numpy(np.ascontiguousarray(arr))
+        stripped = self._store_bytes(ac.Table.from_pydict(columns), grid, parent)
+
+        assert typed.keys() == via_pandas.keys() == stripped.keys()
+        for key in typed:
+            assert typed[key] == via_pandas[key], f"arrow vs pandas differ at {key}"
+            assert typed[key] == stripped[key], f"typed vs pre-#135 strip differ at {key}"
+
+    def test_pandas_carrier_untouched(self):
+        from zagg.grids.morton import is_morton_array
+
+        cfg, grid, parent, stats = self._setup()
+        df = self._carrier(cfg, grid, parent, stats, use_arrow=False)
+        assert isinstance(df, pd.DataFrame)
+        assert is_morton_array(df["morton"].values)
+
+
 class TestChunkResolutionCompanion:
     """Issue #30 item 2: a ``resolution: chunk`` field is written ONCE per chunk to
     a companion array shaped at the chunk grid (main.shape // chunk_shape), indexed

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -434,6 +434,44 @@ class TestParquetIO:
             with pytest.raises(ValueError, match="not a zagg ShardMap parquet manifest"):
                 ShardMap.from_parquet(f.name)
 
+    def test_missing_shard_keys_column_rejected_cleanly(self):
+        # A file carrying the zagg meta key and granules but no shard_keys must
+        # hit the clean ValueError, not a bare pyarrow KeyError.
+        pa_mod = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
+        table = pa_mod.table({"granules": pa_mod.array(["[]"])}).replace_schema_metadata(
+            {ShardMap._PARQUET_META_KEY: b'{"metadata": {}, "grid_signature": {}}'}
+        )
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            pq.write_table(table, f.name)
+            with pytest.raises(ValueError, match="not a zagg ShardMap parquet manifest"):
+                ShardMap.from_parquet(f.name)
+
+    def test_extension_stripped_column_still_loads(self):
+        # import_c_array reads plain uint64 storage too (verified on mortie
+        # 0.8.4), so a manifest whose shard_keys column lost the extension type
+        # still rehydrates with the correct keys.
+        pa_mod = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
+        sm = self._sm()
+        stripped = pa_mod.table(
+            {
+                "shard_keys": pa_mod.array(np.asarray(sm.shard_keys, dtype=np.uint64)),
+                "granules": pa_mod.array([json.dumps(g) for g in sm.granules]),
+            }
+        ).replace_schema_metadata(
+            {
+                ShardMap._PARQUET_META_KEY: json.dumps(
+                    {"metadata": sm.metadata, "grid_signature": sm.grid_signature}
+                ).encode()
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            pq.write_table(stripped, f.name)
+            sm2 = ShardMap.from_parquet(f.name)
+        assert sm2.shard_keys == sm.shard_keys
+        assert sm2.granules == sm.granules
+
 
 def _aoi_config(base="atl06_polar"):
     cfg = default_config(base)

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -370,6 +370,71 @@ class TestIO:
         assert "output_fields" not in sm2.grid_signature
 
 
+class TestParquetIO:
+    """Issue #135 phase 5: the parquet manifest form carries ``shard_keys`` as
+    mortie's ``morton_index`` pyarrow extension type (registered on import) —
+    typed morton columns on the catalog side, off the worker path."""
+
+    @staticmethod
+    def _sm(aoi_mask=None):
+        return ShardMap(
+            {"type": "healpix", "indexing_scheme": "nested", "parent_order": 6},
+            [1050, 1051, 1201],
+            [
+                [{"id": "g1", "s3": "s3://a/g1.h5", "https": "https://a/g1.h5"}],
+                [],
+                [{"id": "g2", "s3": None, "https": "https://a/g2.h5"}],
+            ],
+            {"backend": "mortie", "total_shards": 3},
+            aoi_mask,
+        )
+
+    def test_round_trip(self):
+        pytest.importorskip("pyarrow")
+        sm = self._sm()
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            sm.to_parquet(f.name)
+            sm2 = ShardMap.from_parquet(f.name)
+        assert sm2.shard_keys == sm.shard_keys
+        assert sm2.granules == sm.granules
+        assert sm2.grid_signature == sm.grid_signature
+        assert sm2.metadata == sm.metadata
+        assert sm2.aoi_mask is None
+
+    def test_shard_keys_column_is_extension_typed(self):
+        pq = pytest.importorskip("pyarrow.parquet")
+        import mortie.arrow
+
+        sm = self._sm()
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            sm.to_parquet(f.name)
+            table = pq.read_table(f.name)
+        col_type = table.column("shard_keys").type
+        assert col_type.extension_name == mortie.arrow.EXTENSION_NAME
+        # The words survive byte-equal through the typed column.
+        np.testing.assert_array_equal(
+            mortie.arrow.import_c_array(table.column("shard_keys")),
+            np.asarray(sm.shard_keys, dtype=np.uint64),
+        )
+
+    def test_aoi_mask_round_trips_when_present(self):
+        pytest.importorskip("pyarrow")
+        aoi = [[1, 2, 3], [], [7]]
+        sm = self._sm(aoi_mask=aoi)
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            sm.to_parquet(f.name)
+            sm2 = ShardMap.from_parquet(f.name)
+        assert sm2.aoi_mask == aoi
+
+    def test_foreign_parquet_rejected(self):
+        pa_mod = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            pq.write_table(pa_mod.table({"x": pa_mod.array([1, 2])}), f.name)
+            with pytest.raises(ValueError, match="not a zagg ShardMap parquet manifest"):
+                ShardMap.from_parquet(f.name)
+
+
 def _aoi_config(base="atl06_polar"):
     cfg = default_config(base)
     cfg.output = {**cfg.output, "aoi_mask": True}

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -540,13 +540,20 @@ class TestBuildAOIMask:
 
 
 class TestSpatialSignature:
-    """``spatial_signature()`` is the full signature minus ``output_fields`` (#89)."""
+    """``spatial_signature()`` is the full signature minus the co-aggregation
+    components — ``output_fields`` (#89) and, for HEALPix, ``cell_ids_encoding``
+    (issue #135)."""
 
     def test_healpix_excludes_output_fields(self):
         g = HealpixGrid(6, 12, layout="fullsphere")
         spatial = g.spatial_signature()
         assert "output_fields" not in spatial
-        assert g.signature() == {**spatial, "output_fields": g.signature()["output_fields"]}
+        assert "cell_ids_encoding" not in spatial
+        assert g.signature() == {
+            **spatial,
+            "output_fields": g.signature()["output_fields"],
+            "cell_ids_encoding": "nested",
+        }
 
     def test_rectilinear_excludes_output_fields(self, grid):
         spatial = grid.spatial_signature()


### PR DESCRIPTION
Closes #135

Implements the plan approved in https://github.com/englacial/zagg/issues/135#issuecomment-4881083363 with the amendments from https://github.com/englacial/zagg/issues/135#issuecomment-4881103631: carry mortie's `morton_index` Arrow extension type through the arro3-core worker carrier instead of the deliberate uint64 strip, with the on-disk Zarr output staying plain `uint64` byte-for-byte (the extension metadata lives at the interchange layer only; the #71 storage guarantee is unchanged).

## What / approach

mortie 0.8.4 (espg/mortie#94) ships a pyarrow-free PyCapsule C Data Interface surface: `MortonIndexArray.__arrow_c_array__` / `from_arrow` and `mortie.arrow.export_c_array` / `import_c_array`, with `ARROW:extension:name == "mortie.morton_index"` on the schema and null↔sentinel via a real validity bitmap. zagg adopts it at three boundaries:

1. **Worker carrier** (`src/zagg/processing/write.py`): `_build_output` routes the morton coordinate through `morton_to_arrow` (typed extension column) instead of the uint64 strip; `_iter_carrier_columns` detects the extension column via field metadata and extracts the packed words with `import_c_array` for the Zarr write. Store bytes proven identical to the pre-change strip and to the pandas carrier — including for a sentinel/null-bearing morton column (`tests/test_processing.py::TestTypedMortonCarrier`). The pandas carrier path is untouched.
2. **Boundary adapter** (`src/zagg/grids/morton.py`): `morton_to_arrow(values)`, `morton_from_arrow(col)`, `is_morton_arrow(col)`, plus a pinned `MORTON_EXTENSION_NAME` constant — all type logic stays in the one module the #71 migration established.
3. **Catalog side** (`src/zagg/catalog/shardmap.py`): `ShardMap.to_parquet` / `from_parquet` — the Arrow-native sibling of the JSON manifest, with `shard_keys` as a typed `morton_index` pyarrow extension column (mortie registers the type on import). pyarrow imports stay lazy inside the methods, so the worker path remains pyarrow-free. Degraded manifests (extension type stripped, plain uint64) still load; foreign/truncated files are rejected cleanly. Dispatch stays JSON ([confirmed](https://github.com/englacial/zagg/pull/164#issuecomment-4883419266)).

Per the amendment on question (3): `cell_ids` stays NESTED HEALPix `uint64` by default, and a new validated flag `output.grid.cell_ids_encoding: morton` emits the packed morton words as `cell_ids` instead (HEALPix-only; rejected on rectilinear; value validated both at config load and at grid construction). Default (key absent, explicit null, or `nested`) is byte-identical — asserted by tests. The store's `dggs.indexing_scheme` attr records the active encoding ([confirmed](https://github.com/englacial/zagg/pull/164#issuecomment-4883419266): morton will be upstreamed to the DGGS convention later); the legacy descriptive `output.grid.indexing_scheme` config key is now validated (`nested` only, error pointing at the real knob). Per the [land-b decision](https://github.com/englacial/zagg/pull/164#issuecomment-4883509497), mixed `cell_ids_encoding` grids are **explicitly incompatible for co-aggregation**: `nests_with` compares the encoding and `signature()` records it, while `spatial_signature()` (shard-map reuse, #89) deliberately stays encoding-free (option a1).

Docs: new [Typed morton boundary](../blob/claude/135-morton-arrow-surface/docs/morton_arrow.md) design page (wired into mkdocs nav), updated `grids/morton.py` module docstring (it previously documented the strip as the design), and carrier notes in `write.py`.

## Interop gate result (phase 1)

All four gates **pass** on arro3-core 0.8.1 / mortie 0.8.4 — no fallback needed, no mortie-side change needed (`tests/test_morton_arrow.py`):

- (a) `MortonIndexArray` → `arro3.core.Array.from_arrow` carries `ARROW:extension:name == "mortie.morton_index"`;
- (b) the metadata survives `Table.from_pydict` → `column(name)` → `combine_chunks()` (the exact carrier ops);
- (c) `mortie.arrow.import_c_array(col)` returns the words byte-equal, all-zero sentinel ↔ Arrow null intact, bit-63 southern words non-negative as `uint64`;
- (d) the whole path runs in a subprocess with pyarrow made unimportable (mortie registers its pyarrow extension type eagerly at import when pyarrow is present, so the check must block before import).

## Phases

- [x] Phase 1 — `mortie>=0.8.4` floor bump (`pyproject.toml` only; no other dep or pin changes) + interop gate tests (`tests/test_morton_arrow.py`)
- [x] Phase 2 — boundary adapter in `src/zagg/grids/morton.py` (`morton_to_arrow`, `morton_from_arrow`, `is_morton_arrow`) + round-trip unit tests (`tests/test_grids.py::TestMortonArrowAdapter`)
- [x] Phase 3 — carrier integration in `src/zagg/processing/write.py`; store bytes identical across typed-arrow / pandas / pre-change strip; pandas path untouched (`tests/test_processing.py::TestTypedMortonCarrier`)
- [x] Phase 4 — `output.grid.cell_ids_encoding` flag (default `nested`, byte-identical) + validation and tests (`tests/test_config.py::TestCellIdsEncoding`, `tests/test_grids.py::TestCellIdsEncoding`)
- [x] Phase 5 — catalog/shardmap: `ShardMap.to_parquet`/`from_parquet` with a typed morton `shard_keys` column (`tests/test_shardmap.py::TestParquetIO`)
- [x] Phase 6 — docs: `docs/morton_arrow.md`, `grids/morton.py` module docstring, carrier notes in `write.py`
- [x] Adversarial self-review folded (`c299500`): present-but-null `cell_ids_encoding` no longer bypasses the default; encoding value validated at grid construction; legacy `indexing_scheme` key validated; `from_parquet` clean rejection on missing `shard_keys`; hot-path dict-copy and loop-local import removed; sentinel-bearing store-byte test added
- [x] Phase 7 (`f5d7efa`, per the [land-b decision](https://github.com/englacial/zagg/pull/164#issuecomment-4883509497)) — `cell_ids_encoding` in the co-aggregation gate: `nests_with` rejects mixed encodings, `signature()` records the key; `spatial_signature()` unchanged (a1). Tests: `test_mixed_encodings_do_not_nest`, `test_signature_records_encoding`

## How tested

- `uv run pytest -v` green at every phase: 1097 passed / 24 skipped at baseline → **1136 passed / 24 skipped** with all phases + folds (39 new tests).
- `uv run ruff check` / `ruff format --check` clean on every file this PR touches; `pre-commit` mypy adds **no new errors** over the `main` baseline.
- Byte-identity is asserted directly: the typed-arrow store, the pandas-carrier store, and a store written through a reproduction of the pre-change uint64-strip carrier compare equal key-by-key, byte-for-byte — for both a normal and a sentinel/null-bearing morton column.
- Verified in-env on mortie 0.8.4: `import_c_array` returns correct contiguous `uint64` words for plain (extension-stripped) columns, multi-chunk ChunkedArrays, and null-bearing extension columns.
- `main` moved under the branch (issues #148/#12 landed); re-verified with `git merge-tree`: merges clean, no conflicts.

## Questions for review

All design questions are resolved ([espg's answers](https://github.com/englacial/zagg/pull/164#issuecomment-4883419266), [land-b + a1](https://github.com/englacial/zagg/pull/164#issuecomment-4883509497)): `dggs.indexing_scheme: "morton"` stays; shardmap dispatch stays JSON; `spatial_signature()` stays encoding-free (a1); the co-aggregation gate records the encoding (b, landed in phase 7).

Remaining notes for the reviewer:

- Pre-existing (untouched by this PR, flagged per §4): `ruff check src tests` fails on `main` with one `N818` (`src/zagg/registry.py:64` `UnknownCapability`); `ruff format --check` would reformat 6 files on `main`; codespell flags 2 words (`grids/rectilinear.py:270`, `grids/aoi.py:68`); mypy reports ~39 errors on `main`. All left alone here.