### PR TITLE
Add xarray/h5netcdf/h5py to the Lambda layer (issue #220)

### DIFF
--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -63,8 +63,13 @@ echo "Installing processing deps..."
 # unstrippable C++ core that can't fit the gate while importable). pyarrow is NOT
 # installed here -- its only use is off-Lambda zagg.catalog. Keep the pin in sync
 # with the `lambda` extra in pyproject.toml.
+# xarray + h5netcdf/h5py (issue #220): the temporal worker (process_event)
+# reads collections/masks as xarray datasets and opens NetCDF4/HDF5 bytes
+# in-memory through the h5netcdf engine (h5coro is a byte-range reader, not
+# an xarray engine). Keep the pins in sync with the `lambda` extra.
 $PIP install \
     "pandas==2.2.3" "arro3-core==0.8.1" fastparquet cramjam \
+    "xarray==2026.7.0" "h5netcdf==1.8.1" "h5py==3.16.0" \
     shapely pyproj odc-geo affine cachetools \
     -c "$CONSTRAINTS" \
     -t "$OUTPUT_DIR/python" \
@@ -87,10 +92,11 @@ fi
 # Remove bloat. pyproj is intentionally NOT stripped (rectilinear/odc-geo assign
 # needs it). pyarrow is no longer installed (issue #130): the worker's Arrow carrier
 # is arro3-core, which needs no component strip, so the whole pyarrow strip block is
-# gone with it.
+# gone with it. xarray is intentionally NOT stripped (issue #220): the temporal
+# worker (process_event) imports it and opens NetCDF bytes via h5netcdf/h5py --
+# the pins live in the [lambda] extra.
 echo "Removing bloat..."
-rm -rf "$OUTPUT_DIR/python"/xarray* \
-       "$OUTPUT_DIR/python"/matplotlib* \
+rm -rf "$OUTPUT_DIR/python"/matplotlib* \
        "$OUTPUT_DIR/python"/lonboard* \
        "$OUTPUT_DIR/python"/boto3* \
        "$OUTPUT_DIR/python"/botocore* 2>/dev/null || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,15 @@ lambda = [
     "h5coro-hidefix==0.3.1",
     "cramjam",
     "astropy",
+    # The temporal worker (process_event, issue #220) reads xarray datasets and
+    # opens NetCDF4/HDF5 bytes in-memory via the h5netcdf engine; h5coro is a
+    # byte-range reader, not an xarray engine, so these must ship in the layer.
+    # Pins resolved against numpy==2.2.6/pandas==2.2.3 on the layer's python;
+    # keep in sync with deployment/aws/build_layer.sh (xarray must NOT be in
+    # its strip list).
+    "xarray==2026.7.0",
+    "h5netcdf==1.8.1",
+    "h5py==3.16.0",
 ]
 # STAC fetch + shard-map build deps. Kept out of core so the Lambda layer build
 # (which doesn't run fetch/build) stays lean.


### PR DESCRIPTION
Closes #220. The temporal `process_event` worker mode failed 20/20 events on its first real fleet run (`No module named 'xarray'`, see the issue): the layer build both never installed xarray explicitly and actively stripped the transitive copy, and no NetCDF engine was present for the reader's in-memory `xr.open_dataset(BytesIO)` path.

One commit, two files:
- `pyproject.toml`: `xarray==2026.7.0`, `h5netcdf==1.8.1`, `h5py==3.16.0` added to the `lambda` extra (pins resolved empirically against the layer's `numpy==2.2.6`/`pandas==2.2.3`; the worker's NetCDF4-bytes round-trip verified under exactly these pins on Python 3.13).
- `deployment/aws/build_layer.sh`: the same pins added to the processing-deps install (the script installs an explicit list, not the extra), and `xarray*` removed from the strip list, with comments updated.

The `lambda-build.yml` 250 MB dual-arch gate adjudicates the size cost — the run on this PR will report the new unzipped sizes, which also tells PR #219 (async-tiff, same layer budget, same `lambda` extra block — see the crossover note on #220) its remaining headroom. Whichever of the two PRs lands second rebases the `pyproject.toml` hunk.

Infra scripts touched by name per #220; no live-AWS action here — after merge this needs an operator patch release + `stand_up.sh` redeploy, then the downstream slice run re-fires (espg/antarctic_AR_dataset#1, phase G of #213).

## Questions for review
- Pre-existing N818 in `registry.py` still trips full-`src` ruff locally (untouched here, flagged on #214 previously).