### PR TITLE
Granule-level read concurrency (K in flight, ordered fold)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ The store path and output grid parameters are defined in the YAML config (`outpu
 
 `data_source.read_workers` (default 8) bounds the per-worker read fan-out on the compiled paths: each in-flight read overlaps S3 latency and decodes with the GIL released. Peak worker memory grows with width — dial down for dense shards.
 
+`data_source.granule_workers` (default 1 = serial) keeps K granules in flight per worker on a bounded thread pool, folded in original granule order so output is byte-identical to serial (issue #180). Opt-in until the fleet A/B picks a default. It multiplies with `read_workers` — dial `read_workers` down as K rises to stay inside the S3 connection budget; peak memory grows by roughly K granule footprints.
+
 ### Step 4: Visualize Results
 
 The output Zarr is a public DGGS dataset. The included notebook rasterizes HEALPix cells to a polar stereographic grid for fast rendering with `imshow`.

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -751,6 +751,11 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     # run, not the warm container's lifetime high-water. Stopped in ``finally``.
     rss_sampler = _PeakRSSSampler().start()
 
+    # Per-invocation CPU baseline (issue #180 phase 3): ``os.times()`` is
+    # process-cumulative (like ``ru_maxrss``), so snapshot at entry and diff at
+    # the telemetry stamp below for THIS invocation's user+sys seconds.
+    cpu_t0 = os.times()
+
     try:
         # Validate required parameters. ``child_order`` is HEALPix-specific and
         # only required once the grid is known to be HEALPix (checked below);
@@ -954,6 +959,17 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         sampled_peak = rss_sampler.peak_mb
         metadata["max_memory_mb"] = (
             sampled_peak if sampled_peak is not None else metadata["container_hwm_mb"]
+        )
+
+        # Per-invocation CPU seconds (issue #180 phase 3): user+sys consumed by
+        # this invocation across ALL threads (``os.times()`` aggregates the
+        # process, so the granule/read pools' work is counted), diffed against
+        # the handler-entry snapshot. utilization = cpu_seconds / duration_s is
+        # the K-sweep A/B's vCPU-saturation signal, per invocation, without
+        # CloudWatch access.
+        cpu_t1 = os.times()
+        metadata["cpu_seconds"] = round(
+            (cpu_t1.user - cpu_t0.user) + (cpu_t1.system - cpu_t0.system), 3
         )
 
         # Log structured result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # point (0.1.1 carries only the compiled reader, so `sidecar` does not
     # register from it). 0.2.0 is not on PyPI yet — resolution fails until
     # upstream publishes it.
-    "h5coro-hidefix>=0.3.0",
+    "h5coro-hidefix>=0.3.1",
     "mortie>=0.8.5",
     "earthaccess",
     "boto3",
@@ -65,7 +65,7 @@ lambda = [
     "h5coro==1.0.5",
     # Keep this pin in sync with deployment/aws/build_layer.sh (abi3
     # manylinux_2_28 wheels cover both layer arches, ~2.2 MB each).
-    "h5coro-hidefix==0.3.0",
+    "h5coro-hidefix==0.3.1",
     "cramjam",
     "astropy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "zarr>=3.1.5",
     "obstore>=0.8.2",
     "pyyaml",
-    "pyproj",
+    "pyproj>=3.7.0",
     "shapely",
     "odc-geo",
 ]

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -304,23 +304,6 @@ def validate_config(config: PipelineConfig) -> None:
         raise ValueError(
             f"data_source.granule_workers must be an integer >= 1 (got {granule_workers!r})"
         )
-    # Reject the one known thread-unsafe backend combination at submission
-    # (mirrors the worker's _reject_racy_sidecar_build; see its docstring for
-    # the installed-h5coro-hidefix delegate lazy-init race, issue #180 review).
-    index_cfg = (config.data_source or {}).get("index")
-    if (
-        isinstance(granule_workers, int)
-        and granule_workers > 1
-        and isinstance(index_cfg, dict)
-        and index_cfg.get("backend") == "sidecar"
-        and index_cfg.get("on_miss") == "build"
-    ):
-        raise ValueError(
-            "data_source.granule_workers > 1 is not supported with index backend "
-            "'sidecar' + on_miss: 'build' (h5coro-hidefix write-back delegate "
-            "lazy-init race); use on_miss: fallback/error, or granule_workers: 1"
-        )
-
     # Optional strict-AOI cell mask (issue #101), default off. Must be a bool.
     aoi_mask = config.output.get("aoi_mask")
     if aoi_mask is not None and not isinstance(aoi_mask, bool):

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -292,6 +292,19 @@ def validate_config(config: PipelineConfig) -> None:
     ):
         raise ValueError(f"data_source.read_workers must be an integer >= 1 (got {read_workers!r})")
 
+    # Validate the optional granule fan-out width (issue #180). Mirrors the
+    # worker's guard (_granule_workers) with the same rejection rationale as
+    # read_workers above.
+    granule_workers = (config.data_source or {}).get("granule_workers")
+    if granule_workers is not None and (
+        isinstance(granule_workers, bool)
+        or not isinstance(granule_workers, int)
+        or granule_workers < 1
+    ):
+        raise ValueError(
+            f"data_source.granule_workers must be an integer >= 1 (got {granule_workers!r})"
+        )
+
     # Optional strict-AOI cell mask (issue #101), default off. Must be a bool.
     aoi_mask = config.output.get("aoi_mask")
     if aoi_mask is not None and not isinstance(aoi_mask, bool):

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -304,6 +304,22 @@ def validate_config(config: PipelineConfig) -> None:
         raise ValueError(
             f"data_source.granule_workers must be an integer >= 1 (got {granule_workers!r})"
         )
+    # Reject the one known thread-unsafe backend combination at submission
+    # (mirrors the worker's _reject_racy_sidecar_build; see its docstring for
+    # the installed-h5coro-hidefix delegate lazy-init race, issue #180 review).
+    index_cfg = (config.data_source or {}).get("index")
+    if (
+        isinstance(granule_workers, int)
+        and granule_workers > 1
+        and isinstance(index_cfg, dict)
+        and index_cfg.get("backend") == "sidecar"
+        and index_cfg.get("on_miss") == "build"
+    ):
+        raise ValueError(
+            "data_source.granule_workers > 1 is not supported with index backend "
+            "'sidecar' + on_miss: 'build' (h5coro-hidefix write-back delegate "
+            "lazy-init race); use on_miss: fallback/error, or granule_workers: 1"
+        )
 
     # Optional strict-AOI cell mask (issue #101), default off. Must be a bool.
     aoi_mask = config.output.get("aoi_mask")

--- a/src/zagg/grids/rectilinear.py
+++ b/src/zagg/grids/rectilinear.py
@@ -34,6 +34,7 @@ filter rejects them, so they fall out of the pipeline silently.
 from __future__ import annotations
 
 import math
+import threading
 
 import numpy as np
 from affine import Affine
@@ -168,7 +169,6 @@ class RectilinearGrid:
         affine = Affine.translation(self.xmin, self.ymax) * Affine.scale(self.res_x, -self.res_y)
         self._geobox = GeoBox((self.height, self.width), affine, self.crs)
         self._tiles = GeoboxTiles(self._geobox, (self.chunk_h, self.chunk_w))
-        self._transformer = None  # lazy WGS84 -> grid CRS, for assign
 
     # ── shape properties ─────────────────────────────────────────────────
 
@@ -644,12 +644,36 @@ class RectilinearGrid:
         return (packed // self.n_col_blocks, packed % self.n_col_blocks)
 
     def _transformer_to_grid(self):
-        """WGS84 → grid CRS transformer (lat/lon → x/y)."""
-        if self._transformer is None:
-            from pyproj import Transformer
+        """WGS84 → grid CRS transformer (lat/lon → x/y), one per thread.
 
-            self._transformer = Transformer.from_crs("EPSG:4326", self.crs, always_xy=True)
-        return self._transformer
+        ``assign`` now runs on the granule pool's worker threads (issue #180),
+        and a shared pyproj ``Transformer`` is only documented thread-safe
+        from pyproj 3.7.0 — which ``pyproject.toml`` deliberately leaves
+        unpinned (a floor is a dependency change, §4). Caching one transformer
+        per (thread, crs) in module-level thread-local storage sidesteps the
+        PROJ-context race on any pyproj version; construction is identical, so
+        outputs are byte-identical to the old shared instance.
+        """
+        return _thread_transformer(self.crs)
+
+
+#: Per-thread pyproj Transformer cache (issue #180 — see
+#: ``RectilinearGrid._transformer_to_grid``). Module-level so grid instances
+#: stay free of unpicklable ``threading.local`` state.
+_TRANSFORMER_TLS = threading.local()
+
+
+def _thread_transformer(crs: str):
+    """This thread's WGS84 → ``crs`` transformer, constructed once per thread."""
+    cache = getattr(_TRANSFORMER_TLS, "by_crs", None)
+    if cache is None:
+        cache = _TRANSFORMER_TLS.by_crs = {}
+    tx = cache.get(crs)
+    if tx is None:
+        from pyproj import Transformer
+
+        tx = cache[crs] = Transformer.from_crs("EPSG:4326", crs, always_xy=True)
+    return tx
 
 
 def _whole_ratio(a: float, b: float, tol: float = 1e-9) -> bool:

--- a/src/zagg/grids/rectilinear.py
+++ b/src/zagg/grids/rectilinear.py
@@ -34,7 +34,6 @@ filter rejects them, so they fall out of the pipeline silently.
 from __future__ import annotations
 
 import math
-import threading
 
 import numpy as np
 from affine import Affine
@@ -169,6 +168,7 @@ class RectilinearGrid:
         affine = Affine.translation(self.xmin, self.ymax) * Affine.scale(self.res_x, -self.res_y)
         self._geobox = GeoBox((self.height, self.width), affine, self.crs)
         self._tiles = GeoboxTiles(self._geobox, (self.chunk_h, self.chunk_w))
+        self._transformer = None  # lazy WGS84 -> grid CRS, for assign
 
     # ── shape properties ─────────────────────────────────────────────────
 
@@ -644,36 +644,18 @@ class RectilinearGrid:
         return (packed // self.n_col_blocks, packed % self.n_col_blocks)
 
     def _transformer_to_grid(self):
-        """WGS84 → grid CRS transformer (lat/lon → x/y), one per thread.
+        """WGS84 → grid CRS transformer (lat/lon → x/y).
 
-        ``assign`` now runs on the granule pool's worker threads (issue #180),
-        and a shared pyproj ``Transformer`` is only documented thread-safe
-        from pyproj 3.7.0 — which ``pyproject.toml`` deliberately leaves
-        unpinned (a floor is a dependency change, §4). Caching one transformer
-        per (thread, crs) in module-level thread-local storage sidesteps the
-        PROJ-context race on any pyproj version; construction is identical, so
-        outputs are byte-identical to the old shared instance.
+        Shared across the granule pool's worker threads (issue #180):
+        concurrent ``.transform()`` on one ``Transformer`` is thread-safe from
+        pyproj 3.7.0, which is the ``pyproject.toml`` floor (espg-authorized;
+        the lazy init race here is benign — construction is idempotent).
         """
-        return _thread_transformer(self.crs)
+        if self._transformer is None:
+            from pyproj import Transformer
 
-
-#: Per-thread pyproj Transformer cache (issue #180 — see
-#: ``RectilinearGrid._transformer_to_grid``). Module-level so grid instances
-#: stay free of unpicklable ``threading.local`` state.
-_TRANSFORMER_TLS = threading.local()
-
-
-def _thread_transformer(crs: str):
-    """This thread's WGS84 → ``crs`` transformer, constructed once per thread."""
-    cache = getattr(_TRANSFORMER_TLS, "by_crs", None)
-    if cache is None:
-        cache = _TRANSFORMER_TLS.by_crs = {}
-    tx = cache.get(crs)
-    if tx is None:
-        from pyproj import Transformer
-
-        tx = cache[crs] = Transformer.from_crs("EPSG:4326", crs, always_xy=True)
-    return tx
+            self._transformer = Transformer.from_crs("EPSG:4326", self.crs, always_xy=True)
+        return self._transformer
 
 
 def _whole_ratio(a: float, b: float, tol: float = 1e-9) -> bool:

--- a/src/zagg/index/__init__.py
+++ b/src/zagg/index/__init__.py
@@ -113,9 +113,10 @@ class VirtualIndex:
         thread, and that thread calls ``finish_granule`` after the granule's
         last group — but ``read_group``/``finish_granule`` calls for
         *different* granules may interleave across threads. Any backend state
-        that spans one granule's reads must therefore be keyed per granule
-        (e.g. by the ``h5obj.resource`` URL stem, as ``inline._pending`` and
-        the sidecar backend's ``_cache`` are), never by dataset path alone.
+        that spans one granule's reads must therefore be keyed per granule —
+        by the full ``h5obj.resource`` URL, as ``inline._pending`` is — never
+        by dataset path alone, and not by the basename stem either (stems can
+        collide across prefixes; issue #180 review finding).
         """
 
 

--- a/src/zagg/index/__init__.py
+++ b/src/zagg/index/__init__.py
@@ -106,6 +106,16 @@ class VirtualIndex:
         backends use it for per-granule side effects (e.g. ``inline``
         write-back). Failures are logged by the caller and never fail the
         read. Default: no-op.
+
+        Concurrency contract (issue #180): the worker may hold up to
+        ``data_source.granule_workers`` granules in flight on one backend
+        instance. Each granule's groups are read serially by a single worker
+        thread, and that thread calls ``finish_granule`` after the granule's
+        last group — but ``read_group``/``finish_granule`` calls for
+        *different* granules may interleave across threads. Any backend state
+        that spans one granule's reads must therefore be keyed per granule
+        (e.g. by the ``h5obj.resource`` URL stem, as ``inline._pending`` and
+        the sidecar backend's ``_cache`` are), never by dataset path alone.
         """
 
 

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -51,6 +51,19 @@ from zagg.index import VirtualIndex
 
 logger = logging.getLogger(__name__)
 
+
+def _granule_id(resource) -> str:
+    """Granule id from a URL / resource path: basename minus extension.
+
+    The write-back manifest key convention (issue #160), and the key isolating
+    each in-flight granule's pending chunk maps (issue #180). Mirrors
+    ``_granule_id`` in h5coro-hidefix's ``zagg_backend``: the stem survives
+    every driver URL rewrite, so ids derived from ``h5obj.resource`` (the
+    rewritten URL) and from the worker's original ``granule_url`` agree.
+    """
+    return PurePosixPath(urlsplit(str(resource)).path).stem
+
+
 #: Manifest row schema, single source of truth (same empty-frame-drift
 #: rationale as the bench extractor's ``OFFSETS_DTYPES``). The chunk columns
 #: are PR #159's offsets schema; ``chunk_offset``/``dtype``/``shape``/
@@ -332,10 +345,16 @@ class InlineIndex(VirtualIndex):
     def __init__(self, write_back: bool = False, store: str | None = None):
         self.write_back = bool(write_back)
         self.store = store
-        # Chunk maps accumulated across the current granule's groups (the
-        # worker reads granules serially and calls ``finish_granule`` after
-        # each one, which drains this). Only populated when writing back.
-        self._pending: dict[str, ChunkMap] = {}
+        # Chunk maps accumulated across each in-flight granule's groups,
+        # keyed granule id -> {dataset path -> ChunkMap} (issue #180: the
+        # worker may hold ``data_source.granule_workers`` granules in flight,
+        # and dataset paths repeat across granules, so a flat path-keyed dict
+        # would interleave granules and persist corrupted manifests).
+        # ``finish_granule`` drains exactly its granule's entry. Each granule
+        # is read by a single worker thread, so its sub-dict is never shared;
+        # the outer dict's setdefault/pop are atomic under the GIL. Only
+        # populated when writing back.
+        self._pending: dict[str, dict[str, ChunkMap]] = {}
 
     @classmethod
     def validate_index_config(cls, index_cfg: dict, data_source: dict | None = None) -> None:
@@ -374,6 +393,16 @@ class InlineIndex(VirtualIndex):
             store=index_cfg.get("store"),
         )
 
+    def _pending_for(self, h5obj) -> dict[str, ChunkMap]:
+        """This granule's pending chunk maps (write-back accumulation).
+
+        Keyed by the granule id of ``h5obj.resource`` — the rewritten URL the
+        worker opened the granule with, whose stem matches ``granule_url``'s
+        (see :func:`_granule_id`) — so concurrent in-flight granules (issue
+        #180) never share chunk-map state.
+        """
+        return self._pending.setdefault(_granule_id(h5obj.resource), {})
+
     def _prebuild_group_maps(self, h5obj, group: str, data_source: dict) -> None:
         """Build the chunk maps for every dataset this group's read can touch.
 
@@ -404,26 +433,34 @@ class InlineIndex(VirtualIndex):
             for key in ("index_beg", "count"):
                 if key in link:
                     paths.append(link[key].format(group=group))
+        pending = self._pending_for(h5obj)
         for path in dict.fromkeys(paths):
-            if path not in self._pending:
-                self._pending[path] = build_chunk_map(h5obj, path)
+            if path not in pending:
+                pending[path] = build_chunk_map(h5obj, path)
 
     def finish_granule(self, h5obj, granule_url: str) -> None:
         """Write-back seam: persist the granule's accumulated chunk maps.
 
-        No-op unless ``write_back`` is on. The manifest key is the granule id
-        (URL basename without extension — granule ids carry product +
-        version, so reprocessing changes the key; issue #160 store
-        convention). Raises on store failures — the worker logs and
-        continues, so a broken store degrades to plain ``inline`` reads.
+        Drains only THIS granule's pending entry (issue #180: other granules
+        may still be in flight), keyed as the read side keyed it —
+        ``h5obj.resource``'s granule id — with ``granule_url``'s as fallback
+        for resource-less callers. No-op unless ``write_back`` is on. The
+        manifest key is the granule id (URL basename without extension —
+        granule ids carry product + version, so reprocessing changes the key;
+        issue #160 store convention). Raises on store failures — the worker
+        logs and continues, so a broken store degrades to plain ``inline``
+        reads.
         """
-        maps, self._pending = self._pending, {}
+        granule_id = _granule_id(granule_url)
+        resource = getattr(h5obj, "resource", None)
+        maps = self._pending.pop(_granule_id(resource), None) if resource is not None else None
+        if maps is None:
+            maps = self._pending.pop(granule_id, {})
         if not self.write_back:
             return
         maps = {path: cm for path, cm in maps.items() if cm.raw}
         if not maps:
             return
-        granule_id = PurePosixPath(urlsplit(granule_url).path).stem
         key = write_manifest(granule_manifest(maps), self.store, granule_id)
         logger.info(f"  inline write-back: {len(maps)} dataset(s) -> {self.store}/{key}")
 
@@ -483,12 +520,14 @@ class InlineIndex(VirtualIndex):
         ``read_group`` call, which is exactly one (granule, group): a group's
         datasets are disjoint from every other group's, so nothing is
         rebuilt or leaked across granules. Under ``write_back`` the cache is
-        the instance's pending dict instead, accumulating the granule's maps
-        across groups for ``finish_granule`` to persist. Each dataset gets
+        THIS granule's pending sub-dict instead (``_pending_for`` — keyed per
+        granule so concurrent in-flight granules never interleave, issue
+        #180), accumulating the granule's maps across groups for
+        ``finish_granule`` to persist. Each dataset gets
         its own single-dataset in-memory ``Index`` (~ms), so a spec hidefix
         rejects degrades that dataset alone.
         """
-        maps: dict[str, ChunkMap] = self._pending if self.write_back else {}
+        maps: dict[str, ChunkMap] = self._pending_for(h5obj) if self.write_back else {}
         # One single-dataset Index per path (~ms each): a dataset whose spec
         # hidefix rejects (nonzero filter_mask, non-tiling chunk table) then
         # pins only ITSELF to the fallback — a shared Index rebuilt from all

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -485,9 +485,10 @@ class InlineIndex(VirtualIndex):
             _validate_planned_config(data_source)
         if self.write_back:
             # Deterministic write-back coverage (metadata-only, ~ms): built up
-            # front so routes that bypass the read seam — the ``full_read``
-            # selectivity fallback and empty-shard early returns — still
-            # contribute this group's datasets to the granule manifest.
+            # front so routes that bypass the read seam — empty-shard early
+            # returns (and, before issue #179 routed it through read_fn, the
+            # ``full_read`` selectivity fallback) — still contribute this
+            # group's datasets to the granule manifest.
             self._prebuild_group_maps(h5obj, group, data_source)
         read_fn = self._chunk_aligned_read_fn(h5obj, planned=planned)
         if planned:

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -55,11 +55,12 @@ logger = logging.getLogger(__name__)
 def _granule_id(resource) -> str:
     """Granule id from a URL / resource path: basename minus extension.
 
-    The write-back manifest key convention (issue #160), and the key isolating
-    each in-flight granule's pending chunk maps (issue #180). Mirrors
-    ``_granule_id`` in h5coro-hidefix's ``zagg_backend``: the stem survives
-    every driver URL rewrite, so ids derived from ``h5obj.resource`` (the
-    rewritten URL) and from the worker's original ``granule_url`` agree.
+    The write-back manifest **store key** convention (issue #160). Mirrors
+    ``_granule_id`` in h5coro-hidefix's ``zagg_backend``. Deliberately NOT the
+    in-memory ``_pending`` key: two distinct granules can share a basename
+    under different prefixes, so the stem would collapse them and interleave
+    chunk maps under ``granule_workers > 1`` (issue #180 review finding) —
+    ``_pending`` keys on the full resource URL instead.
     """
     return PurePosixPath(urlsplit(str(resource)).path).stem
 
@@ -346,14 +347,14 @@ class InlineIndex(VirtualIndex):
         self.write_back = bool(write_back)
         self.store = store
         # Chunk maps accumulated across each in-flight granule's groups,
-        # keyed granule id -> {dataset path -> ChunkMap} (issue #180: the
-        # worker may hold ``data_source.granule_workers`` granules in flight,
-        # and dataset paths repeat across granules, so a flat path-keyed dict
-        # would interleave granules and persist corrupted manifests).
-        # ``finish_granule`` drains exactly its granule's entry. Each granule
-        # is read by a single worker thread, so its sub-dict is never shared;
-        # the outer dict's setdefault/pop are atomic under the GIL. Only
-        # populated when writing back.
+        # keyed full resource URL -> {dataset path -> ChunkMap} (issue #180:
+        # the worker may hold ``data_source.granule_workers`` granules in
+        # flight; dataset paths repeat across granules, and even the granule
+        # id stem can collide across prefixes — review finding — so only the
+        # full URL isolates granules). ``finish_granule`` drains exactly its
+        # granule's entry. Each granule is read by a single worker thread, so
+        # its sub-dict is never shared; the outer dict's setdefault/pop are
+        # atomic under the GIL. Only populated when writing back.
         self._pending: dict[str, dict[str, ChunkMap]] = {}
 
     @classmethod
@@ -396,12 +397,14 @@ class InlineIndex(VirtualIndex):
     def _pending_for(self, h5obj) -> dict[str, ChunkMap]:
         """This granule's pending chunk maps (write-back accumulation).
 
-        Keyed by the granule id of ``h5obj.resource`` — the rewritten URL the
-        worker opened the granule with, whose stem matches ``granule_url``'s
-        (see :func:`_granule_id`) — so concurrent in-flight granules (issue
-        #180) never share chunk-map state.
+        Keyed by the FULL ``h5obj.resource`` URL — the rewritten URL the
+        worker opened the granule with — so concurrent in-flight granules
+        (issue #180) never share chunk-map state, even when their basenames
+        collide across prefixes (review finding: the id stem would collapse
+        ``.../p1/granule.h5`` and ``.../p2/granule.h5`` into one entry and
+        serve B's reads through A's chunk maps).
         """
-        return self._pending.setdefault(_granule_id(h5obj.resource), {})
+        return self._pending.setdefault(str(h5obj.resource), {})
 
     def _prebuild_group_maps(self, h5obj, group: str, data_source: dict) -> None:
         """Build the chunk maps for every dataset this group's read can touch.
@@ -442,26 +445,25 @@ class InlineIndex(VirtualIndex):
         """Write-back seam: persist the granule's accumulated chunk maps.
 
         Drains only THIS granule's pending entry (issue #180: other granules
-        may still be in flight), keyed as the read side keyed it —
-        ``h5obj.resource``'s granule id — with ``granule_url``'s as fallback
+        may still be in flight), keyed as the read side keyed it — the full
+        ``h5obj.resource`` URL — with the full ``granule_url`` as fallback
         for resource-less callers. No-op unless ``write_back`` is on. The
-        manifest key is the granule id (URL basename without extension —
-        granule ids carry product + version, so reprocessing changes the key;
-        issue #160 store convention). Raises on store failures — the worker
-        logs and continues, so a broken store degrades to plain ``inline``
-        reads.
+        manifest STORE key stays the granule id (URL basename without
+        extension — granule ids carry product + version, so reprocessing
+        changes the key; issue #160 store convention). Raises on store
+        failures — the worker logs and continues, so a broken store degrades
+        to plain ``inline`` reads.
         """
-        granule_id = _granule_id(granule_url)
         resource = getattr(h5obj, "resource", None)
-        maps = self._pending.pop(_granule_id(resource), None) if resource is not None else None
+        maps = self._pending.pop(str(resource), None) if resource is not None else None
         if maps is None:
-            maps = self._pending.pop(granule_id, {})
+            maps = self._pending.pop(granule_url, {})
         if not self.write_back:
             return
         maps = {path: cm for path, cm in maps.items() if cm.raw}
         if not maps:
             return
-        key = write_manifest(granule_manifest(maps), self.store, granule_id)
+        key = write_manifest(granule_manifest(maps), self.store, _granule_id(granule_url))
         logger.info(f"  inline write-back: {len(maps)} dataset(s) -> {self.store}/{key}")
 
     def read_group(self, h5obj, group, data_source, shard_key, grid, arrow=False, granule_url=None):

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -421,7 +421,11 @@ def _planned_read_group(
     if plan.full_read:
         # Selectivity above threshold: many small reads would still sum to most
         # of the file. Defer to the full-coord-read path; semantics identical.
-        return _read_group_full(h5obj, group, data_source, shard_key, grid, arrow=arrow)
+        # ``read_fn`` rides along (issue #179): the fallback keeps the compiled
+        # + pooled addressing instead of dropping to serial h5coro.
+        return _read_group_full(
+            h5obj, group, data_source, shard_key, grid, arrow=arrow, read_fn=read_fn
+        )
 
     return _execute_plan_group(
         h5obj, group, data_source, shard_key, grid, plan, n_base, arrow, read_fn=read_fn
@@ -448,8 +452,10 @@ def _execute_plan_group(
     computed (:func:`_planned_read_group`'s geolocation-rate mortie mask, or the
     a-priori chunk-boundary plan of issue #148 arm 2a). ``read_fn`` overrides
     the h5coro hyperslice callback (the a-priori path substitutes one that works
-    around h5coro's chunk-aligned-start B-tree bug); ``None`` uses the plain
-    ``readDatasets`` bridge.
+    around h5coro's chunk-aligned-start B-tree bug) and also serves the
+    cross-level coarse-filter reads and segment-level broadcasts (issue #179 —
+    the whole planned read is one addressing seam); ``None`` uses the plain
+    ``readDatasets`` bridge throughout.
     """
     coordinates = data_source["coordinates"]
     variables = data_source["variables"]
@@ -536,7 +542,18 @@ def _execute_plan_group(
             cf_flag_path = f["dataset"].format(group=group)
             cf_ibeg_path = cf_link["index_beg"].format(group=group)
             cf_cnt_path = cf_link["count"].format(group=group)
-            cf_data = h5obj.readDatasets([cf_flag_path, cf_ibeg_path, cf_cnt_path])
+            # Coarse flag + link arrays through the same compiled, pooled
+            # seam as the selection reads (issue #179); ``read_fn is None``
+            # keeps the batched h5coro read byte-identical.
+            cf_paths = [cf_flag_path, cf_ibeg_path, cf_cnt_path]
+            if read_fn is None:
+                cf_data = h5obj.readDatasets(cf_paths)
+            else:
+                cf_data = _read_paths_pooled(
+                    [(p, None) for p in dict.fromkeys(cf_paths)],
+                    lambda p, dt: read_fn(p),
+                    workers,
+                )
             cf_flag = cf_data[cf_flag_path]
             cf_ibeg = cf_data[cf_ibeg_path]
             cf_cnt = cf_data[cf_cnt_path]
@@ -554,8 +571,12 @@ def _execute_plan_group(
     # Segment-level variables (issue #30): read each declared non-base-level
     # variable and broadcast it to a base-rate per-photon column (length n_base),
     # then subset to the concatenated planned indices so it lines up with the
-    # base-rate variables before the spatial / keep masks below.
-    seg_broadcasts = _read_segment_broadcasts(h5obj, group, data_source, levels, n_base)
+    # base-rate variables before the spatial / keep masks below. ``read_fn``
+    # rides along (issue #179) so the coarse variable + link reads keep the
+    # compiled addressing; ``None`` keeps the serial h5coro path.
+    seg_broadcasts = _read_segment_broadcasts(
+        h5obj, group, data_source, levels, n_base, read_fn=read_fn
+    )
     if seg_broadcasts:
         seg_global_idx = np.concatenate(
             [np.arange(s, e, dtype=np.int64) for s, e in plan.base_slices]

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -324,12 +324,13 @@ def _planned_read_group(
     filter order — which matches the full-read path's row ordering because the
     plan's runs are emitted in increasing parent index.
 
-    ``read_fn`` is the base-rate addressing seam (issue #160), forwarded to
-    :func:`_execute_plan_group`: an index backend may supply its own reader
-    (e.g. ``inline``'s boundary-safe chunk-map reads); ``None`` (default) uses
-    the plain h5coro hyperslice bridge — today's path. Selection (the plan),
-    the coarse-level reads, and everything downstream of the returned columns
-    are identical regardless.
+    ``read_fn`` is the addressing seam (issue #160): an index backend may
+    supply its own reader (e.g. ``inline``'s boundary-safe chunk-map reads).
+    It serves the coarse selection reads here (issue #179 — compiled + pooled)
+    and is forwarded to :func:`_execute_plan_group` for the base-rate data
+    reads; ``None`` (default) uses the plain h5coro bridge — the hierarchical
+    baseline. Selection semantics (the plan) and everything downstream of the
+    returned columns are identical regardless.
     """
     levels = data_source["levels"]
     base_level_key = data_source["base_level"]
@@ -349,12 +350,28 @@ def _planned_read_group(
         )
     index_base = int(link.get("index_base", 0))
 
-    # Read coarse-level coordinates + link arrays in one go (small — geolocation
-    # rate is ~30x lighter than photon rate on ATL03).
+    # Read coarse-level coordinates + link arrays (small — geolocation rate is
+    # ~30x lighter than photon rate on ATL03). With a backend-supplied
+    # ``read_fn`` these selection reads take the same compiled, pooled route as
+    # the data reads (issue #179): four independent full-dataset reads per
+    # group is exactly the fan-out the ``read_workers`` pool wants, and until
+    # now they were serial uncompiled h5coro on every backend — roughly half
+    # the read wall on dense shards. ``read_fn`` degrades per dataset inside
+    # the backend (inline) or falls the group back via ``on_miss`` (sidecar),
+    # so behavior on misses matches the data reads. ``None`` keeps the batched
+    # h5coro read byte-identical (the pinned hierarchical baseline).
     si_lat_path, si_lon_path = _level_coord_paths(si_lvl, group)
     ibeg_path = link["index_beg"].format(group=group)
     cnt_path = link["count"].format(group=group)
-    coarse_data = h5obj.readDatasets([si_lat_path, si_lon_path, ibeg_path, cnt_path])
+    selection_paths = [si_lat_path, si_lon_path, ibeg_path, cnt_path]
+    if read_fn is None:
+        coarse_data = h5obj.readDatasets(selection_paths)
+    else:
+        coarse_data = _read_paths_pooled(
+            [(p, None) for p in dict.fromkeys(selection_paths)],
+            lambda p, dt: read_fn(p),
+            _read_workers(data_source),
+        )
     coarse_lats = coarse_data[si_lat_path]
     coarse_lons = coarse_data[si_lon_path]
     ibeg_arr = coarse_data[ibeg_path]

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -18,7 +18,10 @@ the same call-time way, so patching that symbol still intercepts reads.
 import logging
 import time
 import warnings
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from itertools import islice
 from typing import Callable, List, Tuple
 
 import numpy as np
@@ -44,6 +47,21 @@ from zagg.processing.write import _build_output
 from zagg.schema import ProcessingMetadata
 
 logger = logging.getLogger(__name__)
+
+
+def _granule_workers(data_source: dict) -> int:
+    """``data_source.granule_workers``: granules in flight per shard (issue #180).
+
+    Default **1** — today's serial granule loop, byte-identical (opt-in until
+    the fleet A/B picks a default, same measure-then-flip discipline as #170's
+    ``read_workers``). Validated at submission (``validate_config``) and
+    re-checked here with the same int>=1 / bool-trap guard so hand-rolled
+    worker payloads fail loudly before any read.
+    """
+    w = data_source.get("granule_workers", 1)
+    if isinstance(w, bool) or not isinstance(w, int) or w < 1:
+        raise ValueError(f"data_source.granule_workers must be an integer >= 1 (got {w!r})")
+    return w
 
 
 def process_shard(
@@ -260,9 +278,26 @@ def process_shard(
     phase_timings: dict | None = {} if profile else None
     _read_t0 = time.time() if profile else None
 
-    # Read files and filter spatially
-    for s3_url in granule_urls:
+    # Granule fan-out width (issue #180). Resolved before any read so a bad
+    # value is a loud config error, not N per-granule warnings.
+    granule_workers = _granule_workers(data_source)
+
+    def _read_granule(s3_url: str) -> tuple:
+        """One granule end-to-end: H5Coro open → group loop → ``finish_granule``
+        → close, all in the calling thread (issue #180 — under the pool each
+        granule gets its own ``H5Coro``, never shared across threads).
+
+        Returns ``(reads, group_errors)``: ``reads`` is ``[(group, carrier),
+        ...]`` for the groups that returned data (group order) with ``None``
+        (legitimately empty) groups dropped; ``group_errors`` counts raised
+        group reads, warned here but folded into ``read_errors`` by the main
+        thread (a shared ``+= 1`` from worker threads could race). Raises when
+        the granule itself fails (e.g. the open) — the caller warns and skips
+        it, shard continues (issue #116 semantics).
+        """
         h5obj = None
+        reads: list = []
+        group_errors = 0
         try:
             resource_path = _rewrite_url(s3_url)
 
@@ -283,10 +318,7 @@ def process_shard(
                         h5obj, g, data_source, shard_key, grid, **read_kwargs
                     )
                     if chunk is not None:
-                        if buffered is not None:
-                            buffered.add_read(chunk)
-                        else:
-                            all_reads.append(chunk)
+                        reads.append((g, chunk))
                 except Exception as e:
                     # A raised read error is always a real failure: a
                     # legitimately-empty group returns ``None`` (no exception),
@@ -294,13 +326,13 @@ def process_shard(
                     # where many granules simply contribute 0 photons (issue
                     # #116). Logging it at DEBUG hid the dem_h broadcast failure
                     # behind the misleading "No data after filtering" below.
-                    read_errors += 1
+                    group_errors += 1
                     logger.warning(f"  Error reading track {g}: {e}")
                     continue
 
             # Per-granule backend hook (issue #160): side effects only (e.g.
             # ``inline`` write-back). A failure here never fails the read —
-            # the granule's data is already in ``all_reads``.
+            # the granule's data is already in ``reads``.
             try:
                 index_backend.finish_granule(h5obj, s3_url)
             except Exception as e:
@@ -310,18 +342,12 @@ def process_shard(
                 # #175) on a path that never fails the read.
                 logger.warning(f"  index backend finish_granule failed for {s3_url}: {e}")
 
-            files_processed += 1
-            if buffered is not None:
-                buffered.granule_done()
-
-        except Exception as e:
-            logger.warning(f"  Error processing file {s3_url}: {e}")
-            continue
+            return reads, group_errors
         finally:
             # Release this granule's h5coro cache before the next one (issue #66):
             # without it each granule's unevicted cache stays resident for the whole
             # loop → Lambda OOM. ``close()`` is the live path; ``cache.clear()`` is a
-            # fallback for builds lacking it. Retained ``all_reads`` data is already
+            # fallback for builds lacking it. Retained ``reads`` data is already
             # copied off the cache lines (see PR #94), so releasing here is safe.
             if h5obj is not None:
                 try:
@@ -331,6 +357,62 @@ def process_shard(
                         h5obj.cache.clear()
                 except Exception:
                     logger.debug("h5coro cache release failed", exc_info=True)
+
+    def _iter_granule_reads():
+        """Yield ``(s3_url, reads, group_errors)`` in original ``granule_urls`` order.
+
+        ``granule_workers == 1`` reads each granule in this thread — the
+        unchanged serial loop. Above 1, up to ``granule_workers`` granules are
+        in flight on a bounded ``ThreadPoolExecutor`` (issue #180) and results
+        are folded back in submission order: the consumer blocks on the oldest
+        future, so an out-of-order completion parks in its future until its
+        turn — parked results are bounded by the pool width, and the fold
+        (hence the aggregation output) is byte-identical to serial. A granule
+        whose read raised is warned and skipped here, same as the serial
+        except-continue.
+        """
+        if granule_workers == 1:
+            for s3_url in granule_urls:
+                try:
+                    yield s3_url, *_read_granule(s3_url)
+                except Exception as e:
+                    logger.warning(f"  Error processing file {s3_url}: {e}")
+        else:
+            with ThreadPoolExecutor(
+                max_workers=granule_workers, thread_name_prefix="zagg-granule"
+            ) as pool:
+                urls = iter(granule_urls)
+                in_flight = deque(
+                    (u, pool.submit(_read_granule, u)) for u in islice(urls, granule_workers)
+                )
+                while in_flight:
+                    s3_url, future = in_flight.popleft()
+                    try:
+                        reads, group_errors = future.result()
+                    except Exception as e:
+                        logger.warning(f"  Error processing file {s3_url}: {e}")
+                    else:
+                        yield s3_url, reads, group_errors
+                    for u in islice(urls, 1):  # top up: keep ≤ granule_workers in flight
+                        in_flight.append((u, pool.submit(_read_granule, u)))
+
+    # Read files and filter spatially, folding granules in original order.
+    for s3_url, reads, group_errors in _iter_granule_reads():
+        read_errors += group_errors
+        try:
+            for _g, chunk in reads:
+                if buffered is not None:
+                    buffered.add_read(chunk)
+                else:
+                    all_reads.append(chunk)
+            files_processed += 1
+            if buffered is not None:
+                buffered.granule_done()
+        except Exception as e:
+            # Fold-side failure (e.g. a streaming flush): same tolerated
+            # warn-and-continue the serial loop's outer ``except`` applied.
+            logger.warning(f"  Error processing file {s3_url}: {e}")
+            continue
 
     logger.info(f"  Processed {files_processed}/{len(granule_urls)} files")
     metadata["files_processed"] = files_processed

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -71,32 +71,6 @@ def _granule_workers(data_source: dict) -> int:
     return w
 
 
-def _reject_racy_sidecar_build(index_backend) -> None:
-    """Reject ``sidecar`` + ``on_miss: build`` under ``granule_workers > 1``.
-
-    The installed h5coro-hidefix (<= 0.3.0) lazy-initializes the sidecar's
-    inline write-back delegate with an unguarded check-then-act
-    (``if self._inline is None: self._inline = InlineIndex(...)`` in
-    ``zagg_backend._miss``): two granule threads hitting concurrent misses
-    can each construct a delegate, stranding the loser's already-accumulated
-    pending maps on an orphaned instance — a silently sparse manifest (issue
-    #180 review finding). zagg cannot patch the upstream lazy init, so the
-    combination is rejected here (and at submission in ``validate_config``)
-    until an h5coro-hidefix release constructs the delegate eagerly. Duck-
-    typed on the backend's ``name``/``on_miss`` so zagg core never imports
-    the external backend.
-    """
-    if getattr(index_backend, "name", "") == "sidecar":
-        if getattr(index_backend, "on_miss", None) == "build":
-            raise ValueError(
-                "data_source.granule_workers > 1 is not supported with index backend "
-                "'sidecar' + on_miss: 'build': the installed h5coro-hidefix lazily "
-                "initializes its write-back delegate without a guard, so concurrent "
-                "granules can strand pending chunk maps on an orphaned delegate "
-                "(sparse manifests). Use on_miss: fallback/error, or granule_workers: 1."
-            )
-
-
 def process_shard(
     grid,
     shard_key: int,
@@ -312,11 +286,11 @@ def process_shard(
     _read_t0 = time.time() if profile else None
 
     # Granule fan-out width (issue #180). Resolved before any read so a bad
-    # value is a loud config error, not N per-granule warnings; the one known
-    # thread-unsafe backend combination is rejected the same way.
+    # value is a loud config error, not N per-granule warnings. (Backend
+    # thread-safety under the pool is a dependency contract, not a runtime
+    # check: sidecar's on_miss: build delegate needs h5coro-hidefix >= 0.3.1
+    # — its lazy-init race was fixed upstream — enforced by the pyproject pin.)
     granule_workers = _granule_workers(data_source)
-    if granule_workers > 1:
-        _reject_racy_sidecar_build(index_backend)
 
     def _read_granule(s3_url: str) -> tuple:
         """One granule end-to-end: H5Coro open → group loop → ``finish_granule``

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -57,11 +57,44 @@ def _granule_workers(data_source: dict) -> int:
     ``read_workers``). Validated at submission (``validate_config``) and
     re-checked here with the same int>=1 / bool-trap guard so hand-rolled
     worker payloads fail loudly before any read.
+
+    Sizing note (review finding, PR #183): this pool composes multiplicatively
+    with ``read_workers`` (and under ``sidecar`` its chunk-fetch pool too), so
+    worst-case in-flight GETs is granule_workers x read_workers x fetch width
+    against h5coro S3Driver's 100-connection budget — dial ``read_workers``
+    down as K rises, and watch ``read_errors`` (queueing + the 5 s timeout can
+    surface as spurious read failures, not slowdowns) in the K-sweep A/B.
     """
     w = data_source.get("granule_workers", 1)
     if isinstance(w, bool) or not isinstance(w, int) or w < 1:
         raise ValueError(f"data_source.granule_workers must be an integer >= 1 (got {w!r})")
     return w
+
+
+def _reject_racy_sidecar_build(index_backend) -> None:
+    """Reject ``sidecar`` + ``on_miss: build`` under ``granule_workers > 1``.
+
+    The installed h5coro-hidefix (<= 0.3.0) lazy-initializes the sidecar's
+    inline write-back delegate with an unguarded check-then-act
+    (``if self._inline is None: self._inline = InlineIndex(...)`` in
+    ``zagg_backend._miss``): two granule threads hitting concurrent misses
+    can each construct a delegate, stranding the loser's already-accumulated
+    pending maps on an orphaned instance — a silently sparse manifest (issue
+    #180 review finding). zagg cannot patch the upstream lazy init, so the
+    combination is rejected here (and at submission in ``validate_config``)
+    until an h5coro-hidefix release constructs the delegate eagerly. Duck-
+    typed on the backend's ``name``/``on_miss`` so zagg core never imports
+    the external backend.
+    """
+    if getattr(index_backend, "name", "") == "sidecar":
+        if getattr(index_backend, "on_miss", None) == "build":
+            raise ValueError(
+                "data_source.granule_workers > 1 is not supported with index backend "
+                "'sidecar' + on_miss: 'build': the installed h5coro-hidefix lazily "
+                "initializes its write-back delegate without a guard, so concurrent "
+                "granules can strand pending chunk maps on an orphaned delegate "
+                "(sparse manifests). Use on_miss: fallback/error, or granule_workers: 1."
+            )
 
 
 def process_shard(
@@ -279,21 +312,24 @@ def process_shard(
     _read_t0 = time.time() if profile else None
 
     # Granule fan-out width (issue #180). Resolved before any read so a bad
-    # value is a loud config error, not N per-granule warnings.
+    # value is a loud config error, not N per-granule warnings; the one known
+    # thread-unsafe backend combination is rejected the same way.
     granule_workers = _granule_workers(data_source)
+    if granule_workers > 1:
+        _reject_racy_sidecar_build(index_backend)
 
     def _read_granule(s3_url: str) -> tuple:
         """One granule end-to-end: H5Coro open → group loop → ``finish_granule``
         → close, all in the calling thread (issue #180 — under the pool each
         granule gets its own ``H5Coro``, never shared across threads).
 
-        Returns ``(reads, group_errors)``: ``reads`` is ``[(group, carrier),
-        ...]`` for the groups that returned data (group order) with ``None``
-        (legitimately empty) groups dropped; ``group_errors`` counts raised
-        group reads, warned here but folded into ``read_errors`` by the main
-        thread (a shared ``+= 1`` from worker threads could race). Raises when
-        the granule itself fails (e.g. the open) — the caller warns and skips
-        it, shard continues (issue #116 semantics).
+        Returns ``(reads, group_errors)``: ``reads`` is the carriers of the
+        groups that returned data (group order, ``None`` — legitimately empty
+        — groups dropped); ``group_errors`` counts raised group reads, warned
+        here but folded into ``read_errors`` by the main thread (a shared
+        ``+= 1`` from worker threads could race). Raises when the granule
+        itself fails (e.g. the open) — the caller warns and skips it, shard
+        continues (issue #116 semantics).
         """
         h5obj = None
         reads: list = []
@@ -318,7 +354,7 @@ def process_shard(
                         h5obj, g, data_source, shard_key, grid, **read_kwargs
                     )
                     if chunk is not None:
-                        reads.append((g, chunk))
+                        reads.append(chunk)
                 except Exception as e:
                     # A raised read error is always a real failure: a
                     # legitimately-empty group returns ``None`` (no exception),
@@ -391,16 +427,22 @@ def process_shard(
                         reads, group_errors = future.result()
                     except Exception as e:
                         logger.warning(f"  Error processing file {s3_url}: {e}")
-                    else:
-                        yield s3_url, reads, group_errors
-                    for u in islice(urls, 1):  # top up: keep ≤ granule_workers in flight
+                        reads = None
+                    # Top up BEFORE yielding (review): the head is done either
+                    # way, so submitting its replacement here keeps the full
+                    # granule_workers in flight while the main thread folds
+                    # (including streaming granule_done flushes) — the ≤ K
+                    # bound and the fold order are unchanged.
+                    for u in islice(urls, 1):
                         in_flight.append((u, pool.submit(_read_granule, u)))
+                    if reads is not None:
+                        yield s3_url, reads, group_errors
 
     # Read files and filter spatially, folding granules in original order.
     for s3_url, reads, group_errors in _iter_granule_reads():
         read_errors += group_errors
         try:
-            for _g, chunk in reads:
+            for chunk in reads:
                 if buffered is not None:
                     buffered.add_read(chunk)
                 else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1251,23 +1251,14 @@ class TestGranuleWorkersValidation:
             with pytest.raises(ValueError, match=r"data_source\.granule_workers"):
                 validate_config(self._cfg(granule_workers=bad))
 
-    def test_sidecar_build_combo_rejected(self, tmp_path):
-        # granule_workers > 1 with sidecar + on_miss: build is rejected at
-        # submission: the installed h5coro-hidefix lazily initializes its
-        # write-back delegate without a guard (issue #180 review finding).
-        index = {"backend": "sidecar", "store": str(tmp_path), "on_miss": "build"}
-        with pytest.raises(ValueError, match="on_miss: 'build'"):
+    def test_sidecar_combos_pool_freely(self, tmp_path):
+        # Every sidecar on_miss policy pools: the on_miss: build delegate
+        # lazy-init race was fixed in h5coro-hidefix 0.3.1 (issue #180 review
+        # finding 2), enforced by the pyproject pin — no config-level clamp.
+        for on_miss in ("build", "fallback", "error"):
+            index = {"backend": "sidecar", "store": str(tmp_path), "on_miss": on_miss}
             validate_config(self._cfg(granule_workers=2, index=index))
-        # Serial (or defaulted) granule_workers keeps the combo valid...
-        validate_config(self._cfg(granule_workers=1, index=index))
-        validate_config(self._cfg(index=index))
-        # ...and other on_miss policies pool fine (per-granule-keyed _cache).
-        validate_config(
-            self._cfg(
-                granule_workers=2,
-                index={"backend": "sidecar", "store": str(tmp_path), "on_miss": "fallback"},
-            )
-        )
+            validate_config(self._cfg(index=index))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1251,6 +1251,24 @@ class TestGranuleWorkersValidation:
             with pytest.raises(ValueError, match=r"data_source\.granule_workers"):
                 validate_config(self._cfg(granule_workers=bad))
 
+    def test_sidecar_build_combo_rejected(self, tmp_path):
+        # granule_workers > 1 with sidecar + on_miss: build is rejected at
+        # submission: the installed h5coro-hidefix lazily initializes its
+        # write-back delegate without a guard (issue #180 review finding).
+        index = {"backend": "sidecar", "store": str(tmp_path), "on_miss": "build"}
+        with pytest.raises(ValueError, match="on_miss: 'build'"):
+            validate_config(self._cfg(granule_workers=2, index=index))
+        # Serial (or defaulted) granule_workers keeps the combo valid...
+        validate_config(self._cfg(granule_workers=1, index=index))
+        validate_config(self._cfg(index=index))
+        # ...and other on_miss policies pool fine (per-granule-keyed _cache).
+        validate_config(
+            self._cfg(
+                granule_workers=2,
+                index={"backend": "sidecar", "store": str(tmp_path), "on_miss": "fallback"},
+            )
+        )
+
 
 # ---------------------------------------------------------------------------
 # Output grid validation

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1230,6 +1230,28 @@ class TestHandoff:
         assert get_handoff(cfg) == "pandas"
 
 
+class TestGranuleWorkersValidation:
+    """``data_source.granule_workers`` (issue #180) is validated at submission,
+    mirroring the worker's ``_granule_workers`` guard (same int>=1/bool-trap
+    pattern as ``read_workers``)."""
+
+    def _cfg(self, **ds_extra):
+        cfg = _cfg_with_handoff()
+        cfg.data_source.update(ds_extra)
+        return cfg
+
+    def test_absent_validates(self):
+        validate_config(self._cfg())  # should not raise
+
+    def test_valid_value_validates(self):
+        validate_config(self._cfg(granule_workers=4))  # should not raise
+
+    def test_bad_values_rejected_at_submission(self):
+        for bad in (0, -1, 1.5, "2", True, False):
+            with pytest.raises(ValueError, match=r"data_source\.granule_workers"):
+                validate_config(self._cfg(granule_workers=bad))
+
+
 # ---------------------------------------------------------------------------
 # Output grid validation
 # ---------------------------------------------------------------------------

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1155,8 +1155,8 @@ class TestInlineWriteBackWorker:
 
     def test_finish_granule_drains_pending_when_off(self):
         backend = InlineIndex()
-        backend._pending["g"] = {"/x": object()}
-        # A resource-less h5obj falls back to the granule_url's id (issue #180).
+        backend._pending["s3://b/g.h5"] = {"/x": object()}
+        # A resource-less h5obj falls back to the full granule_url key (#180).
         backend.finish_granule(object(), "s3://b/g.h5")
         assert backend._pending == {}
 
@@ -1264,12 +1264,51 @@ class TestInlineInterleavedGranules:
         ha, hb = self._open(a), self._open(b)
         self._read_all_groups(backend, ha)
         self._read_all_groups(backend, hb)
-        assert set(backend._pending) == {"granA", "granB"}
+        # In-memory keys are the FULL resource URLs (review finding: stems can
+        # collide across prefixes); the store keys stay the id stems.
+        assert set(backend._pending) == {str(a), str(b)}
         backend.finish_granule(ha, str(a))
         # A drained + persisted; B's pending maps untouched, nothing written.
-        assert set(backend._pending) == {"granB"}
+        assert set(backend._pending) == {str(b)}
         assert (store / "granA.parquet").is_file()
         assert not (store / "granB.parquet").exists()
         backend.finish_granule(hb, str(b))
         assert backend._pending == {}
         assert (store / "granB.parquet").is_file()
+
+    def test_same_basename_granules_do_not_collide(self, tmp_path, caplog):
+        # Review finding (issue #180): two DISTINCT granules whose URLs share
+        # a basename (.../p1/granule.h5 vs .../p2/granule.h5) must not collapse
+        # to one pending entry — under the stem-keyed dict, B's reads were
+        # served through A's chunk maps and the first finish_granule drained
+        # both into one merged manifest (the second wrote nothing).
+        import logging
+        import shutil
+
+        d1, d2 = tmp_path / "p1", tmp_path / "p2"
+        d1.mkdir()
+        d2.mkdir()
+        a, b = d1 / "granule.h5", d2 / "granule.h5"
+        shutil.copyfile(FIXTURE_H5, a)
+        shutil.copyfile(FIXTURE_H5, b)
+        store = tmp_path / "store"
+        backend = InlineIndex(write_back=True, store=str(store))
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        ha, hb = self._open(a), self._open(b)
+        for g in ds["groups"]:  # interleave, as granule_workers=2 would
+            backend.read_group(ha, g, ds, 1, grid)
+            backend.read_group(hb, g, ds, 1, grid)
+        # Full-URL keys: two isolated entries, not one merged "granule".
+        assert set(backend._pending) == {str(a), str(b)}
+        with caplog.at_level(logging.INFO, logger="zagg.index.inline"):
+            backend.finish_granule(ha, str(a))
+            assert set(backend._pending) == {str(b)}  # B survives A's drain
+            backend.finish_granule(hb, str(b))
+        assert backend._pending == {}
+        # BOTH granules persisted their manifests (the store key is the shared
+        # stem, so the second write idempotently overwrites the first — the
+        # issue #160 last-writer-wins store convention).
+        writes = [r for r in caplog.records if "inline write-back" in r.message]
+        assert len(writes) == 2
+        assert (store / "granule.parquet").is_file()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -811,6 +811,97 @@ class TestInlineReadGroup:
             validate_index_config({"backend": "inline"}, ds)
 
 
+class TestSelectionReads:
+    """Issue #179 (folded into #180): the planned route's selection reads —
+    segment-rate geolocation coordinates + link arrays — go through the same
+    compiled, pooled ``read_fn`` seam as the data reads when an index backend
+    supplies one, and stay serial batched h5coro when it doesn't."""
+
+    SELECTION_PATHS = [
+        "/gt1l/geolocation/reference_photon_lat",
+        "/gt1l/geolocation/reference_photon_lon",
+        "/gt1l/geolocation/ph_index_beg",
+        "/gt1l/geolocation/segment_ph_cnt",
+    ]
+
+    @staticmethod
+    def _record_read_datasets(h5obj):
+        """Shadow ``h5obj.readDatasets`` with a delegating recorder."""
+        calls = []
+        orig = h5obj.readDatasets
+
+        def recorder(datasets, **kwargs):
+            calls.append(datasets)
+            return orig(datasets, **kwargs)
+
+        h5obj.readDatasets = recorder
+        return calls
+
+    def test_inline_selection_reads_bypass_readdatasets(self):
+        # With the inline backend every dataset of a planned group read —
+        # selection AND data — is served by the compiled route; the uncompiled
+        # ``readDatasets`` API is never touched, and rows stay identical to
+        # the hierarchical baseline.
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        h5obj = _open_fixture()
+        calls = self._record_read_datasets(h5obj)
+        df_i = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
+        assert calls == []
+        df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        pd.testing.assert_frame_equal(df_i, df_h)
+
+    def test_inline_selection_reads_pooled_row_identical(self):
+        # The pooled selection reads (read_workers > 1 fans the 4 datasets
+        # across threads) key results by path, so completion order cannot
+        # perturb the plan or the output.
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        df_serial = InlineIndex().read_group(
+            _open_fixture(), "gt1l", _fixture_data_source(read_workers=1), 1, grid
+        )
+        df_pooled = InlineIndex().read_group(
+            _open_fixture(), "gt1l", _fixture_data_source(read_workers=8), 1, grid
+        )
+        pd.testing.assert_frame_equal(df_serial, df_pooled)
+
+    def test_hierarchical_selection_reads_unchanged(self):
+        # No backend read_fn (the pinned uncached baseline): the selection
+        # reads keep the single batched ``readDatasets`` call, byte-for-byte.
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        h5obj = _open_fixture()
+        calls = self._record_read_datasets(h5obj)
+        df = HierarchicalIndex().read_group(h5obj, "gt1l", ds, 1, grid)
+        assert df is not None
+        assert self.SELECTION_PATHS in calls  # the one batched selection read
+
+    def test_selection_dataset_degrades_alone(self, monkeypatch, caplog):
+        # A selection dataset the compiled reader rejects degrades to the
+        # h5coro decoder per dataset — same seam as the data reads (PR #173
+        # convention) — and rows stay identical to hierarchical.
+        import logging
+
+        import h5coro_hidefix.manifest as hh_manifest
+
+        orig = hh_manifest.datasets_from_manifest
+        bad = "/gt1l/geolocation/reference_photon_lat"
+
+        def picky(columns):
+            if bad in set(columns["dataset"]):
+                raise ValueError("unsupported chunk table")
+            return orig(columns)
+
+        monkeypatch.setattr(hh_manifest, "datasets_from_manifest", picky)
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        with caplog.at_level(logging.WARNING, logger="zagg.index.inline"):
+            df_i = InlineIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        pd.testing.assert_frame_equal(df_i, df_h)
+        warned = [r.message for r in caplog.records if "compiled decode unavailable" in r.message]
+        assert len(warned) == 1 and bad in warned[0]
+
+
 class TestInlineWorker:
     def _cfg(self, index=None):
         ds = _fixture_data_source(**({"index": index} if index else {}))

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1121,6 +1121,51 @@ class TestInlineInterleavedGranules:
             assert (inter_store / name).is_file()
             assert (inter_store / name).read_bytes() == (serial_store / name).read_bytes()
 
+    def test_worker_pool_write_back_manifests_match_serial(self, tmp_path):
+        # End-to-end (issue #180 phases 1+2): process_shard with
+        # granule_workers=2 over two write-back granules produces the same
+        # aggregation output and byte-identical manifests as the serial run.
+        from h5coro import filedriver
+
+        a, b = self._granules(tmp_path)
+
+        def run(store, workers):
+            extra = {"granule_workers": workers} if workers > 1 else {}
+            return process_shard(
+                _LeafCellGrid(_UNALIGNED_LEAVES),
+                1,
+                [str(a), str(b)],
+                s3_credentials={},
+                h5coro_driver=filedriver.FileDriver,
+                config=PipelineConfig(
+                    data_source=_fixture_data_source(
+                        index={"backend": "inline", "write_back": True, "store": str(store)},
+                        **extra,
+                    ),
+                    aggregation={
+                        "variables": {
+                            "count": {
+                                "function": "len",
+                                "source": "h_ph",
+                                "dtype": "int32",
+                                "fill_value": 0,
+                            }
+                        }
+                    },
+                    output={"store": "unused"},
+                ),
+            )
+
+        serial_store, pooled_store = tmp_path / "serial", tmp_path / "pooled"
+        df_serial, meta_serial = run(serial_store, 1)
+        df_pooled, meta_pooled = run(pooled_store, 2)
+        assert meta_serial["error"] is None and meta_pooled["error"] is None
+        assert meta_pooled["files_processed"] == 2
+        assert meta_pooled["total_obs"] == meta_serial["total_obs"]
+        pd.testing.assert_frame_equal(df_serial, df_pooled)
+        for name in ("granA.parquet", "granB.parquet"):
+            assert (pooled_store / name).read_bytes() == (serial_store / name).read_bytes()
+
     def test_finish_granule_drains_only_its_granule(self, tmp_path):
         a, b = self._granules(tmp_path)
         store = tmp_path / "store"

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -875,6 +875,68 @@ class TestSelectionReads:
         assert df is not None
         assert self.SELECTION_PATHS in calls  # the one batched selection read
 
+    def test_segment_variable_reads_bypass_readdatasets(self):
+        # issue #179 fold: the segment-level variable + link reads
+        # (_read_segment_broadcasts) ride the same read_fn seam on the
+        # planned route — fully compiled under inline, rows identical to
+        # hierarchical.
+        ds = _fixture_data_source()
+        ds["levels"]["segments"]["variables"] = {
+            "seg_lat": "/{group}/geolocation/reference_photon_lat"
+        }
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        h5obj = _open_fixture()
+        calls = self._record_read_datasets(h5obj)
+        df_i = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
+        assert calls == []
+        assert "seg_lat" in df_i.columns
+        df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        pd.testing.assert_frame_equal(df_i, df_h)
+
+    def test_cross_level_filter_reads_bypass_readdatasets(self):
+        # issue #179 fold: cross-level (Phase B) coarse flag + link reads take
+        # the compiled, pooled seam too. The ne -1 predicate keeps every
+        # segment, so rows stay identical to hierarchical.
+        ds = _fixture_data_source()
+        ds["filters"] = ds["filters"] + [
+            {
+                "dataset": "/{group}/geolocation/segment_ph_cnt",
+                "op": "ne",
+                "value": -1,
+                "level": "segments",
+            }
+        ]
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        h5obj = _open_fixture()
+        calls = self._record_read_datasets(h5obj)
+        df_i = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
+        assert calls == []
+        df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        pd.testing.assert_frame_equal(df_i, df_h)
+
+    def test_full_read_fallback_keeps_compiled_route(self):
+        # issue #179 fold: plan.full_read (selectivity above threshold — 0.0
+        # forces it) defers to _read_group_full WITH the backend's read_fn,
+        # so the fallback stays compiled instead of dropping to serial h5coro.
+        # Baseline: the planned route at the default threshold — full-read and
+        # planned output is row-identical (#43 Phase C parity), and the
+        # hierarchical FULL-read route can't serve this shard at all (its mask
+        # starts on a chunk boundary, photon 512 — the PR #152 h5coro
+        # start-edge bug the compiled route is immune to).
+        ds = _fixture_data_source(
+            read_plan={"spatial_index": "segments", "pad": 1, "full_read_threshold": 0.0}
+        )
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        h5obj = _open_fixture()
+        calls = self._record_read_datasets(h5obj)
+        df_i = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
+        assert calls == []
+        assert df_i is not None and len(df_i) > 0
+        df_h = HierarchicalIndex().read_group(
+            _open_fixture(), "gt1l", _fixture_data_source(), 1, grid
+        )
+        pd.testing.assert_frame_equal(df_i, df_h)
+
     def test_selection_dataset_degrades_alone(self, monkeypatch, caplog):
         # A selection dataset the compiled reader rejects degrades to the
         # h5coro decoder per dataset — same seam as the data reads (PR #173

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1064,6 +1064,76 @@ class TestInlineWriteBackWorker:
 
     def test_finish_granule_drains_pending_when_off(self):
         backend = InlineIndex()
-        backend._pending["/x"] = object()
+        backend._pending["g"] = {"/x": object()}
+        # A resource-less h5obj falls back to the granule_url's id (issue #180).
         backend.finish_granule(object(), "s3://b/g.h5")
         assert backend._pending == {}
+
+
+class TestInlineInterleavedGranules:
+    """Issue #180 phase 1: with granule-level read concurrency the worker may
+    interleave two granules' ``read_group`` calls on one backend instance.
+    ``_pending`` is keyed per granule (not per dataset path — paths repeat
+    across granules), so interleaved write-back reads persist manifests
+    byte-identical to serial ones instead of corrupting them."""
+
+    def _granules(self, tmp_path):
+        import shutil
+
+        a, b = tmp_path / "granA.h5", tmp_path / "granB.h5"
+        shutil.copyfile(FIXTURE_H5, a)
+        shutil.copyfile(FIXTURE_H5, b)
+        return a, b
+
+    def _open(self, path):
+        from h5coro import filedriver
+        from h5coro import h5coro as h5c
+
+        return h5c.H5Coro(str(path), filedriver.FileDriver, errorChecking=True, verbose=False)
+
+    def _read_all_groups(self, backend, h5obj):
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        for g in ds["groups"]:
+            backend.read_group(h5obj, g, ds, 1, grid)
+
+    def test_interleaved_manifests_byte_identical_to_serial(self, tmp_path):
+        a, b = self._granules(tmp_path)
+        serial_store, inter_store = tmp_path / "serial", tmp_path / "interleaved"
+
+        serial = InlineIndex(write_back=True, store=str(serial_store))
+        for path in (a, b):
+            h5obj = self._open(path)
+            self._read_all_groups(serial, h5obj)
+            serial.finish_granule(h5obj, str(path))
+
+        inter = InlineIndex(write_back=True, store=str(inter_store))
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        ha, hb = self._open(a), self._open(b)
+        for g in ds["groups"]:  # A.gt1l, B.gt1l, A.gt2l, B.gt2l
+            inter.read_group(ha, g, ds, 1, grid)
+            inter.read_group(hb, g, ds, 1, grid)
+        inter.finish_granule(ha, str(a))
+        inter.finish_granule(hb, str(b))
+
+        for name in ("granA.parquet", "granB.parquet"):
+            assert (inter_store / name).is_file()
+            assert (inter_store / name).read_bytes() == (serial_store / name).read_bytes()
+
+    def test_finish_granule_drains_only_its_granule(self, tmp_path):
+        a, b = self._granules(tmp_path)
+        store = tmp_path / "store"
+        backend = InlineIndex(write_back=True, store=str(store))
+        ha, hb = self._open(a), self._open(b)
+        self._read_all_groups(backend, ha)
+        self._read_all_groups(backend, hb)
+        assert set(backend._pending) == {"granA", "granB"}
+        backend.finish_granule(ha, str(a))
+        # A drained + persisted; B's pending maps untouched, nothing written.
+        assert set(backend._pending) == {"granB"}
+        assert (store / "granA.parquet").is_file()
+        assert not (store / "granB.parquet").exists()
+        backend.finish_granule(hb, str(b))
+        assert backend._pending == {}
+        assert (store / "granB.parquet").is_file()

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -222,6 +222,39 @@ class TestProcessEventDispatch:
         assert isinstance(body["max_memory_mb"], float)
         assert body["max_memory_mb"] > 0.0
 
+    def test_body_reports_cpu_seconds(self, handler_mod, monkeypatch):
+        """Issue #180 phase 3: every invocation stamps ``cpu_seconds`` (this
+        invocation's user+sys CPU across all threads) next to
+        ``max_memory_mb`` so the orchestrator can compute utilization =
+        cpu_seconds / duration_s per worker without CloudWatch access."""
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        resp, _ = self._run(handler_mod, monkeypatch, event)
+        body = json.loads(resp["body"])
+        assert isinstance(body["cpu_seconds"], float)
+        assert body["cpu_seconds"] >= 0.0
+
+    def test_cpu_seconds_is_per_invocation_delta(self, handler_mod, monkeypatch):
+        """``os.times()`` is process-cumulative (a warm container keeps
+        accruing), so the stamped value must be the entry->stamp delta of
+        user+sys, never the raw counter."""
+        import os as _os
+
+        calls = {"n": 0}
+
+        def fake_times():
+            calls["n"] += 1
+            if calls["n"] == 1:  # the handler-entry snapshot
+                return _os.times_result((10.0, 5.0, 0.0, 0.0, 100.0))
+            return _os.times_result((12.5, 5.5, 0.0, 0.0, 103.0))
+
+        monkeypatch.setattr(handler_mod.os, "times", fake_times)
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        resp, _ = self._run(handler_mod, monkeypatch, event)
+        body = json.loads(resp["body"])
+        assert body["cpu_seconds"] == pytest.approx(3.0)
+
 
 class TestReclaimMemory:
     """Issue #139: each invocation hands freed heap back to the OS at teardown so

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5411,3 +5411,247 @@ class TestProcessShardCacheRelease:
         # rather than the misleading "No data after filtering".
         assert meta["error"] == "No data after filtering (1 group reads raised)"
         assert meta["read_errors"] == 1
+
+
+class TestGranuleReadPool:
+    """Issue #180: ``data_source.granule_workers`` keeps K granules in flight
+    on a bounded thread pool, folding results in original granule order so the
+    output is byte-identical to the serial loop (the default, K == 1)."""
+
+    def _patch_h5(self, monkeypatch, factory):
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", factory)
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+
+    @staticmethod
+    def _granule_arrays(tag: float, n: int = 2):
+        """Per-granule distinct arrays (h_li carries the granule tag)."""
+        return {
+            "/gt1l/lat": np.array([10.0 + i for i in range(n)]),
+            "/gt1l/lon": np.array([20.0 + i for i in range(n)]),
+            "/gt1l/h_li": np.full(n, tag, dtype=np.float32),
+        }
+
+    def _tagged_factory(self, log=None, slow_urls=(), delay=0.15):
+        """H5Coro stub factory: arrays keyed by URL tag; optional per-URL delay
+        (forcing out-of-order completions) and close/thread logging."""
+        import threading
+        import time as _time
+
+        tags = {}
+
+        class _H5(_CloseRecordingH5):
+            def __init__(self, url):
+                tag = tags.setdefault(url, float(len(tags) + 1))
+                super().__init__(
+                    TestGranuleReadPool._granule_arrays(tag),
+                    log if log is not None else [],
+                )
+                self._url = url
+                self.ctor_thread = threading.get_ident()
+
+            def readDatasets(self, datasets):  # noqa: N802 (mirror real h5coro API)
+                if self._url in slow_urls:
+                    _time.sleep(delay)
+                return super().readDatasets(datasets)
+
+            def close(self):
+                self.close_thread = threading.get_ident()
+                super().close()
+
+        instances = []
+
+        def factory(resource_path, *a, **k):
+            h5 = _H5(resource_path)
+            instances.append(h5)
+            return h5
+
+        return factory, instances
+
+    def test_granule_workers_validation(self):
+        from zagg.processing.worker import _granule_workers
+
+        for bad in (0, -1, 1.5, "2", True, False):
+            with pytest.raises(ValueError, match="granule_workers"):
+                _granule_workers({"granule_workers": bad})
+        assert _granule_workers({}) == 1  # default: serial, today's behavior
+        assert _granule_workers({"granule_workers": 3}) == 3
+
+    def test_bad_granule_workers_fails_before_any_read(self, monkeypatch):
+        # Mirror the worker-side read_workers re-check: a hand-rolled payload
+        # with a bad value is a loud config error, not N per-granule warnings.
+        def exploding_factory(*a, **k):
+            raise AssertionError("no granule should be opened")
+
+        self._patch_h5(monkeypatch, exploding_factory)
+        cfg = _release_cfg()
+        cfg.data_source["granule_workers"] = 0
+        with pytest.raises(ValueError, match="granule_workers"):
+            process_shard(_ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=cfg)
+
+    def test_default_serial_never_touches_the_pool(self, monkeypatch):
+        # granule_workers absent -> the serial loop; the pool must not even be
+        # constructed, so the default path carries zero threading machinery.
+        import zagg.processing.worker as worker_mod
+
+        def exploding_pool(*a, **k):
+            raise AssertionError("ThreadPoolExecutor constructed on the serial path")
+
+        monkeypatch.setattr(worker_mod, "ThreadPoolExecutor", exploding_pool)
+        factory, _ = self._tagged_factory()
+        self._patch_h5(monkeypatch, factory)
+        df_out, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=_release_cfg()
+        )
+        assert meta["files_processed"] == 2
+
+    def test_pooled_output_identical_to_serial(self, monkeypatch):
+        # Distinct per-granule data; the slowest granule is submitted FIRST so
+        # completions arrive out of order — the ordered fold must still produce
+        # byte-identical output vs the serial run.
+        results = {}
+        for workers in (1, 3):
+            factory, _ = self._tagged_factory(slow_urls=("s3://a",))
+            self._patch_h5(monkeypatch, factory)
+            cfg = _release_cfg()
+            if workers > 1:
+                cfg.data_source["granule_workers"] = workers
+            results[workers] = process_shard(
+                _ReleaseGrid(),
+                0,
+                ["s3://a", "s3://b", "s3://c"],
+                s3_credentials={},
+                config=cfg,
+            )
+        df_serial, meta_serial = results[1]
+        df_pooled, meta_pooled = results[3]
+        pd.testing.assert_frame_equal(df_serial, df_pooled)
+        for key in ("files_processed", "total_obs", "cells_with_data", "error"):
+            assert meta_serial[key] == meta_pooled[key]
+
+    def test_fold_order_is_submission_order(self, monkeypatch):
+        # Granule a sleeps so b and c complete first; the reads must still fold
+        # a, b, c (out-of-order completions park until their turn).
+        import zagg.processing.worker as worker_mod
+
+        factory, _ = self._tagged_factory(slow_urls=("s3://a",))
+        self._patch_h5(monkeypatch, factory)
+        real = worker_mod._concat_and_group
+        captured = {}
+
+        def spy(reads, grid, handoff):
+            captured["order"] = [float(df["h_li"].iloc[0]) for df in reads]
+            return real(reads, grid, handoff)
+
+        monkeypatch.setattr(worker_mod, "_concat_and_group", spy)
+        cfg = _release_cfg()
+        cfg.data_source["granule_workers"] = 3
+        process_shard(
+            _ReleaseGrid(), 0, ["s3://a", "s3://b", "s3://c"], s3_credentials={}, config=cfg
+        )
+        assert captured["order"] == [1.0, 2.0, 3.0]  # tag i == submission position
+
+    def test_one_h5coro_per_granule_created_and_closed_in_its_thread(self, monkeypatch):
+        # Each granule gets its own H5Coro, opened and closed inside the same
+        # worker thread (never shared across threads), off the main thread.
+        import threading
+
+        log: list = []
+        factory, instances = self._tagged_factory(log=log)
+        self._patch_h5(monkeypatch, factory)
+        cfg = _release_cfg()
+        cfg.data_source["granule_workers"] = 2
+        df_out, meta = process_shard(
+            _ReleaseGrid(),
+            0,
+            ["s3://a", "s3://b", "s3://c", "s3://d"],
+            s3_credentials={},
+            config=cfg,
+        )
+        assert meta["files_processed"] == 4
+        assert len(instances) == 4
+        assert len([e for e in log if e[0] == "close"]) == 4  # one release per granule
+        main = threading.get_ident()
+        for h5 in instances:
+            assert h5.ctor_thread == h5.close_thread  # created + closed in one thread
+            assert h5.ctor_thread != main  # ... a pool thread, not the fold thread
+
+    def test_pooled_granule_failure_skips_and_continues(self, monkeypatch):
+        # A failed granule (constructor raise) under the pool matches the serial
+        # semantics: warn + skip, remaining granules still process and release.
+        log: list = []
+        calls = {"n": 0}
+
+        def factory(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("h5coro open failed")
+            return _CloseRecordingH5(_canned_arrays(), log)
+
+        self._patch_h5(monkeypatch, factory)
+        cfg = _release_cfg()
+        cfg.data_source["granule_workers"] = 2
+        df_out, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://a", "s3://b", "s3://c"], s3_credentials={}, config=cfg
+        )
+        assert len([e for e in log if e[0] == "close"]) == 2
+        assert meta["files_processed"] == 2
+        assert meta["total_obs"] == 4  # 2 photons x 2 surviving granules
+
+    def test_pooled_group_read_error_counted_not_fatal(self, monkeypatch):
+        # A raised group read inside a pooled granule increments read_errors and
+        # the shard continues — exactly the serial issue #116 semantics.
+        class _RaisingReadH5:
+            def readDatasets(self, datasets):  # noqa: N802 (mirror real h5coro API)
+                raise RuntimeError("byte-range read failed")
+
+            def close(self):
+                pass
+
+        def factory(resource_path, *a, **k):
+            if resource_path == "s3://bad":
+                return _RaisingReadH5()
+            return _CloseRecordingH5(_canned_arrays(), [])
+
+        self._patch_h5(monkeypatch, factory)
+        cfg = _release_cfg()
+        cfg.data_source["granule_workers"] = 2
+        df_out, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://bad", "s3://ok"], s3_credentials={}, config=cfg
+        )
+        assert meta["read_errors"] == 1
+        assert meta["files_processed"] == 2  # the bad granule still "processed" (0 groups)
+        assert meta["total_obs"] == 2
+
+    def test_pooled_streaming_identical_to_serial(self, monkeypatch):
+        # The pool must compose with the StreamingAggregator path (issue #148
+        # phase 4): granule_done fires per granule in fold order, so flush
+        # boundaries — and the merged output — match the serial run.
+        from zagg.config import PipelineConfig
+
+        def streaming_cfg():
+            return PipelineConfig(
+                data_source={
+                    "groups": ["gt1l"],
+                    "coordinates": {"latitude": "/{group}/lat", "longitude": "/{group}/lon"},
+                    "variables": {"h_li": "/{group}/h_li"},
+                },
+                aggregation={
+                    "variables": {"count": {"function": "len", "dtype": "int32", "fill_value": 0}},
+                    "streaming": {"buffer_granules": 2},
+                },
+            )
+
+        urls = [f"s3://{c}" for c in "abcde"]
+        results = {}
+        for workers in (1, 3):
+            factory, _ = self._tagged_factory(slow_urls=("s3://a",))
+            self._patch_h5(monkeypatch, factory)
+            cfg = streaming_cfg()
+            if workers > 1:
+                cfg.data_source["granule_workers"] = workers
+            results[workers] = process_shard(_ReleaseGrid(), 0, urls, s3_credentials={}, config=cfg)
+        df_serial, meta_serial = results[1]
+        df_pooled, meta_pooled = results[3]
+        pd.testing.assert_frame_equal(df_serial, df_pooled)
+        assert meta_serial["total_obs"] == meta_pooled["total_obs"] == 10
+        assert meta_serial["files_processed"] == meta_pooled["files_processed"] == 5

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5488,37 +5488,6 @@ class TestGranuleReadPool:
         with pytest.raises(ValueError, match="granule_workers"):
             process_shard(_ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=cfg)
 
-    def test_sidecar_build_combo_rejected_at_worker(self, monkeypatch):
-        # Mirror of the validate_config guard for hand-rolled payloads: the
-        # installed h5coro-hidefix sidecar lazily initializes its write-back
-        # delegate without a guard, so on_miss: build cannot pool (issue #180
-        # review finding). Duck-typed on name/on_miss — zagg never imports the
-        # external backend.
-        class _FakeSidecar:
-            name = "sidecar"
-            on_miss = "build"
-
-        monkeypatch.setattr("zagg.processing.worker.index_from_config", lambda cfg: _FakeSidecar())
-
-        def exploding_factory(*a, **k):
-            raise AssertionError("no granule should be opened")
-
-        self._patch_h5(monkeypatch, exploding_factory)
-        cfg = _release_cfg()
-        cfg.data_source["granule_workers"] = 2
-        with pytest.raises(ValueError, match="on_miss: 'build'"):
-            process_shard(_ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=cfg)
-        # Serial keeps the combo runnable (the delegate is never contended).
-        from zagg.processing.worker import _reject_racy_sidecar_build
-
-        _reject_racy_sidecar_build(object())  # non-sidecar backends: no-op
-
-        class _FallbackSidecar:
-            name = "sidecar"
-            on_miss = "fallback"
-
-        _reject_racy_sidecar_build(_FallbackSidecar())  # keyed _cache: fine
-
     def test_default_serial_never_touches_the_pool(self, monkeypatch):
         # granule_workers absent -> the serial loop; the pool must not even be
         # constructed, so the default path carries zero threading machinery.

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5488,6 +5488,37 @@ class TestGranuleReadPool:
         with pytest.raises(ValueError, match="granule_workers"):
             process_shard(_ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=cfg)
 
+    def test_sidecar_build_combo_rejected_at_worker(self, monkeypatch):
+        # Mirror of the validate_config guard for hand-rolled payloads: the
+        # installed h5coro-hidefix sidecar lazily initializes its write-back
+        # delegate without a guard, so on_miss: build cannot pool (issue #180
+        # review finding). Duck-typed on name/on_miss — zagg never imports the
+        # external backend.
+        class _FakeSidecar:
+            name = "sidecar"
+            on_miss = "build"
+
+        monkeypatch.setattr("zagg.processing.worker.index_from_config", lambda cfg: _FakeSidecar())
+
+        def exploding_factory(*a, **k):
+            raise AssertionError("no granule should be opened")
+
+        self._patch_h5(monkeypatch, exploding_factory)
+        cfg = _release_cfg()
+        cfg.data_source["granule_workers"] = 2
+        with pytest.raises(ValueError, match="on_miss: 'build'"):
+            process_shard(_ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=cfg)
+        # Serial keeps the combo runnable (the delegate is never contended).
+        from zagg.processing.worker import _reject_racy_sidecar_build
+
+        _reject_racy_sidecar_build(object())  # non-sidecar backends: no-op
+
+        class _FallbackSidecar:
+            name = "sidecar"
+            on_miss = "fallback"
+
+        _reject_racy_sidecar_build(_FallbackSidecar())  # keyed _cache: fine
+
     def test_default_serial_never_touches_the_pool(self, monkeypatch):
         # granule_workers absent -> the serial loop; the pool must not even be
         # constructed, so the default path carries zero threading machinery.
@@ -5578,12 +5609,12 @@ class TestGranuleReadPool:
     def test_pooled_granule_failure_skips_and_continues(self, monkeypatch):
         # A failed granule (constructor raise) under the pool matches the serial
         # semantics: warn + skip, remaining granules still process and release.
+        # Gated on the URL, not a shared call counter — the factory runs on
+        # pool threads, where a counter's read-modify-write can race (review).
         log: list = []
-        calls = {"n": 0}
 
-        def factory(*a, **k):
-            calls["n"] += 1
-            if calls["n"] == 2:
+        def factory(resource_path, *a, **k):
+            if resource_path == "s3://b":
                 raise RuntimeError("h5coro open failed")
             return _CloseRecordingH5(_canned_arrays(), log)
 

--- a/tests/test_rectilinear.py
+++ b/tests/test_rectilinear.py
@@ -457,3 +457,32 @@ class TestSharded:
             np.float32
         )
         np.testing.assert_array_equal(arr, expected)
+
+
+class TestThreadLocalTransformer:
+    """Issue #180 (review finding): ``assign`` runs on the granule pool's
+    worker threads, and a shared pyproj Transformer is only documented
+    thread-safe from pyproj 3.7.0 (unpinned) — so each thread caches its own,
+    with identical construction and byte-identical outputs."""
+
+    def test_per_thread_instances_identical_results(self, grid):
+        import threading
+
+        tx_main = grid._transformer_to_grid()
+        assert grid._transformer_to_grid() is tx_main  # cached within a thread
+
+        box = {}
+        t = threading.Thread(target=lambda: box.update(tx=grid._transformer_to_grid()))
+        t.start()
+        t.join()
+        assert box["tx"] is not tx_main  # a pool thread never shares main's
+        # Identical construction -> identical transforms (always_xy: lon, lat).
+        assert box["tx"].transform(-45.0, -70.0) == tx_main.transform(-45.0, -70.0)
+
+    def test_assign_unchanged(self, grid):
+        # The per-thread cache is invisible to assign's outputs.
+        lats = np.array([-70.0, -75.0])
+        lons = np.array([-45.0, 90.0])
+        leaf1 = grid.assign(lats, lons)
+        leaf2 = grid.assign(lats, lons)
+        np.testing.assert_array_equal(leaf1, leaf2)

--- a/tests/test_rectilinear.py
+++ b/tests/test_rectilinear.py
@@ -459,30 +459,40 @@ class TestSharded:
         np.testing.assert_array_equal(arr, expected)
 
 
-class TestThreadLocalTransformer:
-    """Issue #180 (review finding): ``assign`` runs on the granule pool's
-    worker threads, and a shared pyproj Transformer is only documented
-    thread-safe from pyproj 3.7.0 (unpinned) — so each thread caches its own,
-    with identical construction and byte-identical outputs."""
+class TestTransformerThreadSafety:
+    """Issue #180 (review finding 3): ``assign`` runs on the granule pool's
+    worker threads sharing one pyproj ``Transformer``. Concurrent
+    ``.transform()`` is thread-safe from pyproj 3.7.0 — enforced by the
+    ``pyproject.toml`` floor (espg-authorized dependency change) rather than a
+    code-side mitigation."""
 
-    def test_per_thread_instances_identical_results(self, grid):
+    def test_pyproj_floor_matches_pyproject(self):
+        # The runtime floor the shared-Transformer contract depends on. If
+        # this fails, the environment predates the pyproject pin.
+        from importlib.metadata import version
+
+        major, minor, *_ = (int(x) for x in version("pyproj").split(".")[:2])
+        assert (major, minor) >= (3, 7)
+
+    def test_shared_transformer_concurrent_use(self, grid):
         import threading
 
-        tx_main = grid._transformer_to_grid()
-        assert grid._transformer_to_grid() is tx_main  # cached within a thread
+        tx = grid._transformer_to_grid()
+        assert grid._transformer_to_grid() is tx  # one shared instance
+        expected = tx.transform(-45.0, -70.0)  # always_xy: (lon, lat)
+        results = {}
 
-        box = {}
-        t = threading.Thread(target=lambda: box.update(tx=grid._transformer_to_grid()))
-        t.start()
-        t.join()
-        assert box["tx"] is not tx_main  # a pool thread never shares main's
-        # Identical construction -> identical transforms (always_xy: lon, lat).
-        assert box["tx"].transform(-45.0, -70.0) == tx_main.transform(-45.0, -70.0)
+        def use(k):
+            results[k] = tx.transform(-45.0, -70.0)
+
+        threads = [threading.Thread(target=use, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert all(r == expected for r in results.values())
 
     def test_assign_unchanged(self, grid):
-        # The per-thread cache is invisible to assign's outputs.
         lats = np.array([-70.0, -75.0])
         lons = np.array([-45.0, 90.0])
-        leaf1 = grid.assign(lats, lons)
-        leaf2 = grid.assign(lats, lons)
-        np.testing.assert_array_equal(leaf1, leaf2)
+        np.testing.assert_array_equal(grid.assign(lats, lons), grid.assign(lats, lons))


### PR DESCRIPTION
Closes #180
Closes #179 — folded in per the direction on the issue thread ([comment](https://github.com/englacial/zagg/issues/179#issuecomment-4900148836)); the planned-read path is now `read_fn`-routed end to end (sole remnant: range coalescing, see Questions (4)).

## What

The worker's read wall is a ~300-link chain of sequential network waits: `process_shard` loops granules × groups one at a time, and everything shipped under #170 only parallelizes *inside* one link. This PR overlaps the links (K granules in flight, issue #180) and shrinks every remaining serial link inside a granule read (issue #179), behind a default-off knob so the shipped behavior is byte-identical until the fleet A/B picks a K.

## Phases

- [x] **Phase 1 — the correctness trap** (`ff3481e`, hardened in the review fold `d8182ac`): `InlineIndex._pending` was an instance-level dict keyed by **dataset path**; dataset paths repeat across granules (`/gt1l/heights/h_ph`…), so two in-flight granules would interleave chunk maps and persist corrupted write-back manifests. Now keyed by the **full `h5obj.resource` URL** → `{path -> ChunkMap}` (the fold upgraded the original granule-id-stem key after the adversarial review reproduced a stem collision: `.../p1/granule.h5` vs `.../p2/granule.h5` collapsed to one entry, serving B's reads through A's chunk maps). The manifest *store* key stays the id stem per the issue #160 convention. `finish_granule` drains exactly its granule's entry; the `VirtualIndex.finish_granule` protocol docs now state the concurrency contract.
- [x] **Phase 2 — the pool** (`238395b`): the loop body of `process_shard` (H5Coro open → group loop → `finish_granule` → close) is extracted into a per-granule `_read_granule` closure returning the group carriers in group order; `data_source.granule_workers` (default **1** = today's serial loop) keeps up to K granules in flight on a bounded `ThreadPoolExecutor` (threads, not asyncio — espg-confirmed on the issue). Results fold in **original granule order** (the consumer blocks on the oldest future; parked out-of-order completions are bounded by K; the fold moved the top-up ahead of the yield so a full K stays in flight through every fold), so output is byte-identical to serial. One `H5Coro` per granule, created and closed inside its worker thread. Per-granule error semantics preserved. Works under both pooled `all_reads` and `StreamingAggregator` modes. Validated at submission (`validate_config`) AND at the worker; README entry next to `read_workers`.
- [x] **Phase 3 — telemetry** (`f6da016`): `cpu_seconds` added to the worker envelope next to `max_memory_mb`/`container_hwm_mb` in `deployment/aws/lambda_handler.py` (authorized: issue #180 names this file). `os.times()` is process-cumulative, so it is snapshotted at handler entry and diffed at the telemetry stamp — per-invocation user+sys across all threads, making utilization = `cpu_seconds / duration_s` measurable per invocation. (Merged cleanly with the #182 recycle-counting changes to the same file — both semantics verified intact, merge commit `f433f09`.)
- [x] **Phase 4 — selection reads** (`ad0f000`, completed by `11e4361`; issue #179): the **whole planned read is now one addressing seam**. `ad0f000` routed the segment-rate geolocation + link-array selection reads (`reference_photon_lat/lon`, `ph_index_beg`, `segment_ph_cnt`) through the backend-supplied compiled `read_fn`, pooled with the existing `read_workers` machinery via `_read_paths_pooled` (the `_read_group_full` pattern). `11e4361` folded the three remaining planned-path seams (espg-requested): (a) `_read_segment_broadcasts` gets `read_fn` at the planned call site; (b) the cross-level (Phase B) coarse flag + link reads route through `read_fn`, pooled; (c) the `plan.full_read` selectivity fallback forwards `read_fn` to `_read_group_full` so it stays compiled. `read_fn=None` (hierarchical baseline) keeps the batched `readDatasets` calls byte-identical everywhere.
- [x] **Review fold** (`d8182ac`, `d34cede`, `a4a93d8`) — all findings of the [adversarial review](https://github.com/englacial/zagg/pull/183#pullrequestreview-4641833093) addressed: (1) full-URL `_pending` keys + collision test; (2) **h5coro-hidefix pinned at 0.3.1** (`>=0.3.1` core, `==0.3.1` lambda extra, `a4a93d8`) — the sidecar `on_miss: build` delegate lazy-init race is fixed upstream (double-checked lock in `zagg_backend._miss`, verified in the installed wheel), so the combination pools freely under K>1 with **no runtime clamp** (an interim reject-guard was dropped in favor of the pin); (3) **pyproj floor raised to `>=3.7.0`** (first release documenting `Transformer` thread-safety) — espg-authorized dependency change (`d34cede`; the interim thread-local mitigation was backed out in favor of the pin); (4) fan-out sizing note in `_granule_workers`'s docstring + README; (5) pool top-up moved before the yield (full K in flight during folds); (6) dead group tag dropped from `_read_granule`'s return; (7) README line for `granule_workers`; (8) pooled-failure test gated on URL instead of a racy counter.
- [ ] Fleet A/B at K∈{1,2,4,6} + pick default (espg) — user-facing default-flip docs ride along then.

## How it was tested

All hermetic; full non-slow suite green locally against h5coro-hidefix 0.3.1 after the merge with main (`pytest -q`: **1511 passed, 26 skipped** — the suite exercises the sidecar entry-point discovery path), plus `ruff check` / `ruff format --check` on every touched file.

- Phase 1: interleaved granule reads over two copies of `tests/data/index/atl03_mini.h5` produce **byte-identical** parquet manifests to the serial order; `finish_granule` drains only its granule; `test_same_basename_granules_do_not_collide` (same-basename granules under different prefixes → two isolated pending entries, both manifests persisted — under the stem key, B's manifest was never written).
- Phase 2 (`tests/test_processing.py::TestGranuleReadPool`): pooled vs serial output equality with the *slowest granule submitted first*; fold order pinned via a `_concat_and_group` spy; one `H5Coro` per granule created+closed in the same pool thread; failed-granule and raised-group-read semantics match serial; streaming-aggregator parity; the serial default never constructs a pool; `granule_workers` guards at submission (`tests/test_config.py`, incl. sidecar combos pooling freely under the 0.3.1 pin) and worker; end-to-end pool+write_back manifests byte-identical to serial (`tests/test_index.py::TestInlineInterleavedGranules`).
- Phase 3 (`tests/test_lambda_handler.py`): `cpu_seconds` present as a float in the result body; a faked `os.times()` sequence pins it as the entry→stamp **delta**. All 82 handler tests (including #182's recycle-billing additions) pass post-merge.
- Phase 4 (`tests/test_index.py::TestSelectionReads`): with the inline backend a planned group read **never touches `readDatasets`** — selection, data, segment-broadcast, cross-level-filter, and `full_read`-fallback reads are all compiled — and rows match hierarchical in every case (the `full_read` test baselines against the planned route at the default threshold: full-read ≡ planned per #43 Phase C parity, and the hierarchical full-read route can't serve this fixture shard at all — its mask starts on a chunk boundary, the pre-existing PR #152 h5coro start-edge bug the compiled route is immune to). The hierarchical baseline still issues its batched selection read; a compiled-rejected selection dataset degrades alone.
- Review fold: `tests/test_rectilinear.py::TestTransformerThreadSafety` (pyproj floor asserted at runtime; shared-transformer concurrent use; `assign` unchanged).

## Questions for review

1. **Pre-existing lint failure, not fixed here**: `ruff check src tests` fails on `N818` for `UnknownCapability` (`src/zagg/registry.py:64`), present on main and untouched by this PR (the PR lint bot runs `--select=E,F,W,I` so it never fires in CI). Flagging per §4 rather than renaming a public exception in an unrelated PR.
2. **h5coro-hidefix 0.3.1 docs**: the upstream fix landed and is pinned here; its `zagg_backend` module docstring still describes the serial worker contract ("the worker reads granules serially") — worth updating in the next h5coro-hidefix release to match the `VirtualIndex.finish_granule` concurrency contract added on the zagg side.
3. **Fan-out budget (review finding 4)**: worst-case in-flight GETs is `granule_workers × read_workers × chunk-fetch width` (K=6 → 384) vs the S3 driver's ~100-connection pool; queueing + h5coro's 5 s timeout can surface as spurious `read_errors`. Documented in `_granule_workers`'s docstring and the README; no hard cap added (the A/B should see the raw behavior — watch `read_errors` when reading the K-sweep results). Add a `validate_config` warning if you want one.
4. **#179 remnant — range coalescing**: cross-dataset range coalescing is the single #179 item not done here — a real optimization feature that needs its own issue + benchmark evidence (espg-agreed carve-out).
5. **Sidecar behavior note**: selection (and now cross-level/segment) reads consult the manifest when `sidecar` serves the group, so a *sparse* manifest lacking those datasets sends the group to `on_miss` (default `fallback` = hierarchical) where before they bypassed the manifest. Inline write-back has always prebuilt the spatial-index level's coordinate + link arrays into every manifest, so store-populated manifests are covered (full-coverage manifests carry all 1,055 datasets).
6. **Shard-aware K**: the issue sketches a dispatcher-side per-shard `granule_workers` override (the `aoi_payload` precedent). Not implemented — the knob is config-level for the A/B; the worker-side re-validation already accepts an event-injected value, so the dispatcher half can land separately once a default K exists.
7. **Fold-side error micro-difference**: in the old serial loop a failing `buffered.add_read` counted as a per-group `read_errors` increment; now fold-side failures (realistically only a streaming `flush` inside `granule_done`) take the granule-level "Error processing file" warn-and-skip path, same as the old outer `except`. `add_read` is a plain list append (review-verified), so the changed case is unreachable in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wp83fdkH2qhtEvoLgyTWU1