### PR TITLE
add async-tiff to the lambda layer (issue #218)

### DIFF
--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -82,6 +82,13 @@ $PIP install \
 echo "Installing h5coro, h5coro-hidefix and mortie (--no-deps)..."
 $PIP install "h5coro==1.0.5" "h5coro-hidefix==0.3.1" mortie --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
 
+# async-tiff (issue #218): the raster worker's GeoTIFF/COG decode engine
+# (mode="process_raster"). abi3 manylinux_2_28 wheel (~4 MB) on both arches;
+# its only dep is obspec (pure-python, tiny). Keep the pins in sync with the
+# `lambda` extra in pyproject.toml.
+echo "Installing async-tiff (+obspec)..."
+$PIP install "async-tiff==0.7.2" obspec -t "$OUTPUT_DIR/python" --no-cache-dir
+
 # Verify numpy stayed < 2.3
 NUMPY_VERSION=$(ls "$OUTPUT_DIR/python" | grep -E "^numpy-" | head -1)
 echo "Installed: $NUMPY_VERSION"

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -380,3 +380,32 @@ class TestTemplateEnvironment:
         assert props["MaximumRetryAttempts"] == 0
         assert props["MaximumEventAgeInSeconds"] == 60  # API minimum
         assert props["MaximumEventAgeInSeconds"] < _ASYNC_POLL_MARGIN_S
+
+
+class TestLayerExtraParity:
+    """The ``lambda`` extra pins and build_layer.sh must actually stay in sync.
+
+    The script's comments say "keep the pin in sync with the lambda extra",
+    but nothing enforced it: async-tiff (issue #218) was pinned in pyproject
+    yet absent from the layer build, shipping a 0.27.0 layer whose
+    ``mode="process_raster"`` worker died on ``No module named 'async_tiff'``.
+    This pins the contract.
+    """
+
+    def test_every_lambda_extra_pin_is_in_build_layer(self):
+        import tomllib
+
+        pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        pins = pyproject["project"]["optional-dependencies"]["lambda"]
+        script = (REPO_ROOT / "deployment" / "aws" / "build_layer.sh").read_text()
+        missing = []
+        for pin in pins:
+            m = re.match(r"([A-Za-z0-9._-]+)==([A-Za-z0-9.]+)$", pin)
+            if not m:  # unpinned entries (cramjam, astropy) aren't layer-exact
+                continue
+            if f'"{pin}"' not in script:
+                missing.append(pin)
+        assert not missing, (
+            f"lambda-extra pins absent from deployment/aws/build_layer.sh: {missing} "
+            "(the layer would ship without them — see issue #218's async-tiff gap)"
+        )


### PR DESCRIPTION
Refs #218.

**The 0.27.0 Lambda layer shipped without `async-tiff`**, so the fleet's `mode="process_raster"` worker dies with `No module named 'async_tiff'`. Found empirically: the first fleet run of the SERC S2 time-series test (22 shards, account 742127912612's auto-deployed `process-shard`) failed 100% with that ImportError.

Root cause: `build_layer.sh` installs an explicit curated list, and PR #219 synced the async-tiff pin into `pyproject.toml`'s `lambda` extra but not into the script — the exact "keep the pin in sync" trap the script's own comments describe. Nothing enforced the sync, which is why five review passes missed it.

Changes:
- `deployment/aws/build_layer.sh`: install `async-tiff==0.7.2` + `obspec` into the layer (abi3 manylinux_2_28 wheel, ~4 MB per arch — the size gate has ample headroom).
- `tests/test_lambda_build.py`: **new parity test** — every exact pin in the `lambda` extra must appear verbatim in `build_layer.sh`. This turns the comment-based contract into an enforced invariant; it fails on 0.27.0's state and passes with this fix.

Tested: parity test red-before/green-after; `lambda-build.yml`'s dual-arch build + 250 MB gate validates the layer contents on this PR. (`TestFunctionBuild::test_function_build_succeeds` fails locally on unmodified main too — pre-existing environment issue, untouched.)

After merge + release tag, the publish pipeline auto-deploys (as it did for 0.27.0), and the SERC empirical run can re-fire unchanged.
