### PR TITLE
Compiled read path by default: inline via hidefix, read_workers pool, cached/uncached benchmark columns (issue #170)

### DIFF
--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -59,6 +59,10 @@ RECORD_COLUMNS = [
     # predate the codec axis, so the renderer splits new (codec.notna) from frozen
     # (codec.isna) series on this column.
     "codec",
+    # Read-axis label (issue #170): "cached" on the sidecar-read companion
+    # targets, None otherwise. Keeps the cached column out of the inner
+    # codec slot in the renderer; legacy rows read back NaN and key on codec.
+    "read",
 ]
 
 
@@ -163,6 +167,7 @@ def build_record(
         # The ShardingCodec A/B label (issue #133), carried in by run_benchmark from
         # the target. None on targets that don't set it (legacy/frozen rows).
         "codec": context.get("codec"),
+        "read": context.get("read"),
     }
     return record
 

--- a/.github/scripts/plot_series.py
+++ b/.github/scripts/plot_series.py
@@ -290,7 +290,10 @@ def _panel_layout(hist: pd.DataFrame) -> tuple[list[list[str | None]], int, int]
 # o9 -> o11 top-to-bottom (largest shard on top, matching the frozen figure's
 # largest-first convention). Unlike ``_panel_layout`` this is keyed to the codec
 # axis, not the rect/healpix split the frozen rows use.
-CODEC_COLS = ["sharded", "inner"]
+# "cached" is the issue #170 read-axis column: those targets carry codec
+# "inner" (the codec key still drives output.grid.sharded) plus read="cached",
+# and must not collide with the real inner panel in the slot map below.
+CODEC_COLS = ["sharded", "inner", "cached"]
 CODEC_ROWS = ["o9", "o10", "o11"]
 
 
@@ -304,7 +307,10 @@ def _codec_layout(hist: pd.DataFrame) -> tuple[list[list[str | None]], int, int]
     by_slot: dict[tuple[str, str], str] = {}
     meta = hist.dropna(subset=["target"]).drop_duplicates("target")
     for _, r in meta.iterrows():
-        by_slot[(str(r.get("grid_size", "")), str(r.get("codec", "")))] = r["target"]
+        # Read-aware slot label (issue #170): cached targets get their own
+        # column; everything else keys on the codec exactly as before.
+        label = "cached" if str(r.get("read", "")) == "cached" else str(r.get("codec", ""))
+        by_slot[(str(r.get("grid_size", "")), label)] = r["target"]
     grid: list[list[str | None]] = [
         [by_slot.get((order, codec)) for codec in CODEC_COLS] for order in CODEC_ROWS
     ]

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -133,6 +133,10 @@ def run_target(
         # renderer can split the new matrix from frozen rows. None on targets
         # without the key (the provisional/legacy ones).
         codec=target.get("codec"),
+        # Read-axis label (issue #170): the *_cached targets share codec
+        # "inner" with the real inner column, so the renderer needs this to
+        # give them their own panel instead of silently overwriting it.
+        read=target.get("read"),
     )
 
     if dry_run:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ uv run python -m zagg --config atl06.yaml --catalog catalog.json --dry-run
 
 The store path and output grid parameters are defined in the YAML config (`output.store`, `output.grid.child_order`) and can be overridden via `--store` on the command line.
 
+**Read backends** (`data_source.index`, issue #160/#170). Reads go through a pluggable chunk-index backend; the default is the compiled fast path:
+
+- `inline` *(default)* — builds each granule's chunk map at read time (metadata-only, ~1 ranged GET) and decodes through the compiled [h5coro-hidefix](https://github.com/espg/h5coro-hidefix) reader. Works for every chunked-HDF5 data source — planned (ATL03-style hierarchical) and flat alike; datasets the compiled reader cannot serve degrade to h5coro per dataset. With `write_back: true` + `store:`, persists the chunk maps as granule-keyed parquet manifests, populating the sidecar cache.
+- `sidecar` — fetches precomputed manifests from `store:` instead of walking metadata; `on_miss: fallback | error | build` controls behavior for uncovered granules (`build` self-populates the store). Fastest once the cache exists.
+- `hierarchical` — the pure-Python h5coro read, byte-compatible baseline; select explicitly to pin it (the benchmark matrix's uncached column does).
+
+`data_source.read_workers` (default 8) bounds the per-worker read fan-out on the compiled paths: each in-flight read overlaps S3 latency and decodes with the GIL released. Peak worker memory grows with width — dial down for dense shards.
+
 ### Step 4: Visualize Results
 
 The output Zarr is a public DGGS dataset. The included notebook rasterizes HEALPix cells to a polar stereographic grid for fast rendering with `imshow`.

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -282,6 +282,16 @@ def validate_config(config: PipelineConfig) -> None:
     if handoff is not None and handoff not in ("pandas", "arrow"):
         raise ValueError(f"aggregation.handoff must be 'pandas' or 'arrow' (got {handoff!r})")
 
+    # Validate the optional read fan-out width (issue #170). Mirrors the read
+    # module's guard (_read_workers) so a config typo is rejected at
+    # submission -- inside the worker the same error would be swallowed into
+    # per-group read_errors and surface as a silently-empty shard.
+    read_workers = (config.data_source or {}).get("read_workers")
+    if read_workers is not None and (
+        isinstance(read_workers, bool) or not isinstance(read_workers, int) or read_workers < 1
+    ):
+        raise ValueError(f"data_source.read_workers must be an integer >= 1 (got {read_workers!r})")
+
     # Optional strict-AOI cell mask (issue #101), default off. Must be a bool.
     aoi_mask = config.output.get("aoi_mask")
     if aoi_mask is not None and not isinstance(aoi_mask, bool):

--- a/src/zagg/index/__init__.py
+++ b/src/zagg/index/__init__.py
@@ -209,17 +209,30 @@ def validate_index_config(index_cfg: Any, data_source: dict | None = None) -> No
 def index_from_config(config) -> VirtualIndex:
     """Construct the configured backend from a ``PipelineConfig``.
 
-    An absent ``data_source.index`` block is (still) the zero-change path:
-    today's hierarchical read, byte-identical. The issue #170 default flip
-    to ``inline`` lands as ONE unconditional change (espg call on the #170
-    thread, 2026-07-06) once the compiled full-read route makes ``inline``
-    serve read-plan-less (flat) data sources too.
+    An absent ``data_source.index`` block resolves to ``inline`` — the
+    compiled (h5coro-hidefix) decode, output row-identical to
+    ``hierarchical`` — for **every** data source (issue #170; one
+    unconditional flip, espg decision on the #170 thread 2026-07-06):
+    planned sources take chunk-aligned hyperslices, read-plan-less (flat)
+    sources the compiled full-read route. Datasets the compiled reader
+    cannot serve degrade per dataset inside the backend. An explicit
+    ``{backend: hierarchical}`` block pins the pure-h5coro path (the
+    uncached benchmark baseline). The one exception: a-priori
+    ``read_plan.chunk_boundaries`` (issue #148 arm 2a) takes precedence
+    inside ``_read_group`` and is mutually exclusive with inline's
+    addressing, so those sources keep the hierarchical default.
     """
-    index_cfg = (config.data_source or {}).get("index")
+    ds = config.data_source or {}
+    index_cfg = ds.get("index")
     if index_cfg is None:
-        from zagg.index.hierarchical import HierarchicalIndex
+        rp = ds.get("read_plan")
+        if isinstance(rp, dict) and "chunk_boundaries" in rp:
+            from zagg.index.hierarchical import HierarchicalIndex
 
-        return HierarchicalIndex()
+            return HierarchicalIndex()
+        from zagg.index.inline import InlineIndex
+
+        return InlineIndex()
     # Re-validate here (cheap) so dict-built configs that skipped
     # ``validate_config`` (e.g. hand-rolled Lambda payloads) fail loudly at
     # backend resolution rather than deep in a group read.

--- a/src/zagg/index/__init__.py
+++ b/src/zagg/index/__init__.py
@@ -209,8 +209,11 @@ def validate_index_config(index_cfg: Any, data_source: dict | None = None) -> No
 def index_from_config(config) -> VirtualIndex:
     """Construct the configured backend from a ``PipelineConfig``.
 
-    An absent ``data_source.index`` block is the zero-change upgrade path:
-    today's hierarchical read, byte-identical.
+    An absent ``data_source.index`` block is (still) the zero-change path:
+    today's hierarchical read, byte-identical. The issue #170 default flip
+    to ``inline`` lands as ONE unconditional change (espg call on the #170
+    thread, 2026-07-06) once the compiled full-read route makes ``inline``
+    serve read-plan-less (flat) data sources too.
     """
     index_cfg = (config.data_source or {}).get("index")
     if index_cfg is None:

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -477,28 +477,42 @@ class InlineIndex(VirtualIndex):
         datasets are disjoint from every other group's, so nothing is
         rebuilt or leaked across granules. Under ``write_back`` the cache is
         the instance's pending dict instead, accumulating the granule's maps
-        across groups for ``finish_granule`` to persist. The in-memory
-        ``Index`` is rebuilt (~ms) whenever a new dataset's map lands.
+        across groups for ``finish_granule`` to persist. Each dataset gets
+        its own single-dataset in-memory ``Index`` (~ms), so a spec hidefix
+        rejects degrades that dataset alone.
         """
         maps: dict[str, ChunkMap] = self._pending if self.write_back else {}
-        state: dict = {"vidx": None, "n_maps": -1}
+        # One single-dataset Index per path (~ms each): a dataset whose spec
+        # hidefix rejects (nonzero filter_mask, non-tiling chunk table) then
+        # pins only ITSELF to the fallback — a shared Index rebuilt from all
+        # of ``maps`` would fail every subsequent dataset's reconstruction
+        # and degrade innocent paths with it (review finding, PR #173).
+        indices: dict = {}
         direct: set[str] = set()  # datasets pinned to the h5coro decoder
 
-        def _vidx():
-            if state["n_maps"] != len(maps):
+        def _vidx_for(path):
+            vidx = indices.get(path)
+            if vidx is None:
                 from h5coro_hidefix import Index
                 from h5coro_hidefix.manifest import datasets_from_manifest
 
-                state["vidx"] = Index.from_chunks(
-                    "inline", datasets_from_manifest(granule_manifest(maps))
+                vidx = indices[path] = Index.from_chunks(
+                    "inline", datasets_from_manifest(granule_manifest({path: maps[path]}))
                 )
-                state["n_maps"] = len(maps)
-            return state["vidx"]
+            return vidx
 
         def _compiled(path, start, end):
-            vidx = _vidx()
+            vidx = _vidx_for(path)
             addrs, sizes, _ = vidx.read_plan(path, start, end)
-            buffers = [h5obj.ioRequest(int(a), int(s), caching=False) for a, s in zip(addrs, sizes)]
+            buffers = []
+            for a, s in zip(addrs, sizes):
+                buf = h5obj.ioRequest(int(a), int(s), caching=False)
+                if buf is None:
+                    # h5coro's S3 driver swallows exceptions and returns None;
+                    # surface it as I/O so it is never misclassified as a
+                    # decode failure (review finding, PR #173).
+                    raise OSError(f"ranged read failed for {path} at {int(a)}+{int(s)}")
+                buffers.append(buf)
             return vidx.read_from_buffers(path, buffers, start, end)
 
         def _h5coro_read(path, hyperslice, cm):
@@ -529,6 +543,8 @@ class InlineIndex(VirtualIndex):
                         return _compiled(path, None, None)
                     parts = [_compiled(path, s, e) for s, e in hyperslice]
                     return parts[0] if len(parts) == 1 else np.concatenate(parts)
+                except OSError:
+                    raise  # transient I/O, not a decode problem: fail the read loudly
                 except Exception as exc:
                     direct.add(path)
                     logger.warning(

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -444,7 +444,7 @@ class InlineIndex(VirtualIndex):
             # selectivity fallback and empty-shard early returns — still
             # contribute this group's datasets to the granule manifest.
             self._prebuild_group_maps(h5obj, group, data_source)
-        read_fn = self._chunk_aligned_read_fn(h5obj)
+        read_fn = self._chunk_aligned_read_fn(h5obj, planned=planned)
         if planned:
             return _planned_read_group(
                 h5obj, group, data_source, shard_key, grid, arrow=arrow, read_fn=read_fn
@@ -453,7 +453,7 @@ class InlineIndex(VirtualIndex):
             h5obj, group, data_source, shard_key, grid, arrow=arrow, read_fn=read_fn
         )
 
-    def _chunk_aligned_read_fn(self, h5obj):
+    def _chunk_aligned_read_fn(self, h5obj, *, planned=True):
         """Build the addressing seam: planned ranges, compiled decode.
 
         The chunk maps this backend already builds are exactly what
@@ -522,7 +522,7 @@ class InlineIndex(VirtualIndex):
             parts = []
             for s, e in hyperslice:
                 lo = s
-                if s > 0 and len(cm) and cm.starts_on_boundary(s):
+                if s > 0 and cm is not None and len(cm) and cm.starts_on_boundary(s):
                     lo = s - 1  # h5coro start-edge workaround (see docstring)
                 arr = h5obj.readDatasets([{"dataset": path, "hyperslice": [(lo, e)]}])[path]
                 parts.append(arr[s - lo :])
@@ -534,8 +534,11 @@ class InlineIndex(VirtualIndex):
                 try:
                     cm = maps[path] = build_chunk_map(h5obj, path)
                 except Exception:
-                    if hyperslice is not None:
-                        raise  # planned reads required the map before #170 too
+                    if planned and hyperslice is not None:
+                        # The planned route required the map before #170 too:
+                        # without it the boundary workaround can't run, and a
+                        # plain hyperslice read may trip the PR #152 edge.
+                        raise
                     direct.add(path)
                     logger.warning(f"  no chunk map for {path}; reading through h5coro")
             if path not in direct:

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -7,11 +7,17 @@ metadata-only, ~1 ranged GET + tens of ms per granule (the B-trees live in
 the front-of-file metadata block NSIDC keeps inside h5coro's first cache
 line; measured on PR #159's ``bench/offsets`` route (b), cross-validated
 there against h5py and hidefix chunk-for-chunk over 61 granules with zero
-mismatches). Planned reads are issued as-is — the h5coro decoder already
-inflates exactly the covering chunks — except that the chunk map lets reads
-that start exactly on an interior chunk boundary be detected and shifted one
-element early (see below), keeping output row-identical to ``hierarchical``
-while surviving inputs the plain hyperslice read drops.
+mismatches). Decode goes through the compiled h5coro-hidefix reader (issue
+#170): the chunk map reconstructs a per-dataset in-memory ``Index`` whose
+``read_from_buffers`` inflates exactly the covering chunks, byte-identical
+to h5py/h5coro, with the GIL released. Both read routes are served — the
+planned (chunk-aligned hyperslice) route for sources with
+``read_plan.spatial_index``, and the full-read route for read-plan-less
+(flat) sources — so this backend is the package default for every data
+source. Datasets the compiled reader cannot serve degrade to the h5coro
+decoder per dataset, where the chunk map still lets reads that start
+exactly on an interior chunk boundary be detected and shifted one element
+early (see below).
 
 The chunk map is also the write-back payload: with ``write_back: true``
 (opt-in — issue #160 Q2) plus a ``store``, every granule's accumulated chunk

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -453,33 +453,57 @@ class InlineIndex(VirtualIndex):
         )
 
     def _chunk_aligned_read_fn(self, h5obj):
-        """Build the addressing seam: planned ranges, boundary-safe.
+        """Build the addressing seam: planned ranges, compiled decode.
 
-        The plain planned read is already chunk-minimal with the h5coro
-        decoder (it inflates exactly the covering chunks), so ranges are
-        issued as-is — except when a range starts exactly on an interior
-        chunk boundary, which h5coro's B-tree start-edge intersection drops
-        entirely (PR #152 off-by-one, issue #148 thread). The chunk map makes
-        those starts detectable: shift one element early and trim, paying one
-        extra chunk inflate only in that case (the bench extractor's
-        workaround, applied surgically).
+        The chunk maps this backend already builds are exactly what
+        ``h5coro_hidefix.Index.from_chunks`` consumes (the same
+        ``granule_manifest`` columns ``write_back`` persists), so decode goes
+        through the compiled reader (issue #170): plan the covering chunks,
+        fetch their byte ranges through the worker's h5coro driver
+        (``ioRequest`` — no second credential path), and inflate with
+        ``read_from_buffers`` (byte-identical to h5py/h5coro, GIL released).
+        Datasets the compiled route cannot serve — undecodable dtypes
+        (strings, compounds), empty chunk maps, reconstruction failures —
+        degrade to the h5coro decoder per dataset with a warning, never
+        aborting the shard. The h5coro fallback keeps the PR #152 start-edge
+        workaround: a range starting exactly on an interior chunk boundary
+        is shifted one element early and trimmed (h5coro's B-tree start-edge
+        intersection drops the chunk entirely); the compiled reader has
+        exact ``[start, end)`` semantics and needs no workaround.
 
-        Chunk maps are built lazily per dataset (first planned read of that
-        path) and cached for the life of the returned callable — i.e. one
+        Chunk maps are built lazily per dataset (first read of that path)
+        and cached for the life of the returned callable — i.e. one
         ``read_group`` call, which is exactly one (granule, group): a group's
         datasets are disjoint from every other group's, so nothing is
         rebuilt or leaked across granules. Under ``write_back`` the cache is
         the instance's pending dict instead, accumulating the granule's maps
-        across groups for ``finish_granule`` to persist.
+        across groups for ``finish_granule`` to persist. The in-memory
+        ``Index`` is rebuilt (~ms) whenever a new dataset's map lands.
         """
         maps: dict[str, ChunkMap] = self._pending if self.write_back else {}
+        state: dict = {"vidx": None, "n_maps": -1}
+        direct: set[str] = set()  # datasets pinned to the h5coro decoder
 
-        def read_fn(path, hyperslice=None):
+        def _vidx():
+            if state["n_maps"] != len(maps):
+                from h5coro_hidefix import Index
+                from h5coro_hidefix.manifest import datasets_from_manifest
+
+                state["vidx"] = Index.from_chunks(
+                    "inline", datasets_from_manifest(granule_manifest(maps))
+                )
+                state["n_maps"] = len(maps)
+            return state["vidx"]
+
+        def _compiled(path, start, end):
+            vidx = _vidx()
+            addrs, sizes, _ = vidx.read_plan(path, start, end)
+            buffers = [h5obj.ioRequest(int(a), int(s), caching=False) for a, s in zip(addrs, sizes)]
+            return vidx.read_from_buffers(path, buffers, start, end)
+
+        def _h5coro_read(path, hyperslice, cm):
             if hyperslice is None:
                 return h5obj.readDatasets([path])[path]
-            cm = maps.get(path)
-            if cm is None:
-                cm = maps[path] = build_chunk_map(h5obj, path)
             parts = []
             for s, e in hyperslice:
                 lo = s
@@ -488,5 +512,28 @@ class InlineIndex(VirtualIndex):
                 arr = h5obj.readDatasets([{"dataset": path, "hyperslice": [(lo, e)]}])[path]
                 parts.append(arr[s - lo :])
             return parts[0] if len(parts) == 1 else np.concatenate(parts)
+
+        def read_fn(path, hyperslice=None):
+            cm = maps.get(path)
+            if cm is None and path not in direct:
+                try:
+                    cm = maps[path] = build_chunk_map(h5obj, path)
+                except Exception:
+                    if hyperslice is not None:
+                        raise  # planned reads required the map before #170 too
+                    direct.add(path)
+                    logger.warning(f"  no chunk map for {path}; reading through h5coro")
+            if path not in direct:
+                try:
+                    if hyperslice is None:
+                        return _compiled(path, None, None)
+                    parts = [_compiled(path, s, e) for s, e in hyperslice]
+                    return parts[0] if len(parts) == 1 else np.concatenate(parts)
+                except Exception as exc:
+                    direct.add(path)
+                    logger.warning(
+                        f"  compiled decode unavailable for {path} ({exc}); reading through h5coro"
+                    )
+            return _h5coro_read(path, hyperslice, cm)
 
         return read_fn

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -347,16 +347,12 @@ class InlineIndex(VirtualIndex):
                 "index.store is only meaningful for backend 'inline' with "
                 "write_back: true (inline never reads the store)"
             )
-        # The chunk map drives *addressing*; selection still needs the coarse
-        # spatial index, so the hierarchical read_plan surface is required.
+        # Both read routes accept this backend (issue #170 phase 2): sources
+        # with read_plan.spatial_index take the planned route, read-plan-less
+        # (flat) sources the full-read route -- same compiled addressing seam.
         if data_source is not None:
             rp = data_source.get("read_plan")
-            if not (isinstance(rp, dict) and rp.get("spatial_index")):
-                raise ValueError(
-                    "index backend 'inline' requires data_source.read_plan.spatial_index "
-                    "(chunk-aligned addressing plugs into the planned read path)"
-                )
-            if "chunk_boundaries" in rp:
+            if isinstance(rp, dict) and "chunk_boundaries" in rp:
                 # The a-priori arm (issue #148 arm 2a) takes precedence over
                 # spatial_index inside _read_group, which would silently bypass
                 # this backend's chunk-map addressing -- reject the combination.
@@ -426,30 +422,35 @@ class InlineIndex(VirtualIndex):
         logger.info(f"  inline write-back: {len(maps)} dataset(s) -> {self.store}/{key}")
 
     def read_group(self, h5obj, group, data_source, shard_key, grid, arrow=False, granule_url=None):
-        from zagg.processing.read import _planned_read_group, _validate_planned_config
+        from zagg.processing.read import (
+            _planned_read_group,
+            _read_group_full,
+            _validate_planned_config,
+        )
 
         rp = data_source.get("read_plan")
-        # inline is planned-route only: without a spatial index it would have
-        # to silently fall back to the full read (ignoring the chunk map),
-        # so reject rather than degrade. Completeness of the planned config
-        # itself is the shared gate from the read module.
-        if not (isinstance(rp, dict) and rp.get("spatial_index")):
-            raise ValueError("index backend 'inline' requires data_source.read_plan.spatial_index")
-        _validate_planned_config(data_source)
+        # Two routes, one addressing seam (issue #170 phase 2): sources with a
+        # spatial index take the planned (chunk-aligned hyperslice) route;
+        # read-plan-less (flat) sources take the full-read route — both decode
+        # through the compiled read_fn, so non-ATL03-shaped products get the
+        # fast path too. Completeness of the planned config is the shared
+        # gate from the read module.
+        planned = isinstance(rp, dict) and bool(rp.get("spatial_index"))
+        if planned:
+            _validate_planned_config(data_source)
         if self.write_back:
             # Deterministic write-back coverage (metadata-only, ~ms): built up
             # front so routes that bypass the read seam — the ``full_read``
             # selectivity fallback and empty-shard early returns — still
             # contribute this group's datasets to the granule manifest.
             self._prebuild_group_maps(h5obj, group, data_source)
-        return _planned_read_group(
-            h5obj,
-            group,
-            data_source,
-            shard_key,
-            grid,
-            arrow=arrow,
-            read_fn=self._chunk_aligned_read_fn(h5obj),
+        read_fn = self._chunk_aligned_read_fn(h5obj)
+        if planned:
+            return _planned_read_group(
+                h5obj, group, data_source, shard_key, grid, arrow=arrow, read_fn=read_fn
+            )
+        return _read_group_full(
+            h5obj, group, data_source, shard_key, grid, arrow=arrow, read_fn=read_fn
         )
 
     def _chunk_aligned_read_fn(self, h5obj):

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -193,7 +193,7 @@ def _segment_level_variables(data_source: dict) -> dict[str, dict[str, str]]:
 
 
 def _read_segment_broadcasts(
-    h5obj, group: str, data_source: dict, levels: dict, n_base: int
+    h5obj, group: str, data_source: dict, levels: dict, n_base: int, read_fn=None
 ) -> dict[str, np.ndarray]:
     """Read each segment-level variable and broadcast it to a base-rate column (issue #30).
 
@@ -215,9 +215,13 @@ def _read_segment_broadcasts(
         index_base = int(link.get("index_base", 0))
         ibeg_path = link["index_beg"].format(group=group)
         cnt_path = link["count"].format(group=group)
-        link_data = h5obj.readDatasets([ibeg_path, cnt_path])
-        ibeg_arr = link_data[ibeg_path]
-        cnt_arr = link_data[cnt_path]
+        if read_fn is None:
+            link_data = h5obj.readDatasets([ibeg_path, cnt_path])
+            ibeg_arr = link_data[ibeg_path]
+            cnt_arr = link_data[cnt_path]
+        else:
+            ibeg_arr = read_fn(ibeg_path)
+            cnt_arr = read_fn(cnt_path)
         for col_name, tmpl in mapping.items():
             if col_name in base_cols:
                 raise ValueError(
@@ -225,7 +229,10 @@ def _read_segment_broadcasts(
                     f"collides with a data_source.variables column"
                 )
             seg_path = tmpl.format(group=group)
-            seg_values = np.asarray(h5obj.readDatasets([seg_path])[seg_path])
+            if read_fn is None:
+                seg_values = np.asarray(h5obj.readDatasets([seg_path])[seg_path])
+            else:
+                seg_values = np.asarray(read_fn(seg_path))
             out[col_name] = _broadcast_segment_to_base(
                 seg_values, ibeg_arr, cnt_arr, index_base, n_base
             )
@@ -660,7 +667,7 @@ def _validate_planned_config(data_source: dict) -> None:
 
 
 def _read_group_full(
-    h5obj, group: str, data_source: dict, shard_key: int, grid, arrow: bool = False
+    h5obj, group: str, data_source: dict, shard_key: int, grid, arrow: bool = False, read_fn=None
 ):
     """Full-coord-read variant of :func:`_read_group` (the pre-#49-Phase-C path).
 
@@ -673,6 +680,12 @@ def _read_group_full(
     Kept as the explicit fallback for: groups whose ``data_source`` declares no
     ``read_plan.spatial_index``; ``plan_read``'s selectivity fallback
     (``full_read=True``); and the legacy flat (no-levels) form.
+
+    ``read_fn`` (issue #170 phase 2) is the same addressing seam
+    :func:`_planned_read_group` takes — ``(path, hyperslice|None) -> array``
+    — so index backends (``inline``) can route this path's decode through the
+    compiled reader too, giving read-plan-less (flat) data sources the fast
+    decode. ``None`` keeps the batched h5coro reads byte-identical.
     """
     coordinates = data_source["coordinates"]
     variables = data_source["variables"]
@@ -694,7 +707,10 @@ def _read_group_full(
 
     # Resolve coordinate paths
     coord_paths = [path.format(group=group) for path in coordinates.values()]
-    coord_data = h5obj.readDatasets(coord_paths)
+    if read_fn is None:
+        coord_data = h5obj.readDatasets(coord_paths)
+    else:
+        coord_data = {p: read_fn(p) for p in coord_paths}
 
     lat_path = coordinates["latitude"].format(group=group)
     lon_path = coordinates["longitude"].format(group=group)
@@ -729,22 +745,29 @@ def _read_group_full(
             # Read the coarse flag array in full ("hyperslice": [] is h5coro's
             # full-read form; the key is required on dict entries — issue #157).
             # We need all parents to align with the full-length link arrays.
-            coarse_data = h5obj.readDatasets([{"dataset": flag_path, "hyperslice": []}])
-            coarse_arr = coarse_data[flag_path]
+            if read_fn is None:
+                coarse_data = h5obj.readDatasets([{"dataset": flag_path, "hyperslice": []}])
+                coarse_arr = coarse_data[flag_path]
+            else:
+                coarse_arr = read_fn(flag_path)
             coarse_fmask = _predicate_mask(coarse_arr, f)
             # Read the link arrays from this level.
             link = lvl["link"]
             index_base = int(link.get("index_base", 0))
             ibeg_path = link["index_beg"].format(group=group)
             cnt_path = link["count"].format(group=group)
-            link_data = h5obj.readDatasets(
-                [
-                    {"dataset": ibeg_path, "hyperslice": []},
-                    {"dataset": cnt_path, "hyperslice": []},
-                ]
-            )
-            ibeg_arr = link_data[ibeg_path]
-            cnt_arr = link_data[cnt_path]
+            if read_fn is None:
+                link_data = h5obj.readDatasets(
+                    [
+                        {"dataset": ibeg_path, "hyperslice": []},
+                        {"dataset": cnt_path, "hyperslice": []},
+                    ]
+                )
+                ibeg_arr = link_data[ibeg_path]
+                cnt_arr = link_data[cnt_path]
+            else:
+                ibeg_arr = read_fn(ibeg_path)
+                cnt_arr = read_fn(cnt_path)
             expanded = _expand_mask_to_base(coarse_fmask, ibeg_arr, cnt_arr, index_base, len(lats))
             cross_mask = expanded if cross_mask is None else (cross_mask & expanded)
         if cross_mask is not None and np.sum(cross_mask[min_idx:max_idx]) == 0:
@@ -765,7 +788,10 @@ def _read_group_full(
             datasets.append({"dataset": path, "hyperslice": [(min_idx, max_idx)]})
             paths_seen.add(path)
 
-    data = h5obj.readDatasets(datasets)
+    if read_fn is None:
+        data = h5obj.readDatasets(datasets)
+    else:
+        data = {d["dataset"]: read_fn(d["dataset"], d["hyperslice"]) for d in datasets}
 
     # Apply spatial mask to sliced data
     mask_sliced = mask_spatial[min_idx:max_idx]
@@ -788,7 +814,9 @@ def _read_group_full(
     # Segment-level variables (issue #30): read each declared non-base-level
     # variable and broadcast it to a base-rate per-photon column (length len(lats))
     # so it can be sliced through the same masks as the base-rate variables below.
-    seg_broadcasts = _read_segment_broadcasts(h5obj, group, data_source, levels or {}, len(lats))
+    seg_broadcasts = _read_segment_broadcasts(
+        h5obj, group, data_source, levels or {}, len(lats), read_fn=read_fn
+    )
 
     # Build dataframe (variables sliced to spatial mask, then to the keep-mask)
     leaf_sliced = leaf_ids[min_idx:max_idx][mask_sliced]

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -461,10 +461,19 @@ def _execute_plan_group(
     ]
     expressions = [f for f in filters if "expression" in f]
 
+    # Read fan-out (issue #170 phase 4): only when an index backend supplied
+    # a compiled read_fn -- the hierarchical h5coro path (read_fn None) keeps
+    # its serial reads (see _read_workers).
+    workers = _read_workers(data_source) if read_fn is not None else 1
+
     lat_path = coordinates["latitude"].format(group=group)
     lon_path = coordinates["longitude"].format(group=group)
-    lats = execute_read_plan(plan, _read_fn, lat_path, np.float64)
-    lons = execute_read_plan(plan, _read_fn, lon_path, np.float64)
+    coord_arrays = _read_paths_pooled(
+        [(lat_path, np.float64), (lon_path, np.float64)],
+        lambda p, dt: execute_read_plan(plan, _read_fn, p, dt),
+        workers,
+    )
+    lats, lons = coord_arrays[lat_path], coord_arrays[lon_path]
 
     if len(lats) == 0:
         return None
@@ -479,15 +488,14 @@ def _execute_plan_group(
     # each distinct path once (the variable and filter dataset paths can coincide).
     var_paths = {col: tmpl.format(group=group) for col, tmpl in variables.items()}
     filter_paths = {id(f): f["dataset"].format(group=group) for f in base_structured}
-    paths_seen: set[str] = set()
-    arrays_by_path: dict[str, np.ndarray] = {}
-    for path in list(var_paths.values()) + list(filter_paths.values()):
-        if path in paths_seen:
-            continue
-        paths_seen.add(path)
-        # dtype hint isn't load-bearing -- execute_read_plan dtype-casts via
-        # np.asarray, which is a no-op when the source dtype already matches.
-        arrays_by_path[path] = execute_read_plan(plan, _read_fn, path, None)
+    # dtype hint isn't load-bearing -- execute_read_plan dtype-casts via
+    # np.asarray, which is a no-op when the source dtype already matches.
+    # dict.fromkeys: read each distinct path once, in first-seen order.
+    arrays_by_path: dict[str, np.ndarray] = _read_paths_pooled(
+        [(p, None) for p in dict.fromkeys(list(var_paths.values()) + list(filter_paths.values()))],
+        lambda p, dt: execute_read_plan(plan, _read_fn, p, dt),
+        workers,
+    )
 
     # Base-level structured filters: ANDed keep-masks over the concatenated reads.
     keep_mask: np.ndarray | None = None
@@ -666,6 +674,39 @@ def _validate_planned_config(data_source: dict) -> None:
         raise ValueError("data_source.read_plan.spatial_index requires 'base_level'")
 
 
+def _read_workers(data_source: dict) -> int:
+    """``data_source.read_workers``: per-worker read concurrency (issue #170).
+
+    Applies only to reads routed through an index backend's compiled
+    ``read_fn`` (each is one blocking ranged fetch + a GIL-released decode,
+    so threads overlap S3 latency and use both Lambda vCPUs); the
+    hierarchical h5coro path keeps its serial batched reads regardless — it
+    is the pinned uncached benchmark baseline. Default 8. Peak RSS grows
+    with width (each in-flight read holds its compressed buffers + decoded
+    output), so dense-shard configs can dial it down; ``1`` is serial.
+    """
+    w = data_source.get("read_workers", 8)
+    if isinstance(w, bool) or not isinstance(w, int) or w < 1:
+        raise ValueError(f"data_source.read_workers must be an integer >= 1 (got {w!r})")
+    return w
+
+
+def _read_paths_pooled(entries, read_one, workers: int) -> dict:
+    """Run ``read_one(path, dtype)`` per (path, dtype) entry, fanned across a
+    bounded thread pool when ``workers > 1`` (issue #170 phase 4). Results
+    are keyed by path, so completion order cannot affect output; a failed
+    read re-raises at collection exactly as the serial loop would. Serial
+    (entry order) when ``workers <= 1`` or there is a single entry.
+    """
+    if workers <= 1 or len(entries) <= 1:
+        return {p: read_one(p, dt) for p, dt in entries}
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=min(workers, len(entries))) as pool:
+        futures = {p: pool.submit(read_one, p, dt) for p, dt in entries}
+        return {p: f.result() for p, f in futures.items()}
+
+
 def _read_group_full(
     h5obj, group: str, data_source: dict, shard_key: int, grid, arrow: bool = False, read_fn=None
 ):
@@ -705,12 +746,20 @@ def _read_group_full(
     ]
     expressions = [f for f in filters if "expression" in f]
 
+    # Read fan-out (issue #170 phase 4): only when an index backend supplied
+    # a compiled read_fn -- see _read_workers.
+    workers = _read_workers(data_source) if read_fn is not None else 1
+
     # Resolve coordinate paths
     coord_paths = [path.format(group=group) for path in coordinates.values()]
     if read_fn is None:
         coord_data = h5obj.readDatasets(coord_paths)
     else:
-        coord_data = {p: read_fn(p) for p in coord_paths}
+        coord_data = _read_paths_pooled(
+            [(p, None) for p in dict.fromkeys(coord_paths)],
+            lambda p, dt: read_fn(p),
+            workers,
+        )
 
     lat_path = coordinates["latitude"].format(group=group)
     lon_path = coordinates["longitude"].format(group=group)
@@ -791,7 +840,12 @@ def _read_group_full(
     if read_fn is None:
         data = h5obj.readDatasets(datasets)
     else:
-        data = {d["dataset"]: read_fn(d["dataset"], d["hyperslice"]) for d in datasets}
+        hyperslices = {d["dataset"]: d["hyperslice"] for d in datasets}
+        data = _read_paths_pooled(
+            [(p, None) for p in hyperslices],
+            lambda p, dt: read_fn(p, hyperslices[p]),
+            workers,
+        )
 
     # Apply spatial mask to sliced data
     mask_sliced = mask_spatial[min_idx:max_idx]

--- a/tests/data/benchmark/configs/atl03_gain_bias_healpix_o10.yaml
+++ b/tests/data/benchmark/configs/atl03_gain_bias_healpix_o10.yaml
@@ -31,6 +31,11 @@
 # chunks (chunk_inner 13 = 64x64 cells). The worker reads the shard once and
 # writes 16 chunk regions + 16 offset_h/gain_h companion slices.
 data_source:
+  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
+  # column. The package default flipped to the compiled `inline` path; an
+  # unpinned config would silently move this series onto the fast path.
+  index:
+    backend: hierarchical
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]

--- a/tests/data/benchmark/configs/atl03_gain_bias_healpix_o11.yaml
+++ b/tests/data/benchmark/configs/atl03_gain_bias_healpix_o11.yaml
@@ -31,6 +31,11 @@
 # chunks (chunk_inner 13 = 64x64 cells). The worker reads the shard once and
 # writes 16 chunk regions + 16 offset_h/gain_h companion slices.
 data_source:
+  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
+  # column. The package default flipped to the compiled `inline` path; an
+  # unpinned config would silently move this series onto the fast path.
+  index:
+    backend: hierarchical
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]

--- a/tests/data/benchmark/configs/atl03_gain_bias_rect_3km.yaml
+++ b/tests/data/benchmark/configs/atl03_gain_bias_rect_3km.yaml
@@ -31,6 +31,11 @@
 # chunks (chunk_inner 13 = 64x64 cells). The worker reads the shard once and
 # writes 16 chunk regions + 16 offset_h/gain_h companion slices.
 data_source:
+  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
+  # column. The package default flipped to the compiled `inline` path; an
+  # unpinned config would silently move this series onto the fast path.
+  index:
+    backend: hierarchical
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]

--- a/tests/data/benchmark/configs/atl03_gain_bias_rect_6km.yaml
+++ b/tests/data/benchmark/configs/atl03_gain_bias_rect_6km.yaml
@@ -31,6 +31,11 @@
 # chunks (chunk_inner 13 = 64x64 cells). The worker reads the shard once and
 # writes 16 chunk regions + 16 offset_h/gain_h companion slices.
 data_source:
+  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
+  # column. The package default flipped to the compiled `inline` path; an
+  # unpinned config would silently move this series onto the fast path.
+  index:
+    backend: hierarchical
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o10_cached.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o10_cached.yaml
@@ -1,31 +1,18 @@
-# ATL03 photon-height t-digest template (HEALPix, multi-chunk-per-worker).
+# Cached-read companion of atl03_tdigest_healpix_o10.yaml (issue #170 phase 5).
 #
-# Per-cell approximate-quantile sketch: each grid cell stores a t-digest of its
-# photon heights (h_ph) as a ``kind: ragged`` CSR field. A t-digest is a small,
-# mergeable set of (mean, weight) centroids from which any quantile (median,
-# p5/p95, IQR, ...) is recovered at read time -- far cheaper than storing every
-# photon, and exact-enough in the tails. The reducer is the pure-numpy
-# ``zagg.stats.tdigest.build_tdigest`` (issue #48), resolved as the field's
-# ``function`` via ``zagg.config.resolve_function`` (dotted path). ``delta`` is
-# the centroid budget (accuracy knob): ~delta centroids per cell regardless of
-# photon count. Read the digests back with ``zagg.readers.tdigest_tensor``.
-#
-# Grid is HEALPix nested at child_order 19 (the ~10 m cell, now that mortie 0.8.1
-# resolves past the old order-18 reference cap). Multi-chunk-per-worker (issue
-# #30 item 3) is on: one shard (the dispatch unit, parent_order 10 = 512x512
-# cells) owns K = 64 finer Zarr chunks (chunk_inner 13 = 64x64 cells each). The
-# worker reads the shard's granules once and writes 64 chunk regions + 64 CSR
-# groups, one per inner chunk. chunk_inner unset would collapse to K=1 (shard ==
-# chunk), byte-identical to the single-chunk path.
-#
-# Confidence filter, multi-level form and read_plan match atl03.yaml (the planned
-# segment->photon IO of issue #43 applies here too); only the aggregation differs.
+# Identical grid/aggregation/shardmap to the uncached baseline; the ONLY
+# difference is the read backend: `sidecar` consumes the granule-keyed chunk
+# manifests under zagg-index/ATL03/007 (shared with the sponsor example and
+# populated on first run via `on_miss: build`, which delegates to
+# inline+write_back). Column semantics: baseline = pure-h5coro uncached read,
+# this = compiled (hidefix) read against the manifest cache.
 data_source:
-  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
-  # column. The package default flipped to the compiled `inline` path; an
-  # unpinned config would silently move this series onto the fast path.
+  # Cached compiled read (issue #170): consume (or on first run, build) the
+  # granule-keyed sidecar manifests -- the CACHED benchmark column.
   index:
-    backend: hierarchical
+    backend: sidecar
+    on_miss: build
+    store: s3://sliderule-public-cors/zagg-index/ATL03/007
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o11.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o11.yaml
@@ -21,6 +21,11 @@
 # Confidence filter, multi-level form and read_plan match atl03.yaml (the planned
 # segment->photon IO of issue #43 applies here too); only the aggregation differs.
 data_source:
+  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
+  # column. The package default flipped to the compiled `inline` path; an
+  # unpinned config would silently move this series onto the fast path.
+  index:
+    backend: hierarchical
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o11_cached.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o11_cached.yaml
@@ -1,22 +1,18 @@
-# ATL03 photon-height scalar template (HEALPix, multi-chunk-per-worker).
+# Cached-read companion of atl03_tdigest_healpix_o11.yaml (issue #170 phase 5).
 #
-# Purely SCALAR per-cell stats over photon heights (h_ph): count, min, max, and
-# variance -- no vector and no ragged field. It exists purely to benchmark the
-# per-cell carrier handoff (issue #130): the SAME config + SAME shard is dispatched
-# twice -- pandas / arrow -- to isolate the Arrow carrier cost (pandas DataFrame vs
-# an arro3-core Arrow table; both byte-identical, neither imports pyarrow). See the
-# ``provisional_targets`` block in targets.json. (The earlier arrow-kernel reducer
-# was dropped with pyarrow -- arro3 has no hash-aggregate -- per the path-C pivot.)
-#
-# data_source / read_plan / grid match atl03_tdigest_healpix_o11.yaml exactly
-# (the segment->photon planned IO of issue #43 applies here too); only the
-# aggregation differs (scalar-only).
+# Identical grid/aggregation/shardmap to the uncached baseline; the ONLY
+# difference is the read backend: `sidecar` consumes the granule-keyed chunk
+# manifests under zagg-index/ATL03/007 (shared with the sponsor example and
+# populated on first run via `on_miss: build`, which delegates to
+# inline+write_back). Column semantics: baseline = pure-h5coro uncached read,
+# this = compiled (hidefix) read against the manifest cache.
 data_source:
-  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
-  # column. The package default flipped to the compiled `inline` path; an
-  # unpinned config would silently move this series onto the fast path.
+  # Cached compiled read (issue #170): consume (or on first run, build) the
+  # granule-keyed sidecar manifests -- the CACHED benchmark column.
   index:
-    backend: hierarchical
+    backend: sidecar
+    on_miss: build
+    store: s3://sliderule-public-cors/zagg-index/ATL03/007
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]
@@ -62,18 +58,21 @@ aggregation:
       source: h_ph
       dtype: int32
       fill_value: 0
-    h_min:
-      function: min
+    h_tdigest:
+      # Per-cell t-digest of photon heights: a ragged (CSR) field whose payload
+      # is an (n_centroids, 2) array of (mean, weight) centroids. ``build_tdigest``
+      # is called as build_tdigest(h_ph_values, delta=256); ``inner_shape: [2]``
+      # declares the per-element centroid width. To store ONE digest per chunk
+      # instead of per cell, add ``resolution: chunk`` (one CSR payload per inner
+      # chunk under the chunk-uniform contract).
+      kind: ragged
+      function: "zagg.stats.tdigest.build_tdigest"
       source: h_ph
+      inner_shape: [2]
+      params:
+        delta: 256
       dtype: float32
-    h_max:
-      function: max
-      source: h_ph
-      dtype: float32
-    h_variance:
-      function: var
-      source: h_ph
-      dtype: float32
+      fill_value: 0
 
 output:
   grid:

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o8.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o8.yaml
@@ -12,11 +12,13 @@
 #
 # Grid is HEALPix nested at child_order 19 (the ~10 m cell, now that mortie 0.8.1
 # resolves past the old order-18 reference cap). Multi-chunk-per-worker (issue
-# #30 item 3) is on: one shard (the dispatch unit, parent_order 10 = 512x512
-# cells) owns K = 64 finer Zarr chunks (chunk_inner 13 = 64x64 cells each). The
-# worker reads the shard's granules once and writes 64 chunk regions + 64 CSR
+# #30 item 3) is on: one shard (the dispatch unit, parent_order 8 = 2048x2048
+# cells) owns K = 1024 finer Zarr chunks (chunk_inner 13 = 64x64 cells each). The
+# worker reads the shard's granules once and writes 1024 chunk regions + 1024 CSR
 # groups, one per inner chunk. chunk_inner unset would collapse to K=1 (shard ==
-# chunk), byte-identical to the single-chunk path.
+# chunk), byte-identical to the single-chunk path. o8 is the coarsest benchmark
+# order: at ~648 km^2 a single shard spans essentially the whole NEON AOI, so its
+# densest shard aggregates the entire dataset (o9-scale in photons).
 #
 # Confidence filter, multi-level form and read_plan match atl03.yaml (the planned
 # segment->photon IO of issue #43 applies here too); only the aggregation differs.
@@ -91,6 +93,6 @@ output:
   grid:
     type: healpix
     indexing_scheme: nested
-    parent_order: 10             # shard / dispatch unit: 4^(19-10) = 512x512 cells
-    chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=64 per shard)
+    parent_order: 8              # shard / dispatch unit: 4^(19-8) = 2048x2048 cells
+    chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=1024 per shard)
     child_order: 19              # leaf cell resolution (~10 m)

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o9.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o9.yaml
@@ -23,6 +23,11 @@
 # Confidence filter, multi-level form and read_plan match atl03.yaml (the planned
 # segment->photon IO of issue #43 applies here too); only the aggregation differs.
 data_source:
+  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
+  # column. The package default flipped to the compiled `inline` path; an
+  # unpinned config would silently move this series onto the fast path.
+  index:
+    backend: hierarchical
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o9_cached.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o9_cached.yaml
@@ -1,31 +1,18 @@
-# ATL03 photon-height t-digest template (HEALPix, multi-chunk-per-worker).
+# Cached-read companion of atl03_tdigest_healpix_o9.yaml (issue #170 phase 5).
 #
-# Per-cell approximate-quantile sketch: each grid cell stores a t-digest of its
-# photon heights (h_ph) as a ``kind: ragged`` CSR field. A t-digest is a small,
-# mergeable set of (mean, weight) centroids from which any quantile (median,
-# p5/p95, IQR, ...) is recovered at read time -- far cheaper than storing every
-# photon, and exact-enough in the tails. The reducer is the pure-numpy
-# ``zagg.stats.tdigest.build_tdigest`` (issue #48), resolved as the field's
-# ``function`` via ``zagg.config.resolve_function`` (dotted path). ``delta`` is
-# the centroid budget (accuracy knob): ~delta centroids per cell regardless of
-# photon count. Read the digests back with ``zagg.readers.tdigest_tensor``.
-#
-# Grid is HEALPix nested at child_order 19 (the ~10 m cell, now that mortie 0.8.1
-# resolves past the old order-18 reference cap). Multi-chunk-per-worker (issue
-# #30 item 3) is on: one shard (the dispatch unit, parent_order 10 = 512x512
-# cells) owns K = 64 finer Zarr chunks (chunk_inner 13 = 64x64 cells each). The
-# worker reads the shard's granules once and writes 64 chunk regions + 64 CSR
-# groups, one per inner chunk. chunk_inner unset would collapse to K=1 (shard ==
-# chunk), byte-identical to the single-chunk path.
-#
-# Confidence filter, multi-level form and read_plan match atl03.yaml (the planned
-# segment->photon IO of issue #43 applies here too); only the aggregation differs.
+# Identical grid/aggregation/shardmap to the uncached baseline; the ONLY
+# difference is the read backend: `sidecar` consumes the granule-keyed chunk
+# manifests under zagg-index/ATL03/007 (shared with the sponsor example and
+# populated on first run via `on_miss: build`, which delegates to
+# inline+write_back). Column semantics: baseline = pure-h5coro uncached read,
+# this = compiled (hidefix) read against the manifest cache.
 data_source:
-  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
-  # column. The package default flipped to the compiled `inline` path; an
-  # unpinned config would silently move this series onto the fast path.
+  # Cached compiled read (issue #170): consume (or on first run, build) the
+  # granule-keyed sidecar manifests -- the CACHED benchmark column.
   index:
-    backend: hierarchical
+    backend: sidecar
+    on_miss: build
+    store: s3://sliderule-public-cors/zagg-index/ATL03/007
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]
@@ -91,6 +78,6 @@ output:
   grid:
     type: healpix
     indexing_scheme: nested
-    parent_order: 10             # shard / dispatch unit: 4^(19-10) = 512x512 cells
-    chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=64 per shard)
+    parent_order: 9              # shard / dispatch unit: 4^(19-9) = 1024x1024 cells
+    chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=256 per shard)
     child_order: 19              # leaf cell resolution (~10 m)

--- a/tests/data/benchmark/configs/atl03_tdigest_rect_3km.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_rect_3km.yaml
@@ -21,6 +21,11 @@
 # Confidence filter, multi-level form and read_plan match atl03.yaml (the planned
 # segment->photon IO of issue #43 applies here too); only the aggregation differs.
 data_source:
+  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
+  # column. The package default flipped to the compiled `inline` path; an
+  # unpinned config would silently move this series onto the fast path.
+  index:
+    backend: hierarchical
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]

--- a/tests/data/benchmark/configs/atl03_tdigest_rect_6km.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_rect_6km.yaml
@@ -21,6 +21,11 @@
 # Confidence filter, multi-level form and read_plan match atl03.yaml (the planned
 # segment->photon IO of issue #43 applies here too); only the aggregation differs.
 data_source:
+  # Pinned read backend (issue #170): the UNCACHED pure-h5coro baseline
+  # column. The package default flipped to the compiled `inline` path; an
+  # unpinned config would silently move this series onto the fast path.
+  index:
+    backend: hierarchical
   reader: h5coro
   driver: s3
   groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]

--- a/tests/data/benchmark/targets.json
+++ b/tests/data/benchmark/targets.json
@@ -1,5 +1,5 @@
 {
-  "description": "Pinned Lambda-benchmark targets (issue #110). Each target dispatches ONE shard -- the densest cell over the NEON SERC AOP box -- so cost/runtime deltas track code changes, not data drift. Forward matrix (issue #133): all tdigest / HEALPix / arrow, a 2x3 sharded-vs-inner ShardingCodec (issue #108) A/B across orders o9/o10/o11. The two columns of each order share ONE config + ONE shard map and differ only by the per-target codec key (sharded: true|false), which run_benchmark applies to output.grid.sharded. The carrier is config-driven (issue #132): aggregation.handoff defaults to arrow, so the matrix targets carry no redundant per-target handoff key. Shard maps are shared per (grid, order): the densest shard does not depend on the codec. Rebuild + drift check: tests/test_benchmark_shardmap.py.",
+  "description": "Pinned Lambda-benchmark targets (issue #110). Each target dispatches ONE shard -- the densest cell over the NEON SERC AOP box -- so cost/runtime deltas track code changes, not data drift. Forward matrix (issue #133): all tdigest / HEALPix / arrow, a 2x3 sharded-vs-inner ShardingCodec (issue #108) A/B across orders o9/o10/o11. The two columns of each order share ONE config + ONE shard map and differ only by the per-target codec key (sharded: true|false), which run_benchmark applies to output.grid.sharded. The carrier is config-driven (issue #132): aggregation.handoff defaults to arrow, so the matrix targets carry no redundant per-target handoff key. Shard maps are shared per (grid, order): the densest shard does not depend on the codec. Rebuild + drift check: tests/test_benchmark_shardmap.py. Cached-read columns (issue #170): each healpix tdigest order carries a *_cached companion target -- identical config except the read backend (sidecar over zagg-index/ATL03/007 granule manifests, self-populating via on_miss: build) -- so the matrix tracks the uncached pure-h5coro baseline and the compiled cached read side by side.",
   "aoi": {
     "file": "AOP_NEON.geojson",
     "name": "NEON SERC AOP box"
@@ -75,6 +75,16 @@
       "codec": "inner",
       "sharded": false
     },
+    "tdigest_healpix_o11_cached": {
+      "config": "configs/atl03_tdigest_healpix_o11_cached.yaml",
+      "shardmap": "healpix_o11",
+      "aggregator": "tdigest",
+      "grid_type": "healpix",
+      "grid_size": "o11",
+      "codec": "inner",
+      "sharded": false,
+      "read": "cached"
+    },
     "tdigest_healpix_o10_sharded": {
       "config": "configs/atl03_tdigest_healpix_o10.yaml",
       "shardmap": "healpix_o10",
@@ -93,6 +103,16 @@
       "codec": "inner",
       "sharded": false
     },
+    "tdigest_healpix_o10_cached": {
+      "config": "configs/atl03_tdigest_healpix_o10_cached.yaml",
+      "shardmap": "healpix_o10",
+      "aggregator": "tdigest",
+      "grid_type": "healpix",
+      "grid_size": "o10",
+      "codec": "inner",
+      "sharded": false,
+      "read": "cached"
+    },
     "tdigest_healpix_o9_sharded": {
       "config": "configs/atl03_tdigest_healpix_o9.yaml",
       "shardmap": "healpix_o9",
@@ -110,6 +130,16 @@
       "grid_size": "o9",
       "codec": "inner",
       "sharded": false
+    },
+    "tdigest_healpix_o9_cached": {
+      "config": "configs/atl03_tdigest_healpix_o9_cached.yaml",
+      "shardmap": "healpix_o9",
+      "aggregator": "tdigest",
+      "grid_type": "healpix",
+      "grid_size": "o9",
+      "codec": "inner",
+      "sharded": false,
+      "read": "cached"
     }
   },
   "provisional_targets": {

--- a/tests/data/benchmark/targets.json
+++ b/tests/data/benchmark/targets.json
@@ -143,7 +143,7 @@
     }
   },
   "provisional_targets": {
-    "_comment": "PROVISIONAL, PR-TREE-ONLY (issue #130). The two scalar targets share ONE config + ONE shard (healpix_o11) and differ only by handoff (pandas / arrow) to benchmark the per-cell carrier cost: pandas DataFrame vs an arro3-core Arrow table. Both produce byte-identical scalar output and neither imports pyarrow. (The experimental arrow-kernel reducer was dropped with pyarrow per @espg's path-C decision https://github.com/englacial/zagg/pull/131#issuecomment-4838785058, since arro3 has no hash-aggregate.) The two *_88s targets are the issue #148 stress probes: on-demand runs against the pinned worst 88S ring shard, expected to OOM/timeout until the streaming/cached-read work lands -- they must NOT join the every-merge matrix (a red benchmark job every merge). All entries here are deliberately NOT in 'targets': run_benchmark.py runs them by explicit --target name (via /benchmark); 'run all' (no --target) skips them.",
+    "_comment": "PROVISIONAL, PR-TREE-ONLY (issue #130). The two scalar targets share ONE config + ONE shard (healpix_o11) and differ only by handoff (pandas / arrow) to benchmark the per-cell carrier cost: pandas DataFrame vs an arro3-core Arrow table. Both produce byte-identical scalar output and neither imports pyarrow. (The experimental arrow-kernel reducer was dropped with pyarrow per @espg's path-C decision https://github.com/englacial/zagg/pull/131#issuecomment-4838785058, since arro3 has no hash-aggregate.) The two *_88s targets are the issue #148 stress probes: on-demand runs against the pinned worst 88S ring shard, expected to OOM/timeout until the streaming/cached-read work lands -- they must NOT join the every-merge matrix (a red benchmark job every merge). All entries here are deliberately NOT in 'targets': run_benchmark.py runs them by explicit --target name (via /benchmark); 'run all' (no --target) skips them. The *_88s_cached companions (issue #170) are the arm the base _88s probes were waiting for: same pinned 88S shard, read through the sidecar/compiled path (self-populating manifests) -- the base _88s targets stay pinned to the hierarchical baseline (issue #148 arm 1, the honest uncached reference), so the pair measures exactly the cached-vs-uncached delta at the pole.",
     "scalar_pandas_healpix_o11": {
       "config": "configs/atl03_scalar_healpix_o11.yaml",
       "shardmap": "healpix_o11",
@@ -167,12 +167,28 @@
       "grid_type": "healpix",
       "grid_size": "o9_88s"
     },
+    "tdigest_healpix_o9_88s_cached": {
+      "config": "configs/atl03_tdigest_healpix_o9_cached.yaml",
+      "shardmap": "healpix_o9_88s",
+      "aggregator": "tdigest",
+      "grid_type": "healpix",
+      "grid_size": "o9_88s",
+      "read": "cached"
+    },
     "tdigest_healpix_o10_88s": {
       "config": "configs/atl03_tdigest_healpix_o10.yaml",
       "shardmap": "healpix_o10_88s",
       "aggregator": "tdigest",
       "grid_type": "healpix",
       "grid_size": "o10_88s"
+    },
+    "tdigest_healpix_o10_88s_cached": {
+      "config": "configs/atl03_tdigest_healpix_o10_cached.yaml",
+      "shardmap": "healpix_o10_88s",
+      "aggregator": "tdigest",
+      "grid_type": "healpix",
+      "grid_size": "o10_88s",
+      "read": "cached"
     }
   }
 }

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1420,11 +1420,13 @@ def test_codec_layout_is_fixed_2x3_sharded_inner_by_order():
 
     hist = update_series.records_to_frame(_full_codec_matrix("c0"))
     grid, nrows, ncols = plot_series._codec_layout(hist)
-    assert (nrows, ncols) == (3, 2)  # rows o9->o11, cols sharded/inner
+    assert (nrows, ncols) == (3, 3)  # rows o9->o11, cols sharded/inner/cached (issue #170)
+    # Third column is the issue #170 cached-read slot; blank here because this
+    # synthetic history carries no cached rows.
     assert grid == [
-        ["tdigest_healpix_o9_sharded", "tdigest_healpix_o9_inner"],
-        ["tdigest_healpix_o10_sharded", "tdigest_healpix_o10_inner"],
-        ["tdigest_healpix_o11_sharded", "tdigest_healpix_o11_inner"],
+        ["tdigest_healpix_o9_sharded", "tdigest_healpix_o9_inner", None],
+        ["tdigest_healpix_o10_sharded", "tdigest_healpix_o10_inner", None],
+        ["tdigest_healpix_o11_sharded", "tdigest_healpix_o11_inner", None],
     ]
 
 
@@ -1435,9 +1437,9 @@ def test_codec_layout_blanks_missing_order():
 
     rows = [_codec_row("c0", o, c) for o in ("o10", "o11") for c in ("sharded", "inner")]
     grid, nrows, ncols = plot_series._codec_layout(update_series.records_to_frame(rows))
-    assert (nrows, ncols) == (3, 2)
-    assert grid[0] == [None, None]  # o9 row blank
-    assert grid[1] == ["tdigest_healpix_o10_sharded", "tdigest_healpix_o10_inner"]
+    assert (nrows, ncols) == (3, 3)  # cached col, issue #170
+    assert grid[0] == [None, None, None]  # o9 row blank (incl. cached col, issue #170)
+    assert grid[1] == ["tdigest_healpix_o10_sharded", "tdigest_healpix_o10_inner", None]
 
 
 def test_codec_and_frozen_histories_split_on_codec():

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -589,6 +589,7 @@ def test_forward_matrix_is_tdigest_healpix_arrow_codec_ab():
     manifest = json.loads((BENCH / "targets.json").read_text())
     targets = manifest["targets"]
     by_order: dict[str, set[str]] = {}
+    by_order_reads: dict[str, set[str]] = {}
     for tname, t in targets.items():
         assert t["aggregator"] == "tdigest", tname
         assert t["grid_type"] == "healpix", tname
@@ -596,12 +597,22 @@ def test_forward_matrix_is_tdigest_healpix_arrow_codec_ab():
         assert t["codec"] in ("sharded", "inner"), tname
         # codec label and the sharded bool run_benchmark applies must agree.
         assert t["sharded"] is (t["codec"] == "sharded"), tname
+        if t.get("read") == "cached":
+            # Cached-read column (issue #170): inner codec only, sidecar
+            # config companion, named by its read axis instead of codec.
+            assert t["codec"] == "inner", tname
+            assert tname == f"tdigest_healpix_{t['grid_size']}_cached", tname
+            assert t["config"].endswith(f"{t['grid_size']}_cached.yaml"), tname
+            by_order_reads.setdefault(t["grid_size"], set()).add("cached")
+            continue
         # The target name encodes its order + codec, matching the metadata.
         assert tname == f"tdigest_healpix_{t['grid_size']}_{t['codec']}", tname
         by_order.setdefault(t["grid_size"], set()).add(t["codec"])
     # Each present order is a complete A/B pair (both columns), never a half-row.
     for order, codecs in by_order.items():
         assert codecs == {"sharded", "inner"}, f"{order}: incomplete codec pair {codecs}"
+    # And each order carries its cached-read column (issue #170).
+    assert set(by_order_reads) == set(by_order), "cached column missing for some order"
 
 
 def test_o9_row_is_live():
@@ -610,10 +621,20 @@ def test_o9_row_is_live():
     manifest = json.loads((BENCH / "targets.json").read_text())
     assert "_pending_o9" not in manifest, "o9 hold-out stanza should be removed"
     o9_targets = {n for n, t in manifest["targets"].items() if t["grid_size"] == "o9"}
-    assert o9_targets == {"tdigest_healpix_o9_sharded", "tdigest_healpix_o9_inner"}
-    for t in (manifest["targets"][n] for n in o9_targets):
+    assert o9_targets == {
+        "tdigest_healpix_o9_sharded",
+        "tdigest_healpix_o9_inner",
+        "tdigest_healpix_o9_cached",  # cached-read column, issue #170
+    }
+    for n in o9_targets:
+        t = manifest["targets"][n]
         assert t["shardmap"] == "healpix_o9"
-        assert t["config"] == "configs/atl03_tdigest_healpix_o9.yaml"
+        expected = (
+            "configs/atl03_tdigest_healpix_o9_cached.yaml"
+            if t.get("read") == "cached"
+            else "configs/atl03_tdigest_healpix_o9.yaml"
+        )
+        assert t["config"] == expected
     # The shardmap entry is pinned with a real (numeric) densest shard_key.
     sm = manifest["shardmaps"]["healpix_o9"]
     assert isinstance(sm["shard_key"], int)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -123,16 +123,22 @@ def test_build_record_max_memory_null_safe():
 
 
 def test_codec_column_is_last_and_threaded(monkeypatch):
-    # The codec A/B label (issue #133) is the newest schema column -> appended LAST
-    # (stable-schema rule), threaded from context, and null on rows that omit it
-    # (legacy/frozen).
-    assert bench_metrics.RECORD_COLUMNS[-1] == "codec"
+    # Stable-schema rule: new columns append LAST. The read axis (issue #170)
+    # is now the newest column; codec (issue #133) sits just before it. Both
+    # are threaded from context and null on rows that omit them (legacy/frozen).
+    assert bench_metrics.RECORD_COLUMNS[-1] == "read"
+    assert bench_metrics.RECORD_COLUMNS[-2] == "codec"
     g = HealpixGrid(parent_order=11, child_order=19)
     rec = bench_metrics.build_record(_summary(), grid=g, context={"codec": "sharded"})
     assert rec["codec"] == "sharded"
     # Absent in context -> null (a frozen/legacy row carries no codec).
+    cached = bench_metrics.build_record(
+        _summary(), grid=g, context={"codec": "inner", "read": "cached"}
+    )
+    assert cached["read"] == "cached"
     legacy = bench_metrics.build_record(_summary(), grid=g, context={"target": "t"})
     assert legacy["codec"] is None
+    assert legacy["read"] is None
 
 
 def test_run_target_threads_codec_into_record():
@@ -1415,6 +1421,35 @@ def _full_codec_matrix(commit):
     ]
 
 
+def _cached_row(commit, order):
+    # Issue #170 cached-read companion: codec stays "inner" (it still drives
+    # output.grid.sharded); the read axis is what slots it into the third
+    # renderer column. Built through bench_metrics.build_record so the test
+    # pins the WHOLE pipe -- ctx -> record -> frame -> layout (the first fold
+    # of this finding wired the layout but dropped the key in the record).
+    import bench_metrics
+
+    ctx = dict(
+        timestamp=f"2026-01-01T00:00:0{len(commit) % 10}Z",
+        commit=commit,
+        ref="main",
+        event="merge",
+        target=f"tdigest_healpix_{order}_cached",
+        aggregator="tdigest",
+        grid_type="healpix",
+        grid_size=order,
+        shard_key=0,
+        codec="inner",
+        read="cached",
+    )
+    g = HealpixGrid(parent_order=int(order[1:]), child_order=19)
+    return bench_metrics.build_record(
+        {"lambda_time_s": 200.0, "estimated_cost_usd": 0.005, "max_memory_mb": 1200.0},
+        grid=g,
+        context=ctx,
+    )
+
+
 def test_codec_layout_is_fixed_2x3_sharded_inner_by_order():
     import plot_series
 
@@ -1427,6 +1462,26 @@ def test_codec_layout_is_fixed_2x3_sharded_inner_by_order():
         ["tdigest_healpix_o9_sharded", "tdigest_healpix_o9_inner", None],
         ["tdigest_healpix_o10_sharded", "tdigest_healpix_o10_inner", None],
         ["tdigest_healpix_o11_sharded", "tdigest_healpix_o11_inner", None],
+    ]
+    # With cached rows present (issue #170), each lands in its own column and
+    # the real inner target keeps its slot -- the cached companion shares
+    # codec "inner", so a regression here silently overwrites the inner panel.
+    hist = update_series.records_to_frame(
+        _full_codec_matrix("c0") + [_cached_row("c0", o) for o in ("o9", "o10", "o11")]
+    )
+    grid, _, _ = plot_series._codec_layout(hist)
+    assert grid == [
+        ["tdigest_healpix_o9_sharded", "tdigest_healpix_o9_inner", "tdigest_healpix_o9_cached"],
+        [
+            "tdigest_healpix_o10_sharded",
+            "tdigest_healpix_o10_inner",
+            "tdigest_healpix_o10_cached",
+        ],
+        [
+            "tdigest_healpix_o11_sharded",
+            "tdigest_healpix_o11_inner",
+            "tdigest_healpix_o11_cached",
+        ],
     ]
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -769,6 +769,30 @@ class TestInlineReadGroup:
         assert "compiled decode unavailable" not in caplog.text
         assert "no chunk map" not in caplog.text
 
+    def test_read_workers_pool_byte_identical(self):
+        # issue #170 phase 4: pooled reads (read_workers > 1) are keyed by
+        # path, so completion order cannot leak into output -- byte-identical
+        # to the serial form on both routes.
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        df1 = InlineIndex().read_group(
+            _open_fixture(), "gt1l", _fixture_data_source(read_workers=1), 1, grid
+        )
+        df8 = InlineIndex().read_group(
+            _open_fixture(), "gt1l", _fixture_data_source(read_workers=8), 1, grid
+        )
+        pd.testing.assert_frame_equal(df8, df1)
+        for col in df1.columns:
+            assert df8[col].to_numpy().tobytes() == df1[col].to_numpy().tobytes()
+
+    def test_read_workers_validation(self):
+        from zagg.processing.read import _read_workers
+
+        for bad in (0, -1, True, "eight", 2.5):
+            with pytest.raises(ValueError, match="read_workers"):
+                _read_workers({"read_workers": bad})
+        assert _read_workers({}) == 8
+        assert _read_workers({"read_workers": 3}) == 3
+
     def test_inline_accepts_no_stray_keys(self):
         with pytest.raises(ValueError, match="not accepted by backend 'inline'"):
             validate_index_config({"backend": "inline", "on_miss": "fallback"})

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -591,9 +591,13 @@ class TestInlineReadGroup:
         assert df_i["h_ph"].to_numpy().tobytes() == full["/gt1l/heights/h_ph"][keep].tobytes()
         assert df_i["leaf_id"].to_numpy().tolist() == leaf[keep].tolist()
 
-    def test_compiled_decoder_engaged(self, monkeypatch):
+    def test_compiled_decoder_engaged(self, monkeypatch, caplog):
         # Byte-parity alone can't distinguish the compiled route from a silent
-        # per-dataset fallback; pin that the hidefix Index is actually built.
+        # per-dataset fallback; pin that the hidefix Index is actually built
+        # AND that no dataset degraded (the spy alone fires on the attempt,
+        # not the success -- review finding, PR #173).
+        import logging
+
         import h5coro_hidefix.manifest as hh_manifest
 
         calls = []
@@ -604,11 +608,14 @@ class TestInlineReadGroup:
             return orig(columns)
 
         monkeypatch.setattr(hh_manifest, "datasets_from_manifest", spy)
-        df = InlineIndex().read_group(
-            _open_fixture(), "gt1l", _fixture_data_source(), 1, _LeafSetGrid(_UNALIGNED_LEAVES)
-        )
+        with caplog.at_level(logging.WARNING, logger="zagg.index.inline"):
+            df = InlineIndex().read_group(
+                _open_fixture(), "gt1l", _fixture_data_source(), 1, _LeafSetGrid(_UNALIGNED_LEAVES)
+            )
         assert df is not None and len(df) > 0
         assert calls, "compiled decode was never engaged"
+        assert "compiled decode unavailable" not in caplog.text
+        assert "no chunk map" not in caplog.text
 
     def test_falls_back_to_h5coro_on_compiled_failure(self, monkeypatch, caplog):
         # A broken Index reconstruction degrades per dataset (warning, h5coro
@@ -628,6 +635,52 @@ class TestInlineReadGroup:
         df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
         pd.testing.assert_frame_equal(df_i, df_h)
         assert "compiled decode unavailable" in caplog.text
+
+    def test_bad_dataset_degrades_alone(self, monkeypatch, caplog):
+        # A dataset hidefix rejects pins only ITSELF to the fallback; the
+        # group's other datasets stay compiled (PR #173 review: a shared
+        # Index rebuilt from all maps degraded innocent paths in cascade).
+        import logging
+
+        import h5coro_hidefix.manifest as hh_manifest
+
+        orig = hh_manifest.datasets_from_manifest
+        bad = "/gt1l/heights/h_ph"
+
+        def picky(columns):
+            if bad in set(columns["dataset"]):
+                raise ValueError("unsupported chunk table")
+            return orig(columns)
+
+        monkeypatch.setattr(hh_manifest, "datasets_from_manifest", picky)
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        with caplog.at_level(logging.WARNING, logger="zagg.index.inline"):
+            df_i = InlineIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        pd.testing.assert_frame_equal(df_i, df_h)
+        warned = [r.message for r in caplog.records if "compiled decode unavailable" in r.message]
+        assert len(warned) == 1 and bad in warned[0]
+
+    def test_none_buffer_surfaces_as_io_error(self, monkeypatch):
+        # h5coro drivers swallow exceptions and return None on failed ranged
+        # reads; that's transient I/O, not a decode defect -- it must raise,
+        # not silently pin the dataset to the slow path (PR #173 review).
+        # Exercised at the read_fn seam: h5coro's own readDatasets also
+        # issues caching=False requests, so a read_group-wide patch breaks
+        # the selection reads before the compiled path is ever reached.
+        h5obj = _open_fixture()
+        read_fn = InlineIndex()._chunk_aligned_read_fn(h5obj)
+        orig = h5obj.ioRequest
+
+        def flaky(pos, size, caching=True, **kwargs):
+            if caching is False:  # the compiled data reads pass this
+                return None
+            return orig(pos, size, caching=caching, **kwargs)
+
+        monkeypatch.setattr(h5obj, "ioRequest", flaky)
+        with pytest.raises(OSError, match="ranged read failed"):
+            read_fn("/gt1l/heights/h_ph", [(0, 100)])
 
     def test_inline_requires_read_plan_config(self):
         ds = _fixture_data_source()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -682,13 +682,80 @@ class TestInlineReadGroup:
         with pytest.raises(OSError, match="ranged read failed"):
             read_fn("/gt1l/heights/h_ph", [(0, 100)])
 
-    def test_inline_requires_read_plan_config(self):
-        ds = _fixture_data_source()
-        del ds["read_plan"]
-        with pytest.raises(ValueError, match="requires data_source.read_plan.spatial_index"):
-            validate_index_config({"backend": "inline"}, ds)
-        with pytest.raises(ValueError, match="requires data_source.read_plan.spatial_index"):
-            InlineIndex().read_group(_open_fixture(), "gt1l", ds, 1, _LeafSetGrid((4,)))
+    def test_inline_serves_flat_sources(self):
+        # issue #170 phase 2: a read-plan-less (flat) data source takes the
+        # full-read route through the same compiled seam -- row-identical to
+        # hierarchical. This is the shape most non-ATL03 targets have.
+        ds = {
+            "groups": ["gt1l", "gt2l"],
+            "coordinates": {
+                "latitude": "/{group}/heights/lat_ph",
+                "longitude": "/{group}/heights/lon_ph",
+            },
+            "variables": {"h_ph": "/{group}/heights/h_ph"},
+            "filters": [
+                {
+                    "dataset": "/{group}/heights/signal_conf_ph",
+                    "column": 0,
+                    "op": "ne",
+                    "value": -2,
+                }
+            ],
+        }
+        validate_index_config({"backend": "inline"}, ds)  # accepted, not rejected
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        df_i = InlineIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        # Gate against numpy ground truth from full-array reads (the
+        # hierarchical reference trips h5coro's PR #152 start-edge off-by-one
+        # here: this leaf set's flat-route window starts exactly on a chunk
+        # boundary — which the compiled route survives by construction).
+        h5obj = _open_fixture()
+        full = h5obj.readDatasets(
+            [
+                "/gt1l/heights/lat_ph",
+                "/gt1l/heights/h_ph",
+                "/gt1l/heights/signal_conf_ph",
+            ]
+        )
+        leaf = np.round(full["/gt1l/heights/lat_ph"]).astype(np.int64)
+        keep = np.isin(leaf, np.asarray(_UNALIGNED_LEAVES)) & (
+            full["/gt1l/heights/signal_conf_ph"][:, 0] != -2
+        )
+        assert df_i is not None and len(df_i) == int(keep.sum()) > 0
+        assert df_i["h_ph"].to_numpy().tobytes() == full["/gt1l/heights/h_ph"][keep].tobytes()
+        assert df_i["leaf_id"].to_numpy().tolist() == leaf[keep].tolist()
+
+    def test_flat_source_engages_compiled_decoder(self, monkeypatch, caplog):
+        # The flat route must actually decode through hidefix, not silently
+        # fall back per dataset (mirrors test_compiled_decoder_engaged).
+        import logging
+
+        import h5coro_hidefix.manifest as hh_manifest
+
+        calls = []
+        orig = hh_manifest.datasets_from_manifest
+
+        def spy(columns):
+            calls.append(1)
+            return orig(columns)
+
+        monkeypatch.setattr(hh_manifest, "datasets_from_manifest", spy)
+        ds = {
+            "groups": ["gt1l"],
+            "coordinates": {
+                "latitude": "/{group}/heights/lat_ph",
+                "longitude": "/{group}/heights/lon_ph",
+            },
+            "variables": {"h_ph": "/{group}/heights/h_ph"},
+        }
+        with caplog.at_level(logging.WARNING, logger="zagg.index.inline"):
+            df = InlineIndex().read_group(
+                _open_fixture(), "gt1l", ds, 1, _LeafSetGrid(_UNALIGNED_LEAVES)
+            )
+        assert df is not None and len(df) > 0
+        assert calls, "compiled decode was never engaged on the flat route"
+        assert "compiled decode unavailable" not in caplog.text
+        assert "no chunk map" not in caplog.text
 
     def test_inline_accepts_no_stray_keys(self):
         with pytest.raises(ValueError, match="not accepted by backend 'inline'"):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -277,8 +277,20 @@ class TestIndexConfigValidation:
 
 
 class TestIndexFromConfig:
-    def test_absent_block_resolves_hierarchical(self):
+    def test_absent_block_resolves_inline(self):
+        # issue #170 phase 3: the compiled inline read is the default for
+        # every data source -- flat (like this one) and planned alike.
         backend = index_from_config(_worker_cfg())
+        assert isinstance(backend, InlineIndex)
+        backend = index_from_config(_worker_cfg(read_plan={"spatial_index": "segments"}))
+        assert isinstance(backend, InlineIndex)
+
+    def test_absent_block_with_apriori_boundaries_stays_hierarchical(self):
+        # a-priori chunk_boundaries take precedence inside _read_group and
+        # are mutually exclusive with inline's addressing.
+        backend = index_from_config(
+            _worker_cfg(read_plan={"chunk_boundaries": {"prefix": "s3://x/boundaries/"}})
+        )
         assert isinstance(backend, HierarchicalIndex)
 
     def test_explicit_hierarchical(self):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -591,6 +591,44 @@ class TestInlineReadGroup:
         assert df_i["h_ph"].to_numpy().tobytes() == full["/gt1l/heights/h_ph"][keep].tobytes()
         assert df_i["leaf_id"].to_numpy().tolist() == leaf[keep].tolist()
 
+    def test_compiled_decoder_engaged(self, monkeypatch):
+        # Byte-parity alone can't distinguish the compiled route from a silent
+        # per-dataset fallback; pin that the hidefix Index is actually built.
+        import h5coro_hidefix.manifest as hh_manifest
+
+        calls = []
+        orig = hh_manifest.datasets_from_manifest
+
+        def spy(columns):
+            calls.append(1)
+            return orig(columns)
+
+        monkeypatch.setattr(hh_manifest, "datasets_from_manifest", spy)
+        df = InlineIndex().read_group(
+            _open_fixture(), "gt1l", _fixture_data_source(), 1, _LeafSetGrid(_UNALIGNED_LEAVES)
+        )
+        assert df is not None and len(df) > 0
+        assert calls, "compiled decode was never engaged"
+
+    def test_falls_back_to_h5coro_on_compiled_failure(self, monkeypatch, caplog):
+        # A broken Index reconstruction degrades per dataset (warning, h5coro
+        # decode) and never aborts the shard; rows stay identical.
+        import logging
+
+        import h5coro_hidefix.manifest as hh_manifest
+
+        def boom(columns):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(hh_manifest, "datasets_from_manifest", boom)
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        with caplog.at_level(logging.WARNING, logger="zagg.index.inline"):
+            df_i = InlineIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        pd.testing.assert_frame_equal(df_i, df_h)
+        assert "compiled decode unavailable" in caplog.text
+
     def test_inline_requires_read_plan_config(self):
         ds = _fixture_data_source()
         del ds["read_plan"]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -119,6 +119,15 @@ class TestWriteShardToZarr:
         monkeypatch.setattr("zagg.processing._read_group", one_shot)
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the one_shot stub intercepts (the
+        # issue #170 default otherwise resolves to inline, which reads through
+        # its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
     def _read_df(self, grid, shard_key):
         # Two distinct cells in two distinct inner chunks of the shard, so the
@@ -257,6 +266,15 @@ class TestShardOrderObjectSplit:
         monkeypatch.setattr("zagg.processing._read_group", one_shot)
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the one_shot stub intercepts (the
+        # issue #170 default otherwise resolves to inline, which reads through
+        # its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
         store = MemoryStore()
         grid.emit_template(store)
@@ -822,6 +840,15 @@ class TestRaggedCsrWrite:
         monkeypatch.setattr("zagg.processing._read_group", one_shot)
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the one_shot stub intercepts (the
+        # issue #170 default otherwise resolves to inline, which reads through
+        # its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
     @staticmethod
     def _shard_grid(cfg):
@@ -979,6 +1006,15 @@ class TestLocatedRaggedAggregation:
         monkeypatch.setattr("zagg.processing._read_group", one_shot)
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the one_shot stub intercepts (the
+        # issue #170 default otherwise resolves to inline, which reads through
+        # its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
     def test_calculate_cell_statistics_returns_located_pair(self):
         cfg = self._located_cfg()
@@ -1283,6 +1319,15 @@ class TestRaggedWriteFanout:
         monkeypatch.setattr("zagg.processing._read_group", one_shot)
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the one_shot stub intercepts (the
+        # issue #170 default otherwise resolves to inline, which reads through
+        # its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
         seen = {"count": 0, "keys": None}
 
@@ -1353,6 +1398,15 @@ class TestRaggedChunkCompanion:
         monkeypatch.setattr("zagg.processing._read_group", one_shot)
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the one_shot stub intercepts (the
+        # issue #170 default otherwise resolves to inline, which reads through
+        # its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
     def test_healpix_chunk_ragged_collapses_to_one_payload(self, monkeypatch):
         """HEALPix: a chunk-resolution ragged field writes ONE chunk payload, even
@@ -1536,6 +1590,15 @@ class TestMultiChunkWorker:
         monkeypatch.setattr("zagg.processing._read_group", one_shot)
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the one_shot stub intercepts (the
+        # issue #170 default otherwise resolves to inline, which reads through
+        # its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
     def test_k_gt_1_yields_one_carrier_per_chunk(self, monkeypatch):
         """K=4: process_shard returns 4 chunk_results, each a carrier at its own
@@ -2047,6 +2110,15 @@ class TestChunkCompanionWorkedExample:
         monkeypatch.setattr("zagg.processing._read_group", one_shot)
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the one_shot stub intercepts (the
+        # issue #170 default otherwise resolves to inline, which reads through
+        # its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
     def test_scalar_vector_ragged_chunk_companions_roundtrip(self, monkeypatch):
         import zarr
@@ -2373,6 +2445,15 @@ class TestProcessShardKernelBranch:
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         # Avoid resolving a real h5coro driver (s3driver import / creds plumbing).
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the fake_read_group stub intercepts
+        # (the issue #170 default otherwise resolves to inline, which reads
+        # through its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
     def test_invalid_handoff_rejected(self):
         """The ``handoff`` validation rejects unknown carriers before any read."""
@@ -3042,6 +3123,15 @@ class TestChunkResolutionCompanion:
         monkeypatch.setattr("zagg.processing._read_group", one_shot)
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        # These tests pin worker/aggregation logic, not the read backend: pin
+        # the hierarchical delegation seam the one_shot stub intercepts (the
+        # issue #170 default otherwise resolves to inline, which reads through
+        # its own chunk-aligned path and hits the object() h5obj stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
 
         carrier, _meta = process_shard(grid, shard_key, ["s3://x"], s3_credentials={}, config=cfg)
         chunk_idx = grid.block_index(shard_key)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2565,6 +2565,13 @@ class TestWorkerPhaseTimings:
             "_read_group",
             lambda *a, **k: object() if with_data else None,
         )
+        # This test pins the worker's phase brackets, not the read backend:
+        # pin the hierarchical delegation seam the _read_group stub intercepts
+        # (the issue #170 default otherwise resolves to inline, which reads
+        # through its own chunk-aligned path and hits the _H5 stub).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr(worker, "index_from_config", lambda cfg: HierarchicalIndex())
         monkeypatch.setattr(
             worker,
             "_concat_and_group",


### PR DESCRIPTION
Closes #170.

## What

Makes the compiled (hidefix) read path the one zagg actually uses, per the plan on the issue ([plan](https://github.com/englacial/zagg/issues/170#issuecomment-4897072816), [espg's answers](https://github.com/englacial/zagg/issues/170#issuecomment-4897166543), [non-ATL03 design note](https://github.com/englacial/zagg/issues/170#issuecomment-4897624120) — **Option B chosen by espg (session, 2026-07-06): one unconditional default flip after the full-read seam, no conditional interim**).

## Phases

- [x] **Phase 1 — inline decodes through the compiled reader** (planned route). Per-dataset single-dataset `Index` (`from_chunks` ~ms), reads via `read_plan` → `ioRequest(caching=False)` → `read_from_buffers` (GIL released); per-dataset degrade to h5coro (warning, never aborts a shard); transient I/O (`None` buffers) surfaces as `OSError`, never misclassified as decode failure. Review findings folded + independently verified closed.
- [x] **Phase 2 — compiled full-read route.** `_read_group_full` (and `_read_segment_broadcasts`) take the same optional `read_fn` seam as `_planned_read_group`; `read_fn=None` keeps the batched h5coro reads byte-identical. `InlineIndex` now serves **read-plan-less (flat) data sources** through it — the shape most non-ATL03 targets have — and its `spatial_index` config requirement is dropped (`chunk_boundaries` mutual exclusion stays). Bonus: the flat compiled route is immune to h5coro's PR #152 start-edge off-by-one (the new parity test's window lands exactly on a chunk boundary; the hierarchical reference cannot serve it).
- [x] **Phase 3 — unconditional default flip**: `index: None` → `inline` for every data source (flat and planned alike); `hierarchical` stays selectable (the uncached benchmark baseline). Sole exception: a-priori `read_plan.chunk_boundaries` sources keep hierarchical (mutually exclusive with inline's addressing). Flat-route chunk-map build failures degrade per dataset (pre-#170 flat reads never required a map); the planned route keeps its re-raise (the map is what makes the PR #152 boundary workaround possible). Worker-logic tests that stub `_read_group` now pin the hierarchical seam explicitly.
- [x] **Phase 4 — `read_workers` thread pool** (default 8, `data_source.read_workers`): the per-dataset reads in `_execute_plan_group` (coord pair + variable/filter fan-out) and `_read_group_full`'s seamed sites run through a bounded pool. Engages ONLY when a compiled `read_fn` is in play — the hierarchical baseline keeps its exact serial batched reads (pinned benchmark series). Thread safety verified: h5coro FileDriver locks reads, S3Driver rides boto3's thread-safe client, `ioRequest` caching has per-cache-line locks; results keyed by path so completion order can't leak into output (byte-identity test at width 1 vs 8).
- [x] **Phase 5 — benchmark columns**: all 11 configs pinned to `{backend: hierarchical}` (series continuity across the default flip), three `*_cached` companion configs+targets (tdigest HEALPix o9/o10/o11, `sidecar` + `on_miss: build` over `zagg-index/ATL03/007` — the same prefix the sponsor example populates, so the caches are shared). Matrix-pinning tests extended for the new read axis.
- [x] **Phase 6 — docs**: README read-backend section (inline default / sidecar / hierarchical baseline + `read_workers`), inline.py module docstring updated for the compiled decode and dual routes.

## How it was tested

- Phase 1: `TestInlineReadGroup` parity suite (row/byte-identical to hierarchical incl. arrow carrier + boundary case vs numpy ground truth); engagement pinned via spy **and** no-fallback-warnings caplog; poison-dataset isolation (`test_bad_dataset_degrades_alone`); I/O-error surfacing (`test_none_buffer_surfaces_as_io_error`).
- Phase 2: flat-source parity vs numpy ground truth (`test_inline_serves_flat_sources`), flat-route engagement (`test_flat_source_engages_compiled_decoder`); `read_fn=None` default byte-identity covered by the untouched hierarchical/planned suites.
- Suites: test_index 84, test_read_plan (in the 84 run), test_processing 194 — all green; ruff clean.

Fleet A/B: PR #169 [benchmark comment](https://github.com/englacial/zagg/pull/169#issuecomment-4897221283) is the pre-change baseline. The deployed fleet runs released zagg, so branch-code fleet numbers require the next release+deploy; a **local** SERC measurement (inline `read_workers` 1 vs 8: wall + peak RSS) lands here instead before ready-for-review, and the deployed A/B rides the release (espg-run, per convention).

## Questions for review

- Phase 1/2 make reads build chunk maps where they previously went straight to `readDatasets` — under `write_back` this widens manifest coverage to full-read datasets (deliberate: fewer sidecar misses later). Flagging in case wider manifests are unwanted.
