### PR TITLE
Temporal event triggers, reader features, and event contract (issue #213)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -82,9 +82,9 @@ Process-event mode (the temporal/event pipeline worker -- issue #12, Phase 7b):
     "event_key": str,           # identifier for this event row
     "event_mask_uri": str,      # s3:// (or local) URI of the event mask
                                 #   DataArray (one variable, time x lat x lon)
-    "collection_uris": {        # {collection_name: uri} the specs read
-        "merra2_slv": "s3://.../merra2_slv.zarr", ...
-    },
+    "collection_uris": {        # {collection_name: uri or [uris]} the specs
+        "merra2_slv": "s3://.../merra2_slv.zarr", ...  #  read; a list (multi-
+    },                          #  granule event) concats along time
     "static_uris": {            # {static_name: uri}, e.g. ais_mask / climatology
         "ais_mask": "s3://.../ais_mask.nc", ...
     },
@@ -722,8 +722,10 @@ def _handle_process_event(event: Dict[str, Any]) -> Dict[str, Any]:
     ``zagg.temporal.process_event`` for the single event, and write the
     flattened result row to the tabular ``store_path``.
     """
+    from zagg import registry as zagg_registry
+    from zagg.config import collection_options as _collection_options
     from zagg.output import write_tabular
-    from zagg.temporal import open_dataset, process_event, read_temporal_inputs, specs_from_config
+    from zagg.temporal import open_dataset, process_event, specs_from_config
 
     event_key = event.get("event_key")
     logger.info(f"process_event mode: event {event_key!r}")
@@ -758,11 +760,15 @@ def _handle_process_event(event: Dict[str, Any]) -> Dict[str, Any]:
         if mask_vars:
             event_mask = event_mask[mask_vars[0]]
 
-        collections, static_data = read_temporal_inputs(
+        # The reader resolves by name (issue #213 Phase 3): only names present
+        # in the layer's registry are reachable -- the payload stays pure data.
+        reader = zagg_registry.get_reader((config.data_source or {}).get("reader") or "xarray_s3")
+        collections, static_data = reader(
             event.get("collection_uris", {}),
             event.get("static_uris", {}),
             credentials=read_creds,
             region=region,
+            collection_options=_collection_options(config),
         )
 
         results, meta = process_event(event_key, event_mask, collections, specs, static_data)

--- a/docs/temporal_events.md
+++ b/docs/temporal_events.md
@@ -1,0 +1,129 @@
+# Temporal events: the consumer contract
+
+The temporal pipeline (`pipeline.type: temporal`, issues #12/#213) aggregates
+*events* — spatiotemporal objects like storms — into one tabular row of scalar
+attributes each. This page is the stable interface for libraries that feed
+events into `zagg.agg()`: the event shapes both backends accept, the config
+blocks that describe collections and specs, and the capability-resolution
+policy that governs what runs where.
+
+## The event model
+
+An event is **one binary mask** with dims `(time, lat, lon)`: where and when
+the object exists. `process_event` streams the mask's timesteps, applies a
+per-timestep `spatial_func` under a `mask` provider, and reduces across time
+with a `temporal_reducer` — one scalar per configured attribute.
+
+There is deliberately no second mask channel: an attribute set needing a
+different footprint (e.g. a precipitation lookahead window) is a *different
+event set*. Run `agg()` once per mask family and join the tabular outputs on
+`event_key`.
+
+## Passing events
+
+`zagg.agg(config, events=..., backend=...)` accepts events in two shapes,
+chosen by the backend:
+
+**Local backend** — in-memory tuples, one per event:
+
+```python
+(event_key, event_mask, collections, static_data)
+```
+
+- `event_key`: hashable identifier, echoed into the output row.
+- `event_mask`: `xr.DataArray`, dims `(time, lat, lon)`.
+- `collections`: `{name: xr.Dataset}` — the source fields, already opened.
+  The runner applies the config's per-collection options (below) to each
+  event's collections, so local and Lambda semantics match.
+- `static_data`: `{name: DataArray | Dataset}` — e.g. `ais_mask`,
+  `cell_areas`, `climatology`.
+
+**Lambda backend** — URI dicts, one per event; the worker loads its own
+inputs, keeping the async payload far under Lambda's 256 KB Event cap:
+
+```python
+{
+    "event_key": "storm_00042",
+    "event_mask_uri": "s3://.../masks/storm_00042.nc",
+    "collection_uris": {"merra2_slv": ["s3://.../day1.nc4", "s3://.../day2.nc4"]},
+    "static_uris": {"ais_mask": "s3://.../ais_mask.nc", "cell_areas": "s3://.../areas.nc"},
+    "s3_credentials": {...},   # optional, per-event read credentials
+}
+```
+
+- `event_mask_uri` / `static_uris` values: a single URI each (local path,
+  `s3://`; `.zarr` opens as a store, anything else is fetched as bytes and
+  opened in-memory). A single-variable file becomes a `DataArray`.
+- `collection_uris` values: one URI **or a list** — a multi-granule event
+  (e.g. a storm spanning several MERRA-2 daily files) is opened per-URI,
+  concatenated along `time`, and time-sorted.
+- `s3_credentials`: optional. Events without it receive shared credentials
+  fetched once from the `data_source.credentials_provider` registry name when
+  the config sets one (`nsidc` and `gesdisc` ship as built-ins).
+
+The full worker payload (mode, config, `return_results`, `result_url`) is
+assembled by the runner — consumers supply only the dicts above.
+
+## Describing collections
+
+`data_source.collections` accepts a list of names, or a mapping carrying
+declarative per-collection reader options:
+
+```yaml
+data_source:
+  reader: xarray_s3
+  collections:
+    merra2_slv:                 # no options needed
+    merra2_precip:
+      variables: [PRECCU, PRECLS, PRECSN]      # subset before anything else
+      time_offset: "-30min"                     # shift stamps onto the hour
+      resample: {freq: "3h", how: sum, scale: 3600}  # rates -> totals
+      derived:
+        rainfall: "PRECCU + PRECLS"             # numpy expression
+      doi: "10.5067/Q5GVUVUIVGO7"               # unknown keys pass through
+```
+
+Options apply in the order listed above (`prepare_collection`). `derived`
+expressions evaluate in the same restricted namespace as the spatial
+pipeline's `expression` fields: numpy plus the collection's variables, no
+builtins. Unknown keys (like `doi`) are ignored by the reader — they are
+metadata for catalog tooling. Validated option values fail at config load,
+not per-worker.
+
+## Spec keys
+
+Each `aggregation.variables` entry:
+
+| key | required | meaning |
+|---|---|---|
+| `variable` | yes | variable name in the collection (may be `derived`) |
+| `collection` | yes | collection name |
+| `spatial_func` | yes | per-timestep reduction (registry name) |
+| `temporal_reducer` | yes | cross-timestep accumulator (registry name) |
+| `mask` | no (`ais`) | mask provider: `full` / `ais` / `ocean` / registered |
+| `anomaly` | no | sugar for `transform: monthly_anomaly` |
+| `transform` | no | field-transform name applied per timestep |
+| `negate` | no | negate the field (southward-positive fluxes) |
+| `trigger` | no | event-trigger name gating which timesteps update (e.g. `first_landfall`) |
+| `trigger_mask` | no | static field the trigger tests against (default `ais_mask`) |
+| `params` | no | free-form mapping passed to capabilities verbatim |
+
+## Capability resolution and the worker policy
+
+Every name above resolves through `zagg.registry` at run time. The Lambda
+payload is **pure data** — capability names, numpy expressions, URIs — and a
+name only resolves against what is installed in the worker's layer. There is
+no mechanism for shipping third-party code to the fleet, by design (issue
+#213): on `backend="lambda"`, worker-side capabilities are zagg built-ins and
+declarative config, full stop.
+
+The registries stay open on `backend="local"`: register a custom trigger,
+reducer, mask, transform, or reader (directly via `zagg.registry.register_*`
+or a `zagg.plugins` entry point) and run it on your own machine. To make a
+capability Lambda-eligible, upstream it into zagg as a built-in — prototyping
+locally as a plugin and promoting what proves out is the intended
+contribution funnel.
+
+Credential providers run orchestrator-side, so they carry no such
+restriction; `data_source.credentials_provider` may name a plugin provider on
+either backend.

--- a/docs/temporal_events.md
+++ b/docs/temporal_events.md
@@ -52,8 +52,9 @@ inputs, keeping the async payload far under Lambda's 256 KB Event cap:
 ```
 
 - `event_mask_uri` / `static_uris` values: a single URI each (local path,
-  `s3://`; `.zarr` opens as a store, anything else is fetched as bytes and
-  opened in-memory). A single-variable file becomes a `DataArray`.
+  `s3://`; `.zarr` opens as a store, a local non-`.zarr` path opens directly,
+  and an `s3://` non-`.zarr` object is fetched as bytes and opened
+  in-memory). A single-variable file becomes a `DataArray`.
 - `collection_uris` values: one URI **or a list** — a multi-granule event
   (e.g. a storm spanning several MERRA-2 daily files) is opened per-URI,
   concatenated along `time`, and time-sorted.
@@ -106,7 +107,7 @@ Each `aggregation.variables` entry:
 | `negate` | no | negate the field (southward-positive fluxes) |
 | `trigger` | no | event-trigger name gating which timesteps update (e.g. `first_landfall`) |
 | `trigger_mask` | no | static field the trigger tests against (default `ais_mask`) |
-| `params` | no | free-form mapping passed to capabilities verbatim |
+| `params` | no | free-form mapping threaded into mask providers, field transforms, and event triggers (not spatial_funcs or reducers) |
 
 ## Capability resolution and the worker policy
 
@@ -127,5 +128,6 @@ contribution funnel.
 Credential providers run orchestrator-side, so they carry no such
 restriction; `data_source.credentials_provider` may name a plugin provider on
 either backend — including non-NASA S3-compatible sources. The spatial
-pipeline honors the same key for its source reads, defaulting to `nsidc` when
-the key is absent.
+pipeline honors the same key for its S3-driver source reads, defaulting to
+`nsidc` when the key is absent; the HTTPS driver instead authenticates with an
+EDL bearer token and does not consult credential providers.

--- a/docs/temporal_events.md
+++ b/docs/temporal_events.md
@@ -126,4 +126,6 @@ contribution funnel.
 
 Credential providers run orchestrator-side, so they carry no such
 restriction; `data_source.credentials_provider` may name a plugin provider on
-either backend.
+either backend — including non-NASA S3-compatible sources. The spatial
+pipeline honors the same key for its source reads, defaulting to `nsidc` when
+the key is absent.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - "Ragged store layout": "ragged_layout.md"
       - "Hive store layout": "hive_layout.md"
       - "Typed morton boundary": "morton_arrow.md"
+      - "Temporal events": "temporal_events.md"
   - "Deployment":
       - "Standing Up the Backend": "deployment/standup.md"
       - "AWS Lambda": "deployment/lambda.md"

--- a/src/zagg/auth.py
+++ b/src/zagg/auth.py
@@ -17,6 +17,8 @@ import time
 
 import earthaccess
 
+from . import registry
+
 logger = logging.getLogger(__name__)
 
 # ``earthaccess.login()`` makes an HTTPS call to ``urs.earthdata.nasa.gov`` to
@@ -123,5 +125,36 @@ def get_nsidc_s3_credentials() -> dict:
     }
     ```
     """
+    return get_daac_s3_credentials("NSIDC")
+
+
+def get_daac_s3_credentials(daac: str) -> dict:
+    """Return temporary S3 credentials for a NASA DAAC (direct S3 access).
+
+    The generic form of :func:`get_nsidc_s3_credentials` (issue #213, Phase 4):
+    same orchestrator-side call-once contract and ~1 h validity, with the DAAC
+    selected by whatever name ``earthaccess`` accepts (e.g. ``"NSIDC"``,
+    ``"GES_DISC"``). DAAC S3 endpoints are in-region only (us-west-2).
+    """
     auth = _login_with_retry()
-    return auth.get_s3_credentials(daac="NSIDC")
+    return auth.get_s3_credentials(daac=daac)
+
+
+def get_gesdisc_s3_credentials() -> dict:
+    """Return temporary S3 credentials for GES DISC (MERRA-2 and friends)."""
+    return get_daac_s3_credentials("GES_DISC")
+
+
+registry.register_credential_provider(
+    "nsidc",
+    get_nsidc_s3_credentials,
+    description="Earthdata temporary S3 credentials for NSIDC (ICESat-2 products)",
+)
+registry.register_credential_provider(
+    "gesdisc",
+    get_gesdisc_s3_credentials,
+    description="Earthdata temporary S3 credentials for GES DISC (MERRA-2 reanalysis)",
+)
+
+#: The credential-provider registry (``zagg.registry.CREDENTIAL_PROVIDERS``).
+CREDENTIAL_PROVIDERS = registry.CREDENTIAL_PROVIDERS

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -73,6 +73,11 @@ class DataSourceDict(TypedDict):
     # keys are backend-specific and validated against the backend's declared
     # ``config_keys`` — irrelevant keys are config errors, not ignored.
     index: NotRequired[dict]
+    # Credential-provider registry name for source-data S3 reads (issue #213
+    # Phase 4/6): built-ins ``nsidc``/``gesdisc``; plugins may register others.
+    # Absent → the spatial default (NSIDC); temporal events may also carry
+    # per-event ``s3_credentials``, which win.
+    credentials_provider: NotRequired[str]
 
 
 # Structured-predicate comparison operators (issue #43). ``in``/``not_in`` take a
@@ -217,6 +222,15 @@ def validate_config(config: PipelineConfig) -> None:
     # validate their own (much smaller) spec shape and return early -- they
     # carry no output grid and run through the event-streaming engine
     # (``zagg.temporal.process_event``) rather than the point-cloud path.
+    # Both pipeline kinds honor a provider-selected source-credential fetch
+    # (issue #213 Phase 6), so the key's shape is checked before the branch.
+    provider = (config.data_source or {}).get("credentials_provider")
+    if provider is not None and not isinstance(provider, str):
+        raise ValueError(
+            "data_source.credentials_provider must be a credential-provider "
+            f"registry name string, e.g. 'nsidc' or 'gesdisc' (got {provider!r})"
+        )
+
     ptype = get_pipeline_type(config)
     if ptype != "spatial":
         _validate_temporal_config(config)
@@ -565,12 +579,6 @@ def _validate_temporal_config(config: PipelineConfig) -> None:
                 f"temporal variable '{name}' params must be a mapping (got {params!r})"
             )
     _validate_collection_options(config)
-    provider = (config.data_source or {}).get("credentials_provider")
-    if provider is not None and not isinstance(provider, str):
-        raise ValueError(
-            "data_source.credentials_provider must be a credential-provider "
-            f"registry name string, e.g. 'nsidc' or 'gesdisc' (got {provider!r})"
-        )
 
 
 _RESAMPLE_HOWS = ("sum", "mean")

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -559,6 +559,11 @@ def _validate_temporal_config(config: PipelineConfig) -> None:
                 f"temporal variable '{name}' is missing required key(s): "
                 f"{', '.join(missing)} (need {', '.join(_TEMPORAL_SPEC_KEYS)})"
             )
+        params = meta.get("params")
+        if params is not None and not isinstance(params, dict):
+            raise ValueError(
+                f"temporal variable '{name}' params must be a mapping (got {params!r})"
+            )
     _validate_collection_options(config)
     provider = (config.data_source or {}).get("credentials_provider")
     if provider is not None and not isinstance(provider, str):

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -560,6 +560,12 @@ def _validate_temporal_config(config: PipelineConfig) -> None:
                 f"{', '.join(missing)} (need {', '.join(_TEMPORAL_SPEC_KEYS)})"
             )
     _validate_collection_options(config)
+    provider = (config.data_source or {}).get("credentials_provider")
+    if provider is not None and not isinstance(provider, str):
+        raise ValueError(
+            "data_source.credentials_provider must be a credential-provider "
+            f"registry name string, e.g. 'nsidc' or 'gesdisc' (got {provider!r})"
+        )
 
 
 _RESAMPLE_HOWS = ("sum", "mean")

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -559,6 +559,94 @@ def _validate_temporal_config(config: PipelineConfig) -> None:
                 f"temporal variable '{name}' is missing required key(s): "
                 f"{', '.join(missing)} (need {', '.join(_TEMPORAL_SPEC_KEYS)})"
             )
+    _validate_collection_options(config)
+
+
+_RESAMPLE_HOWS = ("sum", "mean")
+
+
+def _validate_collection_options(config: PipelineConfig) -> None:
+    """Validate ``data_source.collections`` (issue #213, Phase 3).
+
+    The block accepts a list of collection names (no options) or a mapping of
+    name -> per-collection reader options consumed by
+    :func:`zagg.temporal.prepare_collection`: ``variables`` (list of names),
+    ``time_offset`` (a pandas-parseable offset string), ``resample``
+    (``{freq, how: sum|mean, scale}``), and ``derived`` (name -> numpy
+    expression string). Unknown option keys (e.g. ``doi``) pass through for
+    catalog tooling. Fails at load so a config typo doesn't surface as a
+    per-event worker error after the Lambda spend.
+    """
+    colls = (config.data_source or {}).get("collections")
+    if colls is None or isinstance(colls, list):
+        return
+    if not isinstance(colls, dict):
+        raise ValueError(
+            "data_source.collections must be a list of names or a mapping of "
+            f"name -> options (got {type(colls).__name__})"
+        )
+    for cname, opts in colls.items():
+        if opts is None:
+            continue
+        if not isinstance(opts, dict):
+            raise ValueError(
+                f"data_source.collections[{cname!r}] must be a mapping of options (or null)"
+            )
+        variables = opts.get("variables")
+        if variables is not None and (
+            not isinstance(variables, list) or not all(isinstance(v, str) for v in variables)
+        ):
+            raise ValueError(
+                f"data_source.collections[{cname!r}].variables must be a list of names"
+            )
+        offset = opts.get("time_offset")
+        if offset is not None and not isinstance(offset, str):
+            raise ValueError(
+                f"data_source.collections[{cname!r}].time_offset must be an offset "
+                f"string like '-30min' (got {offset!r})"
+            )
+        resample = opts.get("resample")
+        if resample is not None:
+            if not isinstance(resample, dict) or "freq" not in resample:
+                raise ValueError(
+                    f"data_source.collections[{cname!r}].resample must be a mapping "
+                    "with at least 'freq' (optional: how, scale)"
+                )
+            how = resample.get("how", "sum")
+            if how not in _RESAMPLE_HOWS:
+                raise ValueError(
+                    f"data_source.collections[{cname!r}].resample.how must be one of "
+                    f"{_RESAMPLE_HOWS} (got {how!r})"
+                )
+            scale = resample.get("scale", 1)
+            if isinstance(scale, bool) or not isinstance(scale, (int, float)):
+                raise ValueError(
+                    f"data_source.collections[{cname!r}].resample.scale must be numeric "
+                    f"(got {scale!r})"
+                )
+        derived = opts.get("derived")
+        if derived is not None and (
+            not isinstance(derived, dict)
+            or not all(isinstance(k, str) and isinstance(v, str) for k, v in derived.items())
+        ):
+            raise ValueError(
+                f"data_source.collections[{cname!r}].derived must map variable names "
+                "to expression strings"
+            )
+
+
+def collection_options(config: PipelineConfig) -> dict[str, dict]:
+    """Normalize ``data_source.collections`` to ``{name: options}``.
+
+    Both config forms collapse to one shape: the list form (names only) yields
+    empty option dicts; the mapping form yields each collection's options
+    verbatim (``null`` becomes ``{}``). Consumed by the temporal reader /
+    :func:`zagg.temporal.prepare_collection`.
+    """
+    colls = (config.data_source or {}).get("collections") or []
+    if isinstance(colls, dict):
+        return {name: dict(opts or {}) for name, opts in colls.items()}
+    return {name: {} for name in colls}
 
 
 def _validate_chunk_precompute(aggregation: dict, ds_vars: set[str]) -> None:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -579,9 +579,10 @@ def _validate_collection_options(config: PipelineConfig) -> None:
     :func:`zagg.temporal.prepare_collection`: ``variables`` (list of names),
     ``time_offset`` (a pandas-parseable offset string), ``resample``
     (``{freq, how: sum|mean, scale}``), and ``derived`` (name -> numpy
-    expression string). Unknown option keys (e.g. ``doi``) pass through for
-    catalog tooling. Fails at load so a config typo doesn't surface as a
-    per-event worker error after the Lambda spend.
+    expression string). ``time_offset`` and ``resample.freq`` are parsed with
+    pandas here so an unparseable value fails at load rather than surfacing as
+    a per-event worker error after the Lambda spend. Unknown option keys (e.g.
+    ``doi``) pass through by design for catalog tooling metadata.
     """
     colls = (config.data_source or {}).get("collections")
     if colls is None or isinstance(colls, list):
@@ -606,11 +607,21 @@ def _validate_collection_options(config: PipelineConfig) -> None:
                 f"data_source.collections[{cname!r}].variables must be a list of names"
             )
         offset = opts.get("time_offset")
-        if offset is not None and not isinstance(offset, str):
-            raise ValueError(
-                f"data_source.collections[{cname!r}].time_offset must be an offset "
-                f"string like '-30min' (got {offset!r})"
-            )
+        if offset is not None:
+            if not isinstance(offset, str):
+                raise ValueError(
+                    f"data_source.collections[{cname!r}].time_offset must be an offset "
+                    f"string like '-30min' (got {offset!r})"
+                )
+            import pandas as pd
+
+            try:
+                pd.to_timedelta(offset)
+            except (ValueError, TypeError) as exc:
+                raise ValueError(
+                    f"data_source.collections[{cname!r}].time_offset is not a valid "
+                    f"pandas offset string (got {offset!r})"
+                ) from exc
         resample = opts.get("resample")
         if resample is not None:
             if not isinstance(resample, dict) or "freq" not in resample:
@@ -618,6 +629,21 @@ def _validate_collection_options(config: PipelineConfig) -> None:
                     f"data_source.collections[{cname!r}].resample must be a mapping "
                     "with at least 'freq' (optional: how, scale)"
                 )
+            freq = resample["freq"]
+            if not isinstance(freq, str):
+                raise ValueError(
+                    f"data_source.collections[{cname!r}].resample.freq must be a "
+                    f"frequency string like '3h' (got {freq!r})"
+                )
+            import pandas as pd
+
+            try:
+                pd.tseries.frequencies.to_offset(freq)
+            except (ValueError, TypeError) as exc:
+                raise ValueError(
+                    f"data_source.collections[{cname!r}].resample.freq is not a valid "
+                    f"pandas frequency string (got {freq!r})"
+                ) from exc
             how = resample.get("how", "sum")
             if how not in _RESAMPLE_HOWS:
                 raise ValueError(

--- a/src/zagg/configs/merra2_storm.yaml
+++ b/src/zagg/configs/merra2_storm.yaml
@@ -13,10 +13,17 @@ pipeline:
 
 data_source:
   reader: xarray_s3
-  # Plural collections joined along time; each worker reads all of them per event.
+  # Plural collections joined along time; each worker reads all of them per
+  # event. Accepts a plain list of names, or (issue #213) a mapping carrying
+  # per-collection reader options -- variables (subset), time_offset (shift
+  # half-hour stamps onto the hour), resample {freq, how, scale} (turn hourly
+  # rates into e.g. 3-hourly totals), derived (numpy-expression variables).
+  # A collection's URIs may be a list (multi-granule events concat along time).
   collections:
-    - merra2_slv   # single-level: T2M, TQV, SLP
-    - merra2_flx   # surface flux: PRECTOT
+    merra2_slv:    # single-level: T2M, TQV, SLP (3-hourly, on the hour)
+    merra2_flx:    # surface flux: PRECTOT (1-hourly rates, half-hour stamps)
+      time_offset: "-30min"
+      resample: {freq: "3h", how: sum, scale: 3600}
   # Static fields the mask providers / anomaly transform consume (see
   # zagg.temporal: ais_mask drives the ais/ocean masks, climatology the anomaly).
   static_data:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -606,7 +606,10 @@ def _run_lambda_events(
 
     ``events`` items are URI-shaped dicts (the by-reference twin of the local
     backend's in-memory tuples): ``{"event_key", "event_mask_uri",
-    "collection_uris", "static_uris", "s3_credentials"?}``. The worker loads
+    "collection_uris", "static_uris", "s3_credentials"?}``. Events without
+    per-event ``s3_credentials`` get the shared credentials fetched once from
+    the ``data_source.credentials_provider`` registry name, when the config
+    sets one (issue #213 Phase 4). The worker loads
     each event's inputs from S3 itself, which keeps the async request payload
     far under the 256 KB Event cap (masks travel by URI, not by value -- unlike
     the AR repo's inline base64 masks, which only fit a synchronous invoke).
@@ -649,6 +652,20 @@ def _run_lambda_events(
         raise ValueError(f"Unknown invocation: {invocation!r} (expected 'async' or 'sync')")
     if function_name is None:
         function_name = os.environ.get("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard")
+
+    # Orchestrator-side credential fetch (issue #213, Phase 4): a config-named
+    # provider is resolved through the registry and called ONCE (DAAC creds
+    # last ~1 h, far past the fan-out), then attached to every event that does
+    # not carry its own per-event s3_credentials.
+    provider_name = (config.data_source or {}).get("credentials_provider")
+    if provider_name:
+        from zagg import registry as zagg_registry
+
+        shared_creds = zagg_registry.get_credential_provider(provider_name)()
+        event_list = [
+            ev if ev.get("s3_credentials") else {**ev, "s3_credentials": shared_creds}
+            for ev in event_list
+        ]
 
     n = len(event_list)
     logger.info(f"Processing {n} events (lambda)")

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -415,7 +415,8 @@ class TemporalStrategy:
         force_cold=False,
         events=None,
     ):
-        from zagg.temporal import process_event, specs_from_config
+        from zagg.config import collection_options
+        from zagg.temporal import prepare_collection, process_event, specs_from_config
 
         if backend not in ("local", "lambda"):
             raise ValueError(f"Unknown backend: {backend!r} (expected 'local' or 'lambda')")
@@ -462,12 +463,21 @@ class TemporalStrategy:
             max_workers = 4
         max_workers = min(max_workers, len(event_list)) if event_list else 1
 
+        # In-memory event tuples skip the reader, so the declarative collection
+        # options (issue #213 Phase 3) are applied here to keep the two
+        # backends' semantics identical.
+        coll_options = collection_options(config)
+
         # One work unit per event, catching its own exceptions so one bad event
         # counts as an error and the run continues -- mirrors the spatial local
         # path's tagged-envelope contract so ``_accumulate`` stays simple.
         def _event_work(payload):
             event_key, event_mask, collections, static_data = payload
             try:
+                collections = {
+                    name: prepare_collection(ds, coll_options.get(name))
+                    for name, ds in collections.items()
+                }
                 results, meta = process_event(
                     event_key,
                     event_mask,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1035,6 +1035,24 @@ def _aoi_payload_map(catalog_data: dict) -> dict:
     return {int(k): payload for k, payload in zip(catalog_data["shard_keys"], aoi)}
 
 
+def _resolve_source_credentials(config) -> dict:
+    """S3 read credentials for the source datasets, provider-selected.
+
+    ``data_source.credentials_provider`` names a credential-provider registry
+    entry (built-ins ``nsidc``/``gesdisc``; plugins may register others,
+    including non-NASA S3-compatible sources -- providers run
+    orchestrator-side, so the built-ins-only Lambda rule does not apply).
+    Absent, the historical spatial default (NSIDC) stands, via the module
+    global so it remains overridable.
+    """
+    name = (config.data_source or {}).get("credentials_provider")
+    if not name:
+        return get_nsidc_s3_credentials()
+    from zagg import registry
+
+    return registry.get_credential_provider(name)()
+
+
 def _dry_run_summary(cells: list[tuple], store_path: str) -> dict:
     """Return summary without processing.
 
@@ -1210,7 +1228,7 @@ def _run_local(
     if driver == "https":
         s3_creds = {"edl_token": get_edl_token()}
     else:
-        s3_creds = get_nsidc_s3_credentials()
+        s3_creds = _resolve_source_credentials(config)
 
     # Build grid from the run config (single source of truth) and refuse a
     # shard map built for a different grid. For HEALPix-dense, populated_shards
@@ -1442,8 +1460,8 @@ def _run_lambda(
     if dry_run:
         return _dry_run_summary(cells, store_path)
 
-    # Authenticate (for per-cell NSIDC reads inside the Lambda)
-    s3_creds = get_nsidc_s3_credentials()
+    # Authenticate (for per-cell source reads inside the Lambda)
+    s3_creds = _resolve_source_credentials(config)
 
     # Build grid from the run config (single source of truth); enforce the
     # shard map was built for the same grid.

--- a/src/zagg/temporal.py
+++ b/src/zagg/temporal.py
@@ -304,6 +304,48 @@ FIELD_TRANSFORMS = registry.FIELD_TRANSFORMS
 
 
 # ---------------------------------------------------------------------------
+# Built-in event triggers
+#
+# An event trigger has signature ``fn(event_mask, static_data, spec) ->
+# timestep value(s)``; :func:`process_event` updates a spec's accumulator only
+# on the returned timesteps. Never-firing triggers return an empty array, so
+# every gated spec finalizes to NaN.
+# ---------------------------------------------------------------------------
+
+
+def first_intersection(event_mask, static_data, spec):
+    """Earliest timestep where the event overlaps a named static mask.
+
+    The mask is ``static_data[spec['trigger_mask']]`` (default ``ais_mask``),
+    so the built-in expresses "first landfall on the ice sheet" without any
+    domain knowledge: the *meaning* of the mask is config. Returns an empty
+    array when the event never intersects it.
+    """
+    static_mask = static_data[spec.get("trigger_mask") or "ais_mask"].astype(bool)
+    space_dims = [d for d in event_mask.dims if d != "time"]
+    hits = (event_mask.where(static_mask, 0) > 0).any(space_dims)
+    times = event_mask["time"].values[np.asarray(hits.values, dtype=bool)]
+    if times.size == 0:
+        return times
+    return times.min()
+
+
+registry.register_event_trigger(
+    "first_intersection",
+    first_intersection,
+    description="First timestep where the event overlaps spec['trigger_mask'] (default 'ais_mask')",
+)
+registry.register_event_trigger(
+    "first_landfall",
+    first_intersection,
+    description="Alias of first_intersection (first timestep on the ice-sheet mask)",
+)
+
+#: The event-trigger registry (``zagg.registry.EVENT_TRIGGERS``).
+EVENT_TRIGGERS = registry.EVENT_TRIGGERS
+
+
+# ---------------------------------------------------------------------------
 # Event worker core
 # ---------------------------------------------------------------------------
 
@@ -344,7 +386,9 @@ def process_event(
         ``temporal_reducer``, ``mask``; optional keys: ``negate``,
         ``transform`` (field-transform name; ``anomaly: true`` desugars to
         ``transform: monthly_anomaly`` in :func:`specs_from_config`),
-        ``trigger`` (event-trigger name).
+        ``trigger`` (event-trigger name) and ``trigger_mask`` (static-mask
+        name the trigger tests against; ``first_intersection`` defaults to
+        ``ais_mask``).
     static_data : dict[str, xr.DataArray | xr.Dataset]
         Static fields keyed by name, e.g. ``ais_mask``, ``cell_areas``,
         ``climatology``. Spatial fields are subset to the event extent.
@@ -460,8 +504,9 @@ def specs_from_config(config):
     list[dict]
         Each dict has keys: ``output_name``, ``variable``, ``collection``,
         ``spatial_func``, ``temporal_reducer``, ``mask``, ``negate``, and the
-        optional generic hooks ``transform``
-        (field-transform name) and ``trigger`` (event-trigger name).
+        optional generic hooks ``transform`` (field-transform name),
+        ``trigger`` (event-trigger name), and ``trigger_mask`` (static-mask
+        name for the trigger).
 
     Notes
     -----
@@ -489,6 +534,7 @@ def specs_from_config(config):
                 "negate": meta.get("negate", False),
                 "transform": transform,
                 "trigger": meta.get("trigger"),
+                "trigger_mask": meta.get("trigger_mask"),
             }
         )
     return specs

--- a/src/zagg/temporal.py
+++ b/src/zagg/temporal.py
@@ -320,8 +320,19 @@ def first_intersection(event_mask, static_data, spec):
     so the built-in expresses "first landfall on the ice sheet" without any
     domain knowledge: the *meaning* of the mask is config. Returns an empty
     array when the event never intersects it.
+
+    Like the mask providers, the static mask must already share the event
+    mask's spatial coordinates (``process_event`` subsets static fields to the
+    event extent before calling triggers); misaligned coordinates raise
+    xarray's exact-join alignment error.
     """
-    static_mask = static_data[spec.get("trigger_mask") or "ais_mask"].astype(bool)
+    name = spec.get("trigger_mask") or "ais_mask"
+    if name not in static_data:
+        raise ValueError(
+            f"event trigger requires static field {name!r}, but static_data only has "
+            f"{sorted(static_data)}"
+        )
+    static_mask = static_data[name].astype(bool)
     space_dims = [d for d in event_mask.dims if d != "time"]
     hits = (event_mask.where(static_mask, 0) > 0).any(space_dims)
     times = event_mask["time"].values[np.asarray(hits.values, dtype=bool)]

--- a/src/zagg/temporal.py
+++ b/src/zagg/temporal.py
@@ -629,8 +629,61 @@ def open_dataset(uri, *, credentials=None, endpoint_url=None, region="us-west-2"
     return xr.open_dataset(io.BytesIO(bytes(payload)))
 
 
+def _eval_derived(name, expression, ds):
+    """Evaluate a ``derived`` variable expression over a collection's variables.
+
+    Same restricted-namespace contract as the spatial pipeline's ``expression``
+    fields (numpy + the collection's data variables; no builtins)."""
+    ns = {"__builtins__": {}, "np": np, "numpy": np, **{v: ds[v] for v in ds.data_vars}}
+    try:
+        return eval(expression, ns)  # noqa: S307
+    except NameError as e:
+        raise ValueError(
+            f"derived variable {name!r}: {e}; available variables: {sorted(ds.data_vars)}"
+        ) from None
+
+
+def prepare_collection(ds, options):
+    """Apply declarative per-collection reader options (issue #213, Phase 3).
+
+    Applied in order: ``variables`` (subset the collection), ``time_offset``
+    (shift timestamps, e.g. ``"-30min"`` moves half-hour stamps onto the hour),
+    ``resample: {freq, how, scale}`` (scale then resample -- turns 1-hourly
+    rates into e.g. 3-hourly totals), ``derived`` (materialize new variables
+    from numpy expressions over the collection's variables). The order matches
+    the MERRA-2 precip flow these options generalize; a falsy ``options``
+    returns ``ds`` unchanged. Unknown option keys (e.g. ``doi``) are ignored
+    here -- they are metadata for catalog tooling.
+    """
+    if not options:
+        return ds
+    variables = options.get("variables")
+    if variables:
+        ds = ds[list(variables)]
+    offset = options.get("time_offset")
+    if offset:
+        import pandas as pd
+
+        ds = ds.assign_coords(time=ds["time"] + pd.to_timedelta(offset).to_timedelta64())
+    resample = options.get("resample")
+    if resample:
+        scale = resample.get("scale", 1)
+        if scale != 1:
+            ds = ds * scale
+        ds = getattr(ds.resample(time=resample["freq"]), resample.get("how", "sum"))()
+    for name, expr in (options.get("derived") or {}).items():
+        ds = ds.assign(**{name: _eval_derived(name, expr, ds)})
+    return ds
+
+
 def read_temporal_inputs(
-    collection_uris, static_uris, *, credentials=None, endpoint_url=None, region="us-west-2"
+    collection_uris,
+    static_uris,
+    *,
+    credentials=None,
+    endpoint_url=None,
+    region="us-west-2",
+    collection_options=None,
 ):
     """Load the ``collections`` and ``static_data`` :func:`process_event` needs.
 
@@ -643,13 +696,19 @@ def read_temporal_inputs(
 
     Parameters
     ----------
-    collection_uris : dict[str, str]
-        ``{collection_name: uri}`` for each collection the specs read.
+    collection_uris : dict[str, str | list[str]]
+        ``{collection_name: uri or [uris]}`` for each collection the specs
+        read. A list (an event spanning several granules) is opened per-URI,
+        concatenated along ``time``, and time-sorted.
     static_uris : dict[str, str]
         ``{static_name: uri}`` for e.g. ``ais_mask`` / ``climatology`` /
         ``cell_areas``.
     credentials, endpoint_url, region
         Forwarded to :func:`open_dataset`.
+    collection_options : dict[str, dict], optional
+        Per-collection declarative options applied by
+        :func:`prepare_collection`; the runner derives this from
+        ``data_source.collections`` via :func:`zagg.config.collection_options`.
 
     Returns
     -------
@@ -657,10 +716,42 @@ def read_temporal_inputs(
         ``(collections, static_data)`` ready for :func:`process_event`.
     """
     kw = {"credentials": credentials, "endpoint_url": endpoint_url, "region": region}
-    collections = {name: open_dataset(uri, **kw) for name, uri in collection_uris.items()}
+    options = collection_options or {}
+    collections = {}
+    for name, uris in collection_uris.items():
+        uri_list = list(uris) if isinstance(uris, (list, tuple)) else [uris]
+        parts = [open_dataset(u, **kw) for u in uri_list]
+        if len(parts) == 1:
+            ds = parts[0]
+        else:
+            import xarray as xr
+
+            ds = xr.concat(parts, dim="time").sortby("time")
+        collections[name] = prepare_collection(ds, options.get(name))
     static_data = {}
     for name, uri in static_uris.items():
         ds = open_dataset(uri, **kw)
         data_vars = list(ds.data_vars)
         static_data[name] = ds[data_vars[0]] if len(data_vars) == 1 else ds
     return collections, static_data
+
+
+def _xarray_s3_reader(collection_uris, static_uris, **kwargs):
+    """Registry entry for the built-in reader.
+
+    Late-binds the module-level :func:`read_temporal_inputs` so a runtime
+    override of that name is honored by registry resolution too."""
+    return read_temporal_inputs(collection_uris, static_uris, **kwargs)
+
+
+registry.register_reader(
+    "xarray_s3",
+    _xarray_s3_reader,
+    description=(
+        "obstore/xarray reader: Zarr or NetCDF from local/s3:// URIs; multi-URI "
+        "collections concat along time; applies declarative collection_options"
+    ),
+)
+
+#: The reader registry (``zagg.registry.READERS``).
+READERS = registry.READERS

--- a/src/zagg/temporal.py
+++ b/src/zagg/temporal.py
@@ -92,6 +92,36 @@ class WeightedMeanAccumulator:
         return np.nan
 
 
+class MeanOfRatiosAccumulator:
+    """Unweighted mean over timesteps of per-timestep weighted ratios.
+
+    Spatial functions paired with this return ``(weighted_sum, weight_sum)``
+    tuples, like :class:`WeightedMeanAccumulator` — but each timestep
+    contributes its *ratio* with equal weight, instead of pooling the parts
+    across time. The two estimators diverge whenever the footprint's weight
+    varies over time; this one matches the downstream ``compute_average``
+    reference kernel (issue #213, parity question 1). Zero-weight (empty
+    footprint) timesteps are skipped, mirroring the reference's NaN-skipping
+    time mean.
+    """
+
+    def __init__(self):
+        self.ratio_sum = 0.0
+        self.count = 0
+
+    def update(self, val):
+        if val is None:
+            return
+        weighted_sum, weight_sum = val
+        if np.isnan(weighted_sum) or np.isnan(weight_sum) or weight_sum == 0:
+            return
+        self.ratio_sum += weighted_sum / weight_sum
+        self.count += 1
+
+    def finalize(self):
+        return float(self.ratio_sum / self.count) if self.count else np.nan
+
+
 class FirstLandfallCapture:
     """Captures a value only at the first triggered (e.g. landfall) timestep."""
 
@@ -117,6 +147,7 @@ registry.register_reducer("max", MaxAccumulator)
 registry.register_reducer("min", MinAccumulator)
 registry.register_reducer("sum", SumAccumulator)
 registry.register_reducer("weighted_mean", WeightedMeanAccumulator)
+registry.register_reducer("mean_of_ratios", MeanOfRatiosAccumulator)
 registry.register_reducer("first_landfall", FirstLandfallCapture)
 
 #: The reducer registry (``zagg.registry.REDUCERS``); plugins may add more via

--- a/src/zagg/temporal.py
+++ b/src/zagg/temporal.py
@@ -547,8 +547,11 @@ def specs_from_config(config):
         Each dict has keys: ``output_name``, ``variable``, ``collection``,
         ``spatial_func``, ``temporal_reducer``, ``mask``, ``negate``, and the
         optional generic hooks ``transform`` (field-transform name),
-        ``trigger`` (event-trigger name), and ``trigger_mask`` (static-mask
-        name for the trigger).
+        ``trigger`` (event-trigger name), ``trigger_mask`` (static-mask
+        name for the trigger), and ``params`` (a free-form mapping passed
+        through verbatim -- capabilities receive the full spec, so registered
+        masks/transforms/triggers read their tuning knobs from
+        ``spec["params"]`` without any zagg change).
 
     Notes
     -----
@@ -577,6 +580,7 @@ def specs_from_config(config):
                 "transform": transform,
                 "trigger": meta.get("trigger"),
                 "trigger_mask": meta.get("trigger_mask"),
+                "params": dict(meta.get("params") or {}),
             }
         )
     return specs

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -110,3 +110,19 @@ def test_ensure_logged_in_warms_singleton_with_retry(monkeypatch):
     calls = _login_seq(monkeypatch, OSError(101, "unreachable"), _FakeAuth())
     auth.ensure_logged_in()  # returns None; must not raise
     assert calls["n"] == 2  # transient failure retried, then succeeded
+
+
+def test_gesdisc_s3_credentials_requests_gesdisc_daac(monkeypatch):
+    """GES DISC creds are the NSIDC flow parameterized by DAAC (issue #213 Phase 4)."""
+    _login_seq(monkeypatch, _FakeAuth())
+    creds = auth.get_gesdisc_s3_credentials()
+    assert creds["daac"] == "GES_DISC"
+
+
+def test_daac_credential_providers_registered():
+    """nsidc/gesdisc resolve by name so configs can select them (issue #213 Phase 4)."""
+    from zagg import registry
+
+    assert {"nsidc", "gesdisc"} <= set(registry.list_credential_providers())
+    assert registry.get_credential_provider("nsidc") is auth.get_nsidc_s3_credentials
+    assert registry.get_credential_provider("gesdisc") is auth.get_gesdisc_s3_credentials

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -251,6 +251,19 @@ class TestCollectionOptions:
         with pytest.raises(ValueError, match="time_offset"):
             validate_config(self._cfg({"merra2": {"time_offset": -30}}))
 
+    def test_time_offset_must_parse(self):
+        # A well-typed but unparseable offset fails at load, not on the worker.
+        with pytest.raises(ValueError, match="time_offset is not a valid"):
+            validate_config(self._cfg({"merra2": {"time_offset": "gibberish"}}))
+
+    def test_resample_freq_must_be_string(self):
+        with pytest.raises(ValueError, match="resample.freq"):
+            validate_config(self._cfg({"merra2": {"resample": {"freq": 3}}}))
+
+    def test_resample_freq_must_parse(self):
+        with pytest.raises(ValueError, match="resample.freq is not a valid"):
+            validate_config(self._cfg({"merra2": {"resample": {"freq": "notafreq"}}}))
+
     def test_derived_must_map_names_to_expressions(self):
         with pytest.raises(ValueError, match="derived"):
             validate_config(self._cfg({"merra2": {"derived": {"rainfall": 3}}}))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,6 +193,77 @@ class TestPipelineType:
             get_pipeline_type(cfg)
 
 
+class TestCollectionOptions:
+    """``data_source.collections`` mapping form + reader options (issue #213 Phase 3)."""
+
+    @staticmethod
+    def _cfg(collections):
+        return load_config_from_dict(
+            {
+                "pipeline": {"type": "temporal"},
+                "data_source": {"reader": "xarray_s3", "collections": collections},
+                "aggregation": {
+                    "variables": {
+                        "max_t2m": {
+                            "variable": "T2M",
+                            "collection": "merra2",
+                            "spatial_func": "max",
+                            "temporal_reducer": "max",
+                        }
+                    }
+                },
+                "output": {"format": "tabular", "store": "."},
+            }
+        )
+
+    def test_list_form_normalizes_to_empty_options(self):
+        from zagg.config import collection_options
+
+        cfg = self._cfg(["merra2_slv", "merra2_flx"])
+        validate_config(cfg)
+        assert collection_options(cfg) == {"merra2_slv": {}, "merra2_flx": {}}
+
+    def test_mapping_form_carries_options_and_null_is_empty(self):
+        from zagg.config import collection_options
+
+        opts = {"time_offset": "-30min", "resample": {"freq": "3h", "how": "sum", "scale": 3600}}
+        cfg = self._cfg({"merra2_slv": None, "merra2_flx": opts})
+        validate_config(cfg)
+        assert collection_options(cfg) == {"merra2_slv": {}, "merra2_flx": opts}
+
+    def test_unknown_option_keys_pass_validation(self):
+        # doi &c. are catalog metadata for downstream tooling.
+        validate_config(self._cfg({"merra2": {"doi": "10.5067/EXAMPLE"}}))
+
+    def test_resample_requires_freq(self):
+        with pytest.raises(ValueError, match="resample.*freq"):
+            validate_config(self._cfg({"merra2": {"resample": {"how": "sum"}}}))
+
+    def test_resample_how_whitelisted(self):
+        with pytest.raises(ValueError, match="resample.how"):
+            validate_config(self._cfg({"merra2": {"resample": {"freq": "3h", "how": "median"}}}))
+
+    def test_resample_scale_must_be_numeric(self):
+        with pytest.raises(ValueError, match="resample.scale"):
+            validate_config(self._cfg({"merra2": {"resample": {"freq": "3h", "scale": "3600"}}}))
+
+    def test_time_offset_must_be_string(self):
+        with pytest.raises(ValueError, match="time_offset"):
+            validate_config(self._cfg({"merra2": {"time_offset": -30}}))
+
+    def test_derived_must_map_names_to_expressions(self):
+        with pytest.raises(ValueError, match="derived"):
+            validate_config(self._cfg({"merra2": {"derived": {"rainfall": 3}}}))
+
+    def test_variables_must_be_name_list(self):
+        with pytest.raises(ValueError, match="variables"):
+            validate_config(self._cfg({"merra2": {"variables": "PRECLS"}}))
+
+    def test_collection_entry_must_be_mapping_or_null(self):
+        with pytest.raises(ValueError, match="mapping of options"):
+            validate_config(self._cfg({"merra2": ["time_offset"]}))
+
+
 # ---------------------------------------------------------------------------
 # ATL03 template
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -282,6 +282,12 @@ class TestCollectionOptions:
         with pytest.raises(ValueError, match="credentials_provider"):
             validate_config(cfg)
 
+    def test_spec_params_must_be_mapping(self):
+        cfg = self._cfg(["merra2"])
+        cfg.aggregation["variables"]["max_t2m"]["params"] = "knob=7"
+        with pytest.raises(ValueError, match="params must be a mapping"):
+            validate_config(cfg)
+
 
 # ---------------------------------------------------------------------------
 # ATL03 template

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -263,6 +263,12 @@ class TestCollectionOptions:
         with pytest.raises(ValueError, match="mapping of options"):
             validate_config(self._cfg({"merra2": ["time_offset"]}))
 
+    def test_credentials_provider_must_be_string(self):
+        cfg = self._cfg(["merra2"])
+        cfg.data_source["credentials_provider"] = ["gesdisc"]
+        with pytest.raises(ValueError, match="credentials_provider"):
+            validate_config(cfg)
+
 
 # ---------------------------------------------------------------------------
 # ATL03 template

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1260,6 +1260,44 @@ class TestProcessEventMode:
         assert body["event_key"] == "storm1"
         assert "read failed" in body["error"]
 
+    def test_reader_resolved_through_registry(self, handler_mod, monkeypatch):
+        # ``data_source.reader`` names a registered reader (issue #213 Phase 3);
+        # the worker forwards the config's collection options to it.
+        import zagg.temporal as temporal
+        from zagg import registry as zagg_registry
+
+        event_mask, collections, static = _temporal_inputs()
+        monkeypatch.setattr(temporal, "open_dataset", lambda uri, **k: event_mask)
+        captured = {}
+
+        def _custom(collection_uris, static_uris, **kwargs):
+            captured["uris"] = collection_uris
+            captured["options"] = kwargs.get("collection_options")
+            return collections, static
+
+        zagg_registry.register_reader("custom_reader", _custom, replace=True)
+        try:
+            cfg = _temporal_config_dict()
+            cfg["data_source"]["reader"] = "custom_reader"
+            cfg["data_source"]["collections"] = {"merra2": {"time_offset": "-30min"}}
+            event = _temporal_event(config=cfg, return_results=True)
+            del event["store_path"]
+            resp = handler_mod._handle_process_event(event)
+            body = json.loads(resp["body"])
+            assert resp["statusCode"] == 200, body
+            assert captured["uris"] == {"merra2": "s3://b/merra2.zarr"}
+            assert captured["options"] == {"merra2": {"time_offset": "-30min"}}
+        finally:
+            zagg_registry.READERS._entries.pop("custom_reader", None)
+
+    def test_unknown_reader_returns_500_naming_it(self, handler_mod, monkeypatch):
+        self._patch(handler_mod, monkeypatch)
+        cfg = _temporal_config_dict()
+        cfg["data_source"]["reader"] = "not_a_reader"
+        resp = handler_mod._handle_process_event(_temporal_event(config=cfg))
+        assert resp["statusCode"] == 500
+        assert "not_a_reader" in json.loads(resp["body"])["error"]
+
 
 class TestProcessEventReturnResults:
     """``return_results`` (issue #12, Phase 8): the fan-out driver's contract.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2427,6 +2427,37 @@ class TestTemporalStrategy:
         summary = agg(_temporal_config(), events=_synthetic_events(), max_cells=1)
         assert summary["total_events"] == 1
 
+    def test_collection_options_applied_on_local_backend(self):
+        # In-memory event tuples skip the reader, so the local path applies the
+        # config's per-collection options itself (issue #213 Phase 3): a
+        # derived variable declared in the config is visible to the specs.
+        from zagg.config import load_config_from_dict
+        from zagg.runner import agg
+
+        cfg_dict = {
+            "pipeline": {"type": "temporal"},
+            "data_source": {
+                "reader": "xarray_s3",
+                "collections": {"merra2": {"derived": {"t2m_double": "T2M * 2"}}},
+            },
+            "aggregation": {
+                "variables": {
+                    "max_double": {
+                        "variable": "t2m_double",
+                        "collection": "merra2",
+                        "spatial_func": "max",
+                        "temporal_reducer": "max",
+                        "mask": "full",
+                    }
+                }
+            },
+            "output": {"format": "tabular", "store": "."},
+        }
+        summary = agg(load_config_from_dict(cfg_dict), events=_synthetic_events())
+        by_key = {r["event_key"]: r for r in summary["results"]}
+        assert by_key["storm1"]["results"]["max_double"] == pytest.approx(10.0)
+        assert by_key["storm2"]["results"]["max_double"] == pytest.approx(18.0)
+
     def test_dry_run_summary(self):
         from zagg.runner import agg
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3476,3 +3476,37 @@ class TestConsolidationGate:
 
     def test_lambda_finalizes_when_enabled(self, monkeypatch, atl06_config):
         assert self._lambda_finalize_calls(monkeypatch, atl06_config, enabled=True) == 1
+
+
+class TestResolveSourceCredentials:
+    """Provider-selected source credentials, both pipelines (issue #213 Phase 6)."""
+
+    def test_default_is_nsidc_via_module_global(self, monkeypatch):
+        from zagg import runner
+        from zagg.config import PipelineConfig
+
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "n"})
+        cfg = PipelineConfig(data_source={"reader": "h5coro"})
+        assert runner._resolve_source_credentials(cfg) == {"accessKeyId": "n"}
+
+    def test_named_provider_resolved_via_registry(self):
+        from zagg import registry as zagg_registry
+        from zagg import runner
+        from zagg.config import PipelineConfig
+
+        zagg_registry.register_credential_provider(
+            "test_src_provider", lambda: {"accessKeyId": "p"}, replace=True
+        )
+        try:
+            cfg = PipelineConfig(data_source={"credentials_provider": "test_src_provider"})
+            assert runner._resolve_source_credentials(cfg) == {"accessKeyId": "p"}
+        finally:
+            zagg_registry.CREDENTIAL_PROVIDERS._entries.pop("test_src_provider", None)
+
+    def test_unknown_provider_raises_with_name(self):
+        from zagg import runner
+        from zagg.config import PipelineConfig
+
+        cfg = PipelineConfig(data_source={"credentials_provider": "not_a_provider"})
+        with pytest.raises(KeyError, match="not_a_provider"):
+            runner._resolve_source_credentials(cfg)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2154,7 +2154,7 @@ class TestTemporalLambdaStrategy:
     write, per-event failure isolation, spatial machinery reused (preflight
     probe seams, LambdaExecutor, LAMBDA_RETRY)."""
 
-    def _drive(self, monkeypatch, *, events=None, fake_invoke=None, **agg_kwargs):
+    def _drive(self, monkeypatch, *, events=None, fake_invoke=None, config=None, **agg_kwargs):
         from unittest.mock import MagicMock
 
         import boto3
@@ -2208,7 +2208,7 @@ class TestTemporalLambdaStrategy:
         monkeypatch.setattr(runner, "_write_tabular_output", _fake_write)
 
         summary = agg(
-            _temporal_s3_config(),
+            _temporal_s3_config() if config is None else config,
             backend="lambda",
             events=_uri_events() if events is None else events,
             **agg_kwargs,
@@ -2237,6 +2237,40 @@ class TestTemporalLambdaStrategy:
         assert summary["gb_seconds"] == pytest.approx(2.0 * 4.0)  # 2 s x 4 GB
         assert summary["results"] == written["rows"]
         assert summary["failures"] == []
+
+    def test_credentials_provider_fetched_once_and_injected(self, monkeypatch):
+        # data_source.credentials_provider resolves through the registry, is
+        # called once, and fills s3_credentials on events lacking their own;
+        # per-event credentials take precedence (issue #213 Phase 4).
+        from zagg import registry as zagg_registry
+
+        calls = {"n": 0}
+
+        def _provider():
+            calls["n"] += 1
+            return {"accessKeyId": "shared"}
+
+        zagg_registry.register_credential_provider("test_provider", _provider, replace=True)
+        try:
+            cfg = _temporal_s3_config()
+            cfg.data_source["credentials_provider"] = "test_provider"
+            events = _uri_events()
+            events[0]["s3_credentials"] = {"accessKeyId": "per-event"}
+            _, captured = self._drive(monkeypatch, config=cfg, events=events)
+            creds_by_key = {
+                ev["event_key"]: ev.get("s3_credentials") for ev, _ in captured["invokes"]
+            }
+            assert calls["n"] == 1
+            assert creds_by_key["storm1"] == {"accessKeyId": "per-event"}
+            assert creds_by_key["storm2"] == {"accessKeyId": "shared"}
+        finally:
+            zagg_registry.CREDENTIAL_PROVIDERS._entries.pop("test_provider", None)
+
+    def test_unknown_credentials_provider_fails_before_invoking(self, monkeypatch):
+        cfg = _temporal_s3_config()
+        cfg.data_source["credentials_provider"] = "not_a_provider"
+        with pytest.raises(KeyError, match="not_a_provider"):
+            self._drive(monkeypatch, config=cfg)
 
     def test_temporal_summary_carries_container_rollup(self, monkeypatch):
         # Issue #171: the temporal path aggregates the same worker container

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -229,6 +229,7 @@ def _temporal_config():
                         "mask": "ocean",
                         "trigger": "first_intersection",
                         "trigger_mask": "grounded_mask",
+                        "params": {"lookahead_hours": 24},
                     },
                 }
             },
@@ -256,6 +257,7 @@ class TestSpecsFromConfig:
             "transform",
             "trigger",
             "trigger_mask",
+            "params",
         }
         for spec in specs:
             assert set(spec) == required, f"bad keys for {spec['output_name']}"
@@ -274,6 +276,9 @@ class TestSpecsFromConfig:
         assert specs["rainfall_ocean"]["trigger_mask"] == "grounded_mask"
         assert specs["max_t2m_ais"]["trigger"] is None
         assert specs["max_t2m_ais"]["trigger_mask"] is None
+        # params pass through verbatim for capabilities; default is {}
+        assert specs["rainfall_ocean"]["params"] == {"lookahead_hours": 24}
+        assert specs["max_t2m_ais"]["params"] == {}
 
     def test_anomaly_sugar_equals_explicit_transform(self):
         # (a) `anomaly: true` produces the same spec as `transform: monthly_anomaly`.
@@ -664,6 +669,25 @@ class TestProcessEvent:
         specs[0]["temporal_reducer"] = "sum"
         with pytest.raises(ValueError, match="cell_areas"):
             process_event("storm1", event_mask, collections, specs, {})
+
+    def test_params_reach_capabilities(self):
+        # spec["params"] is the pass-through channel for capability tuning
+        # knobs -- a registered (local-backend) provider must see it verbatim.
+        seen = {}
+
+        def _param_probe(event_mask_t, static_data, spec):
+            seen["params"] = spec.get("params")
+            return event_mask_t
+
+        registry.register_mask_provider("param_probe", _param_probe, replace=True)
+        try:
+            event_mask, collections, specs, static = _event_inputs()
+            specs[0]["mask"] = "param_probe"
+            specs[0]["params"] = {"knob": 7}
+            process_event("storm1", event_mask, collections, specs, static)
+            assert seen["params"] == {"knob": 7}
+        finally:
+            registry.MASK_PROVIDERS._entries.pop("param_probe", None)
 
     def _gated_inputs(self):
         # Trigger fixture (landfall at t1) + a variable rising 10/20/30 so the

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -871,3 +871,104 @@ class TestTemporalReader:
         )
         assert list(collections) == ["merra2"]
         assert isinstance(static["cell_areas"], xr.DataArray)
+
+    def test_multi_uri_collection_concats_time_sorted(self, monkeypatch):
+        # A multi-granule event: URIs open individually, concat along time,
+        # and land time-sorted even when the URI order is not.
+        xr = pytest.importorskip("xarray")
+        import zagg.temporal as temporal
+        from zagg.temporal import read_temporal_inputs
+
+        def _day(uri, **k):
+            day = int(uri[-4])
+            time = np.array([f"2020-01-0{day}T00"], dtype="datetime64[ns]")
+            return xr.Dataset({"T2M": (("time",), np.array([float(day)]))}, coords={"time": time})
+
+        monkeypatch.setattr(temporal, "open_dataset", _day)
+        collections, _ = read_temporal_inputs({"merra2": ["s3://b/d2.nc", "s3://b/d1.nc"]}, {})
+        assert list(collections["merra2"]["T2M"].values) == [1.0, 2.0]
+
+    def test_collection_options_applied_by_reader(self, monkeypatch):
+        xr = pytest.importorskip("xarray")
+        import zagg.temporal as temporal
+        from zagg.temporal import read_temporal_inputs
+
+        time = np.array(["2020-01-01T00:30"], dtype="datetime64[ns]")
+        ds = xr.Dataset({"T2M": (("time",), np.array([1.0]))}, coords={"time": time})
+        monkeypatch.setattr(temporal, "open_dataset", lambda uri, **k: ds)
+        collections, _ = read_temporal_inputs(
+            {"merra2": "s3://b/merra2.nc"},
+            {},
+            collection_options={"merra2": {"time_offset": "-30min"}},
+        )
+        assert collections["merra2"]["time"].values[0] == np.datetime64("2020-01-01T00:00", "ns")
+
+    def test_xarray_s3_reader_registered(self):
+        assert "xarray_s3" in registry.list_readers()
+        assert callable(registry.get_reader("xarray_s3"))
+
+
+# ---------------------------------------------------------------------------
+# Declarative collection options (issue #213, Phase 3)
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareCollection:
+    @pytest.fixture
+    def hourly(self):
+        # 6 hourly steps stamped on the half hour (the MERRA-2 FLX layout).
+        xr = pytest.importorskip("xarray")
+        time = np.array([f"2020-01-01T{h:02d}:30" for h in range(6)], dtype="datetime64[ns]")
+        coords = {"time": time, "lat": [-70.0], "lon": [0.0]}
+        rate = xr.DataArray(
+            np.arange(1.0, 7.0).reshape(6, 1, 1), dims=["time", "lat", "lon"], coords=coords
+        )
+        return xr.Dataset({"PRECLS": rate, "PRECCU": rate * 2})
+
+    def test_falsy_options_are_identity(self, hourly):
+        from zagg.temporal import prepare_collection
+
+        assert prepare_collection(hourly, None) is hourly
+        assert prepare_collection(hourly, {}) is hourly
+
+    def test_time_offset_shifts_onto_the_hour(self, hourly):
+        from zagg.temporal import prepare_collection
+
+        out = prepare_collection(hourly, {"time_offset": "-30min"})
+        assert out["time"].values[0] == np.datetime64("2020-01-01T00:00", "ns")
+
+    def test_resample_scales_rates_into_totals(self, hourly):
+        from zagg.temporal import prepare_collection
+
+        out = prepare_collection(
+            hourly,
+            {"time_offset": "-30min", "resample": {"freq": "3h", "how": "sum", "scale": 3600}},
+        )
+        # hourly rates 1,2,3 in the first 3h bin -> (1+2+3)*3600
+        assert float(out["PRECLS"].isel(time=0, lat=0, lon=0)) == pytest.approx(6 * 3600)
+        assert out.sizes["time"] == 2
+
+    def test_derived_expression_materialized(self, hourly):
+        from zagg.temporal import prepare_collection
+
+        out = prepare_collection(hourly, {"derived": {"rainfall": "PRECLS + PRECCU"}})
+        assert float(out["rainfall"].isel(time=0, lat=0, lon=0)) == pytest.approx(3.0)
+
+    def test_variables_subsets_collection(self, hourly):
+        from zagg.temporal import prepare_collection
+
+        out = prepare_collection(hourly, {"variables": ["PRECLS"]})
+        assert list(out.data_vars) == ["PRECLS"]
+
+    def test_derived_unknown_name_raises_with_available(self, hourly):
+        from zagg.temporal import prepare_collection
+
+        with pytest.raises(ValueError, match="rainfall.*TYPO.*PRECCU"):
+            prepare_collection(hourly, {"derived": {"rainfall": "PRECLS + TYPO"}})
+
+    def test_unknown_option_keys_ignored(self, hourly):
+        # doi &c. are catalog metadata, not reader options.
+        from zagg.temporal import prepare_collection
+
+        out = prepare_collection(hourly, {"doi": "10.5067/EXAMPLE"})
+        assert list(out.data_vars) == list(hourly.data_vars)

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -96,6 +96,40 @@ class TestWeightedMeanAccumulator:
         assert np.isnan(acc.finalize())
 
 
+class TestMeanOfRatiosAccumulator:
+    def test_equal_weight_per_timestep(self):
+        from zagg.temporal import MeanOfRatiosAccumulator
+
+        acc = MeanOfRatiosAccumulator()
+        # ratios 5 and 6 -> 5.5; WeightedMeanAccumulator pools to 40/5 = 8
+        acc.update((10.0, 2.0))
+        acc.update((30.0, 5.0))
+        assert acc.finalize() == pytest.approx(5.5)
+
+    def test_zero_weight_timestep_skipped(self):
+        from zagg.temporal import MeanOfRatiosAccumulator
+
+        acc = MeanOfRatiosAccumulator()
+        acc.update((10.0, 2.0))
+        acc.update((0.0, 0.0))  # empty footprint: no ratio, no count
+        assert acc.finalize() == pytest.approx(5.0)
+
+    def test_none_and_nan_ignored(self):
+        from zagg.temporal import MeanOfRatiosAccumulator
+
+        acc = MeanOfRatiosAccumulator()
+        acc.update(None)
+        acc.update((np.nan, 2.0))
+        acc.update((10.0, 2.0))
+        assert acc.finalize() == pytest.approx(5.0)
+
+    def test_empty(self):
+        from zagg.temporal import MeanOfRatiosAccumulator
+
+        acc = MeanOfRatiosAccumulator()
+        assert np.isnan(acc.finalize())
+
+
 class TestFirstLandfallCapture:
     def test_captures_first(self):
         acc = FirstLandfallCapture()
@@ -127,6 +161,7 @@ class TestRegistrySeeding:
             "min",
             "sum",
             "weighted_mean",
+            "mean_of_ratios",
             "first_landfall",
         } <= set(registry.list_reducers())
 
@@ -147,7 +182,7 @@ class TestRegistrySeeding:
         assert "monthly_anomaly" in set(registry.list_field_transforms())
 
     def test_reducers_satisfy_protocol(self):
-        for name in ("max", "min", "sum", "weighted_mean", "first_landfall"):
+        for name in ("max", "min", "sum", "weighted_mean", "mean_of_ratios", "first_landfall"):
             acc = registry.get_reducer(name)()
             assert hasattr(acc, "update"), f"{name} missing update()"
             assert hasattr(acc, "finalize"), f"{name} missing finalize()"
@@ -667,6 +702,38 @@ class TestProcessEvent:
         never = event_mask.where(event_mask["lat"] != -70.0, 0)  # clear the ice row
         results, _ = process_event("storm1", never, collections, specs, static)
         assert np.isnan(results["slp_at_landfall"])
+
+    def test_mean_of_ratios_diverges_from_weighted_mean(self):
+        # A footprint growing from 1 cell to 4 cells: per-timestep ratios are
+        # 10 and 20 (mean 15), while pooled parts give 90/5 = 18. Both specs
+        # run in one pass to pin the estimators apart end-to-end.
+        xr = pytest.importorskip("xarray")
+        lat = np.array([-70.0, -69.5])
+        lon = np.array([0.0, 0.5])
+        time = np.array(["2020-01-01T00", "2020-01-01T03"], dtype="datetime64[ns]")
+        coords = {"time": time, "lat": lat, "lon": lon}
+        footprints = np.array([[[1, 0], [0, 0]], [[1, 1], [1, 1]]], dtype=float)
+        event_mask = xr.DataArray(footprints, dims=["time", "lat", "lon"], coords=coords)
+        var = xr.DataArray(
+            np.stack([np.full((2, 2), 10.0), np.full((2, 2), 20.0)]),
+            dims=["time", "lat", "lon"],
+            coords=coords,
+        )
+        collections = {"merra2": xr.Dataset({"VFLXQV": var})}
+        areas = xr.DataArray(np.ones((2, 2)), dims=["lat", "lon"], coords={"lat": lat, "lon": lon})
+        base = {
+            "variable": "VFLXQV",
+            "collection": "merra2",
+            "spatial_func": "weighted_mean",
+            "mask": "full",
+        }
+        specs = [
+            {**base, "output_name": "avg_ratio", "temporal_reducer": "mean_of_ratios"},
+            {**base, "output_name": "avg_pooled", "temporal_reducer": "weighted_mean"},
+        ]
+        results, _ = process_event("storm1", event_mask, collections, specs, {"cell_areas": areas})
+        assert results["avg_ratio"] == pytest.approx(15.0)
+        assert results["avg_pooled"] == pytest.approx(18.0)
 
     @pytest.mark.parametrize("batch", [1, 2])
     def test_trigger_gating_survives_batching(self, batch):

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -192,6 +192,8 @@ def _temporal_config():
                         "spatial_func": "weighted_sum",
                         "temporal_reducer": "sum",
                         "mask": "ocean",
+                        "trigger": "first_intersection",
+                        "trigger_mask": "grounded_mask",
                     },
                 }
             },
@@ -232,6 +234,11 @@ class TestSpecsFromConfig:
         assert "is_anomaly" not in specs["anom_iwv_full"]
         # default mask is "ais" when omitted; here every spec sets it explicitly
         assert specs["rainfall_ocean"]["mask"] == "ocean"
+        # trigger/trigger_mask carry their configured *values* (not just keys)
+        assert specs["rainfall_ocean"]["trigger"] == "first_intersection"
+        assert specs["rainfall_ocean"]["trigger_mask"] == "grounded_mask"
+        assert specs["max_t2m_ais"]["trigger"] is None
+        assert specs["max_t2m_ais"]["trigger_mask"] is None
 
     def test_anomaly_sugar_equals_explicit_transform(self):
         # (a) `anomaly: true` produces the same spec as `transform: monthly_anomaly`.
@@ -470,6 +477,15 @@ class TestFirstIntersectionTrigger:
         shelf.values[:] = [[0, 0], [1, 0]]
         out = first_intersection(event_mask, {"shelf_mask": shelf}, {"trigger_mask": "shelf_mask"})
         assert out == time[0]
+
+    def test_missing_static_field_raises(self):
+        # A typo'd trigger_mask must fail with the name and the available
+        # fields, not a bare KeyError from deep inside a worker.
+        from zagg.temporal import first_intersection
+
+        event_mask, static, _ = _trigger_inputs()
+        with pytest.raises(ValueError, match="shelf_mask.*ais_mask"):
+            first_intersection(event_mask, static, {"trigger_mask": "shelf_mask"})
 
     def test_registered_with_landfall_alias(self):
         from zagg.temporal import first_intersection

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -218,6 +218,7 @@ class TestSpecsFromConfig:
             "negate",
             "transform",
             "trigger",
+            "trigger_mask",
         }
         for spec in specs:
             assert set(spec) == required, f"bad keys for {spec['output_name']}"
@@ -417,6 +418,67 @@ class TestMaskProviders:
 
 
 # ---------------------------------------------------------------------------
+# Event triggers
+# ---------------------------------------------------------------------------
+
+
+def _trigger_inputs():
+    """3-timestep event that first touches the single ice cell at t1."""
+    xr = pytest.importorskip("xarray")
+    lat = np.array([-70.0, -69.5])
+    lon = np.array([0.0, 0.5])
+    time = np.array(["2020-01-01T00", "2020-01-01T03", "2020-01-01T06"], dtype="datetime64[ns]")
+    coords = {"time": time, "lat": lat, "lon": lon}
+    footprints = np.array(
+        [
+            [[0, 1], [1, 1]],  # t0: ocean only
+            [[1, 1], [0, 0]],  # t1: first landfall (covers the ice cell)
+            [[1, 0], [0, 0]],  # t2: still on ice
+        ],
+        dtype=float,
+    )
+    event_mask = xr.DataArray(footprints, dims=["time", "lat", "lon"], coords=coords)
+    ais = xr.DataArray(
+        np.array([[1, 0], [0, 0]], dtype=float),
+        dims=["lat", "lon"],
+        coords={"lat": lat, "lon": lon},
+    )
+    return event_mask, {"ais_mask": ais}, time
+
+
+class TestFirstIntersectionTrigger:
+    def test_returns_first_overlap_timestep(self):
+        from zagg.temporal import first_intersection
+
+        event_mask, static, time = _trigger_inputs()
+        assert first_intersection(event_mask, static, {}) == time[1]
+
+    def test_no_overlap_returns_empty(self):
+        from zagg.temporal import first_intersection
+
+        event_mask, static, _ = _trigger_inputs()
+        never = event_mask.where(event_mask["lat"] != -70.0, 0)  # clear the ice row
+        out = first_intersection(never, static, {})
+        assert np.atleast_1d(out).size == 0
+
+    def test_trigger_mask_key_selects_static_field(self):
+        from zagg.temporal import first_intersection
+
+        event_mask, static, time = _trigger_inputs()
+        # A shelf mask on the other row: the t0 footprint already covers it.
+        shelf = static["ais_mask"].copy()
+        shelf.values[:] = [[0, 0], [1, 0]]
+        out = first_intersection(event_mask, {"shelf_mask": shelf}, {"trigger_mask": "shelf_mask"})
+        assert out == time[0]
+
+    def test_registered_with_landfall_alias(self):
+        from zagg.temporal import first_intersection
+
+        assert registry.get_event_trigger("first_intersection") is first_intersection
+        assert registry.get_event_trigger("first_landfall") is first_intersection
+
+
+# ---------------------------------------------------------------------------
 # process_event end-to-end on synthetic data
 # ---------------------------------------------------------------------------
 
@@ -551,6 +613,53 @@ class TestProcessEvent:
         specs[0]["temporal_reducer"] = "sum"
         with pytest.raises(ValueError, match="cell_areas"):
             process_event("storm1", event_mask, collections, specs, {})
+
+    def _gated_inputs(self):
+        # Trigger fixture (landfall at t1) + a variable rising 10/20/30 so the
+        # captured value identifies which timestep updated the accumulator.
+        xr = pytest.importorskip("xarray")
+        event_mask, static, time = _trigger_inputs()
+        var = xr.DataArray(
+            np.stack([np.full((2, 2), v) for v in (10.0, 20.0, 30.0)]),
+            dims=["time", "lat", "lon"],
+            coords=event_mask.coords,
+        )
+        collections = {"merra2": xr.Dataset({"SLP": var})}
+        specs = [
+            {
+                "output_name": "slp_at_landfall",
+                "variable": "SLP",
+                "collection": "merra2",
+                "spatial_func": "min",
+                "temporal_reducer": "first_landfall",
+                "mask": "full",
+                "trigger": "first_landfall",
+            }
+        ]
+        return event_mask, collections, specs, static
+
+    def test_trigger_gates_to_landfall_timestep(self):
+        # Without the trigger, first_landfall (a first-value capture) would
+        # take t0's value (10); gated, it must take the landfall timestep's.
+        event_mask, collections, specs, static = self._gated_inputs()
+        results, meta = process_event("storm1", event_mask, collections, specs, static)
+        assert results["slp_at_landfall"] == pytest.approx(20.0)
+        assert meta["timesteps_processed"] == 3
+
+    def test_never_landfalling_event_yields_nan(self):
+        event_mask, collections, specs, static = self._gated_inputs()
+        never = event_mask.where(event_mask["lat"] != -70.0, 0)  # clear the ice row
+        results, _ = process_event("storm1", never, collections, specs, static)
+        assert np.isnan(results["slp_at_landfall"])
+
+    @pytest.mark.parametrize("batch", [1, 2])
+    def test_trigger_gating_survives_batching(self, batch):
+        # The triggered timestep must fire even when it falls mid-batch.
+        event_mask, collections, specs, static = self._gated_inputs()
+        results, _ = process_event(
+            "storm1", event_mask, collections, specs, static, max_resident_timesteps=batch
+        )
+        assert results["slp_at_landfall"] == pytest.approx(20.0)
 
 
 class TestSpatialFunctionEdges:


### PR DESCRIPTION
Refs #213 (zagg-side phases; the issue also tracks the downstream antarctic_AR_dataset PR).

Adds the temporal-pipeline capabilities and reader/config features needed for the antarctic_AR_dataset integration, per the design resolution on the issue thread (no third-party code on Lambda workers — everything lands as zagg built-ins or declarative config; see https://github.com/englacial/zagg/issues/213#issuecomment-4965682167).

## Phases

- [x] Phase 1 — `first_intersection` event trigger (aliased `first_landfall`): first timestep where the event mask overlaps the static mask named by `trigger_mask` (default `ais_mask`). `EVENT_TRIGGERS` previously shipped no built-ins, so `trigger:` gating in `process_event` was unreachable from config; without gating, the `first_landfall` *reducer* captures the storm's first timestep rather than first landfall. Never-intersecting events return an empty trigger set, so gated specs finalize to NaN (mirrors the downstream `is_landfalling` filter).
- [x] Phase 2 — `mean_of_ratios` streaming reducer (parity with downstream `compute_average`: per-timestep weighted ratio, unweighted mean over timesteps). Resolves parity question (1) on the issue.
- [x] Phase 3 — declarative reader features: `data_source.collections` mapping form with per-collection options (`variables`, `time_offset`, `resample {freq, how, scale}`, `derived` numpy-expression variables), multi-URI collections concatenated along time, and `data_source.reader` resolved through the registry (worker + `merra2_storm.yaml` example updated). Same semantics applied on the local backend via `prepare_collection`.
- [x] Phase 4 — `gesdisc` credential provider (NSIDC helper generalized to `get_daac_s3_credentials`), both registered in `CREDENTIAL_PROVIDERS`; temporal Lambda fan-out fetches once from `data_source.credentials_provider` and attaches to events lacking per-event `s3_credentials`.
- [x] Phase 5 — event payload contract documented (`docs/temporal_events.md`: event shapes for both backends, collections config, spec keys, capability-resolution policy) + spec `params:` pass-through so registered capabilities receive tuning knobs verbatim.
- [x] Phase 6 — provider-selected credentials unified across both pipelines (maintainer direction on the phase-4 review question): `_resolve_source_credentials` (registry lookup, NSIDC default) now backs the spatial local + lambda paths too; validation hoisted ahead of the pipeline-type branch; `credentials_provider` declared in `DataSourceDict`.

## Testing

Full suite in the worktree venv: 1826 passed, 13 skipped, 1 failed — `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`, which fails identically on a clean `main` checkout (environment/build tooling, unrelated). New coverage per phase: trigger unit + `process_event` gating/batching tests; `MeanOfRatiosAccumulator` unit tests + an end-to-end divergence test pinning mean-of-ratios (15.0) apart from pooled weighted-mean (18.0) on the same event; `prepare_collection`/multi-URI/collection-options tests plus registry-resolved-reader tests in the Lambda handler and a local-backend derived-variable run; auth provider registration + DAAC parameterization tests, payload credential-injection precedence tests; `params` pass-through to a registered capability; `TestResolveSourceCredentials` for the unified provider lookup.

## Adversarial review status

Per-phase fresh-context reviews posted inline (🤖 *from Claude (review)*). All findings folded: phase-1 (trigger_mask guard, alignment contract, value pass-through test), phase-3 (parse-validation of `time_offset`/`resample.freq` at config load), phase-4 (TypedDict declaration; the temporal-only scope question resolved as phase 6 by maintainer direction). Phase-2 review returned no findings.

## Questions for review

- Pre-existing, not addressed here (flagging per convention): `ruff check` on full `src` trips N818 on `registry.py:64` (`UnknownCapability`); `ruff format --check` would reformat 7 files untouched by this PR; and the lambda-build test failure above — all present on clean `main`.
