### PR TITLE
Skip zarr metadata consolidation by default (opt-in)

### DIFF
--- a/notebooks/cryocloud_example.ipynb
+++ b/notebooks/cryocloud_example.ipynb
@@ -465,7 +465,7 @@
     "# open_store applies zagg's read-only retry policy (issue #186).\n",
     "store = open_store(OUTPUT_URL, read_only=True, skip_signature=True)\n",
     "ds = xr.open_dataset(\n",
-    "    store, engine='zarr', consolidated=True, zarr_format=3,\n",
+    "    store, engine='zarr', consolidated=False, zarr_format=3,\n",
     "    group=str(CHILD_ORDER),\n",
     ")\n",
     "\n",

--- a/notebooks/jupyterhub_example.ipynb
+++ b/notebooks/jupyterhub_example.ipynb
@@ -236,7 +236,7 @@
     "pub = xr.open_dataset(\n",
     "    open_store(f\"s3://{PUBLIC_BUCKET}/{PUBLIC_PREFIX}\", read_only=True, skip_signature=True),\n",
     "    engine=\"zarr\",\n",
-    "    consolidated=True,\n",
+    "    consolidated=False,\n",
     "    zarr_format=3,\n",
     "    group=str(CHILD_ORDER),\n",
     ")\n",

--- a/notebooks/rasterized_zarr.ipynb
+++ b/notebooks/rasterized_zarr.ipynb
@@ -88,7 +88,7 @@
     "%%time\n",
     "# Load raw zarr -- no xdggs decode needed\n",
     "ds = xr.open_dataset(\n",
-    "    store, engine=\"zarr\", consolidated=True, zarr_format=3,\n",
+    "    store, engine=\"zarr\", consolidated=False, zarr_format=3,\n",
     "    group=str(CHILD_ORDER),\n",
     ")\n",
     "\n",

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -309,6 +309,15 @@ def validate_config(config: PipelineConfig) -> None:
     if aoi_mask is not None and not isinstance(aoi_mask, bool):
         raise ValueError(f"output.aoi_mask must be a boolean (got {aoi_mask!r})")
 
+    # Optional zarr metadata consolidation (issue #191), default off. Must be a
+    # bool. No zagg reader depends on the consolidated blob, and building it is a
+    # ~70 s serial-GET finalize tax, so it is opt-in.
+    consolidate_metadata = config.output.get("consolidate_metadata")
+    if consolidate_metadata is not None and not isinstance(consolidate_metadata, bool):
+        raise ValueError(
+            f"output.consolidate_metadata must be a boolean (got {consolidate_metadata!r})"
+        )
+
     # Validate bounds structure (optional)
     if config.bounds is not None:
         allowed_keys = {"temporal", "spatial"}
@@ -1515,6 +1524,28 @@ def get_aoi_mask(config: PipelineConfig) -> bool:
     bool
     """
     return bool(config.output.get("aoi_mask", False))
+
+
+def get_consolidate_metadata(config: PipelineConfig) -> bool:
+    """Whether the finalize step consolidates zarr metadata (issue #191).
+
+    ``output.consolidate_metadata: true`` runs ``zarr.consolidate_metadata`` as a
+    finalize step after every cell completes, producing a consolidated-metadata
+    blob. Defaults to ``False``: no zagg reader opens with ``use_consolidated`` —
+    readers navigate to specific paths in a few GETs — and consolidation is an
+    optional zarr-v3 extension that costs ~70 s of serial metadata GETs per run.
+    When off, the finalize invoke is skipped entirely and stores read fine (v3
+    readers do lazy metadata reads natively).
+
+    Parameters
+    ----------
+    config : PipelineConfig
+
+    Returns
+    -------
+    bool
+    """
+    return bool(config.output.get("consolidate_metadata", False))
 
 
 def get_output_endpoint_url(config: PipelineConfig) -> str | None:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -33,6 +33,7 @@ from zagg.concurrency import (
 from zagg.config import (
     PipelineConfig,
     get_child_order,
+    get_consolidate_metadata,
     get_driver,
     get_handoff,
     get_layout,
@@ -1214,7 +1215,11 @@ def _run_local(
     finally:
         executor.shutdown()
 
-    consolidate_metadata(zarr_store, zarr_format=3)
+    # Metadata consolidation is opt-in (issue #191): no zagg reader depends on the
+    # consolidated blob and building it is a ~70 s serial-GET finalize tax, so
+    # skip it unless output.consolidate_metadata is true.
+    if get_consolidate_metadata(config):
+        consolidate_metadata(zarr_store, zarr_format=3)
     wall_time = time.time() - start_time
 
     summary = {
@@ -1429,16 +1434,30 @@ def _run_lambda(
             **extra,
         )
 
+    # Metadata consolidation is opt-in (issue #191): nothing in zagg's read path
+    # uses the consolidated blob and the finalize invoke is a ~70 s serial-GET tax,
+    # so gate the invoke dispatcher-side. When off we hand the executor a no-op
+    # finalize (mirroring the temporal path's ``_run_lambda_events``, which has no
+    # metadata to consolidate) so no ``mode: "finalize"`` Lambda is dispatched.
+    if get_consolidate_metadata(config):
+
+        def _finalize_fn():
+            return _invoke_lambda_finalize(
+                state["lambda_client"],
+                function_name,
+                store_path,
+                output_creds_event=output_creds_event,
+            )
+    else:
+
+        def _finalize_fn():
+            return None
+
     executor = LambdaExecutor(
         _cell_work,
         preflight_fn=_preflight,
         pool_factory=ThreadPoolExecutor,
-        finalize_fn=lambda: _invoke_lambda_finalize(
-            state["lambda_client"],
-            function_name,
-            store_path,
-            output_creds_event=output_creds_event,
-        ),
+        finalize_fn=_finalize_fn,
     )
     # preflight() runs the probe, builds the sized client, and sizes the pool.
     executor.preflight(len(cells))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2099,3 +2099,29 @@ class TestMerra2StormTemplate:
             assert spec["spatial_func"] in registry.list_spatial_funcs()
             assert spec["temporal_reducer"] in registry.list_reducers()
             assert spec["mask"] in registry.list_mask_providers()
+
+
+class TestConsolidateMetadataFlag:
+    """Issue #191: metadata consolidation is opt-in via output.consolidate_metadata
+    (default False) — no zagg reader depends on the consolidated blob and building
+    it is a ~70 s serial-GET finalize tax."""
+
+    def test_default_off(self):
+        from zagg.config import get_consolidate_metadata
+
+        assert get_consolidate_metadata(default_config("atl06")) is False
+
+    def test_accessor_true(self):
+        from zagg.config import get_consolidate_metadata
+
+        cfg = default_config("atl06")
+        cfg.output = {**cfg.output, "consolidate_metadata": True}
+        assert get_consolidate_metadata(cfg) is True
+
+    def test_validate_rejects_non_bool(self):
+        from zagg.config import validate_config
+
+        cfg = default_config("atl06")
+        cfg.output = {**cfg.output, "consolidate_metadata": "yes"}
+        with pytest.raises(ValueError, match="output.consolidate_metadata must be a boolean"):
+            validate_config(cfg)

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -374,7 +374,13 @@ class TestReadParityWithoutConsolidation:
 
     def _build_store(self):
         """A two-shard located t-digest field, written like the worker's CSR
-        path (per-parent-morton subgroups), with no consolidated metadata."""
+        path (per-parent-morton subgroups), with no consolidated metadata.
+
+        The leaf ShardingCodec is deliberately omitted: ``consolidate_metadata``
+        is a pure metadata-tree op (it gathers each group/array ``zarr.json``),
+        orthogonal to the leaf codec, and the per-morton CSR subgroups are
+        exactly the objects that dominate the finalize cost this PR skips — so
+        the parity claim holds without the sharding codec in the fixture."""
         store = MemoryStore()
         # Two coverage chunks (parent mortons 100 and 205), distinct values so
         # read_raw_values is lossless (every centroid weight 1).

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,6 +1,7 @@
 """Tests for the t-digest → tensor read helpers — issue #79."""
 
 import math
+import warnings
 
 import numpy as np
 import pytest
@@ -356,3 +357,92 @@ class TestReadLocations:
         _write_chunk(store, "f", 7, {0: np.array([1.0, 2.0])})
         with pytest.raises(ValueError, match="has no locations array"):
             list(read_locations(store, "f"))
+
+
+class TestReadParityWithoutConsolidation:
+    """Issue #191: consolidation is now opt-out, so published stores are read
+    without a consolidated-metadata blob. Pin that every reader navigates a
+    non-consolidated store to the same bytes it would read from a consolidated
+    one — readers reach paths directly (``zarr.open_group``/``open_array`` per
+    subgroup), never the consolidated blob."""
+
+    @staticmethod
+    def _point_words(n, seed):
+        from conftest import point_words
+
+        return point_words(n, seed)
+
+    def _build_store(self):
+        """A two-shard located t-digest field, written like the worker's CSR
+        path (per-parent-morton subgroups), with no consolidated metadata."""
+        store = MemoryStore()
+        # Two coverage chunks (parent mortons 100 and 205), distinct values so
+        # read_raw_values is lossless (every centroid weight 1).
+        shards = {
+            100: {0: np.array([10.0, 11.0, 12.0]), 5: np.array([13.0, 14.0])},
+            205: {2: np.array([20.0, 21.0]), 63: np.array([22.0, 23.0, 24.0])},
+        }
+        seed = 1
+        for morton, cell_to_vals in shards.items():
+            cell_ids = sorted(cell_to_vals)
+            pairs = [
+                build_tdigest(
+                    cell_to_vals[c],
+                    delta=512,
+                    locations=self._point_words(len(cell_to_vals[c]), seed),
+                )
+                for c in cell_ids
+            ]
+            write_csr(
+                store,
+                f"h_tdigest/{morton}",
+                [p[0] for p in pairs],
+                cell_ids,
+                locations_list=[p[1] for p in pairs],
+            )
+            seed += 1
+        return store
+
+    @staticmethod
+    def _read_all(store):
+        from zagg.readers.tdigest_tensor import read_locations
+
+        tensors = {m: t for t, m in read_tensors(store, "h_tdigest", n_bins=64, resolution=0.5)}
+        raw = {(m, c): v for m, c, v in read_raw_values(store, "h_tdigest")}
+        locs = {(m, c): loc for m, c, loc in read_locations(store, "h_tdigest")}
+        return tensors, raw, locs
+
+    def test_non_consolidated_is_navigable_and_reads_parity(self):
+        store = self._build_store()
+
+        # A freshly written store carries NO consolidated-metadata blob — the
+        # default now (issue #191). Readers must still navigate it.
+        root = zarr.open_group(store, mode="r", zarr_format=3)
+        assert root.metadata.consolidated_metadata is None
+
+        tensors_plain, raw_plain, locs_plain = self._read_all(store)
+        # Sanity: the readers actually reached the data.
+        assert set(tensors_plain) == {100, 205}
+        assert (100, 0) in raw_plain and (205, 63) in raw_plain
+
+        # Consolidate the SAME store and re-read: consolidation only adds a
+        # metadata blob no reader consults, so every byte must match.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            zarr.consolidate_metadata(store, zarr_format=3)
+        assert (
+            zarr.open_group(store, mode="r", zarr_format=3).metadata.consolidated_metadata
+            is not None
+        )
+
+        tensors_cons, raw_cons, locs_cons = self._read_all(store)
+
+        assert set(tensors_cons) == set(tensors_plain)
+        for m in tensors_plain:
+            np.testing.assert_array_equal(tensors_plain[m], tensors_cons[m])
+        assert set(raw_cons) == set(raw_plain)
+        for key in raw_plain:
+            np.testing.assert_array_equal(raw_plain[key], raw_cons[key])
+        assert set(locs_cons) == set(locs_plain)
+        for key in locs_plain:
+            np.testing.assert_array_equal(locs_plain[key], locs_cons[key])

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3115,3 +3115,118 @@ class TestWorkerPhaseTimings:
         meta = self._run(monkeypatch, profile=True, with_data=False)
         assert meta["error"] == "No data after filtering"
         assert set(meta["phase_timings"]) == {"read"}
+
+
+class TestConsolidationGate:
+    """Issue #191: metadata consolidation is opt-in. With the flag off (default)
+    the local runner skips the ``consolidate_metadata`` call and the Lambda
+    dispatcher skips the ``mode: "finalize"`` invoke entirely; with the flag on
+    both still run, byte-identical to the pre-#191 behavior."""
+
+    def _local_consolidate_calls(self, monkeypatch, atl06_config, *, enabled):
+        import zagg.grids as grids_mod
+        from zagg import runner
+
+        monkeypatch.setattr(
+            runner,
+            "get_nsidc_s3_credentials",
+            lambda: {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
+        )
+        monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
+        monkeypatch.setattr(runner, "open_store", lambda *a, **k: object())
+        calls = []
+        monkeypatch.setattr(runner, "consolidate_metadata", lambda *a, **k: calls.append(1))
+        monkeypatch.setattr(
+            runner,
+            "_process_and_write",
+            lambda shard_key, *a, **k: {"shard_key": shard_key, "total_obs": 1, "error": None},
+        )
+        if enabled:
+            atl06_config.output = {**atl06_config.output, "consolidate_metadata": True}
+        runner._run_local(
+            atl06_config,
+            _run_catalog(),
+            "./out.zarr",
+            12,
+            max_cells=None,
+            morton_cell=None,
+            max_workers=1,
+            overwrite=False,
+            dry_run=False,
+            region="us-west-2",
+        )
+        return len(calls)
+
+    def test_local_skips_consolidation_by_default(self, monkeypatch, atl06_config):
+        assert self._local_consolidate_calls(monkeypatch, atl06_config, enabled=False) == 0
+
+    def test_local_consolidates_when_enabled(self, monkeypatch, atl06_config):
+        assert self._local_consolidate_calls(monkeypatch, atl06_config, enabled=True) == 1
+
+    def _lambda_finalize_calls(self, monkeypatch, atl06_config, *, enabled):
+        import boto3
+
+        import zagg.grids as grids_mod
+        from zagg import runner
+        from zagg.concurrency import ConcurrencyReport
+
+        monkeypatch.setattr(
+            runner,
+            "get_nsidc_s3_credentials",
+            lambda: {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
+        )
+        monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
+        monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        calls = []
+        monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: calls.append(1))
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(
+            runner,
+            "compute_available_workers",
+            lambda requested, *a, **k: (
+                1,
+                ConcurrencyReport(
+                    account_limit=1000,
+                    current_concurrent=0,
+                    padding=100,
+                    available=900,
+                    function_reserved=None,
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            runner,
+            "_invoke_lambda_cell",
+            lambda client, chunk_idx, shard_key, *a, **k: {
+                "shard_key": shard_key,
+                "status_code": 200,
+                "body": {"total_obs": 1},
+                "error": None,
+                "timeout": False,
+            },
+        )
+        if enabled:
+            atl06_config.output = {**atl06_config.output, "consolidate_metadata": True}
+        runner._run_lambda(
+            atl06_config,
+            _run_catalog(),
+            "s3://out/x.zarr",
+            12,
+            max_cells=None,
+            morton_cell=None,
+            max_workers=1,
+            overwrite=False,
+            dry_run=False,
+            region="us-west-2",
+            function_name="fn",
+        )
+        return len(calls)
+
+    def test_lambda_skips_finalize_by_default(self, monkeypatch, atl06_config):
+        assert self._lambda_finalize_calls(monkeypatch, atl06_config, enabled=False) == 0
+
+    def test_lambda_finalizes_when_enabled(self, monkeypatch, atl06_config):
+        assert self._lambda_finalize_calls(monkeypatch, atl06_config, enabled=True) == 1


### PR DESCRIPTION
Closes #191

## What / approach

Metadata consolidation (`zarr.consolidate_metadata`, run as a finalize step after every AOI dispatch) costs ~70 s/run and produces a consolidated-metadata blob that nothing in zagg's read path consults — readers navigate to specific paths in a few GETs, and the write path already passes `consolidated=False` everywhere. This makes consolidation **opt-in** via a new `output.consolidate_metadata` flag (default `false`), gated dispatcher-side so the finalize invoke is skipped entirely when off.

- **Config** (`src/zagg/config.py`): added `output.consolidate_metadata` (default `false`) with a boolean validator (mirrors `output.aoi_mask`) and a `get_consolidate_metadata()` accessor (mirrors `get_aoi_mask()`).
- **Local backend** (`src/zagg/runner.py` `_run_local`): the `consolidate_metadata(zarr_store, zarr_format=3)` call now runs only when the flag is true.
- **Lambda backend** (`_run_lambda`): the `mode: "finalize"` invoke is gated dispatcher-side — when the flag is off the executor gets a no-op `finalize_fn` (mirroring the temporal path `_run_lambda_events`, which already skips finalize because tabular output has no metadata to consolidate), so no finalize Lambda is dispatched. When on, `_invoke_lambda_finalize` runs byte-identically to before. The `mode: "finalize"` handler in `deployment/aws/lambda_handler.py` is unchanged — it still consolidates when invoked (which now only happens on the opt-in path), so it needed no edit.

Behavior when the flag **is** true is identical to the pre-change path (still consolidates, both backends).

### Notebooks

The example notebooks read the published `atl06_cycle22_fullsphere.zarr` store with `xr.open_dataset(..., consolidated=True)`. Since that store will be regenerated without consolidation (opt-out, no backward-compat needed), those reads are flipped to `consolidated=False`. `consolidated=False` is a safe v3 read regardless (readers do lazy metadata reads natively). Edited via a surgical JSON round-trip (`indent=1, ensure_ascii=False` — verified identical to the repo's on-disk formatting), so each notebook has a **one-line diff** and cell ids/outputs are untouched.

## Phases

- [x] **Phase 1** — Default-skip gate + `output.consolidate_metadata` config flag (config accessor/validator; local + Lambda dispatcher-side gate).
- [x] **Phase 2** — Notebooks flipped to `consolidated=False` + read-parity test.
- [x] **Phase 3** — Parallelize the opt-in consolidation path. **Out of scope here; tracked in #194** (see Questions for review 2).
- [x] Fold adversarial-review finding ([review](https://github.com/englacial/zagg/pull/193#pullrequestreview-4649930199)): document in the parity fixture that the leaf ShardingCodec is deliberately omitted (orthogonal to the metadata-tree consolidation path).

## How it was tested

- `uv run pytest -q` (excluding two pre-existing `pyarrow`-gated modules — see below): **1443 passed, 20 skipped** in 401 s.
- Touched suites (`test_readers test_config test_runner test_output`): **419 passed**.
- `uv run ruff check` and `uv run ruff format --check` on every touched file: clean.

New tests:
- `tests/test_config.py::TestConsolidateMetadataFlag` — accessor default off, accessor true, validator rejects non-bool.
- `tests/test_runner.py::TestConsolidationGate` — local runner skips `consolidate_metadata` by default and calls it when enabled; Lambda dispatcher skips `_invoke_lambda_finalize` by default and calls it when enabled.
- `tests/test_readers.py::TestReadParityWithoutConsolidation` — builds a two-shard located t-digest CSR store with **no** consolidated metadata (the default now), asserts `read_tensors` / `read_raw_values` / `read_locations` reach the data, then consolidates the same store and asserts every reader returns byte-identical results. Also pins that a freshly written store carries no consolidated-metadata blob (`root.metadata.consolidated_metadata is None`) yet is fully navigable.

## Questions for review

1. **Third notebook beyond the two named in the issue.** `notebooks/rasterized_zarr.ipynb` reads the *same* regenerated store with `consolidated=True`, so it's flipped too (a one-line kwarg change), otherwise it would break against the non-consolidated store. Call out if you'd rather scope this PR to only the two the issue enumerated.
2. **Phase 3 deferred → tracked in #194.** `zarr==3.2.1`'s `consolidate_metadata(store, path, zarr_format)` exposes **no** concurrency parameter; the only lever is the global `zarr.config['async.concurrency']` (default 10), whose effect on the ~4,102-object serial-GET path can't be verified without the production store the issue measured against. Per the issue's guidance ("if it doesn't expose concurrency cleanly, don't fight it — note the finding and defer; do not add a dependency"), it's deferred to #194. The opt-in path is off by default, so it's not a default foot-gun.
3. **Pre-existing lint drift (not fixed, per conventions).** `ruff check src tests` reports 1 pre-existing `N818` in `src/zagg/registry.py` (`UnknownCapability`), and `ruff format --check src tests` would reformat 7 files I did not touch (`src/zagg/__init__.py`, `src/zagg/__main__.py`, `src/zagg/catalog/sources.py`, `src/zagg/viz/crs.py`, `tests/test_catalog.py`, `tests/test_extract.py`, `tests/test_integration.py`). All of my touched files are clean.
4. **Pre-existing test-collection gap.** `tests/test_shardmap.py` and `tests/test_viz.py` fail to collect under `uv sync --extra test` because they `import pyarrow`, which the `test` extra doesn't install (present on `origin/main` too). Excluded from the run above; unrelated to this change.

_Note on the earlier #188 merge-order caveat: PR #188 has since merged to `main`, and this branch is based on `5004df4` (post-merge), so the notebook cells already carry both the `open_store` rewire and `consolidated=False` — no rebase needed._