### PR TITLE
Bound temporal worker memory: subset + load at the event extent (issue #225)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -774,6 +774,15 @@ def _handle_process_event(event: Dict[str, Any]) -> Dict[str, Any]:
         if mask_vars:
             event_mask = event_mask[mask_vars[0]]
 
+        # The mask is open, so the event extent is known before any collection
+        # read: the reader subsets + loads each granule to it and frees the
+        # buffer, bounding peak memory to ~one granule (issue #225 -- a 4 GB
+        # worker OOMs holding whole granules for every collection at once).
+        extent = None
+        coords = getattr(event_mask, "coords", {})
+        if "lat" in coords and "lon" in coords:
+            extent = (event_mask["lat"].values, event_mask["lon"].values)
+
         # The reader resolves by name (issue #213 Phase 3): only names present
         # in the layer's registry are reachable -- the payload stays pure data.
         reader = zagg_registry.get_reader((config.data_source or {}).get("reader") or "xarray_s3")
@@ -784,6 +793,7 @@ def _handle_process_event(event: Dict[str, Any]) -> Dict[str, Any]:
             region=region,
             collection_options=_collection_options(config),
             input_credentials=event.get("input_credentials"),
+            extent=extent,
         )
 
         results, meta = process_event(event_key, event_mask, collections, specs, static_data)

--- a/src/zagg/temporal.py
+++ b/src/zagg/temporal.py
@@ -725,6 +725,7 @@ def read_temporal_inputs(
     region="us-west-2",
     collection_options=None,
     input_credentials=None,
+    extent=None,
 ):
     """Load the ``collections`` and ``static_data`` :func:`process_event` needs.
 
@@ -758,6 +759,15 @@ def read_temporal_inputs(
         ``None`` for the ambient chain. Source credentials scoped to GES DISC
         (or any other provider) are denied on other buckets by the
         cross-account rule, so statics must not ride the collections channel.
+    extent : tuple, optional
+        ``(lats, lons)`` coordinate arrays of the event (issue #225). When
+        given, every granule is subset to the event extent (and the
+        collection's ``variables``, when configured), **loaded**, and its
+        backing byte buffer released before the next granule opens — bounding
+        peak worker memory to ~one granule regardless of storm length. Without
+        it, datasets stay lazy over their full-file buffers (the pre-#225
+        behavior); on a 4 GB Lambda a multi-day, multi-collection event OOMs
+        that way.
 
     Returns
     -------
@@ -776,7 +786,17 @@ def read_temporal_inputs(
     collections = {}
     for name, uris in collection_uris.items():
         uri_list = list(uris) if isinstance(uris, (list, tuple)) else [uris]
-        parts = [open_dataset(u, **kw) for u in uri_list]
+        keep = (options.get(name) or {}).get("variables")
+        parts = []
+        for u in uri_list:
+            ds = open_dataset(u, **kw)
+            if extent is not None:
+                lats, lons = extent
+                part = ds[list(keep)] if keep else ds
+                part = part.sel(lat=lats, lon=lons).load()
+                ds.close()
+                ds = part
+            parts.append(ds)
         if len(parts) == 1:
             ds = parts[0]
         else:

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1327,6 +1327,13 @@ class TestProcessEventMode:
         assert captured["mask_kwargs"]["credentials"] is None
         assert captured["reader_kwargs"]["credentials"] == _CREDS
         assert captured["reader_kwargs"]["input_credentials"] == "unsigned"
+        # the mask's coordinates ride to the reader so granules subset+load to
+        # the event extent (issue #225)
+        import numpy as np
+
+        lats, lons = captured["reader_kwargs"]["extent"]
+        np.testing.assert_array_equal(lats, event_mask["lat"].values)
+        np.testing.assert_array_equal(lons, event_mask["lon"].values)
 
     def test_bad_input_credentials_returns_500(self, handler_mod, monkeypatch):
         self._patch(handler_mod, monkeypatch)

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -979,11 +979,14 @@ class TestTemporalReader:
         with pytest.raises(ValueError, match="input_credentials"):
             _input_channel("anonymous")
 
-    def test_read_temporal_inputs_extent_subsets_loads_and_frees(self, monkeypatch):
+    def test_read_temporal_inputs_extent_subsets_loads_and_closes(self, monkeypatch):
         # With an event extent, each granule is subset to it (and the
         # collection's variables), loaded, and closed before the next opens --
         # peak memory ~one granule instead of every collection whole
-        # (issue #225).
+        # (issue #225). This test asserts close() is invoked once per granule;
+        # the actual buffer release was verified empirically in the PR-226
+        # review (weakref dies after the loop). The structural guarantee here is
+        # that close() runs before the next granule opens.
         xr = pytest.importorskip("xarray")
         import zagg.temporal as temporal
         from zagg.temporal import read_temporal_inputs
@@ -1021,7 +1024,10 @@ class TestTemporalReader:
         # concat + sortby: day 1 before day 2, values loaded as plain numpy
         assert out["T2M"].values[0, 0, 0] == 1.0
         assert isinstance(out["T2M"].data, np.ndarray)
-        assert len(closed) == 2  # each granule's buffer released after load
+        # close() invoked once per granule (spy replaces the h5netcdf closer);
+        # buffer release itself verified empirically in the PR-226 review. The
+        # structural guarantee is that close runs before the next granule opens.
+        assert len(closed) == 2
 
     def test_read_temporal_inputs_no_extent_stays_lazy_shaped(self, monkeypatch):
         # Without an extent the reader returns the opened datasets untouched

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -979,6 +979,62 @@ class TestTemporalReader:
         with pytest.raises(ValueError, match="input_credentials"):
             _input_channel("anonymous")
 
+    def test_read_temporal_inputs_extent_subsets_loads_and_frees(self, monkeypatch):
+        # With an event extent, each granule is subset to it (and the
+        # collection's variables), loaded, and closed before the next opens --
+        # peak memory ~one granule instead of every collection whole
+        # (issue #225).
+        xr = pytest.importorskip("xarray")
+        import zagg.temporal as temporal
+        from zagg.temporal import read_temporal_inputs
+
+        lat = np.arange(-80.0, -60.0, 0.5)
+        lon = np.arange(-30.0, 30.0, 0.625)
+        closed = []
+
+        def _wide(uri, **kwargs):
+            day = int(uri[-4])
+            time = np.array([f"1980-01-0{day}T00", f"1980-01-0{day}T03"], dtype="datetime64[ns]")
+            ds = xr.Dataset(
+                {
+                    "T2M": (("time", "lat", "lon"), np.full((2, lat.size, lon.size), float(day))),
+                    "SLP": (("time", "lat", "lon"), np.zeros((2, lat.size, lon.size))),
+                },
+                coords={"time": time, "lat": lat, "lon": lon},
+            )
+            ds.set_close(lambda u=uri: closed.append(u))
+            return ds
+
+        monkeypatch.setattr(temporal, "open_dataset", _wide)
+        ev_lats = np.array([-70.0, -69.5])
+        ev_lons = np.array([0.0, 0.625])
+        collections, _ = read_temporal_inputs(
+            {"merra2": ["s3://b/d2.nc", "s3://b/d1.nc"]},
+            {},
+            collection_options={"merra2": {"variables": ["T2M"]}},
+            extent=(ev_lats, ev_lons),
+        )
+        out = collections["merra2"]
+        assert list(out.data_vars) == ["T2M"]
+        np.testing.assert_array_equal(out["lat"].values, ev_lats)
+        np.testing.assert_array_equal(out["lon"].values, ev_lons)
+        # concat + sortby: day 1 before day 2, values loaded as plain numpy
+        assert out["T2M"].values[0, 0, 0] == 1.0
+        assert isinstance(out["T2M"].data, np.ndarray)
+        assert len(closed) == 2  # each granule's buffer released after load
+
+    def test_read_temporal_inputs_no_extent_stays_lazy_shaped(self, monkeypatch):
+        # Without an extent the reader returns the opened datasets untouched
+        # (pre-#225 behavior) -- callers outside the worker keep full control.
+        xr = pytest.importorskip("xarray")
+        import zagg.temporal as temporal
+        from zagg.temporal import read_temporal_inputs
+
+        ds = xr.Dataset({"T2M": (("lat",), np.ones(4))}, coords={"lat": np.arange(4.0)})
+        monkeypatch.setattr(temporal, "open_dataset", lambda uri, **k: ds)
+        collections, _ = read_temporal_inputs({"merra2": "s3://b/d1.nc"}, {})
+        assert collections["merra2"]["T2M"].sizes["lat"] == 4
+
     def test_read_temporal_inputs_routes_credential_channels(self, monkeypatch):
         # collections read with the source creds; statics ride the
         # input_credentials channel (here: unsigned) -- issue #223.


### PR DESCRIPTION
Closes #225. Third fleet failure of the temporal fan-out: every slice worker died `Runtime.OutOfMemory` (CloudWatch: 4095–4096 MB used of 4096 MB, killed 26–128 s in), and OOM kills the runtime before the async result mirror writes — so the orchestrator saw 990 s of silence instead of errors. Mechanism: the reader held every collection's whole daily granules (bytes + lazy datasets) simultaneously for the life of `process_event` — four collections × 2–3 days including ~1 GB/day 3-D OMEGA clears 4 GB before the first timestep computes.

One commit:
- `read_temporal_inputs` gains `extent=(lats, lons)`: each granule is opened, subset to the collection's `variables` + the event extent, **loaded**, and closed (buffer released) before the next opens. Peak memory ≈ one granule's bytes + the loaded event-extent slivers, independent of storm length and collection count. Without `extent` the behavior is byte-identical to before (lazy, full-file).
- `_handle_process_event` passes the extent from the already-opened event mask (it reads the mask before any collection).
- Selection semantics are unchanged — the same exact-match `.sel(lat=…, lon=…)` `process_event` performs later simply happens earlier; `prepare_collection` (offset/resample/derived) now operates on small in-memory arrays, which also defuses the eager-resample-over-whole-file hazard in the precip branch.
- Tests: extent path subsets/loads/frees (close spy via `set_close`, multi-URI concat under extent, variables pre-subset), no-extent path unchanged, handler forwards the mask's coordinates.

This is the stopgap that keeps the 4 GB fleet viable; #222 (hidefix chunk-range reads) is the structural successor and this change stays correct under it. Needs a patch release + redeploy; the downstream slice re-fires unchanged.

## Testing
`pytest tests/test_temporal.py tests/test_lambda_handler.py tests/test_runner.py`: 343 passed locally (pre-fix), 172 in the two directly-affected files post-fix; full suite via CI.