### PR TITLE
Force-cold Lambda dispatch option (issue #171)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -130,6 +130,63 @@ from zagg.store import open_store
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+# Container-lifetime telemetry (issue #171, the detect-and-report half of the
+# PR #172 plan). Module globals persist across warm invocations of the same
+# sandbox: the import timestamp marks container init (imports run exactly once
+# per sandbox), and the counter counts invocations served -- the sandbox's
+# "generation". Together with per-invocation start RSS they make the #169
+# warm-container RSS ratchet (959 -> 1650 -> 2029 -> OOM across four fleet
+# runs on the same 9 sandboxes) visible in every result envelope instead of
+# requiring CloudWatch forensics.
+_CONTAINER_INIT_TS = time.time()
+_INVOCATIONS_SERVED = 0
+
+
+def _container_telemetry() -> Dict[str, Any]:
+    """Per-invocation container-telemetry block (issue #171).
+
+    Called exactly once per invocation, at handler entry: increments the
+    sandbox's invocations-served counter and snapshots the *start* RSS --
+    the ratchet signal (a fresh container starts near baseline; a dirty one
+    starts near the previous invocation's retained RSS). ``container_cold``
+    is ``generation == 1`` by construction. ``sandbox_id`` is the CloudWatch
+    log-stream name, unique per sandbox, so the orchestrator can group
+    per-shard results by physical container. Off Linux ``rss_start_mb`` is
+    None (no ``/proc/self/status``), mirroring the #141 sampler fallback.
+    """
+    global _INVOCATIONS_SERVED
+    _INVOCATIONS_SERVED += 1
+    start_kib = _read_vmrss_kib()
+    return {
+        "container_cold": _INVOCATIONS_SERVED == 1,
+        "container_generation": _INVOCATIONS_SERVED,
+        "rss_start_mb": start_kib / 1024.0 if start_kib is not None else None,
+        "sandbox_id": os.environ.get("AWS_LAMBDA_LOG_STREAM_NAME"),
+        "container_init_ts": _CONTAINER_INIT_TS,
+    }
+
+
+def _attach_container_telemetry(
+    response: Dict[str, Any], telemetry: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Merge the telemetry block into a per-unit response body (issue #171).
+
+    The body is a JSON string (Lambda proxy shape); parse-merge-redump at the
+    dispatcher gives one seam covering both per-unit handlers (spatial process,
+    temporal process_event) and every status branch (200/400/500), so the
+    orchestrator can stratify failures -- e.g. an OOM'd generation-4 shard --
+    by container state, not just successes. A non-dict/undecodable body passes
+    through untouched (never turn a valid error envelope into a crash).
+    """
+    try:
+        body = json.loads(response.get("body", "{}"))
+    except (json.JSONDecodeError, TypeError):
+        return response
+    if not isinstance(body, dict):
+        return response
+    body.update(telemetry)
+    return {**response, "body": json.dumps(body)}
+
 
 def _max_memory_mb() -> float:
     """Peak resident set size of this worker in MB (issue #120).
@@ -282,6 +339,11 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     ``mode="extract"`` extracts chunk-boundary geometry parquets (issue #148);
     ``mode="process_event"`` runs the temporal/event worker (issue #12).
     """
+    # Count EVERY invocation toward the sandbox's generation (issue #171): a
+    # setup/finalize/extract invoke warms the container just like a shard does,
+    # so the next shard on this sandbox is genuinely generation N+1. Snapshot
+    # start RSS here, before any per-unit work inflates it.
+    telemetry = _container_telemetry()
     mode = event.get("mode", "process")
     if mode == "setup":
         return _handle_setup(event)
@@ -295,6 +357,10 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         response = _handle_process_event(event)
     else:
         response = _handle_process(event, context)
+    # Container telemetry rides in every per-unit envelope (issue #171) -- the
+    # setup/finalize/extract bodies stay byte-identical (their consumers don't
+    # aggregate container state).
+    response = _attach_container_telemetry(response, telemetry)
     # Async result channel (issue #151): on an Event invoke the return value is
     # discarded, so mirror the response envelope to the orchestrator-supplied
     # result_url for it to poll. Covers every branch (200 / 400 / 500) of both

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -188,6 +188,74 @@ def _attach_container_telemetry(
     return {**response, "body": json.dumps(body)}
 
 
+# Injectable exit seam (issue #171): module-level so tests can monkeypatch it.
+# ``os._exit`` (not sys.exit) is deliberate -- the sandbox is being discarded,
+# not shut down gracefully, and the exit must not be catchable en route.
+_exit = os._exit
+
+
+def _recycle_limit(name: str) -> float:
+    """Read one self-recycle knob from the environment; 0.0 == disabled.
+
+    Absent, empty, "0", or non-numeric (logged) all disable the check, so a
+    stack deployed without the template.yaml defaults behaves exactly as
+    before this feature existed.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return 0.0
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(f"{name}={raw!r} is not numeric; recycle check disabled")
+        return 0.0
+
+
+def _maybe_self_recycle() -> None:
+    """Destroy this sandbox when it is too bloated to trust (issue #171).
+
+    Called ONLY after the invocation's result envelope was successfully
+    mirrored to its ``result_url`` (the issue #151/#153 async channel): the
+    orchestrator polls that S3 object, not the Lambda response, so once the
+    mirror has landed the invocation is operationally complete and exiting
+    loses nothing; ``MaximumRetryAttempts: 0`` (template.yaml) guarantees the
+    cosmetically "failed" invocation is never re-driven. Never called on the
+    synchronous path, where exiting would lose the response.
+
+    Two independent knobs (function env vars with template.yaml defaults;
+    absent/empty/0 disables that check):
+
+    - ``ZAGG_RECYCLE_RSS_MB`` -- recycle when current RSS is at/over this
+      many MB. The #169 ratchet retained ~700-1100 MB per heavy invocation
+      against a 2047 MB cap, so the template's 1400 catches a dirty sandbox
+      after roughly one heavy retention while leaving the triggering
+      invocation ~650 MB of headroom to complete first.
+    - ``ZAGG_RECYCLE_MAX_INVOCATIONS`` -- generation cap (template 8),
+      belt-and-suspenders for retention modes the RSS read misses (and the
+      only check that fires off-Linux, where RSS reads are None).
+
+    Emits one CloudWatch-searchable line (``ZAGG_SELF_RECYCLE ...``) before
+    exiting so dashboards can split intentional recycles from real crashes
+    (metric-filter note in docs/deployment/lambda.md).
+    """
+    rss_limit = _recycle_limit("ZAGG_RECYCLE_RSS_MB")
+    gen_limit = _recycle_limit("ZAGG_RECYCLE_MAX_INVOCATIONS")
+    kib = _read_vmrss_kib()
+    rss_mb = kib / 1024.0 if kib is not None else None
+    generation = _INVOCATIONS_SERVED
+    if rss_limit > 0 and rss_mb is not None and rss_mb >= rss_limit:
+        threshold = rss_limit
+    elif gen_limit > 0 and generation >= gen_limit:
+        threshold = gen_limit
+    else:
+        return
+    rss_repr = f"{rss_mb:.0f}" if rss_mb is not None else "n/a"
+    logger.info(
+        f"ZAGG_SELF_RECYCLE rss_mb={rss_repr} generation={generation} threshold={threshold:g}"
+    )
+    _exit(0)
+
+
 def _max_memory_mb() -> float:
     """Peak resident set size of this worker in MB (issue #120).
 
@@ -366,16 +434,27 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     # result_url for it to poll. Covers every branch (200 / 400 / 500) of both
     # per-unit handlers (spatial process, temporal process_event -- #12 Phase 8).
     if event.get("result_url"):
-        _write_result(event["result_url"], response, event)
+        mirrored = _write_result(event["result_url"], response, event)
+        # Self-recycle strictly AFTER a successful result mirror (issue #171):
+        # the orchestrator polls the result object, not the Lambda response
+        # (#151/#153), so at this point the invocation is complete from the
+        # run's perspective and destroying a bloated sandbox loses nothing.
+        # Sync invokes never reach here (no result_url) -- exiting would lose
+        # their response -- and a failed mirror skips the recycle (the shard
+        # is recorded failed at the poll deadline; don't also churn the
+        # sandbox on what may be a transient S3 fault).
+        if mirrored:
+            _maybe_self_recycle()
     return response
 
 
-def _write_result(result_url: str, response: Dict[str, Any], event: Dict[str, Any]) -> None:
+def _write_result(result_url: str, response: Dict[str, Any], event: Dict[str, Any]) -> bool:
     """Write the response envelope to ``result_url`` as JSON (issue #151).
 
     Uses the same credentials/endpoint resolution as the output store. Never
     raises: on failure the orchestrator's poll times out and records the shard
-    as failed, and the cause lands here in CloudWatch.
+    as failed, and the cause lands here in CloudWatch. Returns True only when
+    the write landed -- the self-recycle gate (issue #171) keys on it.
     """
     import obstore
 
@@ -386,8 +465,10 @@ def _write_result(result_url: str, response: Dict[str, Any], event: Dict[str, An
         store = open_object_store(prefix, **_output_store_kwargs(event))
         obstore.put(store, key, json.dumps(response).encode())
         logger.info(f"Wrote async result to {result_url}")
+        return True
     except Exception as e:
         logger.error(f"Failed to write async result to {result_url}: {e}")
+        return False
 
 
 def _handle_extract(event: Dict[str, Any], context: Any) -> Dict[str, Any]:

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -101,6 +101,15 @@ worker, fanned out the same way per-cell spatial work is.
 Setup and finalize exist so callers without direct S3 write access to the
 output bucket (e.g. cross-account JupyterHub orchestrators) can run the
 full pipeline using only lambda:InvokeFunction.
+
+Every per-unit response envelope (process / process_event, all status
+branches, including the ``result_url`` mirror) additionally carries container
+telemetry -- ``container_cold`` / ``container_generation`` / ``rss_start_mb``
+/ ``sandbox_id`` / ``container_init_ts`` (issue #171; see
+``_container_telemetry``) -- and after a successful async result mirror the
+worker may self-recycle a bloated sandbox (``_maybe_self_recycle``, gated by
+the ``ZAGG_RECYCLE_RSS_MB`` / ``ZAGG_RECYCLE_MAX_INVOCATIONS`` function env
+vars).
 """
 
 import ctypes

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -101,6 +101,32 @@ Parameters:
       trims freed top-of-heap back to the OS immediately, independently
       flattening warm-container memory growth. Set empty to fall back to the glibc default (the key is still emitted, just empty).
 
+  RecycleRssMb:
+    Type: String
+    Default: "1400"
+    Description: >-
+      ZAGG_RECYCLE_RSS_MB for the worker self-recycle (issue #171): after an
+      async invocation's result is safely mirrored to its result_url, the
+      handler exits the sandbox when current RSS meets/exceeds this many MB,
+      forcing the next invocation cold instead of ratcheting toward OOM
+      (issue #169 observed ~700-1100 MB retained per heavy invocation on a
+      2047 MB cap; 1400 leaves ~650 MB of headroom so the triggering
+      invocation itself still completes). The self-exit is AFTER the result
+      write, so the run loses nothing; it shows up as a runtime failure in
+      CloudWatch error metrics only (cosmetic -- the result object is the
+      source of truth, and MaximumRetryAttempts is 0). Set "0" or empty to
+      disable the RSS check.
+
+  RecycleMaxInvocations:
+    Type: String
+    Default: "8"
+    Description: >-
+      ZAGG_RECYCLE_MAX_INVOCATIONS for the worker self-recycle (issue #171):
+      belt-and-suspenders generation cap -- recycle the sandbox (same
+      after-result-mirror mechanics as RecycleRssMb) once it has served this
+      many invocations, bounding retention modes the RSS check misses. Set
+      "0" or empty to disable the generation check.
+
 Conditions:
   ShouldCreateBucket: !Equals [!Ref CreateOutputBucket, "true"]
   ShouldCreateRole: !Equals [!Ref CreateExecutionRole, "true"]
@@ -178,6 +204,8 @@ Resources:
         Variables:
           MALLOC_ARENA_MAX: !Ref MallocArenaMax
           MALLOC_TRIM_THRESHOLD_: !Ref MallocTrimThreshold
+          ZAGG_RECYCLE_RSS_MB: !Ref RecycleRssMb
+          ZAGG_RECYCLE_MAX_INVOCATIONS: !Ref RecycleMaxInvocations
       Code:
         S3Bucket: !Ref ArtifactBucket
         S3Key: !Ref FunctionS3Key
@@ -222,6 +250,8 @@ Resources:
         Variables:
           MALLOC_ARENA_MAX: !Ref MallocArenaMax
           MALLOC_TRIM_THRESHOLD_: !Ref MallocTrimThreshold
+          ZAGG_RECYCLE_RSS_MB: !Ref RecycleRssMb
+          ZAGG_RECYCLE_MAX_INVOCATIONS: !Ref RecycleMaxInvocations
       Code:
         S3Bucket: !Ref ArtifactBucket
         S3Key: !Ref FunctionS3Key

--- a/docs/deployment/benchmark.md
+++ b/docs/deployment/benchmark.md
@@ -10,6 +10,19 @@ data branch; they update live (the docs embed them by raw URL, so no docs rebuil
 is needed). See [Lambda benchmark CI/CD setup](benchmark-cicd.md) for how the
 pipeline is wired.
 
+### Container regime
+
+Benchmark points run with the default `force_cold=False`, so they measure the
+**warm regime** — the same reused containers a routine fleet sees. Since issue
+#171 each run's summary carries container telemetry (`worker_cold_starts` /
+`worker_warm_starts` / `worker_rss_start_max_by_gen`, rolled up from the
+per-worker `container_cold` / `container_generation` / `rss_start_mb` envelope
+fields), so a memory outlier can be stratified by whether its shard landed on a
+fresh or a reused (higher-generation) sandbox. `agg(..., force_cold=True)`
+remains the explicit all-cold certification baseline (it needs
+`lambda:UpdateFunctionConfiguration` on the caller — see
+[Warm-container memory and self-recycle](lambda.md#warm-container-memory-and-self-recycle)).
+
 ## Sharded vs inner-chunk (tdigest, HEALPix)
 
 The forward benchmark (issue #133) is a **2×3 matrix** measuring the ShardingCodec

--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -290,6 +290,54 @@ raises the FD ceiling it can use.
 | Typical memory usage | 1--1.5 GB |
 | Cold start | 3--5 seconds |
 
+## Warm-container memory and self-recycle
+
+Warm (reused) sandboxes retain process RSS across invocations — the issue
+#169 forensics showed container-lifetime memory ratcheting 959 → 1650 →
+2029 MB → OOM at the 2047 MB cap across four back-to-back fleet runs on the
+same 9 sandboxes, even with the glibc allocator tunables
+(`MALLOC_ARENA_MAX`/`MALLOC_TRIM_THRESHOLD_`, issue #143) deployed. Two
+mechanisms address this (issue #171):
+
+- **Container telemetry** — every worker result envelope carries
+  `container_cold`, `container_generation`, `rss_start_mb`, `sandbox_id`,
+  and `container_init_ts`; the run summary rolls these into
+  `worker_cold_starts` / `worker_warm_starts` /
+  `worker_rss_start_max_by_gen` (flat across generations = healthy;
+  climbing = the ratchet).
+- **Self-recycle** — after an async invocation's result envelope is safely
+  mirrored to its `result_url`, the handler exits the sandbox
+  (`os._exit(0)`) when current RSS ≥ `ZAGG_RECYCLE_RSS_MB` (template
+  default 1400) or the sandbox has served `ZAGG_RECYCLE_MAX_INVOCATIONS`
+  (template default 8) invocations. Set either to `0`/empty to disable that
+  check. The next invocation then starts on a fresh container instead of
+  ratcheting toward OOM. Synchronous invocations never self-recycle (the
+  response would be lost).
+
+!!! info "Self-recycles look like runtime failures in CloudWatch"
+    A self-exit after the result write is counted as a runtime error by
+    Lambda's `Errors` metric — **cosmetically only**: the result object at
+    `result_url` is the source of truth for the orchestrator (issue #153),
+    and `MaximumRetryAttempts: 0` in the template guarantees no zombie
+    retry. Each recycle logs one structured line first:
+
+    ```
+    ZAGG_SELF_RECYCLE rss_mb=<current> generation=<n> threshold=<crossed limit>
+    ```
+
+    To keep dashboards honest, split intentional recycles from real crashes
+    with a [metric filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html)
+    on the function's log group, pattern `ZAGG_SELF_RECYCLE`, and subtract
+    (or graph separately) from `AWS/Lambda Errors`.
+
+For guaranteed all-cold fleets (certification/benchmark baselines) there is
+also the dispatch-side big hammer: `agg(..., force_cold=True)` bumps a
+`ZAGG_COLD_EPOCH` function-environment marker before fan-out, invalidating
+every warm sandbox at once. It requires `lambda:GetFunctionConfiguration` +
+`lambda:UpdateFunctionConfiguration` on the *caller* and chills the warm
+pool for all users of the function, so it is off by default and independent
+of the self-recycle knobs (both can be enabled).
+
 ## Cost Estimate
 
 **Per invocation** (180s average, 2 GB memory): ~$0.006

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1941,6 +1941,7 @@ def _force_cold_containers(lambda_client, function_name, *, wait_s=120, poll_int
             "lambda:UpdateFunctionConfiguration; pass force_cold=False to dispatch "
             "onto warm containers instead."
         ) from exc
+    prior = ((current.get("Environment") or {}).get("Variables") or {}).get("ZAGG_COLD_EPOCH")
     env = dict((current.get("Environment") or {}).get("Variables") or {})
     env["ZAGG_COLD_EPOCH"] = token
     while True:
@@ -1952,9 +1953,16 @@ def _force_cold_containers(lambda_client, function_name, *, wait_s=120, poll_int
         except Exception as exc:
             response = getattr(exc, "response", None)
             code = response.get("Error", {}).get("Code", "") if isinstance(response, dict) else ""
-            if code == "ResourceConflictException" and time.time() < deadline:
-                time.sleep(poll_interval_s)  # another config update in flight; retry
-                continue
+            if code == "ResourceConflictException":
+                if time.time() < deadline:
+                    time.sleep(poll_interval_s)  # another config update in flight; retry
+                    continue
+                raise RuntimeError(
+                    f"force_cold: {function_name} has had another configuration update "
+                    f"in flight for the whole {wait_s}s deadline "
+                    "(ResourceConflictException); retry the run, or pass "
+                    "force_cold=False to dispatch onto warm containers."
+                ) from exc
             raise RuntimeError(
                 f"force_cold: updating {function_name} configuration failed ({exc}). The "
                 "caller needs lambda:UpdateFunctionConfiguration; pass force_cold=False "
@@ -1975,6 +1983,19 @@ def _force_cold_containers(lambda_client, function_name, *, wait_s=120, poll_int
                     f"force_cold: {function_name} configuration update failed server-side "
                     "(LastUpdateStatus=Failed); check the function state in the console"
                 )
+        elif marker != prior and status == "Successful":
+            # Superseded: a third epoch value means a CONCURRENT update (e.g.
+            # another force_cold run) was accepted after ours. Lambda
+            # serializes configuration updates, so its acceptance proves ours
+            # applied first (or was subsumed) -- either way every warm sandbox
+            # is already invalidated, which is the outcome the caller asked
+            # for. (Review finding, PR #172: without this branch the poll
+            # spins to deadline and reports a failure that didn't happen.)
+            logger.info(
+                "force_cold: superseded by a concurrent configuration update "
+                "(warm sandboxes already invalidated)"
+            )
+            return
         if time.time() >= deadline:
             raise RuntimeError(
                 f"force_cold: {function_name} configuration update still {status!r} "

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -93,7 +93,7 @@ def agg(
     profile: bool = False,
     max_retries: int = 3,
     invocation: str = "async",
-    force_cold: bool = False,
+    force_cold: bool = True,
     events=None,
 ) -> dict:
     """Run the aggregation pipeline.
@@ -178,20 +178,22 @@ def agg(
         (granule-dense shards with large AOI masks). Ignored by the
         ``"local"`` backend.
     force_cold : bool
-        Lambda-only (issue #171). When ``True``, merge a per-run
-        ``ZAGG_COLD_EPOCH`` marker into the function's environment before
-        fan-out and wait for the update to apply -- any configuration change
-        invalidates every warm sandbox, so each worker starts on a fresh
-        container. Guards against the warm-container RSS ratchet (issues
-        #139/#169): consecutive fleet runs reuse sandboxes that retain memory
-        across invocations and can OOM within a few generations. Existing
-        environment variables (e.g. the issue #143 malloc tunables) are
-        preserved. Requires ``lambda:GetFunctionConfiguration`` and
+        Lambda-only (issue #171). When ``True`` (the default -- espg's call
+        on PR #172), merge a per-run ``ZAGG_COLD_EPOCH`` marker into the
+        function's environment before fan-out and wait for the update to
+        apply -- any configuration change invalidates every warm sandbox, so
+        each worker starts on a fresh container. Guards against the
+        warm-container RSS ratchet (issues #139/#169): consecutive fleet
+        runs reuse sandboxes that retain memory across invocations and can
+        OOM within a few generations. Existing environment variables (e.g.
+        the issue #143 malloc tunables) are preserved. Requires
+        ``lambda:GetFunctionConfiguration`` and
         ``lambda:UpdateFunctionConfiguration`` on the caller, and raises --
         rather than silently degrading to warm containers -- when the update
-        cannot be applied. Costs one config-update round trip plus a few
-        seconds of cold init per container. Default ``False``: no config
-        touch, byte-identical dispatch. Ignored by the ``"local"`` backend.
+        cannot be applied; pass ``force_cold=False`` for callers without the
+        update permission (dispatch is then byte-identical to pre-#171).
+        Costs one config-update round trip plus a few seconds of cold init
+        per container. Ignored by the ``"local"`` backend.
 
     events : iterable, optional
         Temporal pipeline only (``pipeline.type: temporal``/``event``), one
@@ -1918,40 +1920,61 @@ def _force_cold_containers(lambda_client, function_name, *, wait_s=120, poll_int
     Unlike :func:`_get_function_timeout_s`, failures raise: the caller asked
     for cold containers explicitly, so silently proceeding warm would defeat
     the run's memory isolation.
+
+    The poll accepts only *this* update's terminal states: the API is
+    eventually consistent, so a ``Successful`` read immediately after
+    ``update_function_configuration`` can still describe the *prior* update
+    -- acceptance additionally requires the polled environment to carry this
+    run's marker. A ``ResourceConflictException`` on the update (another
+    configuration change in flight -- a concurrent ``force_cold`` run or a
+    deploy) retries until the deadline instead of surfacing as a
+    permissions error.
     """
     token = uuid.uuid4().hex
-    env = dict(
-        (
-            lambda_client.get_function_configuration(FunctionName=function_name).get("Environment")
-            or {}
-        ).get("Variables")
-        or {}
-    )
-    env["ZAGG_COLD_EPOCH"] = token
+    deadline = time.time() + wait_s
     try:
-        lambda_client.update_function_configuration(
-            FunctionName=function_name, Environment={"Variables": env}
-        )
+        current = lambda_client.get_function_configuration(FunctionName=function_name)
     except Exception as exc:
         raise RuntimeError(
-            f"force_cold: updating {function_name} configuration failed ({exc}). The "
+            f"force_cold: reading {function_name} configuration failed ({exc}). The "
             "caller needs lambda:GetFunctionConfiguration and "
             "lambda:UpdateFunctionConfiguration; pass force_cold=False to dispatch "
             "onto warm containers instead."
         ) from exc
-    deadline = time.time() + wait_s
+    env = dict((current.get("Environment") or {}).get("Variables") or {})
+    env["ZAGG_COLD_EPOCH"] = token
     while True:
-        status = lambda_client.get_function_configuration(FunctionName=function_name).get(
-            "LastUpdateStatus"
-        )
-        if status == "Successful":
-            logger.info(f"force_cold: warm sandboxes invalidated (ZAGG_COLD_EPOCH={token})")
-            return
-        if status == "Failed":
-            raise RuntimeError(
-                f"force_cold: {function_name} configuration update failed server-side "
-                "(LastUpdateStatus=Failed); check the function state in the console"
+        try:
+            lambda_client.update_function_configuration(
+                FunctionName=function_name, Environment={"Variables": env}
             )
+            break
+        except Exception as exc:
+            response = getattr(exc, "response", None)
+            code = response.get("Error", {}).get("Code", "") if isinstance(response, dict) else ""
+            if code == "ResourceConflictException" and time.time() < deadline:
+                time.sleep(poll_interval_s)  # another config update in flight; retry
+                continue
+            raise RuntimeError(
+                f"force_cold: updating {function_name} configuration failed ({exc}). The "
+                "caller needs lambda:UpdateFunctionConfiguration; pass force_cold=False "
+                "to dispatch onto warm containers instead."
+            ) from exc
+    while True:
+        cfg = lambda_client.get_function_configuration(FunctionName=function_name)
+        status = cfg.get("LastUpdateStatus")
+        marker = ((cfg.get("Environment") or {}).get("Variables") or {}).get("ZAGG_COLD_EPOCH")
+        if marker == token:
+            # Only this update's states count: a Successful (or Failed) read
+            # without the marker describes the prior configuration.
+            if status == "Successful":
+                logger.info(f"force_cold: warm sandboxes invalidated (ZAGG_COLD_EPOCH={token})")
+                return
+            if status == "Failed":
+                raise RuntimeError(
+                    f"force_cold: {function_name} configuration update failed server-side "
+                    "(LastUpdateStatus=Failed); check the function state in the console"
+                )
         if time.time() >= deadline:
             raise RuntimeError(
                 f"force_cold: {function_name} configuration update still {status!r} "

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -193,9 +193,12 @@ def agg(
         the update cannot be applied: an explicit request hard-fails instead
         of quietly not certifying. Costs one config-update round trip plus a
         few seconds of cold init per container, and chills the warm pool for
-        every concurrent user of the function -- which is why routine runs
-        leave it off even under the warm-container RSS ratchet (issues
-        #139/#169). Ignored by the ``"local"`` backend.
+        every concurrent user of the function. Routine protection against
+        the warm-container RSS ratchet (issues #139/#169) does not need this
+        flag: workers self-recycle bloated sandboxes via the
+        ``ZAGG_RECYCLE_RSS_MB`` / ``ZAGG_RECYCLE_MAX_INVOCATIONS`` function
+        env vars (issue #171), independently of ``force_cold`` -- both can
+        be on. Ignored by the ``"local"`` backend.
 
     events : iterable, optional
         Temporal pipeline only (``pipeline.type: temporal``/``event``), one

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -93,6 +93,7 @@ def agg(
     profile: bool = False,
     max_retries: int = 3,
     invocation: str = "async",
+    force_cold: bool = False,
     events=None,
 ) -> dict:
     """Run the aggregation pipeline.
@@ -176,6 +177,21 @@ def agg(
         ``"sync"`` for older deployed workers or extreme per-cell payloads
         (granule-dense shards with large AOI masks). Ignored by the
         ``"local"`` backend.
+    force_cold : bool
+        Lambda-only (issue #171). When ``True``, merge a per-run
+        ``ZAGG_COLD_EPOCH`` marker into the function's environment before
+        fan-out and wait for the update to apply -- any configuration change
+        invalidates every warm sandbox, so each worker starts on a fresh
+        container. Guards against the warm-container RSS ratchet (issues
+        #139/#169): consecutive fleet runs reuse sandboxes that retain memory
+        across invocations and can OOM within a few generations. Existing
+        environment variables (e.g. the issue #143 malloc tunables) are
+        preserved. Requires ``lambda:GetFunctionConfiguration`` and
+        ``lambda:UpdateFunctionConfiguration`` on the caller, and raises --
+        rather than silently degrading to warm containers -- when the update
+        cannot be applied. Costs one config-update round trip plus a few
+        seconds of cold init per container. Default ``False``: no config
+        touch, byte-identical dispatch. Ignored by the ``"local"`` backend.
 
     events : iterable, optional
         Temporal pipeline only (``pipeline.type: temporal``/``event``), one
@@ -217,6 +233,7 @@ def agg(
         profile=profile,
         max_retries=max_retries,
         invocation=invocation,
+        force_cold=force_cold,
         events=events,
     )
 
@@ -251,6 +268,7 @@ class SpatialStrategy:
         profile=False,
         max_retries=3,
         invocation="async",
+        force_cold=False,
         events=None,
     ):
         # Resolve catalog and store
@@ -337,6 +355,7 @@ class SpatialStrategy:
                 profile=profile,
                 max_retries=max_retries,
                 invocation=invocation,
+                force_cold=force_cold,
             )
         else:
             raise ValueError(f"Unknown backend: {backend!r} (expected 'local' or 'lambda')")
@@ -378,6 +397,7 @@ class TemporalStrategy:
         profile=False,
         max_retries=3,
         invocation="async",
+        force_cold=False,
         events=None,
     ):
         from zagg.temporal import process_event, specs_from_config
@@ -420,6 +440,7 @@ class TemporalStrategy:
                 output_endpoint_url=output_endpoint_url,
                 max_retries=max_retries,
                 invocation=invocation,
+                force_cold=force_cold,
             )
 
         if max_workers is None:
@@ -541,6 +562,7 @@ def _run_lambda_events(
     output_endpoint_url=None,
     max_retries=3,
     invocation="async",
+    force_cold=False,
 ):
     """Fan the temporal pipeline out one event per Lambda invoke (issue #12, Phase 8).
 
@@ -657,6 +679,8 @@ def _run_lambda_events(
             config=boto_config,
         )
         state["function_timeout_s"] = _get_function_timeout_s(state["lambda_client"], function_name)
+        if force_cold:
+            _force_cold_containers(state["lambda_client"], function_name)
         return PreflightReport(workers=clamped, detail=concurrency_report)
 
     def _event_work(ev):
@@ -1182,6 +1206,7 @@ def _run_lambda(
     profile=False,
     max_retries=3,
     invocation="async",
+    force_cold=False,
 ):
     """Run processing via AWS Lambda invocation.
 
@@ -1304,6 +1329,8 @@ def _run_lambda(
         # Read the function Timeout once, pre-fan-out: the async poll deadline
         # is keyed to it (issue #151), and the summary reports it (#100).
         state["function_timeout_s"] = _get_function_timeout_s(state["lambda_client"], function_name)
+        if force_cold:
+            _force_cold_containers(state["lambda_client"], function_name)
         return PreflightReport(workers=clamped, detail=concurrency_report)
 
     # Per-cell invoke, bound to everything but the (shard_key, records) pair so
@@ -1875,6 +1902,62 @@ def _poll_lambda_result(
             }
         # Sub-second jitter de-synchronizes the fan-out's poll bursts.
         time.sleep(poll_interval_s + (time.time() % 1))
+
+
+def _force_cold_containers(lambda_client, function_name, *, wait_s=120, poll_interval_s=2.0):
+    """Invalidate every warm sandbox before fan-out (issue #171).
+
+    Warm containers retain process RSS across invocations (the #139/#169
+    ratchet), so consecutive fleet runs inherit dirty sandboxes that OOM
+    within a few generations. Any function-configuration change invalidates
+    all warm sandboxes at once: merge a per-run ``ZAGG_COLD_EPOCH`` marker
+    into the environment (preserving existing variables -- e.g. the issue
+    #143 malloc tunables) and wait for the update to apply before the first
+    invoke.
+
+    Unlike :func:`_get_function_timeout_s`, failures raise: the caller asked
+    for cold containers explicitly, so silently proceeding warm would defeat
+    the run's memory isolation.
+    """
+    token = uuid.uuid4().hex
+    env = dict(
+        (
+            lambda_client.get_function_configuration(FunctionName=function_name).get("Environment")
+            or {}
+        ).get("Variables")
+        or {}
+    )
+    env["ZAGG_COLD_EPOCH"] = token
+    try:
+        lambda_client.update_function_configuration(
+            FunctionName=function_name, Environment={"Variables": env}
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            f"force_cold: updating {function_name} configuration failed ({exc}). The "
+            "caller needs lambda:GetFunctionConfiguration and "
+            "lambda:UpdateFunctionConfiguration; pass force_cold=False to dispatch "
+            "onto warm containers instead."
+        ) from exc
+    deadline = time.time() + wait_s
+    while True:
+        status = lambda_client.get_function_configuration(FunctionName=function_name).get(
+            "LastUpdateStatus"
+        )
+        if status == "Successful":
+            logger.info(f"force_cold: warm sandboxes invalidated (ZAGG_COLD_EPOCH={token})")
+            return
+        if status == "Failed":
+            raise RuntimeError(
+                f"force_cold: {function_name} configuration update failed server-side "
+                "(LastUpdateStatus=Failed); check the function state in the console"
+            )
+        if time.time() >= deadline:
+            raise RuntimeError(
+                f"force_cold: {function_name} configuration update still {status!r} "
+                f"after {wait_s}s; workers would reuse warm containers"
+            )
+        time.sleep(poll_interval_s)
 
 
 def _get_function_timeout_s(lambda_client, function_name):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -93,7 +93,7 @@ def agg(
     profile: bool = False,
     max_retries: int = 3,
     invocation: str = "async",
-    force_cold: bool = True,
+    force_cold: bool = False,
     events=None,
 ) -> dict:
     """Run the aggregation pipeline.
@@ -178,22 +178,24 @@ def agg(
         (granule-dense shards with large AOI masks). Ignored by the
         ``"local"`` backend.
     force_cold : bool
-        Lambda-only (issue #171). When ``True`` (the default -- espg's call
-        on PR #172), merge a per-run ``ZAGG_COLD_EPOCH`` marker into the
-        function's environment before fan-out and wait for the update to
-        apply -- any configuration change invalidates every warm sandbox, so
-        each worker starts on a fresh container. Guards against the
-        warm-container RSS ratchet (issues #139/#169): consecutive fleet
-        runs reuse sandboxes that retain memory across invocations and can
-        OOM within a few generations. Existing environment variables (e.g.
+        Lambda-only (issue #171), default ``False``. The explicit big-hammer
+        for certification runs -- benchmark baselines, memory forensics, or
+        any run that must be provably unaffected by prior container state:
+        merge a per-run ``ZAGG_COLD_EPOCH`` marker into the function's
+        environment before fan-out and wait for the update to apply -- any
+        configuration change invalidates every warm sandbox, so each worker
+        starts on a fresh container. Existing environment variables (e.g.
         the issue #143 malloc tunables) are preserved. Requires
         ``lambda:GetFunctionConfiguration`` and
-        ``lambda:UpdateFunctionConfiguration`` on the caller, and raises --
-        rather than silently degrading to warm containers -- when the update
-        cannot be applied; pass ``force_cold=False`` for callers without the
-        update permission (dispatch is then byte-identical to pre-#171).
-        Costs one config-update round trip plus a few seconds of cold init
-        per container. Ignored by the ``"local"`` backend.
+        ``lambda:UpdateFunctionConfiguration`` on the caller -- a broad
+        write on the production function, which is why this is opt-in --
+        and raises (rather than silently degrading to warm containers) when
+        the update cannot be applied: an explicit request hard-fails instead
+        of quietly not certifying. Costs one config-update round trip plus a
+        few seconds of cold init per container, and chills the warm pool for
+        every concurrent user of the function -- which is why routine runs
+        leave it off even under the warm-container RSS ratchet (issues
+        #139/#169). Ignored by the ``"local"`` backend.
 
     events : iterable, optional
         Temporal pipeline only (``pipeline.type: temporal``/``event``), one

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -787,6 +787,11 @@ def _run_lambda_events(
         if r.get("status_code") != 200 or r.get("error")
     ]
 
+    # Container-telemetry rollup (issue #171), same additive fields as the
+    # spatial summary; the raw envelopes live in report.results (summary
+    # "results" carries the collected tabular rows instead).
+    container_stats = _container_telemetry_summary([r.get("body") or {} for r in report.results])
+
     summary = {
         "total_events": n,
         "events_with_data": report.cells_with_data,
@@ -803,12 +808,14 @@ def _run_lambda_events(
         "backend": "lambda",
         "results": rows,
         "failures": failures,
+        **container_stats,
     }
     logger.info(
         f"Done: {report.cells_with_data} events, {report.total_obs} timesteps, "
         f"{report.cells_error} errors, {wall_time:.1f}s, "
         f"~${estimated_cost:.4f} ({gb_seconds:.1f} GB-s)"
     )
+    _log_container_stats(container_stats)
     return summary
 
 
@@ -1494,6 +1501,10 @@ def _run_lambda(
     ]
     max_memory_mb = max(worker_memory) if worker_memory else None
 
+    # Container-telemetry rollup (issue #171): cold/warm counts + the ratchet
+    # view (max start-RSS per sandbox generation) from the worker envelopes.
+    container_stats = _container_telemetry_summary([r.get("body") or {} for r in report.results])
+
     # Per-phase worker breakdown (issue #100 phase 2), only when --profile fed
     # the workers a "profile" event so they emitted body["phase_timings"]. Roll
     # the straggler (max) per phase across cells, matching the wall-time framing.
@@ -1528,6 +1539,7 @@ def _run_lambda(
         "backend": "lambda",
         "function_name": function_name,
         "results": report.results,
+        **container_stats,
     }
     if profile:
         summary["worker_phase_max"] = worker_phase_max
@@ -1552,6 +1564,7 @@ def _run_lambda(
     if profile and worker_phase_max:
         breakdown = ", ".join(f"{phase} {secs:.0f}s" for phase, secs in worker_phase_max.items())
         logger.info(f"Worker phases (max across cells): {breakdown}")
+    _log_container_stats(container_stats)
     return summary
 
 
@@ -2004,6 +2017,54 @@ def _force_cold_containers(lambda_client, function_name, *, wait_s=120, poll_int
                 f"after {wait_s}s; workers would reuse warm containers"
             )
         time.sleep(poll_interval_s)
+
+
+def _container_telemetry_summary(bodies):
+    """Aggregate worker container telemetry into additive summary fields (issue #171).
+
+    ``bodies`` are the parsed per-unit result bodies. Workers stamp
+    ``container_cold`` / ``container_generation`` / ``rss_start_mb`` into every
+    envelope (the detect-and-report half of the PR #172 plan), and this rolls
+    them up into the fleet-level view that makes the #169 warm-container RSS
+    ratchet visible in the run summary instead of requiring CloudWatch
+    forensics: how many shards ran on fresh vs reused sandboxes, and the max
+    start-RSS at each sandbox generation (a healthy fleet is flat across
+    generations; the ratchet climbs). All three fields are ``None`` when no
+    worker reported telemetry (older deployed workers), so consumers can
+    distinguish "no data" from a genuinely all-warm run.
+    """
+    reported = [b for b in bodies if b.get("container_generation") is not None]
+    if not reported:
+        return {
+            "worker_cold_starts": None,
+            "worker_warm_starts": None,
+            "worker_rss_start_max_by_gen": None,
+        }
+    cold = sum(1 for b in reported if b.get("container_cold"))
+    by_gen: dict = {}
+    for b in reported:
+        rss = b.get("rss_start_mb")
+        if rss is not None:
+            gen = int(b["container_generation"])
+            by_gen[gen] = max(by_gen.get(gen, 0.0), float(rss))
+    return {
+        "worker_cold_starts": cold,
+        "worker_warm_starts": len(reported) - cold,
+        "worker_rss_start_max_by_gen": dict(sorted(by_gen.items())),
+    }
+
+
+def _log_container_stats(container_stats):
+    """One summary log line for the container-telemetry rollup (issue #171)."""
+    if container_stats.get("worker_cold_starts") is None:
+        return
+    by_gen = container_stats["worker_rss_start_max_by_gen"] or {}
+    ratchet = ", ".join(f"gen{g} {mb:.0f}MB" for g, mb in by_gen.items()) or "n/a"
+    logger.info(
+        f"Containers: {container_stats['worker_cold_starts']} cold / "
+        f"{container_stats['worker_warm_starts']} warm; max start-RSS by "
+        f"generation: {ratchet}"
+    )
 
 
 def _get_function_timeout_s(lambda_client, function_name):

--- a/src/zagg/schema.py
+++ b/src/zagg/schema.py
@@ -37,6 +37,20 @@ class ProcessingMetadata(TypedDict):
     # read is always a real error, so this surfaces a shard whose "no data"
     # result is actually a read failure rather than a legitimately-empty read.
     read_errors: NotRequired[int]
+    # Container telemetry (issue #171), stamped by the Lambda handler's
+    # dispatcher into every per-unit envelope (all status branches) so the
+    # runner can surface the warm-container RSS ratchet (#169). Absent on the
+    # local runner path. ``container_cold``: first invocation on this sandbox.
+    # ``container_generation``: invocations this sandbox has served (all
+    # modes). ``rss_start_mb``: process RSS at handler entry -- the ratchet
+    # signal (None off Linux). ``sandbox_id``: CloudWatch log-stream name,
+    # unique per sandbox. ``container_init_ts``: module-import epoch seconds.
+    # The per-invocation *peak* is the existing ``max_memory_mb`` (issue #141).
+    container_cold: NotRequired[bool]
+    container_generation: NotRequired[int]
+    rss_start_mb: NotRequired[float | None]
+    sandbox_id: NotRequired[str | None]
+    container_init_ts: NotRequired[float]
 
 
 def xdggs_spec(

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -201,6 +201,19 @@ class TestTemplateEnvironment:
         assert params["MallocArenaMax"]["Default"] == "2"
         assert params["MallocTrimThreshold"]["Default"] == "0"
 
+    def test_self_recycle_env_defaults(self):
+        # issue #171: the worker self-recycle knobs ride the function
+        # environment with template defaults (1400 MB on the 2047 MB cap --
+        # ~650 MB of headroom over the observed ~700-1100 MB/invocation
+        # retention -- and a generation cap of 8 as belt-and-suspenders).
+        tpl = self._load_template()
+        params = tpl["Parameters"]
+        assert params["RecycleRssMb"]["Default"] == "1400"
+        assert params["RecycleMaxInvocations"]["Default"] == "8"
+        env = tpl["Resources"]["ProcessFn"]["Properties"]["Environment"]["Variables"]
+        assert env["ZAGG_RECYCLE_RSS_MB"] == {"Ref": "RecycleRssMb"}
+        assert env["ZAGG_RECYCLE_MAX_INVOCATIONS"] == {"Ref": "RecycleMaxInvocations"}
+
     def test_execution_role_grants_zagg_index_store(self):
         # issue #160: inline write-back + sidecar reads target the public
         # zagg-index prefix; the shared execution role gets Get/Put scoped to

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1152,6 +1152,122 @@ class TestPeakRSSSampler:
         assert s._thread is None  # never spawned
 
 
+class TestContainerTelemetry:
+    """Issue #171 (detect-and-report): every per-unit envelope carries the
+    sandbox's container telemetry -- cold/warm sentinel, invocations-served
+    generation, start RSS, sandbox id, init timestamp -- stamped once per
+    invocation at dispatcher entry, so repeat invocations on one warm process
+    report generations 1, 2, ... The per-invocation *peak* stays the existing
+    ``max_memory_mb`` (issue #141) -- telemetry adds the start-RSS ratchet
+    signal without duplicating it."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh_container(self, handler_mod, monkeypatch):
+        # handler_mod is module-scoped, so the generation counter persists
+        # across tests: reset it so each test starts on a "cold" sandbox.
+        monkeypatch.setattr(handler_mod, "_INVOCATIONS_SERVED", 0)
+
+    def _process_event(self, monkeypatch, **extra):
+        import zagg.grids as grids
+        import zagg.processing as processing
+
+        def fake_process_shard(grid, shard_key, granule_urls, **kwargs):
+            meta = {
+                "shard_key": shard_key,
+                "cells_with_data": 0,
+                "total_obs": 0,
+                "granule_count": len(granule_urls),
+                "files_processed": 0,
+                "duration_s": 0.0,
+                "error": None,
+            }
+            return pd.DataFrame(), meta
+
+        monkeypatch.setattr(processing, "process_shard", fake_process_shard)
+        monkeypatch.setattr(grids, "from_config", lambda *a, **k: MagicMock())
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        event.update(extra)
+        return event
+
+    def test_warm_repeat_invocations_ratchet_the_generation(self, handler_mod, monkeypatch):
+        # Two invocations in one process (a warm sandbox): the first is cold /
+        # generation 1, the second warm / generation 2, same init timestamp.
+        event = self._process_event(monkeypatch)
+        first = json.loads(handler_mod.lambda_handler(event, _context())["body"])
+        second = json.loads(handler_mod.lambda_handler(event, _context())["body"])
+        assert first["container_cold"] is True and first["container_generation"] == 1
+        assert second["container_cold"] is False and second["container_generation"] == 2
+        assert first["container_init_ts"] == second["container_init_ts"]
+        assert first["container_init_ts"] == handler_mod._CONTAINER_INIT_TS
+
+    def test_rss_start_sampled_at_entry(self, handler_mod, monkeypatch):
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: 512 * 1024)
+        event = self._process_event(monkeypatch)
+        body = json.loads(handler_mod.lambda_handler(event, _context())["body"])
+        assert body["rss_start_mb"] == pytest.approx(512.0)
+
+    def test_rss_start_none_off_linux(self, handler_mod, monkeypatch):
+        # No /proc/self/status (dev host): rss_start_mb degrades to None, the
+        # same fallback posture as the #141 sampler.
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: None)
+        event = self._process_event(monkeypatch)
+        body = json.loads(handler_mod.lambda_handler(event, _context())["body"])
+        assert body["rss_start_mb"] is None
+
+    def test_sandbox_id_from_log_stream(self, handler_mod, monkeypatch):
+        monkeypatch.setenv("AWS_LAMBDA_LOG_STREAM_NAME", "2026/07/06/[$LATEST]abc123")
+        event = self._process_event(monkeypatch)
+        body = json.loads(handler_mod.lambda_handler(event, _context())["body"])
+        assert body["sandbox_id"] == "2026/07/06/[$LATEST]abc123"
+
+    def test_gate_failure_envelope_carries_telemetry(self, handler_mod, monkeypatch):
+        # 400s carry telemetry too: the attach seam sits at the dispatcher, so
+        # failures can be stratified by container state (e.g. an OOM'd gen-4).
+        event = self._process_event(monkeypatch)
+        del event["shard_key"]
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 400
+        body = json.loads(resp["body"])
+        assert body["container_cold"] is True and body["container_generation"] == 1
+
+    def test_setup_counts_toward_generation_but_body_unchanged(self, handler_mod, monkeypatch):
+        # A setup invoke warms the sandbox (generation ticks) but its body stays
+        # byte-identical -- telemetry rides only in per-unit envelopes.
+        monkeypatch.setattr(
+            handler_mod, "_handle_setup", lambda event: {"statusCode": 200, "body": "{}"}
+        )
+        setup_resp = handler_mod.lambda_handler({"mode": "setup"}, _context())
+        assert json.loads(setup_resp["body"]) == {}
+        event = self._process_event(monkeypatch)
+        body = json.loads(handler_mod.lambda_handler(event, _context())["body"])
+        assert body["container_generation"] == 2  # setup served first
+        assert body["container_cold"] is False
+
+    def test_process_event_mode_carries_telemetry(self, handler_mod, monkeypatch):
+        import zagg.output as output
+        import zagg.temporal as temporal
+
+        event_mask, collections, static = _temporal_inputs()
+        monkeypatch.setattr(temporal, "open_dataset", lambda uri, **k: event_mask)
+        monkeypatch.setattr(temporal, "read_temporal_inputs", lambda *a, **k: (collections, static))
+        monkeypatch.setattr(output, "write_tabular", lambda rows, store_path, **k: store_path)
+        resp = handler_mod.lambda_handler(_temporal_event(), _context())
+        body = json.loads(resp["body"])
+        assert resp["statusCode"] == 200, body
+        assert body["container_cold"] is True and body["container_generation"] == 1
+
+    def test_mirrored_result_carries_telemetry(self, handler_mod, monkeypatch, tmp_path):
+        # The result_url mirror writes the POST-attach envelope, so the async
+        # poller sees the same telemetry a sync caller would.
+        url = str(tmp_path / "status" / "12345.json")
+        event = self._process_event(monkeypatch, result_url=url)
+        resp = handler_mod.lambda_handler(event, _context())
+        written = json.loads(Path(url).read_text())
+        assert written == resp
+        assert json.loads(written["body"])["container_generation"] == 1
+
+
 class TestExtractMode:
     """mode="extract" (issue #148): chunk-boundary geometry extraction."""
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1202,10 +1202,23 @@ class TestContainerTelemetry:
         assert first["container_init_ts"] == handler_mod._CONTAINER_INIT_TS
 
     def test_rss_start_sampled_at_entry(self, handler_mod, monkeypatch):
-        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: 512 * 1024)
+        # The telemetry snapshot is the invocation's FIRST _read_vmrss_kib
+        # call (dispatcher entry, before the #141 sampler even probes): feed
+        # 512 MB to that call only, 2000 MB to every later one. A post-work
+        # sample would report 2000 and corrupt the #169 ratchet signal --
+        # start RSS must be what the sandbox retained BEFORE this
+        # invocation's work (review finding, PR #172).
+        calls = {"n": 0}
+
+        def feed():
+            calls["n"] += 1
+            return (512 if calls["n"] == 1 else 2000) * 1024
+
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", feed)
         event = self._process_event(monkeypatch)
         body = json.loads(handler_mod.lambda_handler(event, _context())["body"])
         assert body["rss_start_mb"] == pytest.approx(512.0)
+        assert calls["n"] > 1  # later reads happened (sampler), all post-entry
 
     def test_rss_start_none_off_linux(self, handler_mod, monkeypatch):
         # No /proc/self/status (dev host): rss_start_mb degrades to None, the
@@ -1266,6 +1279,159 @@ class TestContainerTelemetry:
         written = json.loads(Path(url).read_text())
         assert written == resp
         assert json.loads(written["body"])["container_generation"] == 1
+
+
+class TestSelfRecycle:
+    """Issue #171 (self-recycling workers): after -- and only after -- the
+    invocation's result envelope is successfully mirrored to ``result_url``,
+    the handler destroys a bloated sandbox via the injectable ``_exit`` seam,
+    gated by the ``ZAGG_RECYCLE_RSS_MB`` / ``ZAGG_RECYCLE_MAX_INVOCATIONS``
+    env knobs. The #153 async channel makes this safe: the orchestrator polls
+    the result object, not the Lambda response, and retries are pinned to 0."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh_container(self, handler_mod, monkeypatch):
+        monkeypatch.setattr(handler_mod, "_INVOCATIONS_SERVED", 0)
+        monkeypatch.delenv("ZAGG_RECYCLE_RSS_MB", raising=False)
+        monkeypatch.delenv("ZAGG_RECYCLE_MAX_INVOCATIONS", raising=False)
+
+    def _process_event(self, monkeypatch, **extra):
+        import zagg.grids as grids
+        import zagg.processing as processing
+
+        def fake_process_shard(grid, shard_key, granule_urls, **kwargs):
+            meta = {
+                "shard_key": shard_key,
+                "cells_with_data": 0,
+                "total_obs": 0,
+                "granule_count": len(granule_urls),
+                "files_processed": 0,
+                "duration_s": 0.0,
+                "error": None,
+            }
+            return pd.DataFrame(), meta
+
+        monkeypatch.setattr(processing, "process_shard", fake_process_shard)
+        monkeypatch.setattr(grids, "from_config", lambda *a, **k: MagicMock())
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        event.update(extra)
+        return event
+
+    @staticmethod
+    def _spy_exit(handler_mod, monkeypatch, calls):
+        monkeypatch.setattr(handler_mod, "_exit", lambda code: calls.append(("exit", code)))
+
+    def test_result_mirror_completes_before_exit(self, handler_mod, monkeypatch):
+        # THE load-bearing ordering (issue #153): the S3 result mirror must
+        # return before the sandbox dies, or the run loses the shard.
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_RSS_MB", "100")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: 200 * 1024)
+        monkeypatch.setattr(
+            handler_mod,
+            "_write_result",
+            lambda url, resp, ev: (calls.append(("mirror", url)), True)[1],
+        )
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        event = self._process_event(monkeypatch, result_url="s3://b/status/1.json")
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200
+        assert [c[0] for c in calls] == ["mirror", "exit"]
+        assert calls[1] == ("exit", 0)
+
+    def test_rss_threshold_triggers(self, handler_mod, monkeypatch, tmp_path, caplog):
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_RSS_MB", "1400")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: 1500 * 1024)
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        url = str(tmp_path / "status" / "1.json")
+        event = self._process_event(monkeypatch, result_url=url)
+        with caplog.at_level("INFO"):
+            handler_mod.lambda_handler(event, _context())
+        assert calls == [("exit", 0)]
+        assert Path(url).exists()  # mirror landed before the exit
+        # One structured, CloudWatch-searchable line (dashboard metric filter).
+        assert "ZAGG_SELF_RECYCLE rss_mb=1500 generation=1 threshold=1400" in caplog.text
+
+    def test_below_threshold_no_recycle(self, handler_mod, monkeypatch):
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_RSS_MB", "1400")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: 800 * 1024)
+        monkeypatch.setattr(handler_mod, "_write_result", lambda *a: True)
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        event = self._process_event(monkeypatch, result_url="s3://b/status/1.json")
+        handler_mod.lambda_handler(event, _context())
+        assert calls == []
+
+    def test_generation_cap_triggers_on_nth_invocation(self, handler_mod, monkeypatch, caplog):
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_MAX_INVOCATIONS", "2")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: None)  # RSS check inert
+        monkeypatch.setattr(handler_mod, "_write_result", lambda *a: True)
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        event = self._process_event(monkeypatch, result_url="s3://b/status/1.json")
+        handler_mod.lambda_handler(event, _context())
+        assert calls == []  # generation 1 < cap
+        with caplog.at_level("INFO"):
+            handler_mod.lambda_handler(event, _context())
+        assert calls == [("exit", 0)]  # generation 2 hits the cap
+        assert "ZAGG_SELF_RECYCLE rss_mb=n/a generation=2 threshold=2" in caplog.text
+
+    def test_disabled_by_default_and_by_zero(self, handler_mod, monkeypatch):
+        # No env vars (and explicit "0") -> never recycles, however bloated:
+        # a stack without the template defaults behaves exactly as pre-#171.
+        calls = []
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: 4000 * 1024)
+        monkeypatch.setattr(handler_mod, "_write_result", lambda *a: True)
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        event = self._process_event(monkeypatch, result_url="s3://b/status/1.json")
+        handler_mod.lambda_handler(event, _context())
+        monkeypatch.setenv("ZAGG_RECYCLE_RSS_MB", "0")
+        monkeypatch.setenv("ZAGG_RECYCLE_MAX_INVOCATIONS", "0")
+        handler_mod.lambda_handler(event, _context())
+        assert calls == []
+
+    def test_sync_path_never_recycles(self, handler_mod, monkeypatch):
+        # No result_url (synchronous invoke): the response would be lost, so
+        # the recycle must not run even with both thresholds crossed.
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_RSS_MB", "100")
+        monkeypatch.setenv("ZAGG_RECYCLE_MAX_INVOCATIONS", "1")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: 2000 * 1024)
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        event = self._process_event(monkeypatch)  # no result_url
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200
+        assert calls == []
+
+    def test_failed_mirror_skips_recycle(self, handler_mod, monkeypatch, tmp_path):
+        # A failed result write returns False (poll deadline will record the
+        # shard failed); the sandbox must NOT also self-destruct on it.
+        import obstore
+
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_RSS_MB", "100")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: 2000 * 1024)
+        monkeypatch.setattr(
+            obstore, "put", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("s3 down"))
+        )
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        url = str(tmp_path / "status" / "1.json")
+        event = self._process_event(monkeypatch, result_url=url)
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200  # invocation result unaffected (#151)
+        assert calls == []
+
+    def test_non_numeric_knob_disables_check(self, handler_mod, monkeypatch):
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_RSS_MB", "lots")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: 2000 * 1024)
+        monkeypatch.setattr(handler_mod, "_write_result", lambda *a: True)
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        event = self._process_event(monkeypatch, result_url="s3://b/status/1.json")
+        handler_mod.lambda_handler(event, _context())
+        assert calls == []
 
 
 class TestExtractMode:

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -36,6 +36,26 @@ def handler_mod():
     return mod
 
 
+@pytest.fixture(autouse=True)
+def _no_real_recycle(handler_mod, monkeypatch):
+    """Module-wide self-recycle hygiene (issue #171, review finding PR #172).
+
+    A dev shell exporting ``ZAGG_RECYCLE_*`` must never let a mirror-path test
+    reach the REAL ``os._exit`` -- that kills pytest mid-suite with a
+    success-looking exit code 0 (the module-scoped ``handler_mod`` keeps
+    ``_INVOCATIONS_SERVED`` climbing across tests, so the generation cap WILL
+    fire). Scrub the knobs and make any unexpected exit LOUD; ``TestSelfRecycle``
+    re-enables the knobs and replaces the seam per test.
+    """
+
+    def _unexpected_exit(code):
+        raise AssertionError(f"unexpected self-recycle _exit({code}) in tests")
+
+    monkeypatch.delenv("ZAGG_RECYCLE_RSS_MB", raising=False)
+    monkeypatch.delenv("ZAGG_RECYCLE_MAX_INVOCATIONS", raising=False)
+    monkeypatch.setattr(handler_mod, "_exit", _unexpected_exit)
+
+
 def _context():
     ctx = MagicMock()
     ctx.aws_request_id = "req-1"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2211,6 +2211,7 @@ def _run_lambda_with_durations(
     profile=False,
     phase_timings=None,
     memories=None,
+    **run_kwargs,
 ):
     """Drive ``_run_lambda`` over synthetic per-cell durations.
 
@@ -2284,6 +2285,7 @@ def _run_lambda_with_durations(
         region="us-west-2",
         function_name="process-shard",
         profile=profile,
+        **run_kwargs,
     )
 
 
@@ -2386,6 +2388,81 @@ class TestGetFunctionTimeout:
                 return {"Timeout": "not-a-number"}
 
         assert _get_function_timeout_s(_Client(), "process-shard") == _DEFAULT_FUNCTION_TIMEOUT_S
+
+
+class TestForceCold:
+    """``force_cold`` (issue #171): merge a per-run ``ZAGG_COLD_EPOCH`` env
+    marker pre-fan-out so every warm sandbox is invalidated, preserving the
+    existing environment; failures raise instead of degrading to warm."""
+
+    @staticmethod
+    def _client(env=None, statuses=("InProgress", "Successful")):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        # First get_function_configuration read returns the environment; the
+        # poll loop's reads consume ``statuses`` one per call.
+        responses = iter(
+            [{"Environment": {"Variables": dict(env or {})}}]
+            + [{"LastUpdateStatus": s} for s in statuses]
+        )
+        client.get_function_configuration.side_effect = lambda **k: next(responses)
+        return client
+
+    def test_merges_marker_and_preserves_env(self):
+        from zagg.runner import _force_cold_containers
+
+        client = self._client(env={"MALLOC_ARENA_MAX": "2"})
+        _force_cold_containers(client, "process-shard", poll_interval_s=0)
+        (_, kwargs) = client.update_function_configuration.call_args
+        sent = kwargs["Environment"]["Variables"]
+        assert sent["MALLOC_ARENA_MAX"] == "2"
+        assert len(sent["ZAGG_COLD_EPOCH"]) == 32  # uuid4 hex, unique per run
+        assert kwargs["FunctionName"] == "process-shard"
+
+    def test_raises_when_update_denied(self):
+        import pytest
+
+        from zagg.runner import _force_cold_containers
+
+        client = self._client()
+        client.update_function_configuration.side_effect = RuntimeError("AccessDenied")
+        with pytest.raises(RuntimeError, match="UpdateFunctionConfiguration"):
+            _force_cold_containers(client, "process-shard", poll_interval_s=0)
+
+    def test_raises_on_failed_update(self):
+        import pytest
+
+        from zagg.runner import _force_cold_containers
+
+        client = self._client(statuses=("Failed",))
+        with pytest.raises(RuntimeError, match="LastUpdateStatus=Failed"):
+            _force_cold_containers(client, "process-shard", poll_interval_s=0)
+
+    def test_raises_when_update_never_lands(self):
+        import pytest
+
+        from zagg.runner import _force_cold_containers
+
+        client = self._client(statuses=("InProgress",) * 50)
+        with pytest.raises(RuntimeError, match="warm containers"):
+            _force_cold_containers(client, "process-shard", wait_s=0, poll_interval_s=0)
+
+    def test_run_lambda_forces_cold_before_dispatch(self, monkeypatch, atl06_config):
+        from zagg import runner
+
+        calls = []
+        monkeypatch.setattr(runner, "_force_cold_containers", lambda client, fn: calls.append(fn))
+        _run_lambda_with_durations(monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0], force_cold=True)
+        assert calls == ["process-shard"]
+
+    def test_default_run_never_touches_configuration(self, monkeypatch, atl06_config):
+        from zagg import runner
+
+        calls = []
+        monkeypatch.setattr(runner, "_force_cold_containers", lambda client, fn: calls.append(fn))
+        _run_lambda_with_durations(monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0])
+        assert calls == []
 
 
 class TestProfilePlumbing:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2522,6 +2522,48 @@ class TestForceCold:
         with pytest.raises(RuntimeError, match="warm containers"):
             _force_cold_containers(client, "process-shard", wait_s=0, poll_interval_s=0)
 
+    def test_superseded_by_concurrent_update_counts_as_success(self):
+        # A concurrent run's update replaced our marker after ours was
+        # accepted; Lambda serializes configuration updates, so every warm
+        # sandbox was invalidated regardless -- the poll must count that as
+        # success, not spin to deadline (review finding, PR #172).
+        from zagg.runner import _force_cold_containers
+
+        class _Client:
+            def __init__(self):
+                self.updated = False
+
+            def get_function_configuration(self, FunctionName):  # noqa: N803
+                if self.updated:
+                    return {
+                        "Environment": {"Variables": {"ZAGG_COLD_EPOCH": "someone-else"}},
+                        "LastUpdateStatus": "Successful",
+                    }
+                return {"Environment": {"Variables": {}}, "LastUpdateStatus": "Successful"}
+
+            def update_function_configuration(self, FunctionName, Environment):  # noqa: N803
+                self.updated = True
+
+        _force_cold_containers(_Client(), "process-shard", poll_interval_s=0)
+
+    def test_conflict_past_deadline_reports_conflict_not_permissions(self):
+        import pytest
+
+        from zagg.runner import _force_cold_containers
+
+        class _ConflictError(Exception):
+            response = {"Error": {"Code": "ResourceConflictException"}}
+
+        class _Client:
+            def get_function_configuration(self, FunctionName):  # noqa: N803
+                return {"Environment": {"Variables": {}}, "LastUpdateStatus": "Successful"}
+
+            def update_function_configuration(self, FunctionName, Environment):  # noqa: N803
+                raise _ConflictError("in flight")
+
+        with pytest.raises(RuntimeError, match="another configuration update"):
+            _force_cold_containers(_Client(), "process-shard", wait_s=0, poll_interval_s=0)
+
     def test_run_lambda_forces_cold_before_dispatch(self, monkeypatch, atl06_config):
         from zagg import runner
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -817,6 +817,7 @@ class TestMaxRetriesPassthrough:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
@@ -889,6 +890,7 @@ class TestInvocationPassthrough:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
         monkeypatch.setattr(
             runner,
@@ -1291,6 +1293,7 @@ class TestSummaryKeysByteIdentical:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
@@ -1375,6 +1378,7 @@ class TestSummaryKeysByteIdentical:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
@@ -1450,6 +1454,7 @@ class TestSummaryKeysByteIdentical:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
@@ -1803,6 +1808,7 @@ class TestTemporalLambdaStrategy:
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         monkeypatch.setattr(
             runner,
             "compute_available_workers",
@@ -2393,49 +2399,117 @@ class TestGetFunctionTimeout:
 class TestForceCold:
     """``force_cold`` (issue #171): merge a per-run ``ZAGG_COLD_EPOCH`` env
     marker pre-fan-out so every warm sandbox is invalidated, preserving the
-    existing environment; failures raise instead of degrading to warm."""
+    existing environment; failures raise instead of degrading to warm. The
+    poll accepts only this update's states (marker match), so a stale
+    ``Successful`` from the prior update never returns early."""
 
-    @staticmethod
-    def _client(env=None, statuses=("InProgress", "Successful")):
-        from unittest.mock import MagicMock
+    class _FakeLambdaClient:
+        """Stateful double mirroring the real API: every
+        ``get_function_configuration`` response carries BOTH ``Environment``
+        and ``LastUpdateStatus`` (the AWS shape), and the environment only
+        reflects the update after ``lag`` post-update reads (eventual
+        consistency)."""
 
-        client = MagicMock()
-        # First get_function_configuration read returns the environment; the
-        # poll loop's reads consume ``statuses`` one per call.
-        responses = iter(
-            [{"Environment": {"Variables": dict(env or {})}}]
-            + [{"LastUpdateStatus": s} for s in statuses]
-        )
-        client.get_function_configuration.side_effect = lambda **k: next(responses)
-        return client
+        def __init__(self, env=None, statuses=("InProgress", "Successful"), lag=0):
+            self.env = dict(env or {})
+            self.pending_env = None
+            self.statuses = list(statuses)
+            self.lag = lag  # reads before the new env becomes visible
+            self.update_calls = []
+            self.update_error = None
+            self._updated = False
+
+        def get_function_configuration(self, FunctionName):  # noqa: N803 (boto3 API)
+            if self._updated:
+                if self.lag > 0:
+                    self.lag -= 1
+                    # Stale read: prior env, prior (terminal) status.
+                    return {
+                        "Environment": {"Variables": dict(self.env)},
+                        "LastUpdateStatus": "Successful",
+                    }
+                self.env = dict(self.pending_env)
+                status = self.statuses.pop(0) if len(self.statuses) > 1 else self.statuses[0]
+                return {
+                    "Environment": {"Variables": dict(self.env)},
+                    "LastUpdateStatus": status,
+                }
+            return {
+                "Environment": {"Variables": dict(self.env)},
+                "LastUpdateStatus": "Successful",  # prior update's terminal state
+            }
+
+        def update_function_configuration(self, FunctionName, Environment):  # noqa: N803
+            if self.update_error is not None:
+                err, self.update_error = self.update_error, None
+                raise err
+            self.update_calls.append(Environment["Variables"])
+            self.pending_env = dict(Environment["Variables"])
+            self._updated = True
 
     def test_merges_marker_and_preserves_env(self):
         from zagg.runner import _force_cold_containers
 
-        client = self._client(env={"MALLOC_ARENA_MAX": "2"})
+        client = self._FakeLambdaClient(env={"MALLOC_ARENA_MAX": "2"})
         _force_cold_containers(client, "process-shard", poll_interval_s=0)
-        (_, kwargs) = client.update_function_configuration.call_args
-        sent = kwargs["Environment"]["Variables"]
+        sent = client.update_calls[0]
         assert sent["MALLOC_ARENA_MAX"] == "2"
         assert len(sent["ZAGG_COLD_EPOCH"]) == 32  # uuid4 hex, unique per run
-        assert kwargs["FunctionName"] == "process-shard"
+
+    def test_stale_successful_from_prior_update_is_not_accepted(self):
+        # Eventual consistency: the first post-update reads still show the
+        # PRIOR env with LastUpdateStatus=Successful. The poll must keep
+        # waiting for the marker, not return on the stale terminal state.
+        from zagg.runner import _force_cold_containers
+
+        client = self._FakeLambdaClient(statuses=("InProgress", "Successful"), lag=2)
+        _force_cold_containers(client, "process-shard", poll_interval_s=0)
+        # 1 env read + 2 stale + InProgress + Successful = 5 reads minimum;
+        # early acceptance of a stale Successful would have used only 2.
+        assert client.lag == 0
+
+    def test_resource_conflict_retries_until_free(self):
+        from zagg.runner import _force_cold_containers
+
+        class _ConflictError(Exception):
+            response = {"Error": {"Code": "ResourceConflictException"}}
+
+        client = self._FakeLambdaClient()
+        client.update_error = _ConflictError("update in progress")
+        _force_cold_containers(client, "process-shard", poll_interval_s=0)
+        assert len(client.update_calls) == 1  # succeeded on the retry
 
     def test_raises_when_update_denied(self):
         import pytest
 
         from zagg.runner import _force_cold_containers
 
-        client = self._client()
-        client.update_function_configuration.side_effect = RuntimeError("AccessDenied")
+        class _DeniedError(Exception):
+            response = {"Error": {"Code": "AccessDeniedException"}}
+
+        client = self._FakeLambdaClient()
+        client.update_error = _DeniedError("AccessDenied")
         with pytest.raises(RuntimeError, match="UpdateFunctionConfiguration"):
             _force_cold_containers(client, "process-shard", poll_interval_s=0)
+
+    def test_raises_when_configuration_unreadable(self):
+        import pytest
+
+        from zagg.runner import _force_cold_containers
+
+        class _Client:
+            def get_function_configuration(self, FunctionName):  # noqa: N803
+                raise RuntimeError("AccessDenied")
+
+        with pytest.raises(RuntimeError, match="GetFunctionConfiguration"):
+            _force_cold_containers(_Client(), "process-shard", poll_interval_s=0)
 
     def test_raises_on_failed_update(self):
         import pytest
 
         from zagg.runner import _force_cold_containers
 
-        client = self._client(statuses=("Failed",))
+        client = self._FakeLambdaClient(statuses=("Failed",))
         with pytest.raises(RuntimeError, match="LastUpdateStatus=Failed"):
             _force_cold_containers(client, "process-shard", poll_interval_s=0)
 
@@ -2444,7 +2518,7 @@ class TestForceCold:
 
         from zagg.runner import _force_cold_containers
 
-        client = self._client(statuses=("InProgress",) * 50)
+        client = self._FakeLambdaClient(statuses=("InProgress",))
         with pytest.raises(RuntimeError, match="warm containers"):
             _force_cold_containers(client, "process-shard", wait_s=0, poll_interval_s=0)
 
@@ -2456,13 +2530,23 @@ class TestForceCold:
         _run_lambda_with_durations(monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0], force_cold=True)
         assert calls == ["process-shard"]
 
-    def test_default_run_never_touches_configuration(self, monkeypatch, atl06_config):
+    def test_opt_out_never_touches_configuration(self, monkeypatch, atl06_config):
         from zagg import runner
 
         calls = []
         monkeypatch.setattr(runner, "_force_cold_containers", lambda client, fn: calls.append(fn))
-        _run_lambda_with_durations(monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0])
+        _run_lambda_with_durations(
+            monkeypatch, atl06_config, [1.0, 2.0, 3.0, 4.0], force_cold=False
+        )
         assert calls == []
+
+    def test_agg_defaults_force_cold_on(self):
+        # espg's call on PR #172: the public default is True.
+        import inspect
+
+        from zagg.runner import agg
+
+        assert inspect.signature(agg).parameters["force_cold"].default is True
 
 
 class TestProfilePlumbing:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -817,7 +817,6 @@ class TestMaxRetriesPassthrough:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
-        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
@@ -890,7 +889,6 @@ class TestInvocationPassthrough:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
-        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
         monkeypatch.setattr(
             runner,
@@ -1293,7 +1291,6 @@ class TestSummaryKeysByteIdentical:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
-        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
@@ -1378,7 +1375,6 @@ class TestSummaryKeysByteIdentical:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
-        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
@@ -1454,7 +1450,6 @@ class TestSummaryKeysByteIdentical:
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
-        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
@@ -1808,7 +1803,6 @@ class TestTemporalLambdaStrategy:
 
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
         monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
-        monkeypatch.setattr(runner, "_force_cold_containers", lambda *a, **k: None)
         monkeypatch.setattr(
             runner,
             "compute_available_workers",

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2582,13 +2582,16 @@ class TestForceCold:
         )
         assert calls == []
 
-    def test_agg_defaults_force_cold_on(self):
-        # espg's call on PR #172: the public default is True.
+    def test_agg_defaults_force_cold_off(self):
+        # espg's decision on the PR #172 plan: default False. force_cold is
+        # the explicit certification-run tool (it needs a broad write
+        # permission and chills every caller's warm pool), not a tax on every
+        # agg() call; routine ratchet protection is worker-side instead.
         import inspect
 
         from zagg.runner import agg
 
-        assert inspect.signature(agg).parameters["force_cold"].default is True
+        assert inspect.signature(agg).parameters["force_cold"].default is False
 
 
 class TestProfilePlumbing:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1158,6 +1158,11 @@ class TestSummaryKeysByteIdentical:
         "worker_pstdev_s",
         "worker_pct_timeout",
         "max_memory_mb",
+        # Container-telemetry rollup (issue #171); additive, None-valued when
+        # no worker envelope carried telemetry (older deployed workers).
+        "worker_cold_starts",
+        "worker_warm_starts",
+        "worker_rss_start_max_by_gen",
     }
 
     def test_local_summary_keys_and_counts(self, monkeypatch, atl06_config):
@@ -1875,6 +1880,35 @@ class TestTemporalLambdaStrategy:
         assert summary["results"] == written["rows"]
         assert summary["failures"] == []
 
+    def test_temporal_summary_carries_container_rollup(self, monkeypatch):
+        # Issue #171: the temporal path aggregates the same worker container
+        # telemetry as the spatial path (additive summary fields, shared helper).
+        def _invoke(client, ev, **kwargs):
+            gen = 1 if ev["event_key"] == "storm1" else 2
+            return {
+                "event_key": ev["event_key"],
+                "status_code": 200,
+                "body": {
+                    "results": {"max_t2m": 5.0},
+                    "timesteps_processed": 2,
+                    "duration_s": 1.0,
+                    "meta": {"timesteps_processed": 2},
+                    "container_cold": gen == 1,
+                    "container_generation": gen,
+                    "rss_start_mb": 300.0 * gen,
+                },
+                "wall_time": 1.0,
+                "lambda_duration": 1.0,
+                "error": None,
+                "retries": 0,
+                "timeout": False,
+            }
+
+        summary, _ = self._drive(monkeypatch, fake_invoke=_invoke)
+        assert summary["worker_cold_starts"] == 1
+        assert summary["worker_warm_starts"] == 1
+        assert summary["worker_rss_start_max_by_gen"] == {1: 300.0, 2: 600.0}
+
     def test_async_wiring_threads_result_channel(self, monkeypatch):
         summary, captured = self._drive(monkeypatch)  # invocation defaults to async
         for ev, kwargs in captured["invokes"]:
@@ -2211,6 +2245,7 @@ def _run_lambda_with_durations(
     profile=False,
     phase_timings=None,
     memories=None,
+    containers=None,
     **run_kwargs,
 ):
     """Drive ``_run_lambda`` over synthetic per-cell durations.
@@ -2221,6 +2256,9 @@ def _run_lambda_with_durations(
     ``phase_timings`` is set it is attached to each cell result body.
     ``memories`` (issue #120), when given, is consumed one per cell and attached
     as ``body["max_memory_mb"]`` so the peak-memory rollup can be pinned.
+    ``containers`` (issue #171), when given, is consumed one per cell and merged
+    into each body (container_cold/container_generation/rss_start_mb dicts) so
+    the container-telemetry rollup can be pinned.
     """
     import boto3
 
@@ -2256,6 +2294,7 @@ def _run_lambda_with_durations(
     )
     it = iter(durations)
     mem_it = iter(memories) if memories is not None else None
+    cont_it = iter(containers) if containers is not None else None
 
     def _fake_cell(*a, **k):
         body = {"total_obs": 1}
@@ -2263,6 +2302,8 @@ def _run_lambda_with_durations(
             body["phase_timings"] = phase_timings
         if mem_it is not None:
             body["max_memory_mb"] = next(mem_it)
+        if cont_it is not None:
+            body.update(next(cont_it))
         return {
             "status_code": 200,
             "body": body,
@@ -2586,6 +2627,76 @@ class TestForceCold:
         from zagg.runner import agg
 
         assert inspect.signature(agg).parameters["force_cold"].default is False
+
+
+class TestContainerTelemetrySummary:
+    """Issue #171 (detect-and-report): the runner rolls the workers' container
+    telemetry into additive summary fields -- cold/warm counts and the max
+    start-RSS per sandbox generation (the #169 ratchet made visible)."""
+
+    def test_rollup_counts_and_ratchet(self):
+        from zagg.runner import _container_telemetry_summary
+
+        bodies = [
+            {"container_cold": True, "container_generation": 1, "rss_start_mb": 310.0},
+            {"container_cold": False, "container_generation": 2, "rss_start_mb": 959.0},
+            {"container_cold": False, "container_generation": 2, "rss_start_mb": 640.0},
+            {"container_cold": False, "container_generation": 3, "rss_start_mb": 1650.0},
+        ]
+        stats = _container_telemetry_summary(bodies)
+        assert stats["worker_cold_starts"] == 1
+        assert stats["worker_warm_starts"] == 3
+        # Max per generation, ordered: the ratchet signature (climbing start-RSS).
+        assert stats["worker_rss_start_max_by_gen"] == {1: 310.0, 2: 959.0, 3: 1650.0}
+
+    def test_no_telemetry_is_none_not_zero(self):
+        # Older deployed workers stamp no container fields: the rollup must be
+        # None (no data), never 0 cold / 0 warm (which would read as all-warm).
+        from zagg.runner import _container_telemetry_summary
+
+        stats = _container_telemetry_summary([{"total_obs": 1}, {}])
+        assert stats == {
+            "worker_cold_starts": None,
+            "worker_warm_starts": None,
+            "worker_rss_start_max_by_gen": None,
+        }
+
+    def test_mixed_fleet_counts_only_reporting_workers(self):
+        # A mid-rollout fleet (some workers redeployed, some not): only the
+        # envelopes that carry telemetry are counted, and a missing
+        # rss_start_mb (non-Linux fallback) is skipped, not treated as 0.
+        from zagg.runner import _container_telemetry_summary
+
+        bodies = [
+            {"container_cold": True, "container_generation": 1, "rss_start_mb": None},
+            {"total_obs": 1},  # pre-telemetry worker
+        ]
+        stats = _container_telemetry_summary(bodies)
+        assert stats["worker_cold_starts"] == 1
+        assert stats["worker_warm_starts"] == 0
+        assert stats["worker_rss_start_max_by_gen"] == {}
+
+    def test_lambda_summary_carries_rollup(self, monkeypatch, atl06_config):
+        containers = [
+            {"container_cold": True, "container_generation": 1, "rss_start_mb": 300.0},
+            {"container_cold": True, "container_generation": 1, "rss_start_mb": 320.0},
+            {"container_cold": False, "container_generation": 2, "rss_start_mb": 1100.0},
+            {"container_cold": False, "container_generation": 2, "rss_start_mb": 900.0},
+        ]
+        summary = _run_lambda_with_durations(
+            monkeypatch, atl06_config, [1.0, 1.0, 1.0, 1.0], containers=containers
+        )
+        assert summary["worker_cold_starts"] == 2
+        assert summary["worker_warm_starts"] == 2
+        assert summary["worker_rss_start_max_by_gen"] == {1: 320.0, 2: 1100.0}
+
+    def test_lambda_summary_without_telemetry_is_none(self, monkeypatch, atl06_config):
+        # Default fake bodies carry no container fields -> the additive keys
+        # exist but are None, so downstream consumers see "no data".
+        summary = _run_lambda_with_durations(monkeypatch, atl06_config, [1.0, 1.0, 1.0, 1.0])
+        assert summary["worker_cold_starts"] is None
+        assert summary["worker_warm_starts"] is None
+        assert summary["worker_rss_start_max_by_gen"] is None
 
 
 class TestProfilePlumbing:


### PR DESCRIPTION
Closes #171.

## What

Two mechanisms against the warm-container RSS ratchet (#171; forensics on the issue #169 thread: container RSS 959 → 1650 → 2029 → OOM at 2047 MB across four back-to-back fleet runs on the same 9 sandboxes), per the option analysis and espg's decisions in [the plan comment](https://github.com/englacial/zagg/pull/172#issuecomment-4897717666):

1. **`force_cold: bool = False`** on `zagg.runner.agg` (both Lambda paths) — the explicit certification-run tool. When requested, `_force_cold_containers` merges a per-run `ZAGG_COLD_EPOCH=<uuid4>` marker into the function environment via `update_function_configuration` and polls until **this update** applies (any configuration change invalidates every warm sandbox). Requires `lambda:GetFunctionConfiguration` + `lambda:UpdateFunctionConfiguration` on the caller and hard-fails (actionable message) rather than silently dispatching warm — a feature of an explicit request, which is why it is opt-in rather than the default.
2. **Worker-side container telemetry + self-recycle** (phases B/C) — the durable, zero-new-IAM mechanism: workers report cold/warm, sandbox generation, and per-invocation RSS in the result envelope; bloated sandboxes destroy themselves after their result is safely mirrored to S3 (the #153 async result channel makes this safe: the runner polls the result object, not the Lambda response, and `MaximumRetryAttempts: 0` means no zombie retry).

## Design points (force_cold helper)

- Existing environment variables are read first and preserved (the malloc tunables survive every run).
- **The poll accepts only this update's terminal states**: the API is eventually consistent, so a `Successful` read immediately after the update can still describe the *prior* update — acceptance requires the polled environment to carry this run's marker (self-review finding, folded).
- **`ResourceConflictException` retries until the deadline** (a concurrent `force_cold` run or in-flight deploy is not a permissions problem); a superseding concurrent update counts as success (Lambda serializes config updates, so its acceptance proves ours applied — warm sandboxes are invalidated either way); other failures raise with an actionable message (self-review findings, folded).
- `force_cold=False` (the default): dispatch is byte-identical to pre-#171.
- Cost when enabled: one config-update round trip (seconds) + ~3.6 s cold init per container (measured on the SERC fleet 2026-07-06) — negligible against 180–300 s workers.

## Phases

- [x] `_force_cold_containers` helper + plumbing through `agg` → strategies → both `_run_lambda*` preflights + tests
- [x] Fold self-review findings (marker-verified poll, conflict retry, superseded-success) 
- [x] **A** — flip `force_cold` default back to `False`; reposition docstring as the explicit certification-run tool (per [the plan decision](https://github.com/englacial/zagg/pull/172#issuecomment-4897717666)); update tests
- [x] **B** — container telemetry in the worker result envelope (cold/warm sentinel, generation counter, per-invocation start RSS, sandbox id, init timestamp) + runner summary aggregation (cold/warm counts, per-generation max start-RSS)
- [x] **C** — worker self-recycle: after the `result_url` mirror succeeds, exit the sandbox when `ZAGG_RECYCLE_RSS_MB` / `ZAGG_RECYCLE_MAX_INVOCATIONS` thresholds are crossed (template.yaml defaults; structured `ZAGG_SELF_RECYCLE` log line; injectable exit seam; never on the sync path)
- [x] **D** — polish: docstrings (handler module docstring, `agg()` independence note), deployment-docs note (`docs/deployment/lambda.md` self-recycle section + CloudWatch metric filter; `docs/deployment/benchmark.md` container-regime/stratification note), final gates + review pass

## Telemetry design (phase B)

- Handler: module globals persist per sandbox, so `_CONTAINER_INIT_TS` (import time) and `_INVOCATIONS_SERVED` (incremented once per invocation, **all** modes — a setup/finalize/extract invoke warms the sandbox just like a shard) give cold/warm + generation for free; `rss_start_mb` is `VmRSS` at dispatcher entry (the ratchet signal — a dirty sandbox *starts* high); `sandbox_id` is `AWS_LAMBDA_LOG_STREAM_NAME` (unique per sandbox). Telemetry is merged into the per-unit response body at one dispatcher seam (`_attach_container_telemetry`), covering both per-unit handlers and every status branch (200/400/500) and therefore also the `result_url` mirror — setup/finalize/extract bodies stay byte-identical.
- **No `rss_peak_mb` field was added**: the per-invocation peak already exists in the envelope as `max_memory_mb` (the issue #141 sampled `VmRSS` peak) — extending, not duplicating, per the plan's coordinate-with-#141 note; `schema.py` documents the relationship.
- Runner: `_container_telemetry_summary` (shared by spatial + temporal paths) adds three **additive** summary fields — `worker_cold_starts`, `worker_warm_starts`, `worker_rss_start_max_by_gen` (max start-RSS per sandbox generation: flat = healthy, climbing = the #169 ratchet). All `None` when no envelope carries telemetry (older deployed workers), so "no data" is distinguishable from "all warm". Existing keys untouched.

## Self-recycle design (phase C)

- **Ordering is load-bearing**: `_maybe_self_recycle()` runs only after `_write_result` (the #151/#153 async mirror) **returns True** — the orchestrator polls the result object, not the Lambda response, so at that point the invocation is operationally complete and `os._exit(0)` loses nothing; `MaximumRetryAttempts: 0` guarantees no zombie retry. Pinned by `test_result_mirror_completes_before_exit` (records call order). A **failed** mirror skips the recycle (shard is recorded failed at the poll deadline anyway; don't churn the sandbox on a possibly transient S3 fault) — `_write_result` now returns a bool for that gate (its never-raises contract is unchanged). The sync path never reaches the gate (no `result_url`), pinned by `test_sync_path_never_recycles`.
- **Chosen defaults + rationale** (template.yaml parameters `RecycleRssMb`/`RecycleMaxInvocations` → `ZAGG_RECYCLE_RSS_MB=1400`, `ZAGG_RECYCLE_MAX_INVOCATIONS=8`): the #169 ratchet retained ~700–1100 MB per heavy invocation against the 2047 MB OOM ceiling, so 1400 catches a sandbox after roughly one heavy retention while leaving the triggering invocation ~650 MB of headroom to finish; the generation cap of 8 is belt-and-suspenders for retention the RSS read misses (and the only check that can fire where `/proc/self/status` is unavailable). Either knob absent/empty/`0` disables that check, so a stack without the new parameters behaves exactly as pre-#171. **No deploy was made — espg's next stack update activates the defaults.** (template.yaml edits are named in-scope by the issue #171 plan.)
- **Exit seam**: module-level `_exit = os._exit`, monkeypatched in tests so nothing ever really exits pytest; `os._exit` (not `sys.exit`) because the sandbox is being discarded and the exit must not be catchable en route.
- **Observability**: one structured line before exiting — `ZAGG_SELF_RECYCLE rss_mb=<x> generation=<n> threshold=<t>` — and a docs note (`docs/deployment/lambda.md`) that self-exits appear as runtime failures in CloudWatch `Errors` (cosmetic; result object is the source of truth per #153) with the metric-filter pattern to split them from real crashes.
- `force_cold` and self-recycle are independent (both can be on); the `agg()` docstring says so.

## Testing

`tests/test_runner.py::TestForceCold` (10 tests) against a stateful fake client mirroring the real API shape (every `get_function_configuration` response carries both `Environment` and `LastUpdateStatus`, with configurable eventual-consistency lag): env-merge preservation, stale-`Successful` rejection, conflict-retry, denied-update / unreadable-config / server-side-`Failed` / never-lands failures, superseded-success, exactly-once pre-dispatch invocation, opt-out no-touch, and the public default pinned `False`. Phase C adds `TestSelfRecycle` (mirror-before-exit ordering, RSS trigger + structured log line, below-threshold no-op, generation cap on the Nth invocation, disabled-by-default/`0`, sync-path never, failed-mirror skip, non-numeric knob disabled) and `TestTemplateEnvironment::test_self_recycle_env_defaults` (template parameter defaults + env wiring; the ExtractFn twin stays in lockstep via the existing mirror test). Phase B adds `TestContainerTelemetry` (handler: warm-repeat generation ratchet, start-RSS at entry, off-Linux None fallback, sandbox id, 400-envelope coverage, setup-counts-but-stays-clean, process_event coverage, mirrored-result parity) and `TestContainerTelemetrySummary` (runner: rollup counts + ratchet dict, None-not-zero on no telemetry, mid-rollout mixed fleet, spatial + temporal summary integration). Full suite at phase D: **1435 passed, 27 skipped** (plus `test_lambda_build.py`: 28 passed with only the docker-dependent `test_function_build_succeeds` failing — pre-existing, reproduces on the unmodified tree). `ruff check` + `ruff format --check` clean on every touched file; `pre-commit` (mypy/codespell/check-yaml) shows only pre-existing baseline failures, byte-identical with the branch tip before this work (36 mypy errors; check-yaml has never parsed CloudFormation short-form tags). Each adversarial self-review pass produced findings that were folded before the next phase: phase A → dead test stubs removed (0972e5d); phase B → entry-time RSS sampling pinned with a first-call sentinel (038b8d0); phase C → module-wide recycle-env scrub + loud exit seam so a dev shell exporting `ZAGG_RECYCLE_*` can no longer kill pytest with a success-looking exit 0 (77033fc).

## Questions for review

- ~~With the default **on**, every `agg(backend="lambda")` caller needs `lambda:UpdateFunctionConfiguration` … the weekly benchmark CI role likely lacks it~~ **Resolved by the phase-A default flip**: with `force_cold=False` the benchmark role needs no new permission and no pin — it keeps measuring the warm regime, now stratified by the phase-B telemetry.
- Should the runner *unset* `ZAGG_COLD_EPOCH` after the run? Leaving it costs nothing (workers ignore it); current behavior leaves it set.

## Notes

- Pre-existing, unrelated to this PR: `ruff check` (full local config, which includes `N`) reports `N818` on `src/zagg/registry.py:64` (`UnknownCapability`); it predates this branch's changes (came in via the issue #160 merge) and the PR lint bot's `--select=E,F,W,I` does not flag it. Left alone per repo conventions.
