### PR TITLE
fix main: pin hierarchical seam in worker-double tests + template pins (issue #175)

### DIFF
--- a/deployment/aws/execution_role.yaml
+++ b/deployment/aws/execution_role.yaml
@@ -73,14 +73,16 @@ Resources:
                 Effect: Allow
                 Action: s3:ListBucket
                 Resource: !Sub "arn:aws:s3:::${OutputBucketName}"
-              # Virtual-index store (issue #160) -- keep in lockstep with the
-              # inline ExecutionRole in template.yaml.
-              - Sid: ReadWriteZaggIndexStore
+              # Public sliderule-public-cors bucket (index write-back +
+              # worker-written output zarr stores; espg, PR #176) -- keep in
+              # lockstep with the inline ExecutionRole in template.yaml.
+              - Sid: ReadWritePublicCorsObjects
                 Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
-                Resource: arn:aws:s3:::sliderule-public-cors/zagg-index/*
+                  - s3:DeleteObject
+                Resource: arn:aws:s3:::sliderule-public-cors/*
 
 Outputs:
   RoleArn:

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -239,9 +239,11 @@ def _maybe_self_recycle() -> None:
       against a 2047 MB cap, so the template's 1400 catches a dirty sandbox
       after roughly one heavy retention while leaving the triggering
       invocation ~650 MB of headroom to complete first.
-    - ``ZAGG_RECYCLE_MAX_INVOCATIONS`` -- generation cap (template 8),
-      belt-and-suspenders for retention modes the RSS read misses (and the
-      only check that fires off-Linux, where RSS reads are None).
+    - ``ZAGG_RECYCLE_MAX_INVOCATIONS`` -- generation cap (template default
+      1: recycle after every invocation, the cold-every-time posture; raise
+      it for a belt-and-suspenders cap over retention modes the RSS read
+      misses -- and the only check that fires off-Linux, where RSS reads
+      are None).
 
     Emits one CloudWatch-searchable line (``ZAGG_SELF_RECYCLE ...``) before
     exiting so dashboards can split intentional recycles from real crashes

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -129,9 +129,25 @@ Parameters:
       bounding retention modes that check misses. Set "0" or empty to
       disable the generation check.
 
+  CreateLogMetricFilters:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      Create the CloudWatch metric filters that split intentional
+      self-recycles from genuine worker failures (issue #175): under the
+      cold-every-time posture (RecycleMaxInvocations=1) every async
+      invocation self-exits and counts in Lambda's raw Errors metric, so
+      alarms must key on zagg/lambda WorkerErrorCount instead. Lambda
+      creates /aws/lambda/<fn> log groups lazily on first invocation and
+      AWS::Logs::MetricFilter requires the group to exist, so on a FRESH
+      stack: create with "false", invoke each function once, then update
+      the stack with "true". Existing deployments keep the default.
+
 Conditions:
   ShouldCreateBucket: !Equals [!Ref CreateOutputBucket, "true"]
   ShouldCreateRole: !Equals [!Ref CreateExecutionRole, "true"]
+  ShouldCreateMetricFilters: !Equals [!Ref CreateLogMetricFilters, "true"]
 
 Resources:
   OutputBucket:
@@ -272,6 +288,80 @@ Resources:
       Qualifier: "$LATEST"
       MaximumRetryAttempts: 0
       MaximumEventAgeInSeconds: 60
+
+  # Error-signal recovery under the cold-every-time posture (issue #175):
+  # with RecycleMaxInvocations=1 every async invocation self-exits after its
+  # result mirror, so Lambda's raw Errors metric is 100% noise. These filters
+  # publish the split to the zagg/lambda namespace, per function:
+  #   *SelfRecycleCount  -- the handler's ZAGG_SELF_RECYCLE line (expected).
+  #   *WorkerErrorCount  -- genuine failure signatures only: handler-logged
+  #     [ERROR] lines, unhandled-exception tracebacks, runtime timeouts,
+  #     OOM kills, and nonzero runtime exits. The patterns are deliberately
+  #     DISJOINT from the recycle path: a self-recycle logs at [INFO] and
+  #     exits 0, which the runtime reports as "Runtime exited without
+  #     providing a reason" -- not matched ("Runtime exited with error" is).
+  # The filters reference the implicit /aws/lambda/<fn> log groups by name
+  # rather than owning AWS::Logs::LogGroup resources: adopting a group Lambda
+  # already created fails stack CREATE/UPDATE with "already exists", the
+  # non-recoverable path for deployed stacks. See CreateLogMetricFilters for
+  # the fresh-stack ordering caveat.
+  ProcessSelfRecycleFilter:
+    Type: AWS::Logs::MetricFilter
+    Condition: ShouldCreateMetricFilters
+    DependsOn: ProcessFn
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${FunctionName}"
+      FilterPattern: '"ZAGG_SELF_RECYCLE"'
+      MetricTransformations:
+        - MetricNamespace: zagg/lambda
+          MetricName: ProcessSelfRecycleCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  ProcessWorkerErrorFilter:
+    Type: AWS::Logs::MetricFilter
+    Condition: ShouldCreateMetricFilters
+    DependsOn: ProcessFn
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${FunctionName}"
+      FilterPattern: >-
+        ?"Task timed out" ?"Runtime.OutOfMemory"
+        ?"Runtime exited with error" ?"[ERROR]"
+        ?"Traceback (most recent call last)"
+      MetricTransformations:
+        - MetricNamespace: zagg/lambda
+          MetricName: ProcessWorkerErrorCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  ExtractSelfRecycleFilter:
+    Type: AWS::Logs::MetricFilter
+    Condition: ShouldCreateMetricFilters
+    DependsOn: ExtractFn
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${FunctionName}-extract"
+      FilterPattern: '"ZAGG_SELF_RECYCLE"'
+      MetricTransformations:
+        - MetricNamespace: zagg/lambda
+          MetricName: ExtractSelfRecycleCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  ExtractWorkerErrorFilter:
+    Type: AWS::Logs::MetricFilter
+    Condition: ShouldCreateMetricFilters
+    DependsOn: ExtractFn
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${FunctionName}-extract"
+      FilterPattern: >-
+        ?"Task timed out" ?"Runtime.OutOfMemory"
+        ?"Runtime exited with error" ?"[ERROR]"
+        ?"Traceback (most recent call last)"
+      MetricTransformations:
+        - MetricNamespace: zagg/lambda
+          MetricName: ExtractWorkerErrorCount
+          MetricValue: "1"
+          DefaultValue: 0
 
 Outputs:
   FunctionArn:

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -122,10 +122,12 @@ Parameters:
     Default: "1"
     Description: >-
       ZAGG_RECYCLE_MAX_INVOCATIONS for the worker self-recycle (issue #171):
-      belt-and-suspenders generation cap -- recycle the sandbox (same
-      after-result-mirror mechanics as RecycleRssMb) once it has served this
-      many invocations, bounding retention modes the RSS check misses. Set
-      "0" or empty to disable the generation check.
+      generation cap -- recycle the sandbox (same after-result-mirror
+      mechanics as RecycleRssMb) once it has served this many invocations.
+      The default "1" recycles after every invocation (cold-every-time);
+      raise it to make this a belt-and-suspenders cap over the RSS check,
+      bounding retention modes that check misses. Set "0" or empty to
+      disable the generation check.
 
 Conditions:
   ShouldCreateBucket: !Equals [!Ref CreateOutputBucket, "true"]
@@ -176,8 +178,7 @@ Resources:
                 Action:
                   - s3:GetObject
                   - s3:PutObject
-                  - s3:DeleteObject
-                Resource: arn:aws:s3:::sliderule-public-cors/*
+                Resource: arn:aws:s3:::sliderule-public-cors/zagg-index/*
 
   DepsLayer:
     Type: AWS::Lambda::LayerVersion

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -171,14 +171,17 @@ Resources:
               - Effect: Allow
                 Action: s3:ListBucket
                 Resource: !Sub "arn:aws:s3:::${OutputBucketName}"
-              # Virtual-index store (issue #160): granule-keyed chunk-manifest
-              # write-back (inline backend) + sidecar reads, scoped to the
-              # public zagg-index prefix only.
+              # Public sliderule-public-cors bucket, whole-bucket by intent
+              # (espg, PR #176): virtual-index write-back + sidecar reads
+              # (zagg-index/*, issue #160) AND worker-written output zarr
+              # stores (e.g. zagg-examples/*); Delete covers store overwrite
+              # and manifest cleanup.
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
-                Resource: arn:aws:s3:::sliderule-public-cors/zagg-index/*
+                  - s3:DeleteObject
+                Resource: arn:aws:s3:::sliderule-public-cors/*
 
   DepsLayer:
     Type: AWS::Lambda::LayerVersion

--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -314,21 +314,37 @@ mechanisms address this (issue #171):
   ratcheting toward OOM. Synchronous invocations never self-recycle (the
   response would be lost).
 
-!!! info "Self-recycles look like runtime failures in CloudWatch"
+!!! warning "The raw `Errors` metric is 100% noise under this posture"
     A self-exit after the result write is counted as a runtime error by
     Lambda's `Errors` metric — **cosmetically only**: the result object at
     `result_url` is the source of truth for the orchestrator (issue #153),
     and `MaximumRetryAttempts: 0` in the template guarantees no zombie
-    retry. Each recycle logs one structured line first:
+    retry. With the default `RecycleMaxInvocations=1`, *every* async
+    invocation self-recycles, so raw `Errors` ≈ invocation count. Each
+    recycle logs one structured line first:
 
     ```
     ZAGG_SELF_RECYCLE rss_mb=<current> generation=<n> threshold=<crossed limit>
     ```
 
-    To keep dashboards honest, split intentional recycles from real crashes
-    with a [metric filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html)
-    on the function's log group, pattern `ZAGG_SELF_RECYCLE`, and subtract
-    (or graph separately) from `AWS/Lambda Errors`.
+    The template materializes the real-vs-expected split as CloudWatch
+    metrics (namespace `zagg/lambda`, per function): metric filters on both
+    log groups publish `ProcessSelfRecycleCount` / `ExtractSelfRecycleCount`
+    (the `ZAGG_SELF_RECYCLE` line — expected exits) and
+    `ProcessWorkerErrorCount` / `ExtractWorkerErrorCount` (genuine failure
+    signatures only: `[ERROR]` lines, tracebacks, `Task timed out`,
+    `Runtime.OutOfMemory`, nonzero runtime exits — a clean self-exit
+    reports "Runtime exited *without providing a reason*" and is
+    deliberately not matched). **Alarm and dashboard on
+    `WorkerErrorCount`, never on the raw `Errors` metric.**
+
+    Two operational corollaries: **never attach an async `OnFailure`
+    destination** (SQS/SNS/EventBridge) to these functions while the
+    recycle-every-invocation posture is active — it would receive every
+    invocation; and on a **fresh** stack create with
+    `CreateLogMetricFilters=false`, invoke each function once (Lambda
+    creates the log groups lazily; the filters need them to exist), then
+    update the stack with `true`.
 
 For guaranteed all-cold fleets (certification/benchmark baselines) there is
 also the dispatch-side big hammer: `agg(..., force_cold=True)` bumps a

--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -310,7 +310,8 @@ mechanisms address this (issue #171):
   (`os._exit(0)`) when current RSS ≥ `ZAGG_RECYCLE_RSS_MB` (template
   default 1400) or the sandbox has served `ZAGG_RECYCLE_MAX_INVOCATIONS`
   (template default 1 — recycle after every invocation, the cold-every-time
-  posture) invocations. Set either to `0`/empty to disable that check. The next invocation then starts on a fresh container instead of
+  posture) invocations. Set either to `0`/empty to disable that check. The
+  next invocation then starts on a fresh container instead of
   ratcheting toward OOM. Synchronous invocations never self-recycle (the
   response would be lost).
 

--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -309,8 +309,8 @@ mechanisms address this (issue #171):
   mirrored to its `result_url`, the handler exits the sandbox
   (`os._exit(0)`) when current RSS ≥ `ZAGG_RECYCLE_RSS_MB` (template
   default 1400) or the sandbox has served `ZAGG_RECYCLE_MAX_INVOCATIONS`
-  (template default 8) invocations. Set either to `0`/empty to disable that
-  check. The next invocation then starts on a fresh container instead of
+  (template default 1 — recycle after every invocation, the cold-every-time
+  posture) invocations. Set either to `0`/empty to disable that check. The next invocation then starts on a fresh container instead of
   ratcheting toward OOM. Synchronous invocations never self-recycle (the
   response would be lost).
 

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -303,8 +303,12 @@ def process_shard(
             # the granule's data is already in ``all_reads``.
             try:
                 index_backend.finish_granule(h5obj, s3_url)
-            except Exception:
-                logger.warning(f"  index backend finish_granule failed for {s3_url}", exc_info=True)
+            except Exception as e:
+                # Inline the reason instead of ``exc_info=True`` (the sibling
+                # tolerated-warning style above): a folded traceback in the
+                # log would trip the WorkerErrorCount metric filter (issue
+                # #175) on a path that never fails the read.
+                logger.warning(f"  index backend finish_granule failed for {s3_url}: {e}")
 
             files_processed += 1
             if buffered is not None:

--- a/tests/test_apriori.py
+++ b/tests/test_apriori.py
@@ -382,5 +382,10 @@ class TestWorkerSeam:
 
         ds = _data_source()
         ds["reader"] = "h5coro"
+        # The seam under test is the hierarchical backend's ``_read_group``
+        # delegation; the inline default (issue #170) never calls it, so pin
+        # the backend (the sibling test keeps hierarchical via its
+        # ``chunk_boundaries`` carve-out in ``index_from_config``).
+        ds["index"] = {"backend": "hierarchical"}
         _, meta = self._run(monkeypatch, ds, fake)
         assert meta["error"] == "No data after filtering"

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -392,7 +392,11 @@ class TestWorkerSeam:
         assert meta["files_processed"] == 1
         assert meta["total_obs"] == 3
         assert meta["error"] is None
-        assert any("finish_granule failed" in r.message for r in caplog.records)
+        rec = next(r for r in caplog.records if "finish_granule failed" in r.message)
+        # Reason inlined, no exc_info: a folded traceback would trip the
+        # WorkerErrorCount metric filter (issue #175) on this tolerated path.
+        assert "write-back store unreachable" in rec.message
+        assert rec.exc_info is None
 
     def test_bad_index_block_fails_before_any_read(self, monkeypatch):
         # Resolution happens up front, so a bad block is a loud config error,

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -6,6 +6,7 @@ These tests verify that:
 3. The zagg package can be imported as Lambda would see it
 """
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -253,6 +254,89 @@ class TestTemplateEnvironment:
         ext_matches = _index_statements(ext_role)
         assert len(ext_matches) == 1
         assert sorted(ext_matches[0]["Action"]) == actions
+
+    def test_metric_filters_publish_recycle_error_split(self):
+        # issue #175: under RecycleMaxInvocations=1 every async invocation
+        # self-exits, so Lambda's raw Errors metric is pure noise. The
+        # template publishes the real-vs-expected split to zagg/lambda, per
+        # function, gated on CreateLogMetricFilters (fresh stacks: Lambda
+        # creates the implicit log groups only on first invocation, and
+        # MetricFilter requires the group to exist).
+        tpl = self._load_template()
+        assert tpl["Parameters"]["CreateLogMetricFilters"]["Default"] == "true"
+        assert tpl["Conditions"]["ShouldCreateMetricFilters"] == {
+            "Equals": [{"Ref": "CreateLogMetricFilters"}, "true"]
+        }
+        expected = {
+            "ProcessSelfRecycleFilter": ("/aws/lambda/${FunctionName}", "ProcessSelfRecycleCount"),
+            "ProcessWorkerErrorFilter": ("/aws/lambda/${FunctionName}", "ProcessWorkerErrorCount"),
+            "ExtractSelfRecycleFilter": (
+                "/aws/lambda/${FunctionName}-extract",
+                "ExtractSelfRecycleCount",
+            ),
+            "ExtractWorkerErrorFilter": (
+                "/aws/lambda/${FunctionName}-extract",
+                "ExtractWorkerErrorCount",
+            ),
+        }
+        for name, (group, metric) in expected.items():
+            fltr = tpl["Resources"][name]
+            assert fltr["Type"] == "AWS::Logs::MetricFilter"
+            assert fltr["Condition"] == "ShouldCreateMetricFilters"
+            props = fltr["Properties"]
+            assert props["LogGroupName"] == {"Sub": group}
+            (mt,) = props["MetricTransformations"]
+            assert mt["MetricNamespace"] == "zagg/lambda"
+            assert mt["MetricName"] == metric
+            assert mt["MetricValue"] == "1"
+            assert mt["DefaultValue"] == 0
+
+    @staticmethod
+    def _filter_matches(pattern, line):
+        # Evaluator for the CloudWatch Logs term-filter subset the template
+        # uses: quoted terms only; a leading ? on every term means OR,
+        # otherwise all terms must appear in the line.
+        terms = re.findall(r'(\??)"([^"]*)"', pattern)
+        assert terms, f"unparsed filter pattern: {pattern!r}"
+        any_mode = all(q == "?" for q, _ in terms)
+        hits = [t in line for _, t in terms]
+        return any(hits) if any_mode else all(hits)
+
+    def test_metric_filter_patterns_are_disjoint(self):
+        # The recycle signature must NEVER count as a real error: a
+        # self-recycle logs ZAGG_SELF_RECYCLE at [INFO] and exits 0, which
+        # the runtime reports as "Runtime exited without providing a reason"
+        # -- distinct from a real nonzero exit's "Runtime exited with error".
+        res = self._load_template()["Resources"]
+        recycle = res["ProcessSelfRecycleFilter"]["Properties"]["FilterPattern"]
+        errors = res["ProcessWorkerErrorFilter"]["Properties"]["FilterPattern"]
+        # The Extract twins carry byte-identical patterns.
+        assert res["ExtractSelfRecycleFilter"]["Properties"]["FilterPattern"] == recycle
+        assert res["ExtractWorkerErrorFilter"]["Properties"]["FilterPattern"] == errors
+
+        recycle_lines = [
+            # the handler's structured line (lambda_handler._maybe_self_recycle)
+            "[INFO]\t2026-07-06T22:00:00Z\treq-1\t"
+            "ZAGG_SELF_RECYCLE rss_mb=1450 generation=1 threshold=1",
+            # the runtime's report for the recycle's clean os._exit(0)
+            "RequestId: req-1 Error: Runtime exited without providing a reason Runtime.ExitError",
+        ]
+        error_lines = [
+            "[ERROR]\t2026-07-06T22:00:00Z\treq-2\tFailed to write async result to s3://b/k: boom",
+            "Traceback (most recent call last):",
+            "2026-07-06T22:00:00Z req-3 Task timed out after 900.00 seconds",
+            "REPORT RequestId: req-4\tStatus: error\tError Type: Runtime.OutOfMemory",
+            "RequestId: req-5 Error: Runtime exited with error: exit status 1 Runtime.ExitError",
+        ]
+        assert self._filter_matches(recycle, recycle_lines[0])
+        for line in recycle_lines:
+            assert not self._filter_matches(errors, line)
+        for line in error_lines:
+            assert self._filter_matches(errors, line)
+        # ordinary INFO traffic matches neither metric
+        quiet = "[INFO]\t2026-07-06T22:00:00Z\treq-6\tLambda invocation started"
+        assert not self._filter_matches(recycle, quiet)
+        assert not self._filter_matches(errors, quiet)
 
     def test_extract_fn_mirrors_process_fn(self):
         # issue #148: extraction is both a mode of ProcessFn and a dedicated

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -298,7 +298,10 @@ class TestTemplateEnvironment:
         # otherwise all terms must appear in the line.
         terms = re.findall(r'(\??)"([^"]*)"', pattern)
         assert terms, f"unparsed filter pattern: {pattern!r}"
-        any_mode = all(q == "?" for q, _ in terms)
+        # CloudWatch defines no mixed ?/plain term list; keep the template
+        # within the uniform subset this evaluator models (review fold).
+        assert len({q for q, _ in terms}) == 1, f"mixed ?/plain terms: {pattern!r}"
+        any_mode = terms[0][0] == "?"
         hits = [t in line for _, t in terms]
         return any(hits) if any_mode else all(hits)
 

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -215,12 +215,15 @@ class TestTemplateEnvironment:
         assert env["ZAGG_RECYCLE_RSS_MB"] == {"Ref": "RecycleRssMb"}
         assert env["ZAGG_RECYCLE_MAX_INVOCATIONS"] == {"Ref": "RecycleMaxInvocations"}
 
-    def test_execution_role_grants_zagg_index_store(self):
-        # issue #160: inline write-back + sidecar reads target the public
-        # zagg-index prefix; the shared execution role gets Get/Put scoped to
-        # exactly that prefix (never the bucket), in BOTH copies of the role
-        # (inline ExecutionRole here, admin-created execution_role.yaml).
-        arn = "arn:aws:s3:::sliderule-public-cors/zagg-index/*"
+    def test_execution_role_grants_public_cors_bucket(self):
+        # The shared execution role gets Get/Put/Delete on the whole public
+        # sliderule-public-cors bucket -- deliberate scope (espg, PR #176):
+        # virtual-index write-back + sidecar reads (zagg-index/*, issue #160)
+        # AND worker-written output zarr stores (e.g. zagg-examples/*) -- in
+        # BOTH copies of the role (inline ExecutionRole here, admin-created
+        # execution_role.yaml).
+        arn = "arn:aws:s3:::sliderule-public-cors/*"
+        actions = ["s3:DeleteObject", "s3:GetObject", "s3:PutObject"]
 
         def _index_statements(role_props):
             stmts = role_props["Policies"][0]["PolicyDocument"]["Statement"]
@@ -229,7 +232,7 @@ class TestTemplateEnvironment:
         tpl_role = self._load_template()["Resources"]["ExecutionRole"]["Properties"]
         matches = _index_statements(tpl_role)
         assert len(matches) == 1
-        assert sorted(matches[0]["Action"]) == ["s3:GetObject", "s3:PutObject"]
+        assert sorted(matches[0]["Action"]) == actions
 
         import yaml
 
@@ -249,7 +252,7 @@ class TestTemplateEnvironment:
         ext_role = ext["Resources"]["ExecutionRole"]["Properties"]
         ext_matches = _index_statements(ext_role)
         assert len(ext_matches) == 1
-        assert sorted(ext_matches[0]["Action"]) == ["s3:GetObject", "s3:PutObject"]
+        assert sorted(ext_matches[0]["Action"]) == actions
 
     def test_extract_fn_mirrors_process_fn(self):
         # issue #148: extraction is both a mode of ProcessFn and a dedicated

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -205,11 +205,12 @@ class TestTemplateEnvironment:
         # issue #171: the worker self-recycle knobs ride the function
         # environment with template defaults (1400 MB on the 2047 MB cap --
         # ~650 MB of headroom over the observed ~700-1100 MB/invocation
-        # retention -- and a generation cap of 8 as belt-and-suspenders).
+        # retention -- and a generation cap of 1: recycle after every
+        # invocation, the cold-every-time posture; issue #175).
         tpl = self._load_template()
         params = tpl["Parameters"]
         assert params["RecycleRssMb"]["Default"] == "1400"
-        assert params["RecycleMaxInvocations"]["Default"] == "8"
+        assert params["RecycleMaxInvocations"]["Default"] == "1"
         env = tpl["Resources"]["ProcessFn"]["Properties"]["Environment"]["Variables"]
         assert env["ZAGG_RECYCLE_RSS_MB"] == {"Ref": "RecycleRssMb"}
         assert env["ZAGG_RECYCLE_MAX_INVOCATIONS"] == {"Ref": "RecycleMaxInvocations"}

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -245,6 +245,28 @@ class TestStreamingWorker:
         assert meta["total_obs"] > 0
         assert highwater["n"] <= 2  # one read per granule (single group)
 
+    def test_streaming_via_backend_seam_unpinned_config(self, monkeypatch):
+        # Review fold (PR #176): the other worker tests pin the backend in
+        # config; this one leaves the config UNPINNED (the inline default,
+        # issue #170) and stubs the backend at the worker's
+        # ``index_from_config`` seam instead (the test_processing.py idiom)
+        # -- guarding that the streaming buffer mechanics are independent of
+        # how the backend resolves. Exercising the compiled inline decode
+        # itself needs real HDF5 fixtures (issue #175 tracks the gap).
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        key = _shard_key()
+        cfg = _config(streaming={"buffer_granules": 2})
+        del cfg.data_source["index"]
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda c: HierarchicalIndex()
+        )
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, n_granules=3)
+        df_s, ragged, meta = _run(monkeypatch, cfg, grid, key, dfs)
+        assert meta["total_obs"] > 0
+        assert "h_tdigest" in ragged
+
     def test_streaming_empty_shard_matches_pooled_no_data(self, monkeypatch):
         key = _shard_key()
         cfg = _config(streaming={"buffer_granules": 2})

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -44,7 +44,16 @@ def _config(streaming=None, delta=128):
     if streaming is not None:
         agg["streaming"] = streaming
     return PipelineConfig(
-        data_source={"reader": "h5coro", "driver": "s3", "groups": ["gt1l"]},
+        # The worker-integration tests below fake reads by monkeypatching
+        # ``zagg.processing._read_group`` — the hierarchical backend's seam.
+        # Pin it: the inline default (issue #170) reads through the compiled
+        # path and never calls ``_read_group``, so the fakes would be bypassed.
+        data_source={
+            "reader": "h5coro",
+            "driver": "s3",
+            "groups": ["gt1l"],
+            "index": {"backend": "hierarchical"},
+        },
         aggregation=agg,
     )
 


### PR DESCRIPTION
Closes #175 — restores green `test.yml` on `main` (red since the issue #170 merge chain; two more failures from the template edits after it), then per review direction materializes the CloudWatch error-signal split the cold-every-time posture requires. Full forensics in #175.

## Verdict first: the #170 group is a test artifact, not a regression

The six `test_apriori`/`test_streaming` failures all share one mechanism, and no production behavior changed:

- Those tests fake reads via `monkeypatch.setattr("zagg.processing._read_group", fake)` + `H5Coro = lambda *a, **k: object()`. That is the **hierarchical** backend's seam: `HierarchicalIndex.read_group` late-binds `_processing._read_group` *specifically so monkeypatched fakes keep working* (its own docstring, `src/zagg/index/hierarchical.py`).
- `InlineIndex.read_group` (`src/zagg/index/inline.py`) never calls `zagg.processing._read_group` — it routes through `_planned_read_group` / `_read_group_full` with a compiled `read_fn` that tries `build_chunk_map(h5obj, …)` and degrades to `h5obj.readDatasets(…)`. Against the fake `object()` that raises (`'object' object has no attribute 'readDatasets'` / `'coordinates'`), so the worker's per-group handler counts a read error and the issue #116 accounting *correctly* reports `"No data after filtering (N group reads raised)"`.
- The plain vs. `"(N group reads raised)"` split predates #170 (issue #116, `src/zagg/processing/worker.py`) and is byte-identical on both backends for real callers; the only thing #170 changed here is *which backend an unpinned test config exercises*. Corroboration: `test_apriori.py::TestWorkerSeam::test_granule_url_passed_when_enabled` kept passing, because its `chunk_boundaries` source keeps the hierarchical default via the #170 carve-out in `index_from_config`. Independently reproduced by the adversarial review pass.

Fix: pin `index: {backend: hierarchical}` in the seam-testing configs — the same approach PR #173 took for the benchmark-config pins. Zero `src/` behavior change in this group.

## Phases

- [x] **Phase 1 — test-double pins (the #170 group, 6 failures).** `tests/test_apriori.py::TestWorkerSeam::test_flag_off_call_signature_unchanged` and `tests/test_streaming.py::_config()` pin `index: {backend: hierarchical}` with comments explaining the seam.
- [x] **Phase 2 — template pins + doc truth (2 failures).** `test_self_recycle_env_defaults` now pins `RecycleMaxInvocations` default `"1"` — **the "1" default is espg's explicit choice** (commit `260221b`): recycle after every invocation = cold-every-time posture. Template description, `deployment/aws/lambda_handler.py` docstring, and `docs/deployment/lambda.md` (which said "template 8") updated to match. *(Phase 2 also narrowed the role's bucket grant; superseded by phase 3.)*
- [x] **Phase 3 — role grant per espg's direction** ([comment](https://github.com/englacial/zagg/pull/176#issuecomment-4898554211)): Get/Put/**Delete** on `arn:aws:s3:::sliderule-public-cors/*` is deliberate (virtual-index write-back under `zagg-index/*` **and** worker-written output zarr stores, e.g. `zagg-examples/*`). Implemented in `template.yaml`, brought the admin copy `deployment/aws/execution_role.yaml` into lockstep (it still had the narrow #160 form), and re-scoped the pinning test → `test_execution_role_grants_public_cors_bucket`.
- [x] **Phase 4 — CloudWatch error-signal split.** With `RecycleMaxInvocations=1`, *every* async invocation self-exits and lands in Lambda's raw `Errors` metric — 100% noise. Four `AWS::Logs::MetricFilter` resources (both functions' log groups) publish namespace `zagg/lambda`: `Process/ExtractSelfRecycleCount` (the `ZAGG_SELF_RECYCLE` line) and `Process/ExtractWorkerErrorCount` (genuine signatures only: `[ERROR]`, `Traceback (most recent call last)`, `Task timed out`, `Runtime.OutOfMemory`, `Runtime exited with error`). Patterns verified **disjoint** with the recycle path: the handler logs the recycle at `[INFO]` and exits 0, which the runtime reports as `Runtime exited without providing a reason` — matched by neither error term (a real nonzero exit is `Runtime exited with error`). `docs/deployment/lambda.md` now says "alarm on `WorkerErrorCount`, never raw `Errors`" and warns against async `OnFailure` destinations under this posture.
- [x] **Fold — adversarial-review findings (pass 1):** backend-seam streaming test (`test_streaming_via_backend_seam_unpinned_config`, the `index_from_config` stub idiom from `test_processing.py`) guarding that the streaming mechanics don't depend on the config pin — the stub intercepts before backend resolution, so compiled-inline integration coverage remains the follow-up gap noted in #175; docs line rewrap.
- [x] **Fold — adversarial-review findings (pass 2):** the `finish_granule` tolerated-path warning now inlines the reason instead of `exc_info=True` (a folded traceback would have tripped `WorkerErrorCount` on a path that never fails the read — test strengthened to pin no-exc_info); the pattern evaluator rejects mixed `?`/plain term lists (outside the CloudWatch subset it models).

### Design note: MetricFilters reference the log groups by name

The `/aws/lambda/<fn>` groups are created lazily by Lambda on first invocation. Owning them as `AWS::Logs::LogGroup` resources would fail stack CREATE/UPDATE with "already exists" on any deployed stack (the adoption landmine). Instead the filters reference the groups **by name** and are gated on a `CreateLogMetricFilters` parameter (default `"true"`): existing deployments (groups already present) update cleanly; a **fresh** stack creates with `"false"`, invokes once, then updates with `"true"` (documented in the parameter description and `docs/deployment/lambda.md`).

## How it was tested

- Full `pytest -q` locally on the branch: green except `test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`, a local-environment artifact only (the build script's pip resolves against a local Python 3.10, so `zarr>=3.1.5` has no candidate; it passes on CI in both red runs and is untouched here).
- Same suite on `260221b` (current `main`) reproduces exactly the 8 CI failures listed in #175 plus that same environmental one.
- New tests: template pins for the four filter resources; a pattern evaluator asserting the recycle/error filters are **disjoint** against realistic log lines (handler `ZAGG_SELF_RECYCLE` line, clean-exit runtime report, `[ERROR]`/traceback/timeout/OOM/nonzero-exit signatures); the backend-seam streaming test.
- `ruff check` clean on all changed files; `pre-commit` hooks clean except findings that pre-exist on pristine `main` (see below).

## Questions for review

1. ~~Was the IAM broadening intentional?~~ **Resolved**: deliberate per espg's comment; implemented as directed in phase 3. One standing review-bot note ([r3532665667](https://github.com/englacial/zagg/pull/176#discussion_r3532665667)): whole-bucket Delete also covers the Lambda distribution artifacts (`versions.json`, layer zips) in the same bucket — a two-prefix statement (`zagg-index/*` + `zagg-examples/*`) would exclude them, if ever desired.
2. Metric naming chose per-function metric names (`ProcessWorkerErrorCount` / `ExtractWorkerErrorCount`) over a shared name + dimension: static dimensions aren't expressible in `MetricTransformations` (dimension values must come from pattern fields, and these are term filters). Flagging in case a different naming scheme is preferred for dashboards.
3. Pre-existing, deliberately not fixed here (per convention): `ruff` N818 on `src/zagg/registry.py::UnknownCapability` (present on pristine main; CI lint selects E,F,W,I only); `ruff format --check` under local ruff 0.15.20 flags 7 files the pinned pre-commit ruff v0.14.10 accepts (version skew, also on pristine main); pre-commit `check-yaml` cannot parse CloudFormation `!Equals` tags (pre-existing); mypy `types-PyYAML` stub missing in the hook env (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
