### PR TITLE
Create tabular output parent dirs (issue #213)

### DIFF
--- a/src/zagg/output/tabular.py
+++ b/src/zagg/output/tabular.py
@@ -81,20 +81,21 @@ class TabularWriter:
         """
         path = Path(path)
         fmt = output_format or _EXT_FORMAT.get(path.suffix.lower(), "parquet")
+        if fmt not in ("parquet", "csv"):
+            raise ValueError(f"unknown tabular output format {fmt!r} (expected 'parquet' or 'csv')")
         frame = self.to_frame(rows)
 
         # pandas ``to_parquet``/``to_csv`` do not create missing parent
         # directories, so a nested relative ``output.store`` (e.g.
         # ``./output/zagg/ar_attributes.parquet``) would fail at write with
-        # ``FileNotFoundError``; create the parent tree first.
+        # ``FileNotFoundError``; create the parent tree first. Validate the
+        # format above this so a bad ``output_format`` leaves no stray dir.
         path.parent.mkdir(parents=True, exist_ok=True)
 
         if fmt == "parquet":
             frame.to_parquet(path, index=False)
-        elif fmt == "csv":
+        else:  # fmt == "csv"
             frame.to_csv(path, index=False)
-        else:
-            raise ValueError(f"unknown tabular output format {fmt!r} (expected 'parquet' or 'csv')")
         return path
 
     def to_bytes(self, rows, *, output_format: str = "parquet") -> bytes:

--- a/src/zagg/output/tabular.py
+++ b/src/zagg/output/tabular.py
@@ -83,6 +83,12 @@ class TabularWriter:
         fmt = output_format or _EXT_FORMAT.get(path.suffix.lower(), "parquet")
         frame = self.to_frame(rows)
 
+        # pandas ``to_parquet``/``to_csv`` do not create missing parent
+        # directories, so a nested relative ``output.store`` (e.g.
+        # ``./output/zagg/ar_attributes.parquet``) would fail at write with
+        # ``FileNotFoundError``; create the parent tree first.
+        path.parent.mkdir(parents=True, exist_ok=True)
+
         if fmt == "parquet":
             frame.to_parquet(path, index=False)
         elif fmt == "csv":

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -130,6 +130,14 @@ class TestTabularWriterSerialise:
         with pytest.raises(ValueError, match="unknown tabular output format"):
             TabularWriter().write(_result_rows(), tmp_path / "x", output_format="xml")
 
+    def test_bad_format_leaves_no_dir(self, tmp_path):
+        # A bad format must be rejected before the parent tree is created, so a
+        # failed write does not leave a stray empty directory behind.
+        path = tmp_path / "missing" / "x"
+        with pytest.raises(ValueError, match="unknown tabular output format"):
+            TabularWriter().write(_result_rows(), path, output_format="xml")
+        assert not path.parent.exists()
+
 
 class TestTabularWriterToBytes:
     def test_parquet_bytes_round_trip(self):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -111,6 +111,15 @@ class TestTabularWriterSerialise:
         back = pd.read_csv(path)
         assert list(back["event_key"]) == ["storm1", "storm2"]
 
+    def test_creates_missing_parent_dirs(self, tmp_path):
+        # A nested relative store like ./output/zagg/out.parquet must not fail
+        # with FileNotFoundError -- the local write mkdirs its parents first.
+        path = tmp_path / "nested" / "dir" / "out.parquet"
+        out = TabularWriter().write(_result_rows(), path)
+        assert out == path
+        back = pd.read_parquet(path).set_index("event_key")
+        assert back.loc["storm1", "max_t2m"] == pytest.approx(5.0)
+
     def test_unknown_extension_defaults_to_parquet(self, tmp_path):
         path = tmp_path / "events.unknown"
         TabularWriter().write(_result_rows(), path)


### PR DESCRIPTION
Refs #213. Post-merge follow-up to #214: the local tabular write path (`TabularWriter.write`) now creates missing parent directories before serializing — a nested relative `output.store` like `./output/zagg/ar_attributes.parquet` previously failed with `FileNotFoundError` at the final write on a fresh checkout. Found by the downstream integration review (espg/antarctic_AR_dataset#1, inline thread on the configs); the fix belongs upstream so consumer configs keep nested store paths. One commit, one test (`test_creates_missing_parent_dirs`); the S3 path is untouched.

## Testing
`pytest tests/test_output.py`: 19 passed. Note: this commit was originally pushed to the #214 branch minutes after that PR merged (branch had auto-deleted; the push resurrected it) — re-homed here and the stray branch removed.