### PR TITLE
Small fixes: recycle generation counting + stand_up.sh artifact defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,14 @@ OUTPUT_BUCKET=my-results-bucket bash deployment/aws/stand_up.sh
 ```
 
 In **us-west-2** the stack reads the Lambda code straight from the public
-source.coop mirror — no staging bucket of your own needed. Outside us-west-2,
-CloudFormation requires the code in a same-region bucket, so pass a
-`STAGING_BUCKET` you own and the zips are copied there from the mirror first.
-Deploys [`deployment/aws/template.yaml`](deployment/aws/template.yaml); the
-artifacts are keyed by zagg minor version (derive from your install, or pin with
-`LAMBDA_VERSION=0.N`). Override `ARCH` for x86_64.
+distribution bucket (`s3://sliderule-public-cors/<minor>/`) — no staging bucket
+of your own needed. Outside us-west-2, CloudFormation requires the code in a
+same-region bucket, so pass a `STAGING_BUCKET` you own and the zips are copied
+there from the distribution bucket first. Deploys
+[`deployment/aws/template.yaml`](deployment/aws/template.yaml); the artifacts
+are keyed by zagg minor version (derive from your install, pin with
+`LAMBDA_VERSION=0.N`, or use `LAMBDA_VERSION=latest` for the newest published
+minor). Override `ARCH` for x86_64.
 
 **Build from source** (maintainers, or to customize the layer):
 

--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -57,20 +57,24 @@ layer, and function as a single stack from the pre-built release zips:
 OUTPUT_BUCKET=my-results-bucket bash deployment/aws/stand_up.sh
 ```
 
-The Lambda code (deps layer + function zips) lives on the public **source.coop
-mirror** (`s3://us-west-2.opendata.source.coop/englacial/zagg/lambda/<minor>/`),
-keyed by zagg minor version. CloudFormation reads Lambda code from a same-region
-bucket, so:
+The Lambda code (deps layer + function zips) lives on the public
+**distribution bucket** (`s3://sliderule-public-cors/<minor>/`), keyed by zagg
+minor version and populated by the release pipeline (`publish.yml`'s
+`distribute` job). CloudFormation reads Lambda code from a same-region bucket,
+so:
 
-- **us-west-2** — `stand_up.sh` points the stack straight at the mirror; no
-  staging bucket of your own is needed.
+- **us-west-2** — `stand_up.sh` points the stack straight at the distribution
+  bucket; no staging bucket of your own is needed.
 - **other regions** — pass `STAGING_BUCKET` (a bucket you own in `REGION`); the
-  zips are copied into it from the mirror, then the stack reads them there.
+  zips are copied into it from the distribution bucket, then the stack reads
+  them there.
 
 It then runs `aws cloudformation deploy`. The minor is read from the repo's
 latest git tag (so a clone needs no install), or the installed zagg, unless
-`LAMBDA_VERSION` is set. To (re)populate the mirror after a release,
-maintainers run `deployment/aws/publish_mirror.sh <minor>`. See
+`LAMBDA_VERSION` is set (`latest` reads the bucket's `versions.json`); the
+resolved minor is verified to be staged on the bucket before any stack call,
+and the script confirms the resolved artifacts before deploying (`--yes` skips
+the prompt). See
 [docs/deployment/lambda.md](../docs/deployment/lambda.md) for the parameter
 table and overrides.
 
@@ -206,7 +210,8 @@ aws lambda update-function-code \
 
 > The build half of this is implemented in `.github/workflows/lambda-build.yml`
 > (build + size gate + artifact upload). Automated *deploy*-on-push was never
-> wired up; the source.coop mirror + `stand_up.sh` is the deploy path instead.
+> wired up; the public distribution bucket + `stand_up.sh` is the deploy path
+> instead.
 > Kept below as the original design rationale.
 
 A GitHub Actions workflow for automated Lambda deployment should:

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -150,8 +150,8 @@ logger.setLevel(logging.INFO)
 _CONTAINER_INIT_TS = time.time()
 _INVOCATIONS_SERVED = 0
 # Recycle budget (issue #177), counted separately from the true generation
-# above: only recycle-eligible (async, result_url-mirrored) invocations are
-# billed against ``ZAGG_RECYCLE_MAX_INVOCATIONS``. A synchronous setup/
+# above: only recycle-eligible (async ``result_url``) invocations are billed
+# against ``ZAGG_RECYCLE_MAX_INVOCATIONS``. A synchronous setup/
 # finalize invoke still warms the sandbox (the generation keeps counting it,
 # and telemetry keeps reporting it) but must not consume the worker budget --
 # MAX_INVOCATIONS=1 means "one heavy async invocation per container", not
@@ -260,9 +260,11 @@ def _maybe_self_recycle() -> None:
     exiting so dashboards can split intentional recycles from real crashes
     (metric-filter note in docs/deployment/lambda.md). The line carries both
     the async budget spent and the true container generation.
+
+    Pure check: the async budget itself is billed at the dispatcher (every
+    ``result_url`` invocation, mirror success or not), so a failed mirror --
+    which skips this call -- still burns the budget (issue #177 review fold).
     """
-    global _ASYNC_INVOCATIONS_SERVED
-    _ASYNC_INVOCATIONS_SERVED += 1
     rss_limit = _recycle_limit("ZAGG_RECYCLE_RSS_MB")
     gen_limit = _recycle_limit("ZAGG_RECYCLE_MAX_INVOCATIONS")
     kib = _read_vmrss_kib()
@@ -462,6 +464,13 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     # result_url for it to poll. Covers every branch (200 / 400 / 500) of both
     # per-unit handlers (spatial process, temporal process_event -- #12 Phase 8).
     if event.get("result_url"):
+        # Bill this async invocation against the recycle budget (issue #177)
+        # BEFORE the mirror-success gate: the invocation was served either
+        # way, so a failed mirror must not stretch the sandbox's budget (the
+        # pre-#177 generation counter counted it too). Only the recycle
+        # itself stays gated on the mirror landing.
+        global _ASYNC_INVOCATIONS_SERVED
+        _ASYNC_INVOCATIONS_SERVED += 1
         mirrored = _write_result(event["result_url"], response, event)
         # Self-recycle strictly AFTER a successful result mirror (issue #171):
         # the orchestrator polls the result object, not the Lambda response

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -149,6 +149,14 @@ logger.setLevel(logging.INFO)
 # requiring CloudWatch forensics.
 _CONTAINER_INIT_TS = time.time()
 _INVOCATIONS_SERVED = 0
+# Recycle budget (issue #177), counted separately from the true generation
+# above: only recycle-eligible (async, result_url-mirrored) invocations are
+# billed against ``ZAGG_RECYCLE_MAX_INVOCATIONS``. A synchronous setup/
+# finalize invoke still warms the sandbox (the generation keeps counting it,
+# and telemetry keeps reporting it) but must not consume the worker budget --
+# MAX_INVOCATIONS=1 means "one heavy async invocation per container", not
+# "one invocation of any kind".
+_ASYNC_INVOCATIONS_SERVED = 0
 
 
 def _container_telemetry() -> Dict[str, Any]:
@@ -239,30 +247,38 @@ def _maybe_self_recycle() -> None:
       against a 2047 MB cap, so the template's 1400 catches a dirty sandbox
       after roughly one heavy retention while leaving the triggering
       invocation ~650 MB of headroom to complete first.
-    - ``ZAGG_RECYCLE_MAX_INVOCATIONS`` -- generation cap (template default
-      1: recycle after every invocation, the cold-every-time posture; raise
-      it for a belt-and-suspenders cap over retention modes the RSS read
-      misses -- and the only check that fires off-Linux, where RSS reads
-      are None).
+    - ``ZAGG_RECYCLE_MAX_INVOCATIONS`` -- cap on recycle-eligible (async)
+      invocations served, NOT the raw container generation (issue #177: the
+      runner's synchronous setup invoke warms a sandbox first, and counting
+      it made MAX_INVOCATIONS=1 deliver generation-2 workers while telemetry
+      read as if recycling had failed). Template default 1: recycle after
+      every async invocation, the cold-every-time posture; raise it for a
+      belt-and-suspenders cap over retention modes the RSS read misses --
+      and the only check that fires off-Linux, where RSS reads are None.
 
     Emits one CloudWatch-searchable line (``ZAGG_SELF_RECYCLE ...``) before
     exiting so dashboards can split intentional recycles from real crashes
-    (metric-filter note in docs/deployment/lambda.md).
+    (metric-filter note in docs/deployment/lambda.md). The line carries both
+    the async budget spent and the true container generation.
     """
+    global _ASYNC_INVOCATIONS_SERVED
+    _ASYNC_INVOCATIONS_SERVED += 1
     rss_limit = _recycle_limit("ZAGG_RECYCLE_RSS_MB")
     gen_limit = _recycle_limit("ZAGG_RECYCLE_MAX_INVOCATIONS")
     kib = _read_vmrss_kib()
     rss_mb = kib / 1024.0 if kib is not None else None
+    async_served = _ASYNC_INVOCATIONS_SERVED
     generation = _INVOCATIONS_SERVED
     if rss_limit > 0 and rss_mb is not None and rss_mb >= rss_limit:
         threshold = rss_limit
-    elif gen_limit > 0 and generation >= gen_limit:
+    elif gen_limit > 0 and async_served >= gen_limit:
         threshold = gen_limit
     else:
         return
     rss_repr = f"{rss_mb:.0f}" if rss_mb is not None else "n/a"
     logger.info(
-        f"ZAGG_SELF_RECYCLE rss_mb={rss_repr} generation={generation} threshold={threshold:g}"
+        f"ZAGG_SELF_RECYCLE rss_mb={rss_repr} async_served={async_served} "
+        f"generation={generation} threshold={threshold:g}"
     )
     _exit(0)
 
@@ -421,7 +437,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     # Count EVERY invocation toward the sandbox's generation (issue #171): a
     # setup/finalize/extract invoke warms the container just like a shard does,
     # so the next shard on this sandbox is genuinely generation N+1. Snapshot
-    # start RSS here, before any per-unit work inflates it.
+    # start RSS here, before any per-unit work inflates it. (The recycle
+    # budget is billed separately, per async invocation -- issue #177.)
     telemetry = _container_telemetry()
     mode = event.get("mode", "process")
     if mode == "setup":

--- a/deployment/aws/stand_up.sh
+++ b/deployment/aws/stand_up.sh
@@ -112,20 +112,26 @@ fi
 echo "zagg lambda artifacts: $MINOR ($ARCH), region $REGION"
 
 # Refuse to guess (issue #174): the resolved minor must actually be staged on
-# the distribution bucket. A HEAD on the layer key catches a phantom version
-# (e.g. one derived from post-tag main) here, with an actionable message,
-# instead of as a CloudFormation NoSuchKey mid-update.
+# the distribution bucket. A HEAD on both the layer and function keys catches
+# a phantom version (e.g. one derived from post-tag main) here, with an
+# actionable message, instead of as a CloudFormation NoSuchKey mid-update.
+# The aws stderr is surfaced so a 404 (minor not staged) reads differently
+# from a network/credentials failure of the check itself.
 SRC_BUCKET="$DIST_BUCKET"; SRC_REGION="$DIST_REGION"
 SRC_LAYER_KEY="$(dist_key "$MINOR" "$LAYER_ZIP")"; SRC_FUNC_KEY="$(dist_key "$MINOR" "$FUNC_ZIP")"
-if ! aws s3api head-object --bucket "$DIST_BUCKET" --key "$SRC_LAYER_KEY" --region "$DIST_REGION" --no-sign-request >/dev/null 2>&1; then
-    echo "ERROR: minor $MINOR is not staged: s3://$DIST_BUCKET/$SRC_LAYER_KEY does not exist."
-    STAGED="$(aws s3 cp "s3://$DIST_BUCKET/$(dist_root versions.json)" - --region "$DIST_REGION" --no-sign-request 2>/dev/null \
-        | python3 -c 'import json,sys; print(" ".join(json.load(sys.stdin).get("minors", [])))' 2>/dev/null || true)"
-    [ -n "$STAGED" ] && echo "       Staged minors on s3://$DIST_BUCKET: $STAGED"
-    echo "       Set LAMBDA_VERSION to a staged minor, or LAMBDA_VERSION=latest for the"
-    echo "       newest published one (versions.json)."
-    exit 1
-fi
+for KEY in "$SRC_LAYER_KEY" "$SRC_FUNC_KEY"; do
+    if ! HEAD_ERR="$(aws s3api head-object --bucket "$DIST_BUCKET" --key "$KEY" --region "$DIST_REGION" --no-sign-request 2>&1 >/dev/null)"; then
+        echo "ERROR: minor $MINOR is not staged: could not HEAD s3://$DIST_BUCKET/$KEY"
+        [ -n "$HEAD_ERR" ] && echo "       aws: $HEAD_ERR"
+        STAGED="$(aws s3 cp "s3://$DIST_BUCKET/$(dist_root versions.json)" - --region "$DIST_REGION" --no-sign-request 2>/dev/null \
+            | python3 -c 'import json,sys; print(" ".join(json.load(sys.stdin).get("minors", [])))' 2>/dev/null || true)"
+        [ -n "$STAGED" ] && echo "       Staged minors on s3://$DIST_BUCKET: $STAGED"
+        echo "       Set LAMBDA_VERSION to a staged minor, or LAMBDA_VERSION=latest for the"
+        echo "       newest published one (versions.json). A non-404 aws error above means"
+        echo "       the check itself failed (network/credentials), not that the minor is missing."
+        exit 1
+    fi
+done
 
 echo ""
 echo "Resolved deployment artifacts:"
@@ -134,7 +140,9 @@ echo "  layer:    s3://$SRC_BUCKET/$SRC_LAYER_KEY"
 echo "  function: s3://$SRC_BUCKET/$SRC_FUNC_KEY"
 echo "  stack:    $STACK_NAME ($REGION)"
 if [ "$ASSUME_YES" != "true" ]; then
-    read -r -p "Proceed with deploy? [y/N] " REPLY
+    # `|| REPLY=""` keeps EOF (unattended stdin) on the abort path below with
+    # its message, instead of dying silently under `set -e`.
+    read -r -p "Proceed with deploy? [y/N] " REPLY || REPLY=""
     case "$REPLY" in
         [Yy]|[Yy][Ee][Ss]) ;;
         *) echo "Aborted (pass --yes to skip this prompt)."; exit 1 ;;

--- a/deployment/aws/stand_up.sh
+++ b/deployment/aws/stand_up.sh
@@ -1,21 +1,27 @@
 #!/bin/bash
 # Stand up the zagg Lambda backend in your own AWS account, end to end.
 #
-# Lambda code (the deps layer + function zips) is read from the public CORS bucket
-# (s3://sliderule-public-cors), with the legacy source.coop mirror as a fallback
-# for older minors. CloudFormation requires that code to live in a SAME-REGION
-# bucket:
+# Lambda code (the deps layer + function zips) is read from the public
+# distribution bucket the release pipeline stages to (s3://sliderule-public-cors,
+# keys <minor>/<zip> — publish.yml's distribute job / distribute_zips.sh).
+# CloudFormation requires that code to live in a SAME-REGION bucket:
 #
-#   * In us-west-2 (where the sources live) the stack reads it straight from the
-#     source — no staging bucket of your own needed.
+#   * In us-west-2 (where the distribution bucket lives) the stack reads it
+#     straight from the source — no staging bucket of your own needed.
 #   * In any other region, provide STAGING_BUCKET (a bucket you own in that
 #     region); the zips are copied from the source into it first.
 #
-# Sources are keyed by zagg MINOR version (0.N.x -> 0.N). Run from a zagg git
+# Artifacts are keyed by zagg MINOR version (0.N.x -> 0.N). Run from a zagg git
 # clone and the minor is read from the latest tag (no install needed); otherwise
 # set LAMBDA_VERSION (e.g. LAMBDA_VERSION=0.2). Set LAMBDA_VERSION=latest to read
-# the newest published minor from the CORS bucket's versions.json (so a clone/
-# pip-install isn't hard-pinned to its build-time version).
+# the newest published minor from the bucket's versions.json (so a clone/
+# pip-install isn't hard-pinned to its build-time version). Whatever it resolves
+# to, the layer/function keys are verified to EXIST on the bucket before any
+# stack call — an unstaged minor fails fast with the staged minors listed,
+# instead of surfacing as a CloudFormation NoSuchKey rollback (issue #174).
+#
+# The script echoes the resolved bucket/keys/version and asks for confirmation
+# before deploying; pass --yes to skip the prompt (unattended runs).
 #
 # By default the stack creates its own Lambda execution role (needs
 # iam:CreateRole — fine if you admin your own account). In IAM-constrained
@@ -24,12 +30,21 @@
 #
 # Usage:
 #   OUTPUT_BUCKET=my-results ./stand_up.sh                              # us-west-2, stack makes the role
+#   OUTPUT_BUCKET=my-results ./stand_up.sh --yes                        # no confirm prompt
 #   REGION=us-east-1 OUTPUT_BUCKET=my-results STAGING_BUCKET=my-stage ./stand_up.sh
 #   CREATE_ROLE=false ROLE_ARN=arn:aws:iam::123:role/zagg-exec OUTPUT_BUCKET=my-results ./stand_up.sh
 #
 # Requires: aws CLI (configured).
 
 set -euo pipefail
+
+ASSUME_YES=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --yes|-y) ASSUME_YES=true; shift ;;
+        *) echo "ERROR: unknown argument '$1' (the script is env-driven; the only flag is --yes)"; exit 2 ;;
+    esac
+done
 
 # Verbose by default: echo each AWS command (copy-pasteable) before running it.
 # The command runs in the foreground, so its stdout/stderr stream straight to you.
@@ -55,19 +70,15 @@ if [ "$CREATE_ROLE" != "true" ] && [ -z "$ROLE_ARN" ]; then
     exit 1
 fi
 
-# Distribution sources (issue #25). The public CORS bucket is primary: listable
-# (a versions.json index), keyed by minor as <minor>/<zip>. The legacy source.coop
-# mirror is the fallback for older minors that predate the new bucket (transition
-# window). Override any of these to self-host a copy.
+# Distribution source (issue #25; source.coop mirror retired in issue #174).
+# The public CORS bucket the release pipeline stages to: listable (a
+# versions.json index), keyed by minor as <minor>/<zip> (publish.yml's
+# distribute job / distribute_zips.sh). Override to self-host a copy.
 DIST_BUCKET="${DIST_BUCKET:-sliderule-public-cors}"
 DIST_PREFIX="${DIST_PREFIX:-}"                       # keys: [<prefix>/]<minor>/<zip>
 DIST_REGION="${DIST_REGION:-us-west-2}"
-MIRROR_BUCKET="${MIRROR_BUCKET:-us-west-2.opendata.source.coop}"
-MIRROR_PREFIX="${MIRROR_PREFIX:-englacial/zagg/lambda}"   # keys: <prefix>/<minor>/<zip>
-MIRROR_REGION="${MIRROR_REGION:-us-west-2}"
 
 dist_key()   { local p="$DIST_PREFIX"; [ -n "$p" ] && p="$p/"; echo "${p}${1}/${2}"; }  # minor, zip
-mirror_key() { echo "${MIRROR_PREFIX}/${1}/${2}"; }
 dist_root()  { local p="$DIST_PREFIX"; [ -n "$p" ] && p="$p/"; echo "${p}${1}"; }       # versions.json path
 
 case "$ARCH" in
@@ -100,14 +111,34 @@ else
 fi
 echo "zagg lambda artifacts: $MINOR ($ARCH), region $REGION"
 
-# Pick the source that actually holds this minor: prefer the CORS bucket; if the
-# layer isn't there (an older minor), fall back to the source.coop mirror.
+# Refuse to guess (issue #174): the resolved minor must actually be staged on
+# the distribution bucket. A HEAD on the layer key catches a phantom version
+# (e.g. one derived from post-tag main) here, with an actionable message,
+# instead of as a CloudFormation NoSuchKey mid-update.
 SRC_BUCKET="$DIST_BUCKET"; SRC_REGION="$DIST_REGION"
 SRC_LAYER_KEY="$(dist_key "$MINOR" "$LAYER_ZIP")"; SRC_FUNC_KEY="$(dist_key "$MINOR" "$FUNC_ZIP")"
 if ! aws s3api head-object --bucket "$DIST_BUCKET" --key "$SRC_LAYER_KEY" --region "$DIST_REGION" --no-sign-request >/dev/null 2>&1; then
-    echo "note: $MINOR not on s3://$DIST_BUCKET — falling back to the source.coop mirror"
-    SRC_BUCKET="$MIRROR_BUCKET"; SRC_REGION="$MIRROR_REGION"
-    SRC_LAYER_KEY="$(mirror_key "$MINOR" "$LAYER_ZIP")"; SRC_FUNC_KEY="$(mirror_key "$MINOR" "$FUNC_ZIP")"
+    echo "ERROR: minor $MINOR is not staged: s3://$DIST_BUCKET/$SRC_LAYER_KEY does not exist."
+    STAGED="$(aws s3 cp "s3://$DIST_BUCKET/$(dist_root versions.json)" - --region "$DIST_REGION" --no-sign-request 2>/dev/null \
+        | python3 -c 'import json,sys; print(" ".join(json.load(sys.stdin).get("minors", [])))' 2>/dev/null || true)"
+    [ -n "$STAGED" ] && echo "       Staged minors on s3://$DIST_BUCKET: $STAGED"
+    echo "       Set LAMBDA_VERSION to a staged minor, or LAMBDA_VERSION=latest for the"
+    echo "       newest published one (versions.json)."
+    exit 1
+fi
+
+echo ""
+echo "Resolved deployment artifacts:"
+echo "  version:  $MINOR ($ARCH)"
+echo "  layer:    s3://$SRC_BUCKET/$SRC_LAYER_KEY"
+echo "  function: s3://$SRC_BUCKET/$SRC_FUNC_KEY"
+echo "  stack:    $STACK_NAME ($REGION)"
+if [ "$ASSUME_YES" != "true" ]; then
+    read -r -p "Proceed with deploy? [y/N] " REPLY
+    case "$REPLY" in
+        [Yy]|[Yy][Ee][Ss]) ;;
+        *) echo "Aborted (pass --yes to skip this prompt)."; exit 1 ;;
+    esac
 fi
 
 if [ "$REGION" = "$SRC_REGION" ]; then

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -484,9 +484,10 @@ shows `production` with a reviewer.
 
 ## Distribution transition (source.coop → CORS bucket)
 
-`stand_up.sh` now prefers `sliderule-public-cors` and **falls back to the
-source.coop mirror** for any minor not yet on the new bucket — so older standups
-keep working while new releases populate the new bucket. Once enough releases have
-published to the CORS bucket, retire the source.coop mirror (and its
-`publish_mirror.sh` step) in a follow-up. Set `LAMBDA_VERSION=latest` to always
-pull the newest published minor.
+The transition is complete (issue #174): `stand_up.sh` reads **only**
+`sliderule-public-cors` — the source.coop-mirror fallback is removed, and a
+minor not staged on the CORS bucket fails fast (with the staged minors listed)
+instead of silently falling back to the retired mirror and dying as a
+CloudFormation `NoSuchKey`. Older minors that only ever lived on the mirror
+need a self-hosted copy (`DIST_BUCKET`/`DIST_PREFIX` overrides). Set
+`LAMBDA_VERSION=latest` to always pull the newest published minor.

--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -309,11 +309,14 @@ mechanisms address this (issue #171):
   mirrored to its `result_url`, the handler exits the sandbox
   (`os._exit(0)`) when current RSS ≥ `ZAGG_RECYCLE_RSS_MB` (template
   default 1400) or the sandbox has served `ZAGG_RECYCLE_MAX_INVOCATIONS`
-  (template default 1 — recycle after every invocation, the cold-every-time
-  posture) invocations. Set either to `0`/empty to disable that check. The
-  next invocation then starts on a fresh container instead of
-  ratcheting toward OOM. Synchronous invocations never self-recycle (the
-  response would be lost).
+  **recycle-eligible (async) invocations** (template default 1 — recycle
+  after every async invocation, the cold-every-time posture). Set either to
+  `0`/empty to disable that check. The next invocation then starts on a
+  fresh container instead of ratcheting toward OOM. Synchronous invocations
+  never self-recycle (the response would be lost) and don't consume the
+  recycle budget (issue #177: the runner's sync setup invoke warms a
+  sandbox, so counting it made `MAX_INVOCATIONS=1` deliver generation-2
+  workers); `container_generation` telemetry still counts every invocation.
 
 !!! warning "The raw `Errors` metric is 100% noise under this posture"
     A self-exit after the result write is counted as a runtime error by
@@ -325,7 +328,7 @@ mechanisms address this (issue #171):
     recycle logs one structured line first:
 
     ```
-    ZAGG_SELF_RECYCLE rss_mb=<current> generation=<n> threshold=<crossed limit>
+    ZAGG_SELF_RECYCLE rss_mb=<current> async_served=<n> generation=<n> threshold=<crossed limit>
     ```
 
     The template materializes the real-vs-expected split as CloudWatch

--- a/docs/deployment/standup.md
+++ b/docs/deployment/standup.md
@@ -21,24 +21,34 @@ to hand-assemble zips or wire up the IAM role yourself.
 (it echoes each AWS command before running it). End to end it:
 
 1. **Resolves the artifact version.** Lambda code (the deps layer + function
-   zips) is published to a public **source.coop mirror**, keyed by zagg *minor*
-   version (`0.N.x` -> `0.N`). The minor is read from the repo's latest git tag
-   (so a fresh clone needs no install), falling back to the installed `zagg`, or
-   an explicit `LAMBDA_VERSION` override.
+   zips) is published by the release pipeline to the public
+   **`sliderule-public-cors` distribution bucket**
+   (`s3://sliderule-public-cors/<minor>/`), keyed by zagg *minor* version
+   (`0.N.x` -> `0.N`). The minor is read from the repo's latest git tag (so a
+   fresh clone needs no install), falling back to the installed `zagg`, or an
+   explicit `LAMBDA_VERSION` override (`LAMBDA_VERSION=latest` reads the
+   newest published minor from the bucket's `versions.json`).
 2. **Locates the artifacts for the chosen `ARCH`** (`arm64` default, or
    `x86_64`) -- `lambda_layer_<arch>.zip` and
    `lambda_function_<arch>_py312.zip`.
-3. **Stages code into a same-region bucket if needed.** CloudFormation requires
+3. **Verifies the minor is actually staged and asks for confirmation.** The
+   layer key is HEAD-checked on the distribution bucket before any stack
+   call; an unstaged minor (e.g. one derived from a repo ahead of the last
+   release) fails fast with the staged minors listed, instead of surfacing
+   as a CloudFormation `NoSuchKey` rollback. The resolved bucket/keys/version
+   are then echoed and the script prompts before deploying (pass `--yes` to
+   skip the prompt in unattended runs).
+4. **Stages code into a same-region bucket if needed.** CloudFormation requires
    Lambda code to live in a bucket **in the stack's own region**. In
-   **us-west-2** (where the mirror lives) the stack reads straight from the
-   mirror -- no bucket of your own required. In **any other region** you provide
+   **us-west-2** (where the distribution bucket lives) the stack reads straight
+   from it -- no bucket of your own required. In **any other region** you provide
    `STAGING_BUCKET` (a bucket you own in that region) and `stand_up.sh` copies
    the zips into it first.
-4. **Deploys `template.yaml`** with `aws cloudformation deploy
+5. **Deploys `template.yaml`** with `aws cloudformation deploy
    --capabilities CAPABILITY_NAMED_IAM`, passing the resolved architecture,
    artifact bucket/keys, output bucket, and role settings as parameter
    overrides.
-5. **Prints the stack outputs** (function ARN/name, layer ARN, role ARN, output
+6. **Prints the stack outputs** (function ARN/name, layer ARN, role ARN, output
    bucket).
 
 ## What the stack creates
@@ -66,8 +76,8 @@ to hand-assemble zips or wire up the IAM role yourself.
 
 ## `stand_up.sh` environment variables
 
-Behavior is driven entirely by environment variables (the script takes no
-positional arguments):
+Behavior is driven by environment variables; the only flag is `--yes` (skip
+the pre-deploy confirmation prompt):
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
@@ -77,10 +87,10 @@ positional arguments):
 | `ROLE_ARN` | *(none)* | Pre-existing execution-role ARN, required only when `CREATE_ROLE=false` |
 | `ARCH` | `arm64` | `arm64` or `x86_64` (both py3.12) |
 | `REGION` | `us-west-2` | Deployment region |
-| `STAGING_BUCKET` | *(none)* | Required outside us-west-2: a same-region bucket the mirror zips are copied into |
-| `LAMBDA_VERSION` | *(derived)* | Lambda minor to deploy (default: the repo's latest git tag, else the installed zagg) |
+| `STAGING_BUCKET` | *(none)* | Required outside us-west-2: a same-region bucket the release zips are copied into |
+| `LAMBDA_VERSION` | *(derived)* | Lambda minor to deploy (default: the repo's latest git tag, else the installed zagg; `latest` reads `versions.json`). Whatever it resolves to must be staged on the distribution bucket -- verified before the stack call |
 | `STACK_NAME` | `zagg-backend` | CloudFormation stack name |
-| `MIRROR_BUCKET` / `MIRROR_PREFIX` / `MIRROR_REGION` | source.coop | Override to self-host the artifact mirror |
+| `DIST_BUCKET` / `DIST_PREFIX` / `DIST_REGION` | `sliderule-public-cors` / *(none)* / `us-west-2` | Override to self-host a copy of the release artifacts |
 
 These map onto the `template.yaml` parameters (`Architecture`, `ArtifactBucket`,
 `LayerS3Key`, `FunctionS3Key`, `OutputBucketName`, `CreateOutputBucket`,
@@ -104,14 +114,16 @@ CREATE_ROLE=false ROLE_ARN=arn:aws:iam::123456789012:role/zagg-exec \
 
 ## Updating and tearing down
 
-Re-running `stand_up.sh` with a newer `LAMBDA_VERSION` (or after the mirror is
-re-populated for the current minor) updates the stack in place. To remove
-everything:
+Re-running `stand_up.sh` with a newer `LAMBDA_VERSION` (or after the
+distribution bucket is re-populated for the current minor) updates the stack in
+place. To remove everything:
 
 ```bash
 aws cloudformation delete-stack --stack-name zagg-backend --region us-west-2
 ```
 
-Maintainers (re)populate the mirror after a release with
-`deployment/aws/publish_mirror.sh <minor>`, which pushes the four CI-built zips
-(plus `SHA256SUMS`) to `s3://<mirror>/englacial/zagg/lambda/<minor>/`.
+The distribution bucket is populated automatically on release: pushing a
+version tag runs `publish.yml`'s `distribute` job
+(`.github/scripts/distribute_zips.sh`), which pushes the four CI-built zips
+(plus `SHA256SUMS`) to `s3://sliderule-public-cors/<minor>/` and updates the
+top-level `versions.json` index.

--- a/docs/deployment/standup.md
+++ b/docs/deployment/standup.md
@@ -32,10 +32,10 @@ to hand-assemble zips or wire up the IAM role yourself.
    `x86_64`) -- `lambda_layer_<arch>.zip` and
    `lambda_function_<arch>_py312.zip`.
 3. **Verifies the minor is actually staged and asks for confirmation.** The
-   layer key is HEAD-checked on the distribution bucket before any stack
-   call; an unstaged minor (e.g. one derived from a repo ahead of the last
-   release) fails fast with the staged minors listed, instead of surfacing
-   as a CloudFormation `NoSuchKey` rollback. The resolved bucket/keys/version
+   layer and function keys are HEAD-checked on the distribution bucket before
+   any stack call; an unstaged minor (e.g. one derived from a repo ahead of
+   the last release) fails fast with the staged minors listed, instead of
+   surfacing as a CloudFormation `NoSuchKey` rollback. The resolved bucket/keys/version
    are then echoed and the script prompts before deploying (pass `--yes` to
    skip the prompt in unattended runs).
 4. **Stages code into a same-region bucket if needed.** CloudFormation requires

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1312,6 +1312,7 @@ class TestSelfRecycle:
     @pytest.fixture(autouse=True)
     def _fresh_container(self, handler_mod, monkeypatch):
         monkeypatch.setattr(handler_mod, "_INVOCATIONS_SERVED", 0)
+        monkeypatch.setattr(handler_mod, "_ASYNC_INVOCATIONS_SERVED", 0)
         monkeypatch.delenv("ZAGG_RECYCLE_RSS_MB", raising=False)
         monkeypatch.delenv("ZAGG_RECYCLE_MAX_INVOCATIONS", raising=False)
 
@@ -1372,7 +1373,10 @@ class TestSelfRecycle:
         assert calls == [("exit", 0)]
         assert Path(url).exists()  # mirror landed before the exit
         # One structured, CloudWatch-searchable line (dashboard metric filter).
-        assert "ZAGG_SELF_RECYCLE rss_mb=1500 generation=1 threshold=1400" in caplog.text
+        assert (
+            "ZAGG_SELF_RECYCLE rss_mb=1500 async_served=1 generation=1 threshold=1400"
+            in caplog.text
+        )
 
     def test_below_threshold_no_recycle(self, handler_mod, monkeypatch):
         calls = []
@@ -1395,8 +1399,48 @@ class TestSelfRecycle:
         assert calls == []  # generation 1 < cap
         with caplog.at_level("INFO"):
             handler_mod.lambda_handler(event, _context())
-        assert calls == [("exit", 0)]  # generation 2 hits the cap
-        assert "ZAGG_SELF_RECYCLE rss_mb=n/a generation=2 threshold=2" in caplog.text
+        assert calls == [("exit", 0)]  # second async invocation hits the cap
+        assert "ZAGG_SELF_RECYCLE rss_mb=n/a async_served=2 generation=2 threshold=2" in caplog.text
+
+    def test_sync_setup_does_not_consume_recycle_budget(self, handler_mod, monkeypatch):
+        # Issue #177: a synchronous setup invoke warms the sandbox but must not
+        # be billed against the async budget -- with cap 2, setup + one worker
+        # stays below the cap (pre-fix, generation 2 >= 2 fired after the FIRST
+        # worker), and only the second worker recycles.
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_MAX_INVOCATIONS", "2")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: None)  # RSS check inert
+        monkeypatch.setattr(handler_mod, "_write_result", lambda *a: True)
+        monkeypatch.setattr(
+            handler_mod, "_handle_setup", lambda event: {"statusCode": 200, "body": "{}"}
+        )
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        handler_mod.lambda_handler({"mode": "setup"}, _context())  # sync: no result_url
+        event = self._process_event(monkeypatch, result_url="s3://b/status/1.json")
+        handler_mod.lambda_handler(event, _context())
+        assert calls == []  # async budget spent: 1 < 2 (setup didn't count)
+        handler_mod.lambda_handler(event, _context())
+        assert calls == [("exit", 0)]  # second async invocation hits the cap
+
+    def test_recycle_log_reports_true_generation(self, handler_mod, monkeypatch, caplog):
+        # Issue #177: with cap 1 after a sync setup, the recycle fires on the
+        # FIRST async worker (async_served=1) while both the log line and the
+        # envelope telemetry keep reporting the true container generation (2).
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_MAX_INVOCATIONS", "1")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: None)
+        monkeypatch.setattr(handler_mod, "_write_result", lambda *a: True)
+        monkeypatch.setattr(
+            handler_mod, "_handle_setup", lambda event: {"statusCode": 200, "body": "{}"}
+        )
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        handler_mod.lambda_handler({"mode": "setup"}, _context())
+        event = self._process_event(monkeypatch, result_url="s3://b/status/1.json")
+        with caplog.at_level("INFO"):
+            resp = handler_mod.lambda_handler(event, _context())
+        assert calls == [("exit", 0)]
+        assert "ZAGG_SELF_RECYCLE rss_mb=n/a async_served=1 generation=2 threshold=1" in caplog.text
+        assert json.loads(resp["body"])["container_generation"] == 2  # telemetry: true gen
 
     def test_disabled_by_default_and_by_zero(self, handler_mod, monkeypatch):
         # No env vars (and explicit "0") -> never recycles, however bloated:

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1442,6 +1442,25 @@ class TestSelfRecycle:
         assert "ZAGG_SELF_RECYCLE rss_mb=n/a async_served=1 generation=2 threshold=1" in caplog.text
         assert json.loads(resp["body"])["container_generation"] == 2  # telemetry: true gen
 
+    def test_failed_mirror_still_bills_recycle_budget(self, handler_mod, monkeypatch):
+        # Issue #177 review fold: a failed mirror skips the recycle itself
+        # (transient S3 fault -- don't also churn the sandbox), but the async
+        # invocation WAS served, so it must still burn the budget: with cap 2,
+        # a failed-mirror invoke plus one successful invoke recycles. (Billing
+        # only mirrored invokes would let a flaky mirror extend the sandbox
+        # past its cap -- the pre-#177 generation counter counted it too.)
+        calls = []
+        monkeypatch.setenv("ZAGG_RECYCLE_MAX_INVOCATIONS", "2")
+        monkeypatch.setattr(handler_mod, "_read_vmrss_kib", lambda: None)
+        outcomes = iter([False, True])
+        monkeypatch.setattr(handler_mod, "_write_result", lambda *a: next(outcomes))
+        self._spy_exit(handler_mod, monkeypatch, calls)
+        event = self._process_event(monkeypatch, result_url="s3://b/status/1.json")
+        handler_mod.lambda_handler(event, _context())
+        assert calls == []  # mirror failed: billed, but no recycle
+        handler_mod.lambda_handler(event, _context())
+        assert calls == [("exit", 0)]  # budget spent (2 >= 2), counting the failed one
+
     def test_disabled_by_default_and_by_zero(self, handler_mod, monkeypatch):
         # No env vars (and explicit "0") -> never recycles, however bloated:
         # a stack without the template defaults behaves exactly as pre-#171.

--- a/tests/test_stand_up.py
+++ b/tests/test_stand_up.py
@@ -43,7 +43,7 @@ exit 0
 """
 
 
-def _run(tmp_path, *args, env_extra=None, stdin="", staged=("0.14",), versions=None):
+def _run(tmp_path, *args, env_extra=None, stdin="", staged=("0.14",), versions=None, drop=None):
     bindir = tmp_path / "bin"
     bindir.mkdir(exist_ok=True)
     (bindir / "aws").write_text(STUB_AWS)
@@ -55,6 +55,8 @@ def _run(tmp_path, *args, env_extra=None, stdin="", staged=("0.14",), versions=N
         d.mkdir(parents=True, exist_ok=True)
         (d / "lambda_layer_arm64.zip").write_bytes(b"dummy")
         (d / "lambda_function_arm64_py312.zip").write_bytes(b"dummy")
+    if drop is not None:  # simulate a partially staged minor
+        (staged_dir / drop).unlink()
 
     seed_dir = tmp_path / "seed"
     seed_dir.mkdir(exist_ok=True)
@@ -102,6 +104,21 @@ def test_unstaged_minor_fails_before_any_stack_call(tmp_path):
     assert "cloudformation" not in log
 
 
+def test_partially_staged_minor_fails_before_any_stack_call(tmp_path):
+    # Both keys are HEAD-verified (review fold): a minor with the layer staged
+    # but the function zip missing must still fail before any stack call.
+    result, log = _run(
+        tmp_path,
+        "--yes",
+        env_extra={"LAMBDA_VERSION": "0.14"},
+        drop="0.14/lambda_function_arm64_py312.zip",
+    )
+    assert result.returncode != 0
+    assert "not staged" in result.stdout
+    assert "lambda_function_arm64_py312.zip" in result.stdout
+    assert "cloudformation" not in log
+
+
 def test_staged_minor_deploys_from_distribution_bucket(tmp_path):
     # Happy path: the current release layout (sliderule-public-cors/<minor>/<zip>)
     # is what reaches `cloudformation deploy` — no source.coop anywhere.
@@ -144,9 +161,12 @@ def test_confirm_prompt_proceeds_on_y(tmp_path):
 
 
 def test_no_input_and_no_yes_aborts(tmp_path):
-    # Unattended run without --yes (EOF on stdin) must fail safe, not deploy.
+    # Unattended run without --yes (EOF on stdin) must fail safe, not deploy —
+    # and still print the actionable abort message (review fold: a bare `read`
+    # under `set -e` used to exit on EOF before reaching the message).
     result, log = _run(tmp_path, env_extra={"LAMBDA_VERSION": "0.14"}, stdin="")
     assert result.returncode != 0
+    assert "Aborted (pass --yes" in result.stdout
     assert "cloudformation" not in log
 
 

--- a/tests/test_stand_up.py
+++ b/tests/test_stand_up.py
@@ -1,0 +1,157 @@
+"""Test the backend standup script (deployment/aws/stand_up.sh) — issue #174.
+
+Same harness as test_distribute_zips.py: run the real script with a stub
+``aws`` on PATH (no network, nothing deployed) and assert the artifact
+resolution logic. The stale-defaults failure mode (2026-07-06 forensics) was a
+version derived from git state that was never staged, silently falling back to
+the retired source.coop mirror and dying as a CloudFormation NoSuchKey — so
+the load-bearing cases are: an unstaged minor fails fast (before any
+``cloudformation deploy``) with the staged minors listed, a staged minor
+deploys from the distribution bucket's ``<minor>/<zip>`` layout, and the
+confirm prompt gates the stack call unless ``--yes`` is passed.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "deployment" / "aws" / "stand_up.sh"
+
+# A stub `aws` CLI: logs every call, serves `s3api head-object` from the files
+# under $STAGED_DIR (staged release artifacts), streams a seeded versions.json
+# for `s3 cp s3://.../versions.json -`, and no-ops everything else (including
+# `cloudformation deploy` — the log is how tests assert it ran or didn't).
+STUB_AWS = """#!/bin/bash
+set -euo pipefail
+echo "$*" >> "$AWS_LOG"
+if [ "$1" = "s3api" ] && [ "$2" = "head-object" ]; then
+  key=""
+  while [ $# -gt 0 ]; do
+    case "$1" in --key) key="$2"; shift 2 ;; *) shift ;; esac
+  done
+  [ -f "$STAGED_DIR/$key" ] || exit 254
+  exit 0
+fi
+if [ "$1" = "s3" ] && [ "$2" = "cp" ] && [ "${4:-}" = "-" ]; then
+  [ -f "$SEED_DIR/versions.json" ] || exit 1
+  cat "$SEED_DIR/versions.json"
+  exit 0
+fi
+exit 0
+"""
+
+
+def _run(tmp_path, *args, env_extra=None, stdin="", staged=("0.14",), versions=None):
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    (bindir / "aws").write_text(STUB_AWS)
+    (bindir / "aws").chmod(0o755)
+
+    staged_dir = tmp_path / "staged"
+    for minor in staged:
+        d = staged_dir / minor
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "lambda_layer_arm64.zip").write_bytes(b"dummy")
+        (d / "lambda_function_arm64_py312.zip").write_bytes(b"dummy")
+
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir(exist_ok=True)
+    if versions is None:
+        versions = {"minors": list(staged), "latest": staged[-1] if staged else None}
+    (seed_dir / "versions.json").write_text(json.dumps(versions))
+
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "AWS_LOG": str(tmp_path / "aws.log"),
+        "STAGED_DIR": str(staged_dir),
+        "SEED_DIR": str(seed_dir),
+        "OUTPUT_BUCKET": "my-results",
+        **(env_extra or {}),
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        env=env,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    log_path = tmp_path / "aws.log"
+    log = log_path.read_text() if log_path.exists() else ""
+    return result, log
+
+
+def test_unstaged_minor_fails_before_any_stack_call(tmp_path):
+    # The 2026-07-06 failure mode: a derived-but-never-staged minor (0.15) must
+    # die at the HEAD check with the staged minors listed — NOT reach
+    # CloudFormation and roll back on NoSuchKey.
+    result, log = _run(
+        tmp_path,
+        "--yes",
+        env_extra={"LAMBDA_VERSION": "0.15"},
+        staged=("0.14",),
+        versions={"minors": ["0.13", "0.14"], "latest": "0.14"},
+    )
+    assert result.returncode != 0
+    assert "not staged" in result.stdout
+    assert "0.13 0.14" in result.stdout  # actionable: the staged minors
+    assert "LAMBDA_VERSION" in result.stdout
+    assert "cloudformation" not in log
+
+
+def test_staged_minor_deploys_from_distribution_bucket(tmp_path):
+    # Happy path: the current release layout (sliderule-public-cors/<minor>/<zip>)
+    # is what reaches `cloudformation deploy` — no source.coop anywhere.
+    result, log = _run(tmp_path, "--yes", env_extra={"LAMBDA_VERSION": "0.14"})
+    assert result.returncode == 0, result.stdout + result.stderr
+    (deploy,) = [ln for ln in log.splitlines() if ln.startswith("cloudformation deploy")]
+    assert "ArtifactBucket=sliderule-public-cors" in deploy
+    assert "LayerS3Key=0.14/lambda_layer_arm64.zip" in deploy
+    assert "FunctionS3Key=0.14/lambda_function_arm64_py312.zip" in deploy
+    assert "source.coop" not in log and "source.coop" not in result.stdout
+    # The resolved artifacts are echoed before the stack call (issue #174).
+    assert "s3://sliderule-public-cors/0.14/lambda_layer_arm64.zip" in result.stdout
+
+
+def test_latest_resolves_from_versions_index(tmp_path):
+    result, log = _run(
+        tmp_path,
+        "--yes",
+        env_extra={"LAMBDA_VERSION": "latest"},
+        staged=("0.13", "0.14"),
+        versions={"minors": ["0.13", "0.14"], "latest": "0.14"},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "LayerS3Key=0.14/lambda_layer_arm64.zip" in log
+
+
+def test_confirm_prompt_aborts_without_yes(tmp_path):
+    # No --yes and a "n" answer: the script echoes the resolved artifacts and
+    # stops before any deploy.
+    result, log = _run(tmp_path, env_extra={"LAMBDA_VERSION": "0.14"}, stdin="n\n")
+    assert result.returncode != 0
+    assert "Aborted" in result.stdout
+    assert "cloudformation" not in log
+
+
+def test_confirm_prompt_proceeds_on_y(tmp_path):
+    result, log = _run(tmp_path, env_extra={"LAMBDA_VERSION": "0.14"}, stdin="y\n")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "cloudformation deploy" in log
+
+
+def test_no_input_and_no_yes_aborts(tmp_path):
+    # Unattended run without --yes (EOF on stdin) must fail safe, not deploy.
+    result, log = _run(tmp_path, env_extra={"LAMBDA_VERSION": "0.14"}, stdin="")
+    assert result.returncode != 0
+    assert "cloudformation" not in log
+
+
+def test_unknown_flag_rejected(tmp_path):
+    result, log = _run(tmp_path, "--force", env_extra={"LAMBDA_VERSION": "0.14"})
+    assert result.returncode != 0
+    assert "unknown argument" in result.stdout
+    assert "cloudformation" not in log


### PR DESCRIPTION
Closes #177
Closes #174

Bundled `small-fix` PR (one commit per issue, plus one review-fold commit). The `deployment/aws/` touch is authorized by the issue naming it and by the maintainer comment on the thread (https://github.com/englacial/zagg/issues/174#issuecomment-4900055257).

## Checklist

- [x] #177 — count only recycle-eligible (async) invocations toward the self-recycle budget (`deployment/aws/lambda_handler.py`)
- [x] #174 — `stand_up.sh` artifact defaults: current release layout, refuse-to-guess version verification, confirm prompt, docs (`deployment/aws/stand_up.sh` + docs)
- [x] fold adversarial-review findings (see "Review fold" below)

## Issue #177 — recycle budget vs. container generation

Option (1) from the issue. A new module global `_ASYNC_INVOCATIONS_SERVED` is billed at the dispatcher, on every async (`result_url`) invocation, and `ZAGG_RECYCLE_MAX_INVOCATIONS` now compares against it instead of the raw generation:

```python
elif gen_limit > 0 and async_served >= gen_limit:
    threshold = gen_limit
```

So the runner's synchronous setup invocation (the one observed warming a container in the 2026-07-07 00:52 UTC benchmark run) no longer consumes the worker budget: `MAX_INVOCATIONS=1` now means "one heavy async invocation per container". Telemetry is unchanged — `_INVOCATIONS_SERVED` / `container_generation` still count every invocation (the existing `test_setup_counts_toward_generation_but_body_unchanged` pins this). The `ZAGG_SELF_RECYCLE` log line now carries both counters (`async_served=<n> generation=<n>`); the metric filters in `template.yaml` key only on the `ZAGG_SELF_RECYCLE` prefix, so they are unaffected. `docs/deployment/lambda.md` updated to match.

## Issue #174 — stand_up.sh stale artifact defaults

Per the issue's four scope items:

1. **Current release layout only.** The `MIRROR_BUCKET`/`MIRROR_PREFIX` (`us-west-2.opendata.source.coop/englacial/zagg/lambda`) defaults and the silent fallback to them are removed. The single source is `s3://sliderule-public-cors/<minor>/<zip>` + root `versions.json` — matching `publish.yml`'s `distribute` job / `.github/scripts/distribute_zips.sh`. Self-hosting still works via `DIST_BUCKET`/`DIST_PREFIX`/`DIST_REGION`.
2. **Refuse to guess.** After the minor resolves (explicit / `latest` / git tag / installed zagg), both the layer and function keys are verified with `aws s3api head-object ... --no-sign-request` before any CloudFormation call. An unstaged minor (the failed run's phantom `0.15`) fails fast with the `aws` stderr surfaced, the staged minors read from `versions.json`, and a pointer to `LAMBDA_VERSION`.
3. **Echo + confirm.** The resolved version/layer/function/stack are echoed and a `Proceed with deploy? [y/N]` prompt gates the stack call; `--yes` skips it. EOF on stdin (unattended without `--yes`) aborts safely with the actionable message.
4. **Docs.** `docs/deployment/standup.md` (steps, env-var table, release-population paragraph), `deployment/LAMBDA_DEPLOYMENT.md`, `README.md`, and the `docs/deployment/benchmark-cicd.md` transition section updated; stale `source.coop` artifact references removed (the source.coop mentions left in `docs/deployment/lambda.md` are about *output* stores, not artifacts, and stand alone).

Nothing was run against AWS — all changes verified statically and via the stubbed-CLI tests below.

## Review fold (commit `fold review: bill recycle budget on failed mirror + stand_up HEAD/EOF fixes`)

All four diff-scoped findings from the adversarial review folded:

- **Failed-mirror billing (correctness):** the budget increment moved out of `_maybe_self_recycle()` (now a pure check) to the dispatcher's `result_url` branch, before the mirror-success gate — a failed-mirror async invocation is served and now burns budget, matching pre-#177 behavior. New `test_failed_mirror_still_bills_recycle_budget` (mirror fails on invoke 1, succeeds on invoke 2, cap 2 → recycle fires on invoke 2).
- **HEAD both keys:** chose to verify **both** the layer and function zips (a two-iteration loop; a partially staged minor now also fails fast) rather than scoping the header down — the header/echo claims and `docs/deployment/standup.md` now match the code. New `test_partially_staged_minor_fails_before_any_stack_call`.
- **HEAD error detail:** the `head-object` stderr is captured and printed in the error block, so a network/credential failure of the check reads differently from a 404 (message says so explicitly).
- **EOF prompt abort:** `read ... || REPLY=""` so an unattended run without `--yes` prints "Aborted (pass --yes ...)" instead of dying silently under `set -e`; `test_no_input_and_no_yes_aborts` now asserts the message.

## How tested

- **#177:** `tests/test_lambda_handler.py` — new `test_sync_setup_does_not_consume_recycle_budget` (cap 2: sync setup + first worker stays below the cap — fails on pre-fix code — second worker recycles), `test_recycle_log_reports_true_generation` (cap 1 after setup: recycles on the first async worker with `async_served=1 generation=2`, envelope `container_generation == 2`), and `test_failed_mirror_still_bills_recycle_budget`; the two existing log-format assertions updated. 80/80 pass.
- **#174:** new `tests/test_stand_up.py` runs the real script with a stub `aws` on `PATH` (no network, nothing deployed), mirroring the existing `tests/test_distribute_zips.py` harness: unstaged and partially staged minors fail before any `cloudformation` call with staged minors listed; staged minor deploys with `ArtifactBucket=sliderule-public-cors` / `LayerS3Key=<minor>/lambda_layer_arm64.zip`; `LAMBDA_VERSION=latest` resolves via `versions.json`; prompt aborts on `n`/EOF (with message) and proceeds on `y`/`--yes`; unknown flags rejected. 8/8 pass, plus `bash -n`.
- Full suite: `pytest -q` → **1480 passed, 26 skipped** (pre-fold; folded files re-run green at 88/88); `ruff check` and `ruff format --check` clean on every touched file.

## Questions for review

- **`deployment/aws/lambda_handler.py` is now ~1035 lines**, past the ~1000-line convention ceiling (it was already over at base, 1012). Standing note from the review: a decision on whether/how to split (or bless the size) belongs on a follow-up issue rather than this small-fix PR.
- **Pre-existing lint drift on `main` (not touched here):** `ruff check src tests` fails with one `N818` (`src/zagg/registry.py:64`, `UnknownCapability`), and `ruff format --check` would reformat 7 files (`src/zagg/__init__.py`, `src/zagg/__main__.py`, `src/zagg/catalog/sources.py`, `src/zagg/viz/crs.py`, `tests/test_catalog.py`, `tests/test_extract.py`, `tests/test_integration.py`). Both reproduce on a clean `origin/main` checkout, so they are flagged rather than fixed per repo convention.
- **`template.yaml` `RecycleMaxInvocations` description** now reads slightly stale ("recycles after every invocation" → after every *async* invocation). Issue #177 names only `lambda_handler.py`, so the template was left untouched per the deployment-files convention — happy to fold the one-line description update in if that's preferred.
- **`publish_mirror.sh`** (the legacy source.coop publisher) still exists; the benchmark-cicd doc previously said to retire it "in a follow-up". This PR only removes the *consumption* side in `stand_up.sh`; deleting the script itself is left for a separate decision.
- **stand_up.sh behavior change:** older minors that only ever lived on the source.coop mirror now require `DIST_BUCKET`/`DIST_PREFIX` overrides instead of falling back silently. This reads as intended by the issue ("removing the source.coop defaults") but is a hard cut for pre-0.14 standups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wp83fdkH2qhtEvoLgyTWU1