### PR TITLE
Split the temporal worker's input credential channel (issue #223)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -90,7 +90,12 @@ Process-event mode (the temporal/event pipeline worker -- issue #12, Phase 7b):
     },
     "store_path": str,          # s3:// (or local) tabular output, e.g. .parquet
     "config": dict,             # temporal pipeline config (specs etc.)
-    "s3_credentials": dict (optional),     # read creds for source datasets
+    "s3_credentials": dict (optional),     # read creds for the SOURCE collections
+                                           #   only (issue #223)
+    "input_credentials": dict | "unsigned" (optional),  # consumer-owned mask +
+                                           #   statics channel: explicit creds,
+                                           #   "unsigned" (public bucket), or
+                                           #   absent -> execution role
     "output_credentials": dict (optional), # write creds for the tabular store
     "return_results": bool (optional),  # fan-out driver mode (issue #12 Phase
                                         #   8): skip the worker-side tabular
@@ -725,7 +730,7 @@ def _handle_process_event(event: Dict[str, Any]) -> Dict[str, Any]:
     from zagg import registry as zagg_registry
     from zagg.config import collection_options as _collection_options
     from zagg.output import write_tabular
-    from zagg.temporal import open_dataset, process_event, specs_from_config
+    from zagg.temporal import _input_channel, open_dataset, process_event, specs_from_config
 
     event_key = event.get("event_key")
     logger.info(f"process_event mode: event {event_key!r}")
@@ -748,12 +753,19 @@ def _handle_process_event(event: Dict[str, Any]) -> Dict[str, Any]:
         config = load_config_from_dict(event["config"])
         specs = specs_from_config(config)
 
-        # s3_credentials reads source datasets; output_credentials writes the
-        # tabular store. Either may be omitted to fall back to the execution role.
+        # Two read channels (issue #223): s3_credentials covers the SOURCE
+        # collections it was fetched for (e.g. GES DISC STS creds — scoped, so
+        # signing other buckets with them is denied cross-account);
+        # input_credentials covers the consumer-owned mask + statics (dict |
+        # "unsigned" for public buckets | absent -> execution role).
+        # output_credentials writes the tabular store.
         read_creds = event.get("s3_credentials") or None
+        in_creds, in_unsigned = _input_channel(event.get("input_credentials"))
         region = os.environ.get("AWS_REGION", "us-west-2")
 
-        event_mask = open_dataset(event["event_mask_uri"], credentials=read_creds, region=region)
+        event_mask = open_dataset(
+            event["event_mask_uri"], credentials=in_creds, region=region, unsigned=in_unsigned
+        )
         # The event mask is a single-variable file; index that variable so masks
         # operate on a DataArray (mirrors the local events= contract).
         mask_vars = list(getattr(event_mask, "data_vars", []))
@@ -769,6 +781,7 @@ def _handle_process_event(event: Dict[str, Any]) -> Dict[str, Any]:
             credentials=read_creds,
             region=region,
             collection_options=_collection_options(config),
+            input_credentials=event.get("input_credentials"),
         )
 
         results, meta = process_event(event_key, event_mask, collections, specs, static_data)

--- a/docs/temporal_events.md
+++ b/docs/temporal_events.md
@@ -47,7 +47,8 @@ inputs, keeping the async payload far under Lambda's 256 KB Event cap:
     "event_mask_uri": "s3://.../masks/storm_00042.nc",
     "collection_uris": {"merra2_slv": ["s3://.../day1.nc4", "s3://.../day2.nc4"]},
     "static_uris": {"ais_mask": "s3://.../ais_mask.nc", "cell_areas": "s3://.../areas.nc"},
-    "s3_credentials": {...},   # optional, per-event read credentials
+    "s3_credentials": {...},          # optional: read creds for the collections
+    "input_credentials": "unsigned",  # optional: mask/statics channel
 }
 ```
 
@@ -58,9 +59,15 @@ inputs, keeping the async payload far under Lambda's 256 KB Event cap:
 - `collection_uris` values: one URI **or a list** — a multi-granule event
   (e.g. a storm spanning several MERRA-2 daily files) is opened per-URI,
   concatenated along `time`, and time-sorted.
-- `s3_credentials`: optional. Events without it receive shared credentials
-  fetched once from the `data_source.credentials_provider` registry name when
-  the config sets one (`nsidc` and `gesdisc` ship as built-ins).
+- `s3_credentials`: optional; covers **only the source collections** it was
+  fetched for. Events without it receive shared credentials fetched once from
+  the `data_source.credentials_provider` registry name when the config sets
+  one (`nsidc` and `gesdisc` ship as built-ins).
+- `input_credentials`: optional; the channel for the **consumer-owned mask and
+  statics** — an explicit creds dict, `"unsigned"` (anonymous requests: the
+  correct mechanism for public buckets, since a request *signed* with scoped
+  source credentials is denied cross-account even where anonymous access is
+  granted), or absent for the worker's execution role.
 
 The full worker payload (mode, config, `return_results`, `result_url`) is
 assembled by the runner — consumers supply only the dicts above.

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -606,7 +606,10 @@ def _run_lambda_events(
 
     ``events`` items are URI-shaped dicts (the by-reference twin of the local
     backend's in-memory tuples): ``{"event_key", "event_mask_uri",
-    "collection_uris", "static_uris", "s3_credentials"?}``. Events without
+    "collection_uris", "static_uris", "s3_credentials"?,
+    "input_credentials"?}``. ``input_credentials`` (a creds dict or
+    ``"unsigned"``) covers the consumer-owned mask + statics; ``s3_credentials``
+    covers only the source collections (issue #223). Events without
     per-event ``s3_credentials`` get the shared credentials fetched once from
     the ``data_source.credentials_provider`` registry name, when the config
     sets one (issue #213 Phase 4). The worker loads
@@ -2082,6 +2085,8 @@ def _invoke_lambda_event(
     }
     if ev.get("s3_credentials"):
         event["s3_credentials"] = ev["s3_credentials"]
+    if ev.get("input_credentials"):
+        event["input_credentials"] = ev["input_credentials"]
     if output_creds_event is not None:
         event["output_credentials"] = output_creds_event
 

--- a/src/zagg/temporal.py
+++ b/src/zagg/temporal.py
@@ -591,7 +591,7 @@ def specs_from_config(config):
 # ---------------------------------------------------------------------------
 
 
-def open_dataset(uri, *, credentials=None, endpoint_url=None, region="us-west-2"):
+def open_dataset(uri, *, credentials=None, endpoint_url=None, region="us-west-2", unsigned=False):
     """Open a single xarray ``Dataset`` from a local path or ``s3://`` URI.
 
     A ``.zarr`` URI opens through :func:`zagg.store.open_store` (the obstore S3
@@ -599,14 +599,25 @@ def open_dataset(uri, *, credentials=None, endpoint_url=None, region="us-west-2"
     bytes and opened in-memory, so the reader needs no ``s3fs``/``fsspec`` on the
     Lambda worker. ``credentials``/``endpoint_url`` are the camelCase write/read
     creds used elsewhere; omit to use the ambient chain (execution role).
+    ``unsigned`` sends anonymous (unsigned) requests — the mechanism for public
+    buckets, where a request *signed* by scoped credentials is denied by the
+    cross-account rule even though anonymous access is granted (issue #223).
     """
     import xarray as xr
+
+    if unsigned and credentials:
+        raise ValueError("unsigned=True and explicit credentials are mutually exclusive")
 
     if uri.endswith(".zarr"):
         from .store import open_store
 
         store = open_store(
-            uri, read_only=True, credentials=credentials, endpoint_url=endpoint_url, region=region
+            uri,
+            read_only=True,
+            credentials=credentials,
+            endpoint_url=endpoint_url,
+            region=region,
+            **({"skip_signature": True} if unsigned else {}),
         )
         return xr.open_zarr(store)
 
@@ -628,9 +639,34 @@ def open_dataset(uri, *, credentials=None, endpoint_url=None, region="us-west-2"
         endpoint_url=endpoint_url,
         region=region,
         retry_config=_S3_READONLY_RETRY_CONFIG,
+        **({"skip_signature": True} if unsigned else {}),
     )
     payload = obstore.get(store, key).bytes()
     return xr.open_dataset(io.BytesIO(bytes(payload)))
+
+
+def _input_channel(input_credentials):
+    """Resolve the consumer-input credential channel (issue #223).
+
+    ``input_credentials`` is the payload field covering ``event_mask_uri`` and
+    ``static_uris`` — consumer-owned inputs, as opposed to the source
+    collections that ``s3_credentials`` was fetched for: an explicit camelCase
+    creds dict, the string ``"unsigned"`` (anonymous requests — public
+    buckets), or ``None`` for the ambient chain (execution role).
+
+    Returns
+    -------
+    tuple[dict | None, bool]
+        ``(credentials, unsigned)`` ready for :func:`open_dataset`.
+    """
+    if input_credentials == "unsigned":
+        return None, True
+    if input_credentials is None or isinstance(input_credentials, dict):
+        return input_credentials, False
+    raise ValueError(
+        f"input_credentials must be a credentials dict, 'unsigned', or None "
+        f"(got {input_credentials!r})"
+    )
 
 
 def _eval_derived(name, expression, ds):
@@ -688,6 +724,7 @@ def read_temporal_inputs(
     endpoint_url=None,
     region="us-west-2",
     collection_options=None,
+    input_credentials=None,
 ):
     """Load the ``collections`` and ``static_data`` :func:`process_event` needs.
 
@@ -708,11 +745,19 @@ def read_temporal_inputs(
         ``{static_name: uri}`` for e.g. ``ais_mask`` / ``climatology`` /
         ``cell_areas``.
     credentials, endpoint_url, region
-        Forwarded to :func:`open_dataset`.
+        Forwarded to :func:`open_dataset` for the **collections** — the source
+        datasets these credentials were fetched for (e.g. the GES DISC STS
+        creds from ``credentials_provider``).
     collection_options : dict[str, dict], optional
         Per-collection declarative options applied by
         :func:`prepare_collection`; the runner derives this from
         ``data_source.collections`` via :func:`zagg.config.collection_options`.
+    input_credentials : dict | str | None, optional
+        Credential channel for the **consumer-owned statics** (issue #223): an
+        explicit creds dict, ``"unsigned"`` (anonymous — public buckets), or
+        ``None`` for the ambient chain. Source credentials scoped to GES DISC
+        (or any other provider) are denied on other buckets by the
+        cross-account rule, so statics must not ride the collections channel.
 
     Returns
     -------
@@ -720,6 +765,13 @@ def read_temporal_inputs(
         ``(collections, static_data)`` ready for :func:`process_event`.
     """
     kw = {"credentials": credentials, "endpoint_url": endpoint_url, "region": region}
+    in_creds, unsigned = _input_channel(input_credentials)
+    static_kw = {
+        "credentials": in_creds,
+        "endpoint_url": endpoint_url,
+        "region": region,
+        "unsigned": unsigned,
+    }
     options = collection_options or {}
     collections = {}
     for name, uris in collection_uris.items():
@@ -734,7 +786,7 @@ def read_temporal_inputs(
         collections[name] = prepare_collection(ds, options.get(name))
     static_data = {}
     for name, uri in static_uris.items():
-        ds = open_dataset(uri, **kw)
+        ds = open_dataset(uri, **static_kw)
         data_vars = list(ds.data_vars)
         static_data[name] = ds[data_vars[0]] if len(data_vars) == 1 else ds
     return collections, static_data

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1298,6 +1298,42 @@ class TestProcessEventMode:
         assert resp["statusCode"] == 500
         assert "not_a_reader" in json.loads(resp["body"])["error"]
 
+    def test_input_credentials_channel_routing(self, handler_mod, monkeypatch):
+        # input_credentials covers the mask + statics; s3_credentials covers
+        # only the source collections (issue #223).
+        import zagg.output as output
+        import zagg.temporal as temporal
+
+        event_mask, collections, static = _temporal_inputs()
+        captured = {}
+
+        def _open(uri, **kwargs):
+            captured["mask_kwargs"] = kwargs
+            return event_mask
+
+        def _read(collection_uris, static_uris, **kwargs):
+            captured["reader_kwargs"] = kwargs
+            return collections, static
+
+        monkeypatch.setattr(temporal, "open_dataset", _open)
+        monkeypatch.setattr(temporal, "read_temporal_inputs", _read)
+        monkeypatch.setattr(output, "write_tabular", lambda rows, sp, **k: sp)
+
+        event = _temporal_event(input_credentials="unsigned", return_results=True)
+        del event["store_path"]
+        resp = handler_mod._handle_process_event(event)
+        assert json.loads(resp["body"])["ok"] is True
+        assert captured["mask_kwargs"]["unsigned"] is True
+        assert captured["mask_kwargs"]["credentials"] is None
+        assert captured["reader_kwargs"]["credentials"] == _CREDS
+        assert captured["reader_kwargs"]["input_credentials"] == "unsigned"
+
+    def test_bad_input_credentials_returns_500(self, handler_mod, monkeypatch):
+        self._patch(handler_mod, monkeypatch)
+        resp = handler_mod._handle_process_event(_temporal_event(input_credentials="anonymous"))
+        assert resp["statusCode"] == 500
+        assert "input_credentials" in json.loads(resp["body"])["error"]
+
 
 class TestProcessEventReturnResults:
     """``return_results`` (issue #12, Phase 8): the fan-out driver's contract.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2007,7 +2007,7 @@ class TestInvokeLambdaEvent:
         client = self._client()
         result = runner._invoke_lambda_event(
             client,
-            dict(self._EV, s3_credentials={"accessKeyId": "a"}),
+            dict(self._EV, s3_credentials={"accessKeyId": "a"}, input_credentials="unsigned"),
             function_name="process-shard",
             config_dict={"pipeline": {"type": "temporal"}},
             output_creds_event={"accessKeyId": "w"},
@@ -2021,6 +2021,7 @@ class TestInvokeLambdaEvent:
         assert event["config"] == {"pipeline": {"type": "temporal"}}
         assert event["return_results"] is True
         assert event["s3_credentials"] == {"accessKeyId": "a"}
+        assert event["input_credentials"] == "unsigned"
         assert event["output_credentials"] == {"accessKeyId": "w"}
         assert "store_path" not in event  # driver writes; worker must not
         assert client.invoke.call_args.kwargs["InvocationType"] == "RequestResponse"
@@ -2042,6 +2043,7 @@ class TestInvokeLambdaEvent:
         )
         event = json.loads(client.invoke.call_args.kwargs["Payload"])
         assert "s3_credentials" not in event
+        assert "input_credentials" not in event
         assert "output_credentials" not in event
         assert "result_url" not in event
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -931,6 +931,81 @@ class TestTemporalReader:
         assert "xarray_s3" in registry.list_readers()
         assert callable(registry.get_reader("xarray_s3"))
 
+    def test_open_dataset_unsigned_builds_anonymous_store(self, monkeypatch):
+        # unsigned=True routes to the skip_signature store construction: no
+        # credential provider, anonymous requests (issue #223).
+        xr = pytest.importorskip("xarray")
+        import obstore
+        import obstore.store
+
+        from zagg.temporal import open_dataset
+
+        captured = {}
+        sentinel = xr.Dataset({"mask": (("lat",), np.ones(2))}, coords={"lat": [0, 1]})
+
+        monkeypatch.setattr(
+            obstore.store,
+            "S3Store",
+            lambda bucket, **o: captured.update(bucket=bucket, opts=o) or None,
+        )
+
+        class _Bytes:
+            @staticmethod
+            def bytes():
+                return b"NETCDFBYTES"
+
+        monkeypatch.setattr(obstore, "get", lambda store, key: captured.update(key=key) or _Bytes())
+        monkeypatch.setattr(xr, "open_dataset", lambda buf: sentinel)
+
+        out = open_dataset("s3://public-bucket/masks/storm_00001.nc", unsigned=True)
+        assert captured["bucket"] == "public-bucket"
+        assert captured["opts"].get("skip_signature") is True
+        assert "access_key_id" not in captured["opts"]
+        assert list(out.data_vars) == ["mask"]
+
+    def test_open_dataset_unsigned_with_credentials_raises(self):
+        from zagg.temporal import open_dataset
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            open_dataset("s3://b/m.nc", credentials={"accessKeyId": "a"}, unsigned=True)
+
+    def test_input_channel_forms(self):
+        from zagg.temporal import _input_channel
+
+        creds = {"accessKeyId": "a"}
+        assert _input_channel(creds) == (creds, False)
+        assert _input_channel("unsigned") == (None, True)
+        assert _input_channel(None) == (None, False)
+        with pytest.raises(ValueError, match="input_credentials"):
+            _input_channel("anonymous")
+
+    def test_read_temporal_inputs_routes_credential_channels(self, monkeypatch):
+        # collections read with the source creds; statics ride the
+        # input_credentials channel (here: unsigned) -- issue #223.
+        xr = pytest.importorskip("xarray")
+        import zagg.temporal as temporal
+        from zagg.temporal import read_temporal_inputs
+
+        seen = {}
+        ds = xr.Dataset({"T2M": (("lat",), np.ones(2))}, coords={"lat": [0, 1]})
+
+        def _capture(uri, **kwargs):
+            seen[uri] = kwargs
+            return ds
+
+        monkeypatch.setattr(temporal, "open_dataset", _capture)
+        source_creds = {"accessKeyId": "gesdisc"}
+        read_temporal_inputs(
+            {"merra2": "s3://gesdisc/day1.nc4"},
+            {"ais_mask": "s3://public/ais.nc"},
+            credentials=source_creds,
+            input_credentials="unsigned",
+        )
+        assert seen["s3://gesdisc/day1.nc4"]["credentials"] == source_creds
+        assert not seen["s3://gesdisc/day1.nc4"].get("unsigned")
+        assert seen["s3://public/ais.nc"]["credentials"] is None
+        assert seen["s3://public/ais.nc"]["unsigned"] is True
+
 
 # ---------------------------------------------------------------------------
 # Declarative collection options (issue #213, Phase 3)


### PR DESCRIPTION
Closes #223. Second field failure of the temporal fan-out: with #221's layer fix in place, workers reached the read stage and every mask/static GET 403'd — the handler was signing reads of the consumer's (public) mirror bucket with the GES DISC STS credentials, which the cross-account rule denies (scoped identity policy + foreign bucket), even though anonymous access is granted.

One commit:
- `s3_credentials` now scopes to the **source collections** it was fetched for; a new optional payload field `input_credentials` covers `event_mask_uri` + `static_uris`: an explicit creds dict, `"unsigned"` (anonymous requests via the store layer's existing `skip_signature` branch — the correct mechanism for public buckets), or absent → ambient execution role (previous default, so payloads without the field behave as before for in-account inputs).
- `zagg.temporal.open_dataset` gains `unsigned=` (mutually exclusive with credentials); `read_temporal_inputs` gains `input_credentials=` and routes the two channels independently; `_handle_process_event` wires both; `_invoke_lambda_event` passes the field through from event dicts; `docs/temporal_events.md` contract updated.
- Tests: channel routing in the reader and the handler (mask read unsigned + collections still credentialed), unsigned store construction (skip_signature, no credential provider), mutual-exclusion and bad-value guards, payload passthrough/omission.

Back-compat: payloads without `input_credentials` are byte-identical in behavior **except** that mask/static reads no longer inherit `s3_credentials` — they fall back to the execution role. That inheritance is precisely the bug (scoped source creds can never validly sign consumer buckets), so no working deployment depended on it.

Needs 0.26.1 + fleet redeploy after merge; downstream follow-up sets `input_credentials: "unsigned"` in `events_for_zagg` (espg/antarctic_AR_dataset#1).

## Testing
`pytest tests/test_temporal.py tests/test_lambda_handler.py tests/test_runner.py tests/test_output.py`: 362 passed. Full suite locally pending CI.