### PR TITLE
Add total AOI wall + finalize to benchmark columns (issue #180)

### DIFF
--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -63,6 +63,16 @@ RECORD_COLUMNS = [
     # targets, None otherwise. Keeps the cached column out of the inner
     # codec slot in the renderer; legacy rows read back NaN and key on codec.
     "read",
+    # Wall-time breakdown (issue #180): end-to-end AOI dispatch wall and its
+    # three phases. ``runtime_s`` above is the single worker's compute;
+    # ``total_wall_s`` is what the orchestrator actually waits (setup +
+    # fanout/poll + finalize). ``finalize_s`` is the zarr metadata
+    # consolidation invoke -- a ~fixed cost worth tracking for regression
+    # (issue #191). Null on rows recorded before these were surfaced.
+    "total_wall_s",
+    "setup_s",
+    "fanout_s",
+    "finalize_s",
 ]
 
 
@@ -168,6 +178,12 @@ def build_record(
         # the target. None on targets that don't set it (legacy/frozen rows).
         "codec": context.get("codec"),
         "read": context.get("read"),
+        # Wall-time breakdown (issue #180): total end-to-end AOI dispatch wall
+        # plus its phases, straight from the agg summary.
+        "total_wall_s": summary.get("wall_time_s"),
+        "setup_s": summary.get("setup_s"),
+        "fanout_s": summary.get("fanout_s"),
+        "finalize_s": summary.get("finalize_s"),
     }
     return record
 
@@ -188,6 +204,8 @@ TABLE_HEADERS = [
     "target",
     "obs",
     "runtime (s)",
+    "wall (s)",
+    "finalize (s)",
     "cost/shard",
     "cost/100 km²",
     "% timeout",
@@ -209,6 +227,8 @@ def format_record_cells(r: dict) -> dict:
         "target": _fmt(r.get("target")),
         "obs": _fmt(obs, ",d") if obs is not None else "n/a",
         "runtime (s)": _fmt(r.get("runtime_s"), ".1f"),
+        "wall (s)": _fmt(r.get("total_wall_s"), ".1f"),
+        "finalize (s)": _fmt(r.get("finalize_s"), ".1f"),
         "cost/shard": "$" + _fmt(r.get("cost_per_shard_usd"), ".5f"),
         "cost/100 km²": "$" + _fmt(r.get("cost_per_100km2_usd"), ".5f"),
         "% timeout": _fmt(r.get("worker_pct_timeout"), ".0%"),

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -85,6 +85,9 @@ def _summary():
         "function_timeout_s": 720,
         "worker_pct_timeout": 0.285,
         "max_memory_mb": 1963.0,
+        "setup_s": 5.0,
+        "fanout_s": 140.0,
+        "finalize_s": 65.0,
     }
 
 
@@ -123,11 +126,14 @@ def test_build_record_max_memory_null_safe():
 
 
 def test_codec_column_is_last_and_threaded(monkeypatch):
-    # Stable-schema rule: new columns append LAST. The read axis (issue #170)
-    # is now the newest column; codec (issue #133) sits just before it. Both
-    # are threaded from context and null on rows that omit them (legacy/frozen).
-    assert bench_metrics.RECORD_COLUMNS[-1] == "read"
-    assert bench_metrics.RECORD_COLUMNS[-2] == "codec"
+    # Stable-schema rule: new columns append LAST. codec (issue #133) and the
+    # read axis (issue #170) are threaded from context and null on rows that
+    # omit them; the wall-breakdown columns (issue #180) were appended after
+    # them, so codec/read are no longer literally last -- assert order, not
+    # tail position.
+    cols = bench_metrics.RECORD_COLUMNS
+    assert cols.index("codec") < cols.index("read") < cols.index("total_wall_s")
+    assert cols[-4:] == ["total_wall_s", "setup_s", "fanout_s", "finalize_s"]
     g = HealpixGrid(parent_order=11, child_order=19)
     rec = bench_metrics.build_record(_summary(), grid=g, context={"codec": "sharded"})
     assert rec["codec"] == "sharded"
@@ -139,6 +145,24 @@ def test_codec_column_is_last_and_threaded(monkeypatch):
     legacy = bench_metrics.build_record(_summary(), grid=g, context={"target": "t"})
     assert legacy["codec"] is None
     assert legacy["read"] is None
+
+
+def test_wall_breakdown_columns_threaded_and_rendered():
+    # issue #180: total AOI wall + its phases flow from the agg summary into
+    # the record, and total wall + finalize surface in the rendered table.
+    g = HealpixGrid(parent_order=11, child_order=19)
+    rec = bench_metrics.build_record(_summary(), grid=g, context={"target": "t"})
+    assert rec["total_wall_s"] == 210.0
+    assert rec["setup_s"] == 5.0
+    assert rec["fanout_s"] == 140.0
+    assert rec["finalize_s"] == 65.0
+    # A summary missing the phases (older worker) -> null, not a crash.
+    bare = bench_metrics.build_record({"total_obs": 1}, grid=g, context={})
+    assert bare["total_wall_s"] is None and bare["finalize_s"] is None
+    cells = bench_metrics.format_record_cells(rec)
+    assert cells["wall (s)"] == "210.0" and cells["finalize (s)"] == "65.0"
+    assert "wall (s)" in bench_metrics.TABLE_HEADERS
+    assert "finalize (s)" in bench_metrics.TABLE_HEADERS
 
 
 def test_run_target_threads_codec_into_record():


### PR DESCRIPTION
Refs #180. Adds the wall-time breakdown to the benchmark record + PR comment table, per the request on the issue thread.

## What

`agg` already returns `wall_time_s` + `setup_s`/`fanout_s`/`finalize_s` in every summary; this surfaces them:

- **`RECORD_COLUMNS`** gains `total_wall_s`, `setup_s`, `fanout_s`, `finalize_s` (appended last, stable-schema rule — old parquet rows reindex to null, no migration).
- **`build_record`** threads them straight from the summary.
- **The rendered table** (PR comment / `latest.md` / PNG) gains two columns: **`wall (s)`** (total end-to-end AOI dispatch) and **`finalize (s)`** (the metadata-consolidation invoke). The existing `runtime (s)` (single-worker compute) is unchanged.

## Why

`runtime (s)` is per-shard worker compute; it badly understates what the orchestrator actually waits. On the o9 AOI, median worker ~56 s but **total wall ~154 s** — the gap is fanout/poll (≈ slowest worker) + a **~70 s fixed finalize** (`consolidate_metadata`) that's now ~half the wall since workers got 8× faster ([breakdown](https://github.com/englacial/zagg/issues/180#issuecomment-4909625641)). Surfacing `wall (s)` + `finalize (s)` makes both trackable run-over-run — and gives the finalize-cost regression (#191) a column to watch.

The CI runs one shard/target, so its `wall (s)` ≈ single-shard worker + finalize; still the right metric to track the finalize component.

## Testing

`tests/test_benchmark.py`: new `test_wall_breakdown_columns_threaded_and_rendered` (record threading, null-safe on older summaries, table cells), and the schema-order test updated for the four appended columns. Full file green; consumers verified (`update_series` reindexes → old rows null; `plot_series` untouched).
