### PR TITLE
Layer build still pins h5coro 1.0.4 — sync to 1.0.5 (issue #154)

### DIFF
--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -75,7 +75,7 @@ $PIP install \
 # its only runtime dep is numpy (already installed above). Keep the pin in
 # sync with the `lambda` extra in pyproject.toml.
 echo "Installing h5coro, h5coro-hidefix and mortie (--no-deps)..."
-$PIP install "h5coro==1.0.4" "h5coro-hidefix==0.3.0" mortie --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
+$PIP install "h5coro==1.0.5" "h5coro-hidefix==0.3.0" mortie --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
 
 # Verify numpy stayed < 2.3
 NUMPY_VERSION=$(ls "$OUTPUT_DIR/python" | grep -E "^numpy-" | head -1)


### PR DESCRIPTION
Refs #154, #170.

The 0.16.0 pyproject bump (core `h5coro>=1.0.5`, lambda extra `==1.0.5`) missed the third pin site: `deployment/aws/build_layer.sh:78` still installs `h5coro==1.0.4` into the layer — verified in the tier-2 layer `:50` built from that merge (contains `h5coro-1.0.4.dist-info` alongside h5coro-hidefix 0.3.0). Without this, the 0.16.0 production deploy ships a layer whose h5coro contradicts the package floor, and the fleet never gets the 3.8x numpy `shuffleChunk` decode (SlideRuleEarth/h5coro#44).

One line: `h5coro==1.0.4` → `==1.0.5` in the layer install. The benchmark tier-2 auto-deploy of this PR's merge is also what unblocks arm (b) of the o9 read matrix (#170 thread).

Same trap as always (§7: 'keep these pins in sync with the layer') — a follow-up worth considering: a test that asserts the build_layer.sh pins match the `lambda` extra, so this can't drift silently again.