### PR TITLE
Inline selection-read heuristic + granule_workers default 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The store path and output grid parameters are defined in the YAML config (`outpu
 
 `data_source.read_workers` (default 8) bounds the per-worker read fan-out on the compiled paths: each in-flight read overlaps S3 latency and decodes with the GIL released. Peak worker memory grows with width — dial down for dense shards.
 
-`data_source.granule_workers` (default 1 = serial) keeps K granules in flight per worker on a bounded thread pool, folded in original granule order so output is byte-identical to serial (issue #180). Opt-in until the fleet A/B picks a default. It multiplies with `read_workers` — dial `read_workers` down as K rises to stay inside the S3 connection budget; peak memory grows by roughly K granule footprints.
+`data_source.granule_workers` (default 4; issues #180/#185) keeps K granules in flight per worker on a bounded thread pool, folded in original granule order — output is byte-identical to serial by construction of the ordered fold, though the default no longer executes serially (`1` restores the serial loop). The dispatcher clamps each cell to `min(K, n_granules)` so small shards don't spin idle threads (issue #184). It multiplies with `read_workers` — dial `read_workers` down as K rises to stay inside the S3 connection budget; peak memory grows by roughly K granule footprints.
 
 ### Step 4: Visualize Results
 

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -529,7 +529,27 @@ class InlineIndex(VirtualIndex):
         ``finish_granule`` to persist. Each dataset gets
         its own single-dataset in-memory ``Index`` (~ms), so a spec hidefix
         rejects degrades that dataset alone.
+
+        Selection-shaped reads skip the walk (issue #185): on the planned
+        route a full-dataset read (``hyperslice is None``) is a segment-rate
+        selection read — data reads arrive as hyperslices — and h5coro's
+        ``readDatasets`` (4 MiB cache lines) serves those faster than the
+        compiled route once the B-tree walk is priced in (the 0.18 inline
+        regression, ~41% at ``granule_workers: 1``; the #170 matrix measured
+        the same trade). So with ``write_back`` off, an unmapped full-dataset
+        read on the planned route goes straight through ``readDatasets`` and
+        builds no chunk map. A path already mapped (e.g. one that is both a
+        data and a selection read) keeps the compiled route — the map is paid
+        for. With ``write_back`` ON nothing changes: the walk's product IS
+        the manifest payload, so selection datasets stay mapped (and served
+        compiled) to keep manifests covering them for sidecar consumers. The
+        full-read route (``planned=False``) is untouched — its compiled
+        full-dataset decode is the point of issue #170.
         """
+        # Issue #185: with write_back off there is no manifest to enrich, so
+        # the planned route's full-dataset (selection) reads bypass the
+        # chunk-map build entirely -- see read_fn below.
+        selection_direct = planned and not self.write_back
         maps: dict[str, ChunkMap] = self._pending_for(h5obj) if self.write_back else {}
         # One single-dataset Index per path (~ms each): a dataset whose spec
         # hidefix rejects (nonzero filter_mask, non-tiling chunk table) then
@@ -579,6 +599,13 @@ class InlineIndex(VirtualIndex):
         def read_fn(path, hyperslice=None):
             cm = maps.get(path)
             if cm is None and path not in direct:
+                if selection_direct and hyperslice is None:
+                    # Selection-shaped read (issue #185): serve through
+                    # h5coro's cache-line path, build no chunk map. Full
+                    # readDatasets reads never trip the PR #152 start-edge
+                    # off-by-one (that is a ranged-read quirk), so no
+                    # boundary workaround is needed here.
+                    return h5obj.readDatasets([path])[path]
                 try:
                     cm = maps[path] = build_chunk_map(h5obj, path)
                 except Exception:

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -52,11 +52,16 @@ logger = logging.getLogger(__name__)
 def _granule_workers(data_source: dict) -> int:
     """``data_source.granule_workers``: granules in flight per shard (issue #180).
 
-    Default **1** — today's serial granule loop, byte-identical (opt-in until
-    the fleet A/B picks a default, same measure-then-flip discipline as #170's
-    ``read_workers``). Validated at submission (``validate_config``) and
-    re-checked here with the same int>=1 / bool-trap guard so hand-rolled
-    worker payloads fail loudly before any read.
+    Default **4** — picked from the PR #183 K-sweep fleet A/B (issue #185:
+    K=4 inline read 296.9 s vs 0.17's 323 s median on the o9 NEON AOI; the
+    #170 measure-then-flip discipline, flipped). Output stays byte-identical
+    to serial by construction — results fold in submission order — the
+    default just no longer *executes* serially; ``1`` restores the serial
+    loop. Validated at submission (``validate_config``) and re-checked here
+    with the same int>=1 / bool-trap guard so hand-rolled worker payloads
+    fail loudly before any read. The dispatcher clamps each cell's width to
+    ``min(K, n_granules)`` (issue #184) so small shards don't spin idle
+    threads.
 
     Sizing note (review finding, PR #183): this pool composes multiplicatively
     with ``read_workers`` (and under ``sidecar`` its chunk-fetch pool too), so
@@ -65,7 +70,7 @@ def _granule_workers(data_source: dict) -> int:
     down as K rises, and watch ``read_errors`` (queueing + the 5 s timeout can
     surface as spurious read failures, not slowdowns) in the K-sweep A/B.
     """
-    w = data_source.get("granule_workers", 1)
+    w = data_source.get("granule_workers", 4)
     if isinstance(w, bool) or not isinstance(w, int) or w < 1:
         raise ValueError(f"data_source.granule_workers must be an integer >= 1 (got {w!r})")
     return w

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -31,6 +31,11 @@ from zagg.grids.morton import is_morton_array, is_morton_arrow, morton_to_arrow,
 # path's ``async.concurrency`` budget (issue #108).
 _RAGGED_WRITE_CONCURRENCY = 128
 
+# Cap on the per-failure roll call logged when sharded CSR writes fail
+# (issue #186): enough to show the race signature across subgroups without
+# flooding CloudWatch when many of the K writes fail at once.
+_RAGGED_FAILURE_LOG_CAP = 20
+
 logger = logging.getLogger(__name__)
 
 
@@ -439,18 +444,20 @@ def _write_ragged_fanout(ragged_writes: list, store: Store, *, grid) -> None:
         # the operator — the worker envelope and CloudWatch both record only
         # this summary string — so log the first failure's full traceback
         # here, and carry its type + message in the summary text too. A
-        # bounded one-line-per-failure roll call makes the race signature
-        # ACROSS subgroups visible (which keys, same or different errors)
-        # without flooding the log when many of the K writes fail at once.
-        for key, exc in errors[:20]:
-            logger.error(f"  ragged (CSR) subgroup {key}: {type(exc).__name__}: {exc}")
-        if len(errors) > 20:
-            logger.error(f"  ... and {len(errors) - 20} more subgroup write failure(s)")
+        # bounded one-line-per-failure roll call (after the header, so the
+        # indented lines read as its continuation) makes the race signature
+        # ACROSS subgroups visible (which keys, same or different errors).
         logger.error(
             f"ragged (CSR) subgroup write failed (shard_key {first_key}): "
             f"{type(first_exc).__name__}: {first_exc}",
             exc_info=first_exc,
         )
+        if len(errors) > 1:
+            for key, exc in errors[:_RAGGED_FAILURE_LOG_CAP]:
+                logger.error(f"  ragged (CSR) subgroup {key}: {type(exc).__name__}: {exc}")
+            if len(errors) > _RAGGED_FAILURE_LOG_CAP:
+                n_more = len(errors) - _RAGGED_FAILURE_LOG_CAP
+                logger.error(f"  ... and {n_more} more subgroup write failure(s)")
         raise RuntimeError(
             f"ragged (CSR) write failed for {len(errors)} of {len(ragged_writes)} "
             f"subgroup(s) on the sharded path (first failing shard_key {first_key}: "

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -7,6 +7,7 @@ Assembles the per-shard output carrier and writes it to the Zarr template
 stays acyclic.
 """
 
+import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import numpy as np
@@ -29,6 +30,8 @@ from zagg.grids.morton import is_morton_array, is_morton_arrow, morton_to_arrow,
 # a serial loop dominated a t-digest shard's write time. 128 mirrors the dense
 # path's ``async.concurrency`` budget (issue #108).
 _RAGGED_WRITE_CONCURRENCY = 128
+
+logger = logging.getLogger(__name__)
 
 
 def _arrow_column(block: np.ndarray, sig: dict):
@@ -432,9 +435,19 @@ def _write_ragged_fanout(ragged_writes: list, store: Store, *, grid) -> None:
                 errors.append((futures[fut], exc))
     if errors:
         first_key, first_exc = errors[0]
+        # Observability (issue #186 ask 1): the chained cause never reaches
+        # the operator — the worker envelope and CloudWatch both record only
+        # this summary string — so log the first failure's full traceback
+        # here, and carry its type + message in the summary text too.
+        logger.error(
+            f"ragged (CSR) subgroup write failed (shard_key {first_key}): "
+            f"{type(first_exc).__name__}: {first_exc}",
+            exc_info=first_exc,
+        )
         raise RuntimeError(
             f"ragged (CSR) write failed for {len(errors)} of {len(ragged_writes)} "
-            f"subgroup(s) on the sharded path (first failing shard_key {first_key})"
+            f"subgroup(s) on the sharded path (first failing shard_key {first_key}: "
+            f"{type(first_exc).__name__}: {first_exc})"
         ) from first_exc
 
 

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -438,7 +438,14 @@ def _write_ragged_fanout(ragged_writes: list, store: Store, *, grid) -> None:
         # Observability (issue #186 ask 1): the chained cause never reaches
         # the operator — the worker envelope and CloudWatch both record only
         # this summary string — so log the first failure's full traceback
-        # here, and carry its type + message in the summary text too.
+        # here, and carry its type + message in the summary text too. A
+        # bounded one-line-per-failure roll call makes the race signature
+        # ACROSS subgroups visible (which keys, same or different errors)
+        # without flooding the log when many of the K writes fail at once.
+        for key, exc in errors[:20]:
+            logger.error(f"  ragged (CSR) subgroup {key}: {type(exc).__name__}: {exc}")
+        if len(errors) > 20:
+            logger.error(f"  ... and {len(errors) - 20} more subgroup write failure(s)")
         logger.error(
             f"ragged (CSR) subgroup write failed (shard_key {first_key}): "
             f"{type(first_exc).__name__}: {first_exc}",

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1151,8 +1151,11 @@ def _run_local(
             extra["aoi_payload"] = aoi_by_shard.get(int(shard_key))
         # Per-cell granule_workers clamp (issue #184): min(K, n_granules), so
         # a small cell doesn't spin idle reader threads; unclamped cells pass
-        # the shared config through untouched.
-        ds = _clamped_data_source(config.data_source, len(records))
+        # the shared config through untouched. Count the RESOLVED urls — what
+        # the worker actually reads — not the raw records: _resolve_urls
+        # drops href-less records, so len(records) would under-clamp a
+        # partially-resolvable cell (review finding, PR #187).
+        ds = _clamped_data_source(config.data_source, len(_resolve_urls(records, driver)))
         cell_config = replace(config, data_source=ds) if ds is not None else config
         try:
             meta = _process_and_write(
@@ -1398,7 +1401,11 @@ def _run_lambda(
         # Per-cell granule_workers clamp (issue #184): the worker reads the
         # width from the event's config, so the clamp rides a per-cell copy
         # of it; unclamped cells send the shared config_dict byte-identical.
-        ds = _clamped_data_source(config.data_source, len(records))
+        # Clamp on the RESOLVED url count — what the worker actually reads —
+        # since _resolve_urls drops href-less records (review finding,
+        # PR #187).
+        granule_urls = _resolve_urls(records, "s3")
+        ds = _clamped_data_source(config.data_source, len(granule_urls))
         cell_config_dict = {**config_dict, "data_source": ds} if ds is not None else config_dict
         return _invoke_lambda_cell(
             state["lambda_client"],
@@ -1406,7 +1413,7 @@ def _run_lambda(
             int(shard_key),
             parent_order,
             child_order,
-            _resolve_urls(records, "s3"),
+            granule_urls,
             store_path,
             s3_creds,
             function_name=function_name,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1154,7 +1154,9 @@ def _run_local(
         # the shared config through untouched. Count the RESOLVED urls — what
         # the worker actually reads — not the raw records: _resolve_urls
         # drops href-less records, so len(records) would under-clamp a
-        # partially-resolvable cell (review finding, PR #187).
+        # partially-resolvable cell (review finding, PR #187). This resolve
+        # must stay in lockstep with _process_and_write's own
+        # _resolve_urls(records, driver) — same inputs, so same count.
         ds = _clamped_data_source(config.data_source, len(_resolve_urls(records, driver)))
         cell_config = replace(config, data_source=ds) if ds is not None else config
         try:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -19,6 +19,7 @@ import time
 import uuid
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 
 from zarr import consolidate_metadata
 
@@ -964,6 +965,26 @@ def _resolve_urls(records: list, driver: str | None) -> list[str]:
     return [r[key] for r in records if r.get(key)]
 
 
+def _clamped_data_source(data_source: dict, n_granules: int) -> dict | None:
+    """Per-cell ``granule_workers`` clamp: ``min(K, n_granules)`` (issue #184).
+
+    The shardmap gives the dispatcher each cell's granule count up front, so a
+    2-granule cell never asks the worker for a 4-wide pool (the issue #185
+    default). Returns a shallow-copied ``data_source`` carrying the clamped
+    width when it is below the configured/default K, else ``None`` — the
+    caller then passes the shared config through untouched, keeping unclamped
+    cell payloads byte-identical. Just the simple ``min()`` policy; the
+    worker still resolves the value through its ``_granule_workers`` guard.
+    """
+    from zagg.processing.worker import _granule_workers
+
+    k = _granule_workers(data_source)
+    clamped = min(k, max(int(n_granules), 1))
+    if clamped == k:
+        return None
+    return {**data_source, "granule_workers": clamped}
+
+
 def _check_signature(grid, catalog_data: dict) -> None:
     """Refuse a ShardMap built for a different *spatial* grid than the run config.
 
@@ -1128,6 +1149,11 @@ def _run_local(
         extra = {}
         if aoi_by_shard:
             extra["aoi_payload"] = aoi_by_shard.get(int(shard_key))
+        # Per-cell granule_workers clamp (issue #184): min(K, n_granules), so
+        # a small cell doesn't spin idle reader threads; unclamped cells pass
+        # the shared config through untouched.
+        ds = _clamped_data_source(config.data_source, len(records))
+        cell_config = replace(config, data_source=ds) if ds is not None else config
         try:
             meta = _process_and_write(
                 shard_key,
@@ -1136,7 +1162,7 @@ def _run_local(
                 grid,
                 s3_creds,
                 zarr_store,
-                config,
+                cell_config,
                 driver=driver,
                 handoff=handoff,
                 **extra,
@@ -1369,6 +1395,11 @@ def _run_lambda(
                 result_box, result_prefix, output_creds_event, region, key
             )
             extra["poll_timeout_s"] = state["function_timeout_s"] + _ASYNC_POLL_MARGIN_S
+        # Per-cell granule_workers clamp (issue #184): the worker reads the
+        # width from the event's config, so the clamp rides a per-cell copy
+        # of it; unclamped cells send the shared config_dict byte-identical.
+        ds = _clamped_data_source(config.data_source, len(records))
+        cell_config_dict = {**config_dict, "data_source": ds} if ds is not None else config_dict
         return _invoke_lambda_cell(
             state["lambda_client"],
             grid.block_index(int(shard_key)),
@@ -1379,7 +1410,7 @@ def _run_lambda(
             store_path,
             s3_creds,
             function_name=function_name,
-            config_dict=config_dict,
+            config_dict=cell_config_dict,
             output_creds_event=output_creds_event,
             max_retries=max_retries,
             max_workers=state["workers"],

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -812,16 +812,26 @@ class TestInlineReadGroup:
 
 
 class TestSelectionReads:
-    """Issue #179 (folded into #180): the planned route's selection reads —
-    segment-rate geolocation coordinates + link arrays — go through the same
-    compiled, pooled ``read_fn`` seam as the data reads when an index backend
-    supplies one, and stay serial batched h5coro when it doesn't."""
+    """Issue #179 routed the planned route's selection reads — segment-rate
+    geolocation coordinates + link arrays — through the backend ``read_fn``
+    seam. Issue #185: inline serves those (full-dataset, no hyperslice) reads
+    straight through h5coro's ``readDatasets`` WITHOUT building chunk maps
+    when ``write_back`` is off (the shipped ``index: None`` default — the
+    B-tree walks were the 0.18 ~41% regression); with ``write_back`` ON the
+    maps ARE the manifest payload, so selection reads stay compiled and
+    manifests keep covering the selection datasets for sidecar consumers."""
 
     SELECTION_PATHS = [
         "/gt1l/geolocation/reference_photon_lat",
         "/gt1l/geolocation/reference_photon_lon",
         "/gt1l/geolocation/ph_index_beg",
         "/gt1l/geolocation/segment_ph_cnt",
+    ]
+    DATA_PATHS = [
+        "/gt1l/heights/lat_ph",
+        "/gt1l/heights/lon_ph",
+        "/gt1l/heights/h_ph",
+        "/gt1l/heights/signal_conf_ph",
     ]
 
     @staticmethod
@@ -837,17 +847,57 @@ class TestSelectionReads:
         h5obj.readDatasets = recorder
         return calls
 
-    def test_inline_selection_reads_bypass_readdatasets(self):
-        # With the inline backend every dataset of a planned group read —
-        # selection AND data — is served by the compiled route; the uncompiled
-        # ``readDatasets`` API is never touched, and rows stay identical to
-        # the hierarchical baseline.
+    @staticmethod
+    def _spy_chunk_map_builds(monkeypatch):
+        """Record every dataset path ``build_chunk_map`` walks (the map-build
+        seam: lazy read_fn builds AND write_back's ``_prebuild_group_maps``)."""
+        import zagg.index.inline as inline_mod
+
+        built = []
+        orig = inline_mod.build_chunk_map
+
+        def spy(h5obj, path):
+            built.append(path)
+            return orig(h5obj, path)
+
+        monkeypatch.setattr(inline_mod, "build_chunk_map", spy)
+        return built
+
+    def test_default_selection_reads_skip_chunk_maps(self, monkeypatch):
+        # The default path (planned, write_back off): selection reads are
+        # served whole via readDatasets — never walked into chunk maps — while
+        # the data reads keep the compiled route; rows stay identical to the
+        # hierarchical baseline (i.e. to the pre-#179 selection behavior).
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        h5obj = _open_fixture()
+        built = self._spy_chunk_map_builds(monkeypatch)
+        calls = self._record_read_datasets(h5obj)
+        df_i = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
+        assert set(built) & set(self.SELECTION_PATHS) == set()
+        assert "/gt1l/heights/h_ph" in built  # data reads still map + compile
+        # readDatasets served exactly the selection datasets, one full read
+        # each (list-of-one-path calls, no hyperslice dicts).
+        served = [d for call in calls for d in call]
+        assert all(isinstance(d, str) for d in served)
+        assert set(served) == set(self.SELECTION_PATHS)
+        df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        pd.testing.assert_frame_equal(df_i, df_h)
+
+    def test_write_back_selection_reads_stay_compiled(self, tmp_path):
+        # write_back ON keeps the pre-#185 behavior byte-for-byte: every
+        # dataset — selection AND data — is served by the compiled route (the
+        # walk's product is the manifest payload), readDatasets is never
+        # touched, and rows stay identical to the hierarchical baseline.
         ds = _fixture_data_source()
         grid = _LeafSetGrid(_UNALIGNED_LEAVES)
         h5obj = _open_fixture()
         calls = self._record_read_datasets(h5obj)
-        df_i = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
+        backend = InlineIndex(write_back=True, store=str(tmp_path))
+        df_i = backend.read_group(h5obj, "gt1l", ds, 1, grid)
         assert calls == []
+        # The pending maps (the manifest payload) cover the selection datasets.
+        assert set(self.SELECTION_PATHS) <= set(backend._pending[str(h5obj.resource)])
         df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
         pd.testing.assert_frame_equal(df_i, df_h)
 
@@ -875,28 +925,29 @@ class TestSelectionReads:
         assert df is not None
         assert self.SELECTION_PATHS in calls  # the one batched selection read
 
-    def test_segment_variable_reads_bypass_readdatasets(self):
-        # issue #179 fold: the segment-level variable + link reads
-        # (_read_segment_broadcasts) ride the same read_fn seam on the
-        # planned route — fully compiled under inline, rows identical to
-        # hierarchical.
+    def test_segment_variable_reads_skip_chunk_maps(self, monkeypatch):
+        # The segment-level variable + link reads (_read_segment_broadcasts)
+        # arrive as full-dataset reads on the planned route, so the issue #185
+        # heuristic serves them via readDatasets too — no chunk-map walks —
+        # with rows identical to hierarchical.
         ds = _fixture_data_source()
         ds["levels"]["segments"]["variables"] = {
             "seg_lat": "/{group}/geolocation/reference_photon_lat"
         }
         grid = _LeafSetGrid(_UNALIGNED_LEAVES)
         h5obj = _open_fixture()
-        calls = self._record_read_datasets(h5obj)
+        built = self._spy_chunk_map_builds(monkeypatch)
         df_i = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
-        assert calls == []
+        assert set(built) & set(self.SELECTION_PATHS) == set()
         assert "seg_lat" in df_i.columns
         df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
         pd.testing.assert_frame_equal(df_i, df_h)
 
-    def test_cross_level_filter_reads_bypass_readdatasets(self):
-        # issue #179 fold: cross-level (Phase B) coarse flag + link reads take
-        # the compiled, pooled seam too. The ne -1 predicate keeps every
-        # segment, so rows stay identical to hierarchical.
+    def test_cross_level_filter_reads_skip_chunk_maps(self, monkeypatch):
+        # Cross-level (Phase B) coarse flag + link reads are full-dataset
+        # reads on the planned route — served direct, never walked. The ne -1
+        # predicate keeps every segment, so rows stay identical to
+        # hierarchical.
         ds = _fixture_data_source()
         ds["filters"] = ds["filters"] + [
             {
@@ -908,37 +959,41 @@ class TestSelectionReads:
         ]
         grid = _LeafSetGrid(_UNALIGNED_LEAVES)
         h5obj = _open_fixture()
-        calls = self._record_read_datasets(h5obj)
+        built = self._spy_chunk_map_builds(monkeypatch)
         df_i = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
-        assert calls == []
+        assert set(built) & set(self.SELECTION_PATHS) == set()
         df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
         pd.testing.assert_frame_equal(df_i, df_h)
 
-    def test_full_read_fallback_keeps_compiled_route(self):
-        # issue #179 fold: plan.full_read (selectivity above threshold — 0.0
-        # forces it) defers to _read_group_full WITH the backend's read_fn,
-        # so the fallback stays compiled instead of dropping to serial h5coro.
-        # Baseline: the planned route at the default threshold — full-read and
-        # planned output is row-identical (#43 Phase C parity), and the
-        # hierarchical FULL-read route can't serve this shard at all (its mask
-        # starts on a chunk boundary, photon 512 — the PR #152 h5coro
-        # start-edge bug the compiled route is immune to).
+    def test_full_read_fallback_data_reads_stay_compiled(self, monkeypatch):
+        # plan.full_read (selectivity above threshold — 0.0 forces it) defers
+        # to _read_group_full WITH the backend's read_fn (issue #179). Under
+        # the issue #185 heuristic its full-dataset COORDINATE reads are
+        # served direct (no walk — matching the pre-#179 fallback, which
+        # bypassed the seam entirely), while the hyperslice DATA reads keep
+        # the compiled route — which this shard needs: its mask window starts
+        # on a chunk boundary (photon 512), the PR #152 h5coro start-edge bug
+        # the compiled route is immune to. Baseline: the planned route at the
+        # default threshold — full-read and planned output is row-identical
+        # (#43 Phase C parity).
         ds = _fixture_data_source(
             read_plan={"spatial_index": "segments", "pad": 1, "full_read_threshold": 0.0}
         )
         grid = _LeafSetGrid(_UNALIGNED_LEAVES)
         h5obj = _open_fixture()
-        calls = self._record_read_datasets(h5obj)
+        built = self._spy_chunk_map_builds(monkeypatch)
         df_i = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
-        assert calls == []
         assert df_i is not None and len(df_i) > 0
+        assert "/gt1l/heights/lat_ph" not in built  # full coord reads: direct
+        assert "/gt1l/heights/h_ph" in built  # ranged data reads: compiled
         df_h = HierarchicalIndex().read_group(
             _open_fixture(), "gt1l", _fixture_data_source(), 1, grid
         )
         pd.testing.assert_frame_equal(df_i, df_h)
 
-    def test_selection_dataset_degrades_alone(self, monkeypatch, caplog):
-        # A selection dataset the compiled reader rejects degrades to the
+    def test_selection_dataset_degrades_alone_under_write_back(self, monkeypatch, caplog, tmp_path):
+        # With write_back ON selection reads stay compiled (issue #185), so a
+        # selection dataset the compiled reader rejects still degrades to the
         # h5coro decoder per dataset — same seam as the data reads (PR #173
         # convention) — and rows stay identical to hierarchical.
         import logging
@@ -956,8 +1011,9 @@ class TestSelectionReads:
         monkeypatch.setattr(hh_manifest, "datasets_from_manifest", picky)
         ds = _fixture_data_source()
         grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        backend = InlineIndex(write_back=True, store=str(tmp_path))
         with caplog.at_level(logging.WARNING, logger="zagg.index.inline"):
-            df_i = InlineIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+            df_i = backend.read_group(_open_fixture(), "gt1l", ds, 1, grid)
         df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
         pd.testing.assert_frame_equal(df_i, df_h)
         warned = [r.message for r in caplog.records if "compiled decode unavailable" in r.message]
@@ -1195,6 +1251,26 @@ class TestInlineWriteBackWorker:
         assert meta["error"] is None
         df = pd.read_parquet(store / "atl03_mini.parquet", engine="fastparquet")
         assert set(df["dataset"]) == self._expected_datasets()
+
+    def test_manifest_byte_identical_to_direct_chunk_maps(self, tmp_path):
+        # Pins the sidecar-build product (issue #185): the persisted manifest
+        # is byte-identical to one assembled directly from build_chunk_map
+        # over the deterministic per-group coverage — the selection datasets
+        # included — so the default path's skip-the-walk heuristic cannot
+        # erode what write_back runs persist.
+        from zagg.index.inline import write_manifest
+
+        store = tmp_path / "via-backend"
+        df_out, meta = self._run(
+            tmp_path, {"backend": "inline", "write_back": True, "store": str(store)}
+        )
+        assert meta["error"] is None
+        h5obj = _open_fixture()
+        direct = {p: build_chunk_map(h5obj, p) for p in self._expected_datasets()}
+        write_manifest(granule_manifest(direct), str(tmp_path / "direct"), "atl03_mini")
+        assert (store / "atl03_mini.parquet").read_bytes() == (
+            tmp_path / "direct" / "atl03_mini.parquet"
+        ).read_bytes()
 
     def test_write_back_off_writes_nothing(self, tmp_path):
         df_out, meta = self._run(tmp_path, {"backend": "inline"})

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1291,6 +1291,35 @@ class TestRaggedWriteFanout:
         assert "OSError: disk full" in tb_text
         assert "in boom" in tb_text
 
+    def test_fanout_logs_each_failure_bounded(self, monkeypatch, caplog):
+        """Multiple subgroup failures each get a one-line ``key: Type: msg``
+        summary (issue #186: the race signature ACROSS subgroups), capped at
+        20 lines, while exactly one record — the first completed failure —
+        carries the full traceback."""
+        import logging
+
+        import zagg.processing.write as wmod
+        from zagg.processing.write import _write_ragged_fanout
+
+        grid, writes = self._grid_and_writes(25)
+
+        def boom(ragged, store, *, grid, shard_key):
+            raise OSError(f"reset {shard_key}")
+
+        monkeypatch.setattr(wmod, "write_ragged_to_zarr", boom)
+        with caplog.at_level(logging.ERROR, logger="zagg.processing.write"):
+            with pytest.raises(RuntimeError, match=r"failed for 25 of 25"):
+                _write_ragged_fanout([(r, k) for r, k in writes], MemoryStore(), grid=grid)
+        lines = [r.message for r in caplog.records]
+        roll_call = [m for m in lines if m.startswith("  ragged (CSR) subgroup ")]
+        assert len(roll_call) == 20  # bounded roll call
+        assert any("and 5 more subgroup write failure(s)" in m for m in lines)
+        # Each roll-call line names its own subgroup key and its own error.
+        for m in roll_call:
+            key = m.split("subgroup ")[1].split(":")[0]
+            assert f"reset {key}" in m
+        assert sum(1 for r in caplog.records if r.exc_info) == 1
+
     def test_fanout_empty_is_noop(self):
         """No ragged writes -> nothing written, no pool spun up."""
         from zagg.processing.write import _write_ragged_fanout

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1257,8 +1257,15 @@ class TestRaggedWriteFanout:
         _write_ragged_fanout([(r, k) for r, k in writes], MemoryStore(), grid=grid)
         assert "workers" not in recorded
 
-    def test_fanout_surfaces_write_failure(self, monkeypatch):
-        """A failure in any subgroup write is re-raised (not silently swallowed)."""
+    def test_fanout_surfaces_write_failure(self, monkeypatch, caplog):
+        """A failure in any subgroup write is re-raised (not silently swallowed).
+        Issue #186 (ask 1): the chained cause never reached the operator — the
+        worker envelope and CloudWatch only record the summary string — so the
+        summary now carries the cause's type + message, and the first failure
+        is logged with its full traceback."""
+        import logging
+        import traceback
+
         import zagg.processing.write as wmod
         from zagg.processing.write import _write_ragged_fanout
 
@@ -1266,11 +1273,23 @@ class TestRaggedWriteFanout:
 
         def boom(ragged, store, *, grid, shard_key):
             if shard_key == 3:
-                raise RuntimeError("disk full")
+                raise OSError("disk full")
 
         monkeypatch.setattr(wmod, "write_ragged_to_zarr", boom)
-        with pytest.raises(RuntimeError, match="ragged"):
-            _write_ragged_fanout([(r, k) for r, k in writes], MemoryStore(), grid=grid)
+        with caplog.at_level(logging.ERROR, logger="zagg.processing.write"):
+            with pytest.raises(
+                RuntimeError, match=r"first failing shard_key 3: OSError: disk full"
+            ):
+                _write_ragged_fanout([(r, k) for r, k in writes], MemoryStore(), grid=grid)
+        rec = next(r for r in caplog.records if "subgroup write failed" in r.message)
+        assert "shard_key 3" in rec.message
+        assert "OSError: disk full" in rec.message
+        # Full traceback attached: the log shows WHERE the cause raised, not
+        # just its repr — the actual S3/zarr frame in a real reproduction.
+        assert rec.exc_info is not None
+        tb_text = "".join(traceback.format_exception(*rec.exc_info))
+        assert "OSError: disk full" in tb_text
+        assert "in boom" in tb_text
 
     def test_fanout_empty_is_noop(self):
         """No ragged writes -> nothing written, no pool spun up."""

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1270,6 +1270,9 @@ class TestRaggedWriteFanout:
         from zagg.processing.write import _write_ragged_fanout
 
         grid, writes = self._grid_and_writes(5)
+        # Pin the fd ceiling high so the pool branch runs (the serial branch
+        # re-raises the bare OSError, not the RuntimeError summary).
+        monkeypatch.setattr(wmod, "fd_safe_max_workers", lambda: 128)
 
         def boom(ragged, store, *, grid, shard_key):
             if shard_key == 3:
@@ -1290,6 +1293,8 @@ class TestRaggedWriteFanout:
         tb_text = "".join(traceback.format_exception(*rec.exc_info))
         assert "OSError: disk full" in tb_text
         assert "in boom" in tb_text
+        # A single failure logs no roll call — it would just repeat the header.
+        assert not any(r.message.startswith("  ragged (CSR) subgroup ") for r in caplog.records)
 
     def test_fanout_logs_each_failure_bounded(self, monkeypatch, caplog):
         """Multiple subgroup failures each get a one-line ``key: Type: msg``
@@ -1302,6 +1307,9 @@ class TestRaggedWriteFanout:
         from zagg.processing.write import _write_ragged_fanout
 
         grid, writes = self._grid_and_writes(25)
+        # Pin the fd ceiling high so the run truly takes the pool branch (the
+        # serial branch raises the first bare exception and logs no roll call).
+        monkeypatch.setattr(wmod, "fd_safe_max_workers", lambda: 128)
 
         def boom(ragged, store, *, grid, shard_key):
             raise OSError(f"reset {shard_key}")
@@ -1311,8 +1319,10 @@ class TestRaggedWriteFanout:
             with pytest.raises(RuntimeError, match=r"failed for 25 of 25"):
                 _write_ragged_fanout([(r, k) for r, k in writes], MemoryStore(), grid=grid)
         lines = [r.message for r in caplog.records]
+        # Header first (traceback record), then the roll call as its continuation.
+        assert lines[0].startswith("ragged (CSR) subgroup write failed")
         roll_call = [m for m in lines if m.startswith("  ragged (CSR) subgroup ")]
-        assert len(roll_call) == 20  # bounded roll call
+        assert len(roll_call) == wmod._RAGGED_FAILURE_LOG_CAP  # bounded roll call
         assert any("and 5 more subgroup write failure(s)" in m for m in lines)
         # Each roll-call line names its own subgroup key and its own error.
         for m in roll_call:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5473,7 +5473,8 @@ class TestGranuleReadPool:
         for bad in (0, -1, 1.5, "2", True, False):
             with pytest.raises(ValueError, match="granule_workers"):
                 _granule_workers({"granule_workers": bad})
-        assert _granule_workers({}) == 1  # default: serial, today's behavior
+        # Default K=4, from the PR #183 K-sweep evidence (issue #185).
+        assert _granule_workers({}) == 4
         assert _granule_workers({"granule_workers": 3}) == 3
 
     def test_bad_granule_workers_fails_before_any_read(self, monkeypatch):
@@ -5488,9 +5489,11 @@ class TestGranuleReadPool:
         with pytest.raises(ValueError, match="granule_workers"):
             process_shard(_ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=cfg)
 
-    def test_default_serial_never_touches_the_pool(self, monkeypatch):
-        # granule_workers absent -> the serial loop; the pool must not even be
-        # constructed, so the default path carries zero threading machinery.
+    def test_k1_never_touches_the_pool(self, monkeypatch):
+        # granule_workers: 1 -> the serial loop; the pool must not even be
+        # constructed, so the serial escape hatch carries zero threading
+        # machinery. (The default is 4 since issue #185 -- pooled -- so the
+        # serial guarantee is now opt-in rather than the default.)
         import zagg.processing.worker as worker_mod
 
         def exploding_pool(*a, **k):
@@ -5499,10 +5502,35 @@ class TestGranuleReadPool:
         monkeypatch.setattr(worker_mod, "ThreadPoolExecutor", exploding_pool)
         factory, _ = self._tagged_factory()
         self._patch_h5(monkeypatch, factory)
+        cfg = _release_cfg()
+        cfg.data_source["granule_workers"] = 1
         df_out, meta = process_shard(
-            _ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=_release_cfg()
+            _ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=cfg
         )
         assert meta["files_processed"] == 2
+
+    def test_default_output_identical_to_serial(self, monkeypatch):
+        # The new default (K=4, issue #185) folds in submission order, so a
+        # default-config run is byte-identical to an explicit serial one.
+        results = {}
+        for workers in (1, None):
+            factory, _ = self._tagged_factory(slow_urls=("s3://a",))
+            self._patch_h5(monkeypatch, factory)
+            cfg = _release_cfg()
+            if workers is not None:
+                cfg.data_source["granule_workers"] = workers
+            results[workers] = process_shard(
+                _ReleaseGrid(),
+                0,
+                ["s3://a", "s3://b", "s3://c"],
+                s3_credentials={},
+                config=cfg,
+            )
+        df_serial, meta_serial = results[1]
+        df_default, meta_default = results[None]
+        pd.testing.assert_frame_equal(df_serial, df_default)
+        for key in ("files_processed", "total_obs", "cells_with_data", "error"):
+            assert meta_serial[key] == meta_default[key]
 
     def test_pooled_output_identical_to_serial(self, monkeypatch):
         # Distinct per-granule data; the slowest granule is submitted FIRST so

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1396,11 +1396,21 @@ class TestSummaryKeysByteIdentical:
 
     @staticmethod
     def _clamp_catalog():
-        # Per-shard granule counts 2 / 6 / 4 / 1 against the default K=4:
-        # shards 10 and 13 clamp, 11 (above K) and 12 (exactly K) pass through.
+        # Per-shard record counts 2 / 6 / 6 / 1 against the default K=4:
+        # shards 10 and 13 clamp, 11 passes through (above K). Shard 12 has 6
+        # records but only 3 with an s3 href — the clamp must count the
+        # RESOLVED urls (what the worker reads), not the raw records, so it
+        # clamps to 3 (PR #187 review finding: len(records) under-clamps a
+        # partially-resolvable cell).
         cat = _run_catalog()
         cat["granules"] = [
-            [{"s3": f"s3://b/g{i}_{j}.h5"} for j in range(n)] for i, n in enumerate((2, 6, 4, 1))
+            [{"s3": f"s3://b/g0_{j}.h5"} for j in range(2)],
+            [{"s3": f"s3://b/g1_{j}.h5"} for j in range(6)],
+            [
+                {"s3": f"s3://b/g2_{j}.h5"} if j < 3 else {"https": f"https://h/g2_{j}.h5"}
+                for j in range(6)
+            ],
+            [{"s3": "s3://b/g3_0.h5"}],
         ]
         return cat
 
@@ -1441,8 +1451,8 @@ class TestSummaryKeysByteIdentical:
             dry_run=False,
             region="us-west-2",
         )
-        assert seen == {10: 2, 11: "ABSENT", 12: "ABSENT", 13: 1}
-        assert shared[11] and shared[12]  # unclamped cells: shared config as-is
+        assert seen == {10: 2, 11: "ABSENT", 12: 3, 13: 1}
+        assert shared[11]  # unclamped cell: shared config object as-is
 
     def test_lambda_clamps_granule_workers_per_cell(self, monkeypatch, atl06_config):
         # Issue #184 (item 1): _run_lambda's per-cell event config carries
@@ -1508,7 +1518,7 @@ class TestSummaryKeysByteIdentical:
             region="us-west-2",
             function_name="fn",
         )
-        assert seen == {10: 2, 11: "ABSENT", 12: "ABSENT", 13: 1}
+        assert seen == {10: 2, 11: "ABSENT", 12: 3, 13: 1}
 
     def test_lambda_summary_keys_and_cost(self, monkeypatch, atl06_config):
         import boto3

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1116,6 +1116,36 @@ def _run_catalog():
     }
 
 
+class TestClampedDataSource:
+    """Dispatcher-side per-cell granule_workers clamp (issue #184, item 1's
+    simple ``min(K, n_granules)`` case): a copy carrying the clamped width
+    only when clamping actually lowers K, else None (shared config rides
+    through untouched, keeping unclamped payloads byte-identical)."""
+
+    def test_min_policy(self):
+        from zagg.runner import _clamped_data_source
+
+        ds = {"granule_workers": 4}
+        assert _clamped_data_source(ds, 2) == {"granule_workers": 2}
+        assert _clamped_data_source(ds, 4) is None
+        assert _clamped_data_source(ds, 9) is None
+        assert ds == {"granule_workers": 4}  # never mutated in place
+
+    def test_default_k_applies(self):
+        # The issue #185 default (K=4) clamps without an explicit key.
+        from zagg.runner import _clamped_data_source
+
+        assert _clamped_data_source({}, 2) == {"granule_workers": 2}
+        assert _clamped_data_source({}, 4) is None
+        # A degenerate 0-granule cell still sends a valid width (>= 1).
+        assert _clamped_data_source({}, 0) == {"granule_workers": 1}
+
+    def test_serial_k1_never_clamped(self):
+        from zagg.runner import _clamped_data_source
+
+        assert _clamped_data_source({"granule_workers": 1}, 5) is None
+
+
 class TestSummaryKeysByteIdentical:
     """The dispatch refactor (#63) must leave the run-summary dict keys -- and
     the data/error counting -- byte-identical for both backends.
@@ -1363,6 +1393,122 @@ class TestSummaryKeysByteIdentical:
             function_name="fn",
         )
         assert all(v == "OMITTED" for v in seen.values())
+
+    @staticmethod
+    def _clamp_catalog():
+        # Per-shard granule counts 2 / 6 / 4 / 1 against the default K=4:
+        # shards 10 and 13 clamp, 11 (above K) and 12 (exactly K) pass through.
+        cat = _run_catalog()
+        cat["granules"] = [
+            [{"s3": f"s3://b/g{i}_{j}.h5"} for j in range(n)] for i, n in enumerate((2, 6, 4, 1))
+        ]
+        return cat
+
+    def test_local_clamps_granule_workers_per_cell(self, monkeypatch, atl06_config):
+        # Issue #184 (item 1): _run_local threads a per-cell config whose
+        # granule_workers is min(K, n_granules); cells at/above K get the
+        # SHARED config object untouched.
+        import zagg.grids as grids_mod
+        from zagg import runner
+
+        monkeypatch.setattr(
+            runner,
+            "get_nsidc_s3_credentials",
+            lambda: {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
+        )
+        monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
+        monkeypatch.setattr(runner, "open_store", lambda *a, **k: object())
+        monkeypatch.setattr(runner, "consolidate_metadata", lambda *a, **k: None)
+
+        seen, shared = {}, {}
+
+        def fake_paw(shard_key, chunk_idx, records, grid, s3_creds, zarr_store, config, **kw):
+            seen[int(shard_key)] = config.data_source.get("granule_workers", "ABSENT")
+            shared[int(shard_key)] = config is atl06_config
+            return {"shard_key": shard_key, "total_obs": 1, "error": None}
+
+        monkeypatch.setattr(runner, "_process_and_write", fake_paw)
+
+        runner._run_local(
+            atl06_config,
+            self._clamp_catalog(),
+            "./out.zarr",
+            12,
+            max_cells=None,
+            morton_cell=None,
+            max_workers=1,
+            overwrite=False,
+            dry_run=False,
+            region="us-west-2",
+        )
+        assert seen == {10: 2, 11: "ABSENT", 12: "ABSENT", 13: 1}
+        assert shared[11] and shared[12]  # unclamped cells: shared config as-is
+
+    def test_lambda_clamps_granule_workers_per_cell(self, monkeypatch, atl06_config):
+        # Issue #184 (item 1): _run_lambda's per-cell event config carries
+        # min(K, n_granules); cells at/above K keep the shared config_dict
+        # byte-identical (no granule_workers key injected).
+        import boto3
+
+        import zagg.grids as grids_mod
+        from zagg import runner
+        from zagg.concurrency import ConcurrencyReport
+
+        monkeypatch.setattr(
+            runner,
+            "get_nsidc_s3_credentials",
+            lambda: {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
+        )
+        monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
+        monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(
+            runner,
+            "compute_available_workers",
+            lambda requested, *a, **k: (
+                4,
+                ConcurrencyReport(
+                    account_limit=1000,
+                    current_concurrent=0,
+                    padding=100,
+                    available=900,
+                    function_reserved=None,
+                ),
+            ),
+        )
+
+        seen = {}
+
+        def fake_cell(client, chunk_idx, shard_key, *a, **kw):
+            seen[int(shard_key)] = kw["config_dict"]["data_source"].get("granule_workers", "ABSENT")
+            return {
+                "shard_key": shard_key,
+                "status_code": 200,
+                "body": {"total_obs": 1},
+                "error": None,
+                "timeout": False,
+            }
+
+        monkeypatch.setattr(runner, "_invoke_lambda_cell", fake_cell)
+
+        runner._run_lambda(
+            atl06_config,
+            self._clamp_catalog(),
+            "s3://out/x.zarr",
+            12,
+            max_cells=None,
+            morton_cell=None,
+            max_workers=1,
+            overwrite=False,
+            dry_run=False,
+            region="us-west-2",
+            function_name="fn",
+        )
+        assert seen == {10: 2, 11: "ABSENT", 12: "ABSENT", 13: 1}
 
     def test_lambda_summary_keys_and_cost(self, monkeypatch, atl06_config):
         import boto3


### PR DESCRIPTION
Closes #185. Refs #184 (the per-cell clamp below is item 1's simple `min()` case — the rest of #184 stays open). Refs #186 (ask (1) only — root-cause of the sharded write race stays on #186).

Implements option (2) from the issue thread — the **inline-internal heuristic** — plus the default `granule_workers` bump, per the approval on [issue #185](https://github.com/englacial/zagg/issues/185#issuecomment-4901692895) ("yup, sounds like (2) it is (plus the default granule workers bump)"). The mechanism and evidence are the [K-sweep tables on PR #183](https://github.com/englacial/zagg/pull/183#issuecomment-4901386362): #179's selection routing costs inline ~41% at K=1 (B-tree chunk-map walks for the segment-rate selection datasets) while being a pure win for sidecar.

## Phases

- [x] Phase 1 — inline selection-read heuristic (`src/zagg/index/inline.py`)
- [x] Phase 2 — `granule_workers` default 1 → 4 (`src/zagg/processing/worker.py`, README)
- [x] Phase 3 — dispatcher-side per-cell `min(K, n_granules)` clamp (`src/zagg/runner.py`)
- [x] Phase 4 — surface the chained CSR write failure (issue #186 ask (1), `src/zagg/processing/write.py`)
- [x] Fold adversarial-review findings ([review](https://github.com/englacial/zagg/pull/187#pullrequestreview-4643501393)): clamp on resolved-URL count; bounded per-failure write summary
- [x] Fold second-round review findings ([review](https://github.com/englacial/zagg/pull/187#pullrequestreview-4644501334)): header-first failure roll call + single-failure guard; named `_RAGGED_FAILURE_LOG_CAP`; `fd_safe_max_workers` pins in the fanout failure tests; lockstep comment on the local clamp resolve

## What / approach

**Phase 1 — the heuristic, contained in `InlineIndex._chunk_aligned_read_fn`.** `read.py`'s call sites are untouched; the seam stays uniform. The discriminator is the call shape: on the planned route, data reads arrive as hyperslices (`execute_read_plan`) and selection reads (coarse coords + link arrays, cross-level filter flags, segment-level broadcasts) arrive as full-dataset reads (`hyperslice is None`). The change is one early exit:

```python
if selection_direct and hyperslice is None:   # selection_direct = planned and not write_back
    return h5obj.readDatasets([path])[path]
```

- **Default path** (`planned=True`, `write_back` off — the shipped `index: None` default where the regression lives): unmapped full-dataset reads are served whole through h5coro's `readDatasets` (its 4 MiB cache-line path, the fast side of the #170 matrix for these datasets) and build **no chunk map** — restoring the 0.17 selection behavior.
- **`write_back` ON**: unchanged byte-for-byte. The walk's product *is* the manifest payload (`_pending_for`/`finish_granule`), so selection datasets stay mapped and served compiled — freshly built manifests keep covering the selection datasets, preserving sidecar's −25% K=1 win.
- **`planned=False`** (flat sources): unchanged in all modes — the compiled full-dataset decode there is the point of issue #170.
- A path already mapped this `read_group` (e.g. both a data and a selection read) keeps the compiled route — the map is already paid for. Full `readDatasets` reads don't need the PR #152 start-edge workaround (that's a ranged-read quirk), so no boundary handling is added.

Call-shape note beyond the issue-thread sketch: the `plan.full_read` selectivity fallback (`_planned_read_group` → `_read_group_full` with the planned `read_fn`, routed through the seam since #179) also issues full-dataset reads — the base-rate *coordinate* reads. The heuristic serves those direct too, which matches the pre-#179 fallback (it bypassed the seam entirely, per `inline.py`'s own docstring); the fallback's ranged data reads stay compiled. Pinned by `test_full_read_fallback_data_reads_stay_compiled`.

A/B watch-list (review finding 2, no code change): direct `readDatasets` reads retain their 4 MiB cache lines until granule close. On the `full_read` fallback that can be ~245 MB/beam of base-rate volume, × K=4 granules in flight at the new default — no fleet datapoint yet; watch as an issue #117 memory axis in the next sweep.

**Phase 2 — default `granule_workers: 4`.** Directed on the PR #183 K-sweep evidence (K=4 inline 296.9 s vs 0.17's 323 s median, o9 NEON AOI) via the same [approval comment](https://github.com/englacial/zagg/issues/185#issuecomment-4901692895). Docs updated honestly: output remains byte-identical to serial by construction of the ordered fold — the *default* just no longer equals serial execution (`granule_workers: 1` restores the serial loop, which still constructs no pool).

**Phase 3 — dispatcher-side clamp (Refs #184, item 1's simple case).** `_clamped_data_source(data_source, n_granules)` in `runner.py` returns a shallow-copied `data_source` carrying `min(K, n_granules)` only when that lowers K, else `None`. Both `_cell_work` sites use it: `_run_local` via `dataclasses.replace(config, data_source=...)`, `_run_lambda` via a per-cell `{**config_dict, "data_source": ...}`. Unclamped cells pass the shared config through untouched, keeping their event payloads byte-identical. Per the review fold, the clamp counts the **resolved** URLs (`_resolve_urls` output — what the worker actually reads), not raw records, so a partially-resolvable cell no longer under-clamps. **Deviation from the plan sketch:** there is no dedicated worker event key for this — the worker reads the width from the event's `config` (`_granule_workers(event["config"]["data_source"])`, PR #183), so the clamp rides the per-cell config copy rather than a new top-level key (no `lambda_handler` change needed).

**Phase 4 — CSR write-failure observability (issue #186 ask (1) only).** `_write_ragged_fanout`'s failure path now (a) logs the first failing subgroup's chained exception with its **full traceback** (`logger.error(..., exc_info=first_exc)`), (b) when more than one subgroup failed, follows that header with a bounded one-line-per-failure roll call (`subgroup_key: ExcType: message`, capped at `_RAGGED_FAILURE_LOG_CAP = 20` lines) so the race signature across subgroups is visible, and (c) carries `TypeName: message` inside the raised summary string, so the worker envelope (`lambda_handler`'s `Failed to write zarr: {e}`) shows the actual S3/zarr error even without log access. Envelope schema unchanged; no behavior change on the write path itself — the root-cause/race fix stays on #186.

## How tested

- **Phase 1** (`tests/test_index.py`): `test_default_selection_reads_skip_chunk_maps` spies the map-build seam (`build_chunk_map`) and a `readDatasets` recorder — selection paths are never walked, are served as whole-dataset `readDatasets` calls, data paths still map + compile, rows identical to the hierarchical baseline. `test_write_back_selection_reads_stay_compiled` pins the ON mode (`readDatasets` never touched, pending maps cover the selection datasets, rows identical). `test_manifest_byte_identical_to_direct_chunk_maps` pins the sidecar-build product: the persisted parquet is byte-identical to one assembled directly from `build_chunk_map` over the deterministic coverage. Segment-variable, cross-level-filter, full-read-fallback, and per-dataset-degrade tests updated to the new mode split.
- **Phase 2** (`tests/test_processing.py`): default asserted as 4; `test_k1_never_touches_the_pool` keeps the serial guarantee on the explicit escape hatch; `test_default_output_identical_to_serial` pins default-vs-serial frame equality under out-of-order completions.
- **Phase 3** (`tests/test_runner.py`): `TestClampedDataSource` unit-tests the `min()` policy (incl. default-K and the 0-granule floor); dispatcher tests for both backends assert per-shard event/config values (2-granule cell → 2, 1-granule cell → 1, 6-granule cell → untouched, and a 6-record cell with only 3 s3-resolvable hrefs → 3) and that unclamped local cells receive the shared config object as-is.
- **Phase 4** (`tests/test_processing.py`): the fanout failure test asserts the raised summary matches `first failing shard_key 3: OSError: disk full`, that the log record carries `exc_info` whose formatted traceback names the raising frame, and that a single failure logs no roll call (the header alone); `test_fanout_logs_each_failure_bounded` pins the multi-failure roll call (header first, then 25 failures → `_RAGGED_FAILURE_LOG_CAP` per-key lines + "and 5 more", exactly one traceback record). Both tests pin `fd_safe_max_workers` so a low-ulimit host can't silently take the serial branch.
- Full local gate: `pytest -q` green — 1516 passed, 26 skipped (3.12, `uv sync --extra test`) on the first-fold state; the second fold re-ran `tests/test_index.py tests/test_processing.py tests/test_runner.py` (425 passed) plus the two changed modules in full (352 passed); `ruff check` + `ruff format --check` clean on every touched file.

## Questions for review

1. **Concurrent `readDatasets` on one `h5obj`:** selection reads now reach `readDatasets` through the `read_workers` pool (`_read_paths_pooled`), so up to four single-path calls can be in flight on one granule handle. **Answered safe** by the [adversarial review](https://github.com/englacial/zagg/pull/187#pullrequestreview-4643501393)'s h5coro source inspection: `h5promise.py` already fans one thread per dataset over the shared resource, cache-line access is locked per line, and the S3 client is documented thread-safe.
2. **Pre-existing lint drift (flagged, not fixed, per the §4 convention):** on clean `main`, `ruff check src tests` fails N818 (`UnknownCapability`, `src/zagg/registry.py:64`) and `ruff format --check` would reformat 7 untouched files (`src/zagg/__init__.py`, `src/zagg/__main__.py`, `src/zagg/catalog/sources.py`, `src/zagg/viz/crs.py`, `tests/test_catalog.py`, `tests/test_extract.py`, `tests/test_integration.py`). The PR lint bot selects only `E,F,W,I`, so PRs won't see these.
3. The K=4 default reaches **direct `process_shard` callers** (no dispatcher) unclamped — a 1-granule hand-rolled call now constructs a 4-wide pool (threads spawn lazily, so the cost is one idle pool object). Worth a worker-side `min(K, len(granule_urls))` too, or keep the clamp dispatcher-only as agreed on #184?