### PR TITLE
Declarative coord_round for dirty source-grid coordinates (issue #229)

### DIFF
--- a/docs/temporal_events.md
+++ b/docs/temporal_events.md
@@ -83,7 +83,8 @@ data_source:
   collections:
     merra2_slv:                 # no options needed
     merra2_precip:
-      variables: [PRECCU, PRECLS, PRECSN]      # subset before anything else
+      coord_round: 5                            # round lat/lon coords first (float dirt)
+      variables: [PRECCU, PRECLS, PRECSN]      # subset before the rest
       time_offset: "-30min"                     # shift stamps onto the hour
       resample: {freq: "3h", how: sum, scale: 3600}  # rates -> totals
       derived:
@@ -91,7 +92,10 @@ data_source:
       doi: "10.5067/Q5GVUVUIVGO7"               # unknown keys pass through
 ```
 
-Options apply in the order listed above (`prepare_collection`). `derived`
+Options apply in the order listed above (`prepare_collection`): `coord_round`
+runs first (it rounds the source grid's own lat/lon coordinate arrays, so a
+grid that ships float dirt still matches the rounded event/static coords),
+then `variables`, `time_offset`, `resample`, and `derived`. `derived`
 expressions evaluate in the same restricted namespace as the spatial
 pipeline's `expression` fields: numpy plus the collection's variables, no
 builtins. Unknown keys (like `doi`) are ignored by the reader — they are

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -702,6 +702,14 @@ def _validate_collection_options(config: PipelineConfig) -> None:
             raise ValueError(
                 f"data_source.collections[{cname!r}].variables must be a list of names"
             )
+        coord_round = opts.get("coord_round")
+        if coord_round is not None and (
+            isinstance(coord_round, bool) or not isinstance(coord_round, int) or coord_round < 0
+        ):
+            raise ValueError(
+                f"data_source.collections[{cname!r}].coord_round must be a "
+                f"non-negative integer (got {coord_round!r})"
+            )
         offset = opts.get("time_offset")
         if offset is not None:
             if not isinstance(offset, str):

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -672,7 +672,9 @@ def _validate_collection_options(config: PipelineConfig) -> None:
 
     The block accepts a list of collection names (no options) or a mapping of
     name -> per-collection reader options consumed by
-    :func:`zagg.temporal.prepare_collection`: ``variables`` (list of names),
+    :func:`zagg.temporal.prepare_collection`: ``coord_round`` (non-negative
+    int, decimals to round lat/lon coords to -- for source grids whose own
+    coordinate arrays carry float dirt), ``variables`` (list of names),
     ``time_offset`` (a pandas-parseable offset string), ``resample``
     (``{freq, how: sum|mean, scale}``), and ``derived`` (name -> numpy
     expression string). ``time_offset`` and ``resample.freq`` are parsed with

--- a/src/zagg/configs/merra2_storm.yaml
+++ b/src/zagg/configs/merra2_storm.yaml
@@ -21,7 +21,9 @@ data_source:
   # A collection's URIs may be a list (multi-granule events concat along time).
   collections:
     merra2_slv:    # single-level: T2M, TQV, SLP (3-hourly, on the hour)
+      coord_round: 5    # MERRA-2 coord arrays carry float dirt (issue #229)
     merra2_flx:    # surface flux: PRECTOT (1-hourly rates, half-hour stamps)
+      coord_round: 5    # MERRA-2 coord arrays carry float dirt (issue #229)
       time_offset: "-30min"
       resample: {freq: "3h", how: sum, scale: 3600}
   # Static fields the mask providers / anomaly transform consume (see

--- a/src/zagg/temporal.py
+++ b/src/zagg/temporal.py
@@ -697,6 +697,7 @@ def prepare_collection(ds, options):
     """
     if not options:
         return ds
+    ds = _round_coords(ds, options.get("coord_round"))
     variables = options.get("variables")
     if variables:
         ds = ds[list(variables)]
@@ -714,6 +715,20 @@ def prepare_collection(ds, options):
     for name, expr in (options.get("derived") or {}).items():
         ds = ds.assign(**{name: _eval_derived(name, expr, ds)})
     return ds
+
+
+def _round_coords(ds, decimals):
+    """Round spatial coordinates to ``decimals`` places (issue #229).
+
+    Source grids can carry float dirt in their own coordinate arrays (MERRA-2
+    ships one dirty longitude and one dirty latitude per granule), which
+    breaks the exact-match ``.sel`` against rounded event/static coords.
+    No-op when ``decimals`` is None or a coordinate is absent.
+    """
+    if decimals is None:
+        return ds
+    updates = {c: ds[c].round(decimals) for c in ("lat", "lon") if c in ds.coords}
+    return ds.assign_coords(**updates) if updates else ds
 
 
 def read_temporal_inputs(
@@ -786,10 +801,14 @@ def read_temporal_inputs(
     collections = {}
     for name, uris in collection_uris.items():
         uri_list = list(uris) if isinstance(uris, (list, tuple)) else [uris]
-        keep = (options.get(name) or {}).get("variables")
+        opts = options.get(name) or {}
+        keep = opts.get("variables")
         parts = []
         for u in uri_list:
             ds = open_dataset(u, **kw)
+            # rounding must precede the extent .sel so it compares like with
+            # like (issue #229); prepare_collection re-applies it harmlessly
+            ds = _round_coords(ds, opts.get("coord_round"))
             if extent is not None:
                 lats, lons = extent
                 part = ds[list(keep)] if keep else ds

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -276,6 +276,12 @@ class TestCollectionOptions:
         with pytest.raises(ValueError, match="mapping of options"):
             validate_config(self._cfg({"merra2": ["time_offset"]}))
 
+    def test_coord_round_must_be_nonnegative_int(self):
+        validate_config(self._cfg({"merra2": {"coord_round": 5}}))
+        for bad in (True, -1, 5.0, "5"):
+            with pytest.raises(ValueError, match="coord_round"):
+                validate_config(self._cfg({"merra2": {"coord_round": bad}}))
+
     def test_credentials_provider_must_be_string(self):
         cfg = self._cfg(["merra2"])
         cfg.data_source["credentials_provider"] = ["gesdisc"]

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1029,6 +1029,39 @@ class TestTemporalReader:
         # structural guarantee is that close runs before the next granule opens.
         assert len(closed) == 2
 
+    def test_reader_coord_round_precedes_extent_sel(self, monkeypatch):
+        # A rounded event extent must select cleanly against a granule whose
+        # native coords carry float dirt when coord_round is declared; without
+        # it the exact-match .sel fails (issue #229 -- storm_00003 on the
+        # fleet, prime-meridian bbox vs MERRA-2's dirty lon).
+        xr = pytest.importorskip("xarray")
+        import zagg.temporal as temporal
+        from zagg.temporal import read_temporal_inputs
+
+        dirty_lon = np.array([-0.625, -5.920304394294029e-13, 0.625])
+        lat = np.array([-70.0, -69.5])
+
+        def _granule(uri, **kwargs):
+            time = np.array(["1980-01-06T00"], dtype="datetime64[ns]")
+            return xr.Dataset(
+                {"T2M": (("time", "lat", "lon"), np.ones((1, 2, 3)))},
+                coords={"time": time, "lat": lat, "lon": dirty_lon},
+            )
+
+        monkeypatch.setattr(temporal, "open_dataset", _granule)
+        extent = (lat, np.array([-0.625, 0.0]))  # mask coords: rounded
+
+        with pytest.raises(KeyError):
+            read_temporal_inputs({"merra2": "s3://b/d6.nc"}, {}, extent=extent)
+
+        collections, _ = read_temporal_inputs(
+            {"merra2": "s3://b/d6.nc"},
+            {},
+            collection_options={"merra2": {"coord_round": 5}},
+            extent=extent,
+        )
+        np.testing.assert_array_equal(collections["merra2"]["lon"].values, np.array([-0.625, 0.0]))
+
     def test_read_temporal_inputs_no_extent_stays_lazy_shaped(self, monkeypatch):
         # Without an extent the reader returns the opened datasets untouched
         # (pre-#225 behavior) -- callers outside the worker keep full control.
@@ -1126,6 +1159,15 @@ class TestPrepareCollection:
 
         with pytest.raises(ValueError, match="rainfall.*TYPO.*PRECCU"):
             prepare_collection(hourly, {"derived": {"rainfall": "PRECLS + TYPO"}})
+
+    def test_coord_round_cleans_dirty_grid(self, hourly):
+        # MERRA-2 granules carry float dirt in their own coord arrays (one
+        # dirty lon per file, -5.92e-13 where 0.0 belongs) -- issue #229.
+        from zagg.temporal import prepare_collection
+
+        dirty = hourly.assign_coords(lon=[-5.920304394294029e-13])
+        out = prepare_collection(dirty, {"coord_round": 5})
+        assert out["lon"].values[0] == 0.0
 
     def test_unknown_option_keys_ignored(self, hourly):
         # doi &c. are catalog metadata, not reader options.


### PR DESCRIPTION
Closes #229. Fifth fleet finding, root cause upstream of every pipeline involved: MERRA-2 granules carry float dirt in their own coordinate arrays (one dirty lon — `-5.92e-13` for 0.0 — and one dirty lat per file, verified live). Rounded event masks then fail the reader's exact-match extent `.sel` for any event crossing the prime meridian; the local backend never sees it because `local_event_tuples` rounds granule coords, which is why the 84/84 parity run stayed green while the fleet failed.

One commit: per-collection `coord_round: <decimals>` — validated in `_validate_collection_options` (non-negative int, bools rejected), applied in `read_temporal_inputs` immediately after each granule opens (before the variables/extent subset, so the extent sel compares like with like), and as the first step of `prepare_collection` (local-path parity; idempotent when the caller already rounded). Default off — silently rounding arbitrary source grids is a data mutation zagg must not assume; the downstream configs opt in with `coord_round: 5`, expressing declaratively the same convention the reference pipeline hard-codes ('avoid any issues with -0 not matching 0').

Tests: dirty-grid round in `prepare_collection`; reader-level dirty-granule + rounded-extent case (KeyError without the option, clean subset with it); config validation. 411 passing across the three affected files.

Needs a patch release + fleet redeploy; the downstream configs gain `coord_round: 5` in the same window (espg/antarctic_AR_dataset#1).