### PR TITLE
Bound raster worker memory: cap cross-timestep sampling concurrency + stream slab writes

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -897,10 +897,22 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
         # #231) — parity with the local RasterStrategy's per-shard streaming.
         store = open_store(event["store_path"], **_output_store_kwargs(event))
         wrote = False
+        # Opt-in phase timing (the issue #100 convention, raster flavor):
+        # ``write`` is the sink's accumulated wall and ``sample`` the
+        # remainder — the split the PR #232 double-buffer decision needs
+        # measured. Exact at write_buffer=1 (writes serialize in the loop);
+        # at write_buffer>1 writes overlap sampling, so the remainder is
+        # approximate — A/B on ``duration_s`` instead. Default (no
+        # ``profile`` key) emits nothing: the body stays byte-identical.
+        profile = bool(event.get("profile"))
+        write_s = 0.0
 
         def _write_slab(t_idx: int, slab: dict) -> None:
-            nonlocal wrote
+            nonlocal wrote, write_s
+            w0 = time.time() if profile else 0.0
             write_raster_slab(store, grid, shard_key, t_idx, slab)
+            if profile:
+                write_s += time.time() - w0
             wrote = True
 
         _slabs, meta = process_raster_shard(
@@ -927,6 +939,9 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
             "total_obs": meta["timesteps"],
             "duration_s": time.time() - start_time,
         }
+        if profile:
+            total = time.time() - start_time
+            body["phase_timings"] = {"sample": total - write_s, "write": write_s}
         return {"statusCode": 200, "body": json.dumps(body)}
     except Exception as e:
         logger.error(f"raster worker failed: {e}", exc_info=True)

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -890,7 +890,19 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
         shard_key = int(event["shard_key"])
         time_index = {k: int(v) for k, v in event["time_index"].items()}
         source = config.data_source or {}
-        slabs, meta = process_raster_shard(
+
+        # Stream the slabs: open the store up front and write + free each
+        # timestep's slab as ``process_raster_shard`` completes its acquisition
+        # group, so peak output memory holds ~1 slab instead of all T (issue
+        # #231) — parity with the local RasterStrategy's per-shard streaming.
+        store = open_store(event["store_path"], **_output_store_kwargs(event))
+        wrote = {"any": False}
+
+        def _write_slab(t_idx: int, slab: dict) -> None:
+            write_raster_slab(store, grid, shard_key, t_idx, slab)
+            wrote["any"] = True
+
+        _slabs, meta = process_raster_shard(
             grid,
             shard_key,
             event["granules"],
@@ -898,12 +910,9 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
             time_index,
             region=source.get("source_region"),
             anonymous=source.get("anonymous", True),
+            on_slab=_write_slab,
         )
-
-        store = open_store(event["store_path"], **_output_store_kwargs(event))
-        for t_idx, slab in slabs.items():
-            write_raster_slab(store, grid, shard_key, t_idx, slab)
-        if slabs:
+        if wrote["any"]:
             write_raster_coords(store, grid, shard_key)
 
         body = {
@@ -913,7 +922,7 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
             "skipped": meta["skipped"],
             # The shared summary accumulators key on these two names: a raster
             # shard's observation tally is its shard x timestep slab count.
-            "cells_with_data": grid.cells_per_shard if slabs else 0,
+            "cells_with_data": grid.cells_per_shard if wrote["any"] else 0,
             "total_obs": meta["timesteps"],
             "duration_s": time.time() - start_time,
         }

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -896,11 +896,12 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
         # group, so peak output memory holds ~1 slab instead of all T (issue
         # #231) — parity with the local RasterStrategy's per-shard streaming.
         store = open_store(event["store_path"], **_output_store_kwargs(event))
-        wrote = {"any": False}
+        wrote = False
 
         def _write_slab(t_idx: int, slab: dict) -> None:
+            nonlocal wrote
             write_raster_slab(store, grid, shard_key, t_idx, slab)
-            wrote["any"] = True
+            wrote = True
 
         _slabs, meta = process_raster_shard(
             grid,
@@ -912,7 +913,7 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
             anonymous=source.get("anonymous", True),
             on_slab=_write_slab,
         )
-        if wrote["any"]:
+        if wrote:
             write_raster_coords(store, grid, shard_key)
 
         body = {
@@ -922,7 +923,7 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
             "skipped": meta["skipped"],
             # The shared summary accumulators key on these two names: a raster
             # shard's observation tally is its shard x timestep slab count.
-            "cells_with_data": grid.cells_per_shard if wrote["any"] else 0,
+            "cells_with_data": grid.cells_per_shard if wrote else 0,
             "total_obs": meta["timesteps"],
             "duration_s": time.time() - start_time,
         }

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -316,16 +316,13 @@ def validate_config(config: PipelineConfig) -> None:
 
     # Validate the optional granule fan-out width (issue #180). Mirrors the
     # worker's guard (_granule_workers) with the same rejection rationale as
-    # read_workers above.
-    granule_workers = (config.data_source or {}).get("granule_workers")
-    if granule_workers is not None and (
-        isinstance(granule_workers, bool)
-        or not isinstance(granule_workers, int)
-        or granule_workers < 1
-    ):
-        raise ValueError(
-            f"data_source.granule_workers must be an integer >= 1 (got {granule_workers!r})"
-        )
+    # read_workers above. ``shard_workers`` is the canonical cross-pipeline
+    # name (issue #232 — "source units in flight per shard"); the legacy
+    # ``granule_workers`` key stays honored (canonical wins when both set).
+    for _key in ("shard_workers", "granule_workers"):
+        _w = (config.data_source or {}).get(_key)
+        if _w is not None and (isinstance(_w, bool) or not isinstance(_w, int) or _w < 1):
+            raise ValueError(f"data_source.{_key} must be an integer >= 1 (got {_w!r})")
     # Optional strict-AOI cell mask (issue #101), default off. Must be a bool.
     aoi_mask = config.output.get("aoi_mask")
     if aoi_mask is not None and not isinstance(aoi_mask, bool):
@@ -625,20 +622,29 @@ def _validate_raster_config(config: PipelineConfig) -> None:
     nodata = config.data_source.get("nodata")
     if nodata is not None and (not isinstance(nodata, (int, float)) or isinstance(nodata, bool)):
         raise ValueError(f"data_source.nodata must be a number (got {nodata!r})")
-    # Optional sampling-concurrency cap (issue #231): how many acquisition
-    # groups (timesteps) sample concurrently per shard. Mirrors the
-    # read_workers/granule_workers guard so a config typo is rejected at
-    # submission, not swallowed inside the worker's event loop. Default 4
-    # (``process_raster.raster._sample_concurrency``); ``1`` is serial.
-    sample_concurrency = config.data_source.get("sample_concurrency")
-    if sample_concurrency is not None and (
-        isinstance(sample_concurrency, bool)
-        or not isinstance(sample_concurrency, int)
-        or sample_concurrency < 1
+    # Optional per-shard fan-out cap (issues #231/#232): ``shard_workers`` is
+    # the ONE cross-pipeline knob for "source units in flight per shard" —
+    # here, acquisition groups (timesteps) sampling concurrently. Guarded like
+    # read_workers so a config typo is rejected at submission, not swallowed
+    # inside the worker's event loop. Default 4
+    # (``processing.raster._shard_workers``); ``1`` is serial. NOTE: the
+    # memory cost per unit is pipeline-dependent (a granule read buffer on the
+    # spatial path vs a timestep of decoded COG tiles here) — see issue #228.
+    shard_workers = config.data_source.get("shard_workers")
+    if shard_workers is not None and (
+        isinstance(shard_workers, bool) or not isinstance(shard_workers, int) or shard_workers < 1
     ):
         raise ValueError(
-            f"data_source.sample_concurrency must be an integer >= 1 (got {sample_concurrency!r})"
+            f"data_source.shard_workers must be an integer >= 1 (got {shard_workers!r})"
         )
+    # Streamed-write slab budget (PR #232 double-buffer): ``1`` (default) is
+    # the strict serial bound; ``N`` overlaps up to N-1 slab writes with
+    # sampling at a peak of N slabs alive (``processing.raster._write_buffer``).
+    write_buffer = config.data_source.get("write_buffer")
+    if write_buffer is not None and (
+        isinstance(write_buffer, bool) or not isinstance(write_buffer, int) or write_buffer < 1
+    ):
+        raise ValueError(f"data_source.write_buffer must be an integer >= 1 (got {write_buffer!r})")
     grid = config.output.get("grid")
     if not isinstance(grid, dict) or grid.get("type") != "healpix":
         raise ValueError(

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -625,6 +625,20 @@ def _validate_raster_config(config: PipelineConfig) -> None:
     nodata = config.data_source.get("nodata")
     if nodata is not None and (not isinstance(nodata, (int, float)) or isinstance(nodata, bool)):
         raise ValueError(f"data_source.nodata must be a number (got {nodata!r})")
+    # Optional sampling-concurrency cap (issue #231): how many acquisition
+    # groups (timesteps) sample concurrently per shard. Mirrors the
+    # read_workers/granule_workers guard so a config typo is rejected at
+    # submission, not swallowed inside the worker's event loop. Default 4
+    # (``process_raster.raster._sample_concurrency``); ``1`` is serial.
+    sample_concurrency = config.data_source.get("sample_concurrency")
+    if sample_concurrency is not None and (
+        isinstance(sample_concurrency, bool)
+        or not isinstance(sample_concurrency, int)
+        or sample_concurrency < 1
+    ):
+        raise ValueError(
+            f"data_source.sample_concurrency must be an integer >= 1 (got {sample_concurrency!r})"
+        )
     grid = config.output.get("grid")
     if not isinstance(grid, dict) or grid.get("type") != "healpix":
         raise ValueError(

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -351,6 +351,29 @@ def _chord2(lons, lats, lon0: float, lat0: float) -> np.ndarray:
     return x * x + y * y + z * z
 
 
+# Default cap on how many acquisition groups sample concurrently per shard
+# (issue #231). Mirrors ``data_source.granule_workers``' default of 4: every
+# in-flight group holds one timestep's decoded COG tiles + per-band gather
+# buffers, so the cap bounds peak sampling memory to ~K timesteps instead of
+# all T at once, while still overlapping S3 fetches at fine orders.
+_DEFAULT_SAMPLE_CONCURRENCY = 4
+
+
+def _sample_concurrency(config) -> int:
+    """``data_source.sample_concurrency``: acquisition groups in flight per shard.
+
+    Bounds the :class:`asyncio.Semaphore` over timesteps in
+    :func:`process_raster_shard` (issue #231). Default 4; ``1`` samples one
+    timestep at a time. Re-checked here with the same int>=1 / bool-trap guard
+    ``validate_config`` applies at submission, so a hand-rolled worker payload
+    fails loudly rather than passing a bad width to ``Semaphore``.
+    """
+    k = (config.data_source or {}).get("sample_concurrency", _DEFAULT_SAMPLE_CONCURRENCY)
+    if isinstance(k, bool) or not isinstance(k, int) or k < 1:
+        raise ValueError(f"data_source.sample_concurrency must be an integer >= 1 (got {k!r})")
+    return k
+
+
 def process_raster_shard(
     grid,
     shard_key: int,
@@ -402,12 +425,21 @@ def process_raster_shard(
                 "the shards were dispatched from — see raster_time_index"
             )
 
-    # One event loop per shard: fan out across every item of every timestep
-    # concurrently (S3 fetches overlap), instead of one asyncio.run per item.
+    # One event loop per shard, but bound how many acquisition groups sample
+    # concurrently: an ``asyncio.Semaphore(K)`` over the timesteps caps peak
+    # memory at ~K in-flight timesteps of decoded COG tiles + per-band gather
+    # buffers instead of all T at once (issue #231). Within a bounded group
+    # every item still fans out concurrently — adjacent MGRS tiles of one
+    # datatake are seconds apart, so the wall-clock overlap survives at fine
+    # orders.
+    k = _sample_concurrency(config)
+
     async def _sample_all():
-        return await asyncio.gather(
-            *[
-                asyncio.gather(
+        sem = asyncio.Semaphore(k)
+
+        async def _sample_group(items):
+            async with sem:
+                return await asyncio.gather(
                     *[
                         sample_item_async(
                             grid,
@@ -421,9 +453,8 @@ def process_raster_shard(
                         for e in items
                     ]
                 )
-                for items in groups.values()
-            ]
-        )
+
+        return await asyncio.gather(*[_sample_group(items) for items in groups.values()])
 
     group_results = _run_sync(_sample_all())
 

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -352,15 +352,17 @@ def _chord2(lons, lats, lon0: float, lat0: float) -> np.ndarray:
 
 
 # Default cap on how many acquisition groups sample concurrently per shard
-# (issue #231). Mirrors ``data_source.granule_workers``' default of 4: every
+# (issue #231). One knob per pipeline family (issue #232): ``shard_workers`` is
+# "source units in flight per shard" — granules on the spatial path, acquisition
+# groups (timesteps) here — mirroring the spatial default of 4: every
 # in-flight group holds one timestep's decoded COG tiles + per-band gather
 # buffers, so the cap bounds peak sampling memory to ~K timesteps instead of
 # all T at once, while still overlapping S3 fetches at fine orders.
-_DEFAULT_SAMPLE_CONCURRENCY = 4
+_DEFAULT_SHARD_WORKERS = 4
 
 
-def _sample_concurrency(config) -> int:
-    """``data_source.sample_concurrency``: acquisition groups in flight per shard.
+def _shard_workers(config) -> int:
+    """``data_source.shard_workers``: acquisition groups in flight per shard.
 
     Bounds the :class:`asyncio.Semaphore` over timesteps in
     :func:`process_raster_shard` (issue #231). Default 4; ``1`` samples one
@@ -368,10 +370,31 @@ def _sample_concurrency(config) -> int:
     ``validate_config`` applies at submission, so a hand-rolled worker payload
     fails loudly rather than passing a bad width to ``Semaphore``.
     """
-    k = (config.data_source or {}).get("sample_concurrency", _DEFAULT_SAMPLE_CONCURRENCY)
+    k = (config.data_source or {}).get("shard_workers", _DEFAULT_SHARD_WORKERS)
     if isinstance(k, bool) or not isinstance(k, int) or k < 1:
-        raise ValueError(f"data_source.sample_concurrency must be an integer >= 1 (got {k!r})")
+        raise ValueError(f"data_source.shard_workers must be an integer >= 1 (got {k!r})")
     return k
+
+
+# Streamed-write slab budget (PR #232 review): ``1`` is the strict serial
+# bound — a completed slab is written and freed before the next group drains.
+# ``N`` allows N-1 writes in flight on worker threads while the next slab
+# builds, so peak output memory holds <= N slabs; write latency then overlaps
+# sampling instead of serializing against it.
+_DEFAULT_WRITE_BUFFER = 1
+
+
+def _write_buffer(config) -> int:
+    """``data_source.write_buffer``: max slabs alive under a streamed sink.
+
+    Only meaningful when ``process_raster_shard`` runs with ``on_slab``;
+    dict-mode accumulation ignores it. Same int>=1 / bool-trap guard as the
+    sibling worker knobs.
+    """
+    n = (config.data_source or {}).get("write_buffer", _DEFAULT_WRITE_BUFFER)
+    if isinstance(n, bool) or not isinstance(n, int) or n < 1:
+        raise ValueError(f"data_source.write_buffer must be an integer >= 1 (got {n!r})")
+    return n
 
 
 def process_raster_shard(
@@ -402,10 +425,13 @@ def process_raster_shard(
     on_slab : callable, optional
         ``on_slab(t_idx, slab)`` sink invoked once per timestep as its
         acquisition group completes (issue #231). When given, the slab is
-        handed off and dropped immediately, so peak output memory holds ~1
-        timestep instead of all ``T``; the returned ``slabs`` is then empty.
-        When ``None`` (the default) every slab accumulates into ``slabs`` and
-        is returned, as before.
+        handed off and dropped immediately, so peak output memory holds
+        ``data_source.write_buffer`` slabs (default 1: written + freed before
+        the next group drains; ``N`` runs up to ``N-1`` sink calls on worker
+        threads so write latency overlaps sampling — the PR #232
+        double-buffer); the returned ``slabs`` is then empty. When ``None``
+        (the default) every slab accumulates into ``slabs`` and is returned,
+        as before, and ``write_buffer`` is ignored.
 
     Returns
     -------
@@ -444,7 +470,8 @@ def process_raster_shard(
     # every item still fans out concurrently — adjacent MGRS tiles of one
     # datatake are seconds apart, so the wall-clock overlap survives at fine
     # orders.
-    k = _sample_concurrency(config)
+    k = _shard_workers(config)
+    wb = _write_buffer(config)
 
     async def _run_all():
         sem = asyncio.Semaphore(k)
@@ -469,28 +496,53 @@ def process_raster_shard(
 
         lonlat = None  # computed once, only if some timestep has overlapping items
         slabs: dict = {}
+        # Streamed-sink hand-off. At the default ``write_buffer`` of 1 the
+        # sink runs synchronously in the loop: a completed slab is written +
+        # freed before the next group drains (the strict issue #231 bound).
+        # At N>1 (the PR #232 double-buffer) up to N-1 sink calls run on
+        # worker threads while the next slab builds — <= N slabs alive, write
+        # latency overlapped with sampling. A sink error surfaces at most one
+        # group late, at the next hand-off (or the final drain below).
+        pending: list = []
+
+        async def _emit(t, slab):
+            if wb <= 1:
+                on_slab(t, slab)
+                return
+            while len(pending) >= wb - 1:
+                await pending.pop(0)
+            pending.append(asyncio.create_task(asyncio.to_thread(on_slab, t, slab)))
+
         # Drain groups as they finish (as_completed): build each timestep's slab
-        # and hand it to the sink, so a completed slab is written + freed before
-        # the next arrives — the output side stays ~1 timestep (issue #231).
-        for fut in asyncio.as_completed(
-            [_sample_group(key, items) for key, items in groups.items()]
-        ):
-            t, sampled = await fut
-            if len(sampled) == 1:
-                values, valid, _center = sampled[0]
-            else:
-                if lonlat is None:
-                    lonlat = grid.cell_lonlat(cells)
-                values, valid = _combine_by_ownership(sampled, lonlat, bands)
-            slab = {}
-            for f, v in values.items():
-                out = v.copy()  # keep the asset dtype (np.where would promote)
-                out[~valid] = bands[f]["fill_value"]
-                slab[f] = out
-            if on_slab is not None:
-                on_slab(t, slab)  # write + free this timestep before the next
-            else:
-                slabs[t] = slab
+        # and hand it to the sink — the output side stays ~write_buffer
+        # timesteps (issues #231/#232).
+        try:
+            for fut in asyncio.as_completed(
+                [_sample_group(key, items) for key, items in groups.items()]
+            ):
+                t, sampled = await fut
+                if len(sampled) == 1:
+                    values, valid, _center = sampled[0]
+                else:
+                    if lonlat is None:
+                        lonlat = grid.cell_lonlat(cells)
+                    values, valid = _combine_by_ownership(sampled, lonlat, bands)
+                slab = {}
+                for f, v in values.items():
+                    out = v.copy()  # keep the asset dtype (np.where would promote)
+                    out[~valid] = bands[f]["fill_value"]
+                    slab[f] = out
+                if on_slab is not None:
+                    await _emit(t, slab)
+                else:
+                    slabs[t] = slab
+        except BaseException:
+            # Reap in-flight writes before propagating the primary error, so
+            # no task is left un-awaited (their own errors are secondary here).
+            await asyncio.gather(*pending, return_exceptions=True)
+            raise
+        if pending:
+            await asyncio.gather(*pending)  # propagate any trailing write error
         return slabs
 
     slabs = _run_sync(_run_all())

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -383,6 +383,7 @@ def process_raster_shard(
     *,
     region: str | None = None,
     anonymous: bool = True,
+    on_slab=None,
 ):
     """Process one shard of a raster pipeline: every acquisition group -> slab.
 
@@ -396,12 +397,23 @@ def process_raster_shard(
     acquisition-group key is absent raises :class:`ValueError` naming the key,
     rather than failing with an opaque ``KeyError`` deep in the gather.
 
+    Parameters
+    ----------
+    on_slab : callable, optional
+        ``on_slab(t_idx, slab)`` sink invoked once per timestep as its
+        acquisition group completes (issue #231). When given, the slab is
+        handed off and dropped immediately, so peak output memory holds ~1
+        timestep instead of all ``T``; the returned ``slabs`` is then empty.
+        When ``None`` (the default) every slab accumulates into ``slabs`` and
+        is returned, as before.
+
     Returns
     -------
     (slabs, metadata)
         ``slabs``: ``{t_idx: {field: values}}`` — one dense per-cell array per
-        band per timestep, fill where no valid source. ``metadata``: counts
-        (``granule_count``, ``skipped``, ``timesteps``, ``shard_key``).
+        band per timestep, fill where no valid source (empty when ``on_slab``
+        streamed them). ``metadata``: counts (``granule_count``, ``skipped``,
+        ``timesteps``, ``shard_key``).
     """
     from zagg.config import get_raster_bands
 
@@ -434,12 +446,12 @@ def process_raster_shard(
     # orders.
     k = _sample_concurrency(config)
 
-    async def _sample_all():
+    async def _run_all():
         sem = asyncio.Semaphore(k)
 
-        async def _sample_group(items):
+        async def _sample_group(key, items):
             async with sem:
-                return await asyncio.gather(
+                sampled = await asyncio.gather(
                     *[
                         sample_item_async(
                             grid,
@@ -453,32 +465,40 @@ def process_raster_shard(
                         for e in items
                     ]
                 )
+            return time_index[key], sampled
 
-        return await asyncio.gather(*[_sample_group(items) for items in groups.values()])
+        lonlat = None  # computed once, only if some timestep has overlapping items
+        slabs: dict = {}
+        # Drain groups as they finish (as_completed): build each timestep's slab
+        # and hand it to the sink, so a completed slab is written + freed before
+        # the next arrives — the output side stays ~1 timestep (issue #231).
+        for fut in asyncio.as_completed(
+            [_sample_group(key, items) for key, items in groups.items()]
+        ):
+            t, sampled = await fut
+            if len(sampled) == 1:
+                values, valid, _center = sampled[0]
+            else:
+                if lonlat is None:
+                    lonlat = grid.cell_lonlat(cells)
+                values, valid = _combine_by_ownership(sampled, lonlat, bands)
+            slab = {}
+            for f, v in values.items():
+                out = v.copy()  # keep the asset dtype (np.where would promote)
+                out[~valid] = bands[f]["fill_value"]
+                slab[f] = out
+            if on_slab is not None:
+                on_slab(t, slab)  # write + free this timestep before the next
+            else:
+                slabs[t] = slab
+        return slabs
 
-    group_results = _run_sync(_sample_all())
-
-    lonlat = None  # computed once, only if some timestep has overlapping items
-    slabs: dict = {}
-    for (key, _items), sampled in zip(groups.items(), group_results):
-        t = time_index[key]
-        if len(sampled) == 1:
-            values, valid, _center = sampled[0]
-        else:
-            if lonlat is None:
-                lonlat = grid.cell_lonlat(cells)
-            values, valid = _combine_by_ownership(sampled, lonlat, bands)
-        slab = {}
-        for f, v in values.items():
-            out = v.copy()  # keep the asset dtype (np.where would promote)
-            out[~valid] = bands[f]["fill_value"]
-            slab[f] = out
-        slabs[t] = slab
+    slabs = _run_sync(_run_all())
     metadata = {
         "shard_key": int(shard_key),
         "granule_count": len(granules),
         "skipped": skipped,
-        "timesteps": len(slabs),
+        "timesteps": len(groups),
     }
     return slabs, metadata
 

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -51,7 +51,13 @@ logger = logging.getLogger(__name__)
 
 
 def _granule_workers(data_source: dict) -> int:
-    """``data_source.granule_workers``: granules in flight per shard (issue #180).
+    """Granules in flight per shard (issue #180).
+
+    Read from ``data_source.shard_workers`` — the canonical cross-pipeline
+    knob (issue #232: "source units in flight per shard"; the raster path
+    reads the same key for acquisition groups) — falling back to the legacy
+    ``granule_workers`` name, which shipped configs still carry. Canonical
+    wins when both are set.
 
     Default **4** — picked from the PR #183 K-sweep fleet A/B (issue #185:
     K=4 inline read 296.9 s vs 0.17's 323 s median on the o9 NEON AOI; the
@@ -71,9 +77,12 @@ def _granule_workers(data_source: dict) -> int:
     down as K rises, and watch ``read_errors`` (queueing + the 5 s timeout can
     surface as spurious read failures, not slowdowns) in the K-sweep A/B.
     """
-    w = data_source.get("granule_workers", 4)
+    w = data_source.get("shard_workers", data_source.get("granule_workers", 4))
     if isinstance(w, bool) or not isinstance(w, int) or w < 1:
-        raise ValueError(f"data_source.granule_workers must be an integer >= 1 (got {w!r})")
+        raise ValueError(
+            f"data_source.shard_workers (or legacy granule_workers) must be an "
+            f"integer >= 1 (got {w!r})"
+        )
     return w
 
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -684,12 +684,25 @@ class RasterStrategy:
 
         def _one(pair):
             shard_key, granules = pair
-            slabs, meta = process_raster_shard(
-                grid, int(shard_key), granules, config, time_index, **src_kwargs
-            )
-            for t_idx, slab in slabs.items():
+            wrote = False
+
+            def _write_slab(t_idx, slab):
+                nonlocal wrote
                 write_raster_slab(zarr_store, grid, int(shard_key), t_idx, slab)
-            if slabs:
+                wrote = True
+
+            # Stream: write + free each timestep's slab as it completes (issue
+            # #231), so a shard holds ~1 slab, not all T.
+            _slabs, meta = process_raster_shard(
+                grid,
+                int(shard_key),
+                granules,
+                config,
+                time_index,
+                on_slab=_write_slab,
+                **src_kwargs,
+            )
+            if wrote:
                 write_raster_coords(zarr_store, grid, int(shard_key))
             return meta
 

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -117,6 +117,52 @@ class TestProcessRasterMode:
             np.asarray(grid.encode_cell_ids(cells), dtype=np.uint64),
         )
 
+    def test_handler_streams_slabs_incrementally(self, handler_mod, raster_event, monkeypatch):
+        # The handler must write + free each timestep's slab as it completes
+        # (issue #231), not accumulate all T then loop. A fake worker drives the
+        # on_slab sink per timestep and tracks how many slabs are live at each
+        # write: exactly one, proving write-then-free rather than accumulate.
+        import zagg.processing.raster as raster_mod
+
+        event, grid, _data = raster_event
+        n_time = 3
+        live = {"cur": 0, "max": 0}
+        writes = []
+        coords_calls = []
+
+        def _fake_process(grid_, shard_key, granules, config, time_index, *, on_slab=None, **kw):
+            assert on_slab is not None  # handler must pass a sink (stream, not buffer)
+            for t in range(n_time):
+                slab = {"red": np.zeros(grid_.cells_per_shard, dtype=np.uint16)}
+                live["cur"] += 1
+                live["max"] = max(live["max"], live["cur"])
+                on_slab(t, slab)  # handler writes here; the slab is dropped next loop
+                live["cur"] -= 1
+            return {}, {
+                "shard_key": int(shard_key),
+                "granule_count": 1,
+                "skipped": 0,
+                "timesteps": n_time,
+            }
+
+        monkeypatch.setattr(raster_mod, "process_raster_shard", _fake_process)
+        monkeypatch.setattr(
+            raster_mod, "write_raster_slab", lambda store, g, sk, t, slab: writes.append(t)
+        )
+        monkeypatch.setattr(
+            raster_mod, "write_raster_coords", lambda *a, **k: coords_calls.append(1)
+        )
+
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200, resp
+        assert writes == [0, 1, 2]  # one write per timestep, in stream order
+        assert live["max"] == 1  # never more than one slab alive
+        assert coords_calls == [1]  # coords written once, after the slabs
+        body = json.loads(resp["body"])
+        assert body["timesteps"] == n_time
+        assert body["cells_with_data"] == grid.cells_per_shard
+        assert body["total_obs"] == n_time
+
     def test_missing_params_400(self, handler_mod):
         resp = handler_mod.lambda_handler({"mode": "process_raster"}, MagicMock())
         assert resp["statusCode"] == 400

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -190,3 +190,21 @@ class TestProcessRasterMode:
         resp = handler_mod.lambda_handler(event, MagicMock())
         assert resp["statusCode"] == 500
         assert "asset" in json.loads(resp["body"])["error"]
+
+
+class TestRasterPhaseTimings:
+    def test_profile_emits_sample_write_split(self, handler_mod, raster_event):
+        event, _grid, _data = raster_event
+        event["profile"] = True
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200, resp
+        body = json.loads(resp["body"])
+        pt = body["phase_timings"]
+        assert set(pt) == {"sample", "write"}
+        assert pt["write"] > 0.0
+        assert pt["sample"] + pt["write"] == pytest.approx(body["duration_s"], rel=0.05)
+
+    def test_no_profile_key_no_timings(self, handler_mod, raster_event):
+        event, _grid, _data = raster_event
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert "phase_timings" not in json.loads(resp["body"])

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5658,6 +5658,17 @@ class TestGranuleReadPool:
 
         return factory, instances
 
+    def test_shard_workers_canonical_and_legacy(self):
+        # Issue #232: shard_workers is the canonical cross-pipeline knob; the
+        # legacy granule_workers key stays honored, canonical wins when both set.
+        from zagg.processing.worker import _granule_workers
+
+        assert _granule_workers({"shard_workers": 6}) == 6
+        assert _granule_workers({"shard_workers": 6, "granule_workers": 2}) == 6
+        assert _granule_workers({"granule_workers": 2}) == 2
+        with pytest.raises(ValueError, match="shard_workers"):
+            _granule_workers({"shard_workers": 0})
+
     def test_granule_workers_validation(self):
         from zagg.processing.worker import _granule_workers
 

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -170,17 +170,20 @@ class _FakeGrid:
 
 
 class TestSampleConcurrency:
-    def test_semaphore_bounds_in_flight_groups(self, monkeypatch):
+    # k=1 serial (peak 1), an interior cap (peak k), and k>=n_groups (peak
+    # n_groups): an off-by-one in the semaphore width passes k=3 but fails k=1.
+    @pytest.mark.parametrize("k", [1, 3, 10, 12])
+    def test_semaphore_bounds_in_flight_groups(self, monkeypatch, k):
         # N single-item acquisition groups sampled under Semaphore(K): each
         # group is one ``sample_item_async`` call, so concurrent calls track
         # concurrent timesteps. An instrumented fake records the peak, which
-        # must be capped at K yet actually reach K (issue #231: the cap bounds
-        # memory without serializing the fan-out).
+        # must be capped at min(K, N) yet actually reach it (issue #231: the cap
+        # bounds memory without serializing the fan-out).
         import asyncio as _asyncio
 
         from zagg.processing import raster as raster_mod
 
-        n_cells, n_groups, k = 8, 10, 3
+        n_cells, n_groups = 8, 10
         state = {"cur": 0, "max": 0}
         lock = _asyncio.Lock()
 
@@ -207,7 +210,8 @@ class TestSampleConcurrency:
         slabs, meta = process_raster_shard(_FakeGrid(n_cells), 0, granules, cfg, index)
         assert meta["timesteps"] == n_groups
         assert set(slabs) == set(range(n_groups))
-        assert state["max"] == k  # bounded by K, and the fan-out reaches K
+        # Bounded by min(K, N), and the fan-out reaches it (not serialized).
+        assert state["max"] == min(k, n_groups)
 
 
 def _rect_grid(bounds, chunk):

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -17,8 +17,9 @@ from zagg.config import get_raster_bands, load_config_from_dict, validate_config
 from zagg.grids import HealpixGrid, RectilinearGrid
 from zagg.processing.raster import (
     _run_sync,
-    _sample_concurrency,
     _shard_cell_range,
+    _shard_workers,
+    _write_buffer,
     emit_raster_template,
     process_raster_shard,
     raster_group_spec,
@@ -110,21 +111,21 @@ class TestRasterConfigValidation:
         assert bands["red"]["fill_value"] == 0
         assert bands["scl"]["attrs"] == {}
 
-    def test_sample_concurrency_default_and_override(self):
-        assert _sample_concurrency(_raster_config()) == 4  # issue #231 default
+    def test_shard_workers_default_and_override(self):
+        assert _shard_workers(_raster_config()) == 4  # issue #231 default
         cfg = _raster_config()
-        cfg.data_source["sample_concurrency"] = 8
-        assert _sample_concurrency(cfg) == 8
+        cfg.data_source["shard_workers"] = 8
+        assert _shard_workers(cfg) == 8
 
-    def test_sample_concurrency_rejected(self):
+    def test_shard_workers_rejected(self):
         for bad in (0, -1, True, 2.0):
             cfg = _raster_config()
-            cfg.data_source["sample_concurrency"] = bad
-            with pytest.raises(ValueError, match="sample_concurrency"):
+            cfg.data_source["shard_workers"] = bad
+            with pytest.raises(ValueError, match="shard_workers"):
                 validate_config(cfg)
             # The worker helper re-checks with the same guard (hand-rolled payload).
-            with pytest.raises(ValueError, match="sample_concurrency"):
-                _sample_concurrency(cfg)
+            with pytest.raises(ValueError, match="shard_workers"):
+                _shard_workers(cfg)
 
 
 class TestRasterTimeIndex:
@@ -202,7 +203,7 @@ class TestSampleConcurrency:
         monkeypatch.setattr(raster_mod, "sample_item_async", _fake_sample_item)
 
         cfg = _raster_config(bands={"red": {"asset": "red", "dtype": "uint16"}}, nodata=None)
-        cfg.data_source["sample_concurrency"] = k
+        cfg.data_source["shard_workers"] = k
         granules = [
             _entry(f"g{i}", {"red": f"r{i}.tif"}, T0, time_key=f"dt-{i}") for i in range(n_groups)
         ]
@@ -358,6 +359,82 @@ class TestOwnership:
         slabs, meta = process_raster_shard(grid, 0, granules, cfg, index)
         assert meta["skipped"] == 1 and meta["granule_count"] == 2
         assert (slabs[0]["red"] == 7).all()
+
+    @pytest.mark.parametrize("wb", [2, 3])
+    def test_write_buffer_bounded_and_matches(self, tmp_path, wb):
+        # PR #232 double-buffer: with write_buffer=N the sink runs on worker
+        # threads, at most N slabs are alive at once, overlap actually occurs,
+        # and the streamed output still matches dict mode exactly.
+        import threading
+        import time as _time
+
+        vals = {"dt-1": 11, "dt-2": 22, "dt-3": 33, "dt-4": 44}
+        granules = []
+        for i, (tk, v) in enumerate(vals.items()):
+            _write_tiff(tmp_path / f"s{i}.tif", np.full((96, 96), v, dtype=np.uint16))
+            granules.append(
+                _entry(
+                    f"g{i}",
+                    {"red": str(tmp_path / f"s{i}.tif")},
+                    f"2026-07-{13 + i:02d}T16:02:20+00:00",
+                    time_key=tk,
+                )
+            )
+        grid = _rect_grid([ORIGIN[0], ORIGIN[1] - 960.0, ORIGIN[0] + 960.0, ORIGIN[1]], [96, 96])
+        cfg = _raster_config(bands={"red": {"asset": "red", "dtype": "uint16"}}, nodata=None)
+        index, _ = raster_time_index([granules])
+        golden, _gm = process_raster_shard(grid, 0, granules, cfg, index)
+
+        cfg.data_source["write_buffer"] = wb
+        lock = threading.Lock()
+        live = {"now": 0, "max": 0}
+        streamed = {}
+
+        def _sink(t_idx, slab):
+            with lock:
+                live["now"] += 1
+                live["max"] = max(live["max"], live["now"])
+            _time.sleep(0.05)  # slow write: forces overlap under the buffer
+            streamed[t_idx] = slab
+            with lock:
+                live["now"] -= 1
+
+        slabs, meta = process_raster_shard(grid, 0, granules, cfg, index, on_slab=_sink)
+        assert slabs == {} and meta["timesteps"] == 4
+        assert live["max"] <= wb - 1  # sink calls in flight (slabs alive <= wb)
+        assert set(streamed) == set(golden)
+        for t in golden:
+            np.testing.assert_array_equal(streamed[t]["red"], golden[t]["red"])
+
+    def test_write_buffer_validation(self):
+        cfg = _raster_config()
+        assert _write_buffer(cfg) == 1  # default: strict serial bound
+        cfg.data_source["write_buffer"] = 2
+        assert _write_buffer(cfg) == 2
+        for bad in (0, -1, 1.5, True, "2"):
+            cfg.data_source["write_buffer"] = bad
+            with pytest.raises(ValueError, match="write_buffer"):
+                _write_buffer(cfg)
+            with pytest.raises(ValueError, match="write_buffer"):
+                validate_config(cfg)
+
+    def test_write_buffer_sink_error_propagates(self, tmp_path):
+        _write_tiff(tmp_path / "t0.tif", np.full((96, 96), 11, dtype=np.uint16))
+        _write_tiff(tmp_path / "t1.tif", np.full((96, 96), 22, dtype=np.uint16))
+        grid = _rect_grid([ORIGIN[0], ORIGIN[1] - 960.0, ORIGIN[0] + 960.0, ORIGIN[1]], [96, 96])
+        cfg = _raster_config(bands={"red": {"asset": "red", "dtype": "uint16"}}, nodata=None)
+        cfg.data_source["write_buffer"] = 2
+        granules = [
+            _entry("A", {"red": str(tmp_path / "t0.tif")}, T0, time_key="dt-1"),
+            _entry("B", {"red": str(tmp_path / "t1.tif")}, T1, time_key="dt-2"),
+        ]
+        index, _ = raster_time_index([granules])
+
+        def _sink(t_idx, slab):
+            raise OSError("s3 write failed")
+
+        with pytest.raises(OSError, match="s3 write failed"):
+            process_raster_shard(grid, 0, granules, cfg, index, on_slab=_sink)
 
     def test_on_slab_streams_and_matches_dict(self, tmp_path):
         # The on_slab sink (issue #231): each timestep's slab is handed off as

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -17,6 +17,7 @@ from zagg.config import get_raster_bands, load_config_from_dict, validate_config
 from zagg.grids import HealpixGrid, RectilinearGrid
 from zagg.processing.raster import (
     _run_sync,
+    _sample_concurrency,
     _shard_cell_range,
     emit_raster_template,
     process_raster_shard,
@@ -109,6 +110,22 @@ class TestRasterConfigValidation:
         assert bands["red"]["fill_value"] == 0
         assert bands["scl"]["attrs"] == {}
 
+    def test_sample_concurrency_default_and_override(self):
+        assert _sample_concurrency(_raster_config()) == 4  # issue #231 default
+        cfg = _raster_config()
+        cfg.data_source["sample_concurrency"] = 8
+        assert _sample_concurrency(cfg) == 8
+
+    def test_sample_concurrency_rejected(self):
+        for bad in (0, -1, True, 2.0):
+            cfg = _raster_config()
+            cfg.data_source["sample_concurrency"] = bad
+            with pytest.raises(ValueError, match="sample_concurrency"):
+                validate_config(cfg)
+            # The worker helper re-checks with the same guard (hand-rolled payload).
+            with pytest.raises(ValueError, match="sample_concurrency"):
+                _sample_concurrency(cfg)
+
 
 class TestRasterTimeIndex:
     def test_time_key_groups_adjacent_tiles(self):
@@ -139,6 +156,58 @@ class TestRasterTimeIndex:
     def test_missing_datetime_raises(self):
         with pytest.raises(ValueError, match="no datetime"):
             raster_time_index([[{"id": "bad", "assets": {"red": "x"}}]])
+
+
+class _FakeGrid:
+    """Minimal grid for the sampling-concurrency test: only ``children`` is
+    touched on the single-item-per-group path (no ownership combine)."""
+
+    def __init__(self, n_cells):
+        self._n = n_cells
+
+    def children(self, shard_key):
+        return np.arange(self._n)
+
+
+class TestSampleConcurrency:
+    def test_semaphore_bounds_in_flight_groups(self, monkeypatch):
+        # N single-item acquisition groups sampled under Semaphore(K): each
+        # group is one ``sample_item_async`` call, so concurrent calls track
+        # concurrent timesteps. An instrumented fake records the peak, which
+        # must be capped at K yet actually reach K (issue #231: the cap bounds
+        # memory without serializing the fan-out).
+        import asyncio as _asyncio
+
+        from zagg.processing import raster as raster_mod
+
+        n_cells, n_groups, k = 8, 10, 3
+        state = {"cur": 0, "max": 0}
+        lock = _asyncio.Lock()
+
+        async def _fake_sample_item(
+            grid, cells, assets, bands, *, nodata=None, region=None, anonymous=True
+        ):
+            async with lock:
+                state["cur"] += 1
+                state["max"] = max(state["max"], state["cur"])
+            await _asyncio.sleep(0.02)
+            async with lock:
+                state["cur"] -= 1
+            n = len(cells)
+            return {f: np.zeros(n, dtype=np.uint16) for f in bands}, np.ones(n, bool), (0.0, 0.0)
+
+        monkeypatch.setattr(raster_mod, "sample_item_async", _fake_sample_item)
+
+        cfg = _raster_config(bands={"red": {"asset": "red", "dtype": "uint16"}}, nodata=None)
+        cfg.data_source["sample_concurrency"] = k
+        granules = [
+            _entry(f"g{i}", {"red": f"r{i}.tif"}, T0, time_key=f"dt-{i}") for i in range(n_groups)
+        ]
+        index, _ = raster_time_index([granules])
+        slabs, meta = process_raster_shard(_FakeGrid(n_cells), 0, granules, cfg, index)
+        assert meta["timesteps"] == n_groups
+        assert set(slabs) == set(range(n_groups))
+        assert state["max"] == k  # bounded by K, and the fan-out reaches K
 
 
 def _rect_grid(bounds, chunk):

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -355,6 +355,33 @@ class TestOwnership:
         assert meta["skipped"] == 1 and meta["granule_count"] == 2
         assert (slabs[0]["red"] == 7).all()
 
+    def test_on_slab_streams_and_matches_dict(self, tmp_path):
+        # The on_slab sink (issue #231): each timestep's slab is handed off as
+        # its group completes and NOT accumulated (returned slabs is empty),
+        # yet the streamed slabs match the buffered dict-mode output exactly.
+        _write_tiff(tmp_path / "t0.tif", np.full((96, 96), 11, dtype=np.uint16))
+        _write_tiff(tmp_path / "t1.tif", np.full((96, 96), 22, dtype=np.uint16))
+        grid = _rect_grid([ORIGIN[0], ORIGIN[1] - 960.0, ORIGIN[0] + 960.0, ORIGIN[1]], [96, 96])
+        cfg = _raster_config(bands={"red": {"asset": "red", "dtype": "uint16"}}, nodata=None)
+        granules = [
+            _entry("A", {"red": str(tmp_path / "t0.tif")}, T0, time_key="dt-1"),
+            _entry("B", {"red": str(tmp_path / "t1.tif")}, T1, time_key="dt-2"),
+        ]
+        index, _ = raster_time_index([granules])
+        golden, _gm = process_raster_shard(grid, 0, granules, cfg, index)
+
+        streamed = {}
+
+        def _sink(t_idx, slab):
+            streamed[t_idx] = slab
+
+        slabs, meta = process_raster_shard(grid, 0, granules, cfg, index, on_slab=_sink)
+        assert slabs == {}  # streamed + freed, nothing accumulated
+        assert meta["timesteps"] == 2
+        assert set(streamed) == set(golden) == {0, 1}
+        for t in golden:
+            np.testing.assert_array_equal(streamed[t]["red"], golden[t]["red"])
+
 
 def _healpix_setup(tmp_path):
     """Order-10 shard over the synthetic raster; order-16 cells (~97 m)."""


### PR DESCRIPTION
Closes #231. Refs #218 (pipeline), #228, #217.

## What / approach

`process_raster_shard` gathered **all** acquisition groups (timesteps) concurrently in one event loop, and `_handle_process_raster` accumulated all `T` slabs before writing. At coarse shard orders that is unbounded memory (SERC o9 × 2025: 85 timesteps × 5 bands OOM'd every shard at 4096 MB). This bounds both sides.

**Phase 1 — cap sampling concurrency.** An `asyncio.Semaphore(K)` over the acquisition groups in `process_raster_shard`, so at most `K` timesteps of decoded COG tiles + per-band gather buffers are in flight at once. Within a bounded group every item still fans out concurrently (adjacent MGRS tiles of one datatake are seconds apart), so the wall-clock overlap survives at fine orders.

`K` is config-surfaced as `data_source.sample_concurrency`, mirroring the existing `data_source.read_workers` / `data_source.granule_workers` worker knobs: default **4** (same as `granule_workers`), validated at submission in `_validate_raster_config` and re-checked in the worker helper `_sample_concurrency` with the same `int>=1` / bool-trap guard.

**Phase 2 — stream slab writes.** `process_raster_shard` gains an optional `on_slab(t_idx, slab)` callback; when set it builds each timestep's slab as its group completes (`asyncio.as_completed`) and hands it to the sink, which writes + frees it before the next arrives — bounding the output side to ~1 timestep. `_handle_process_raster` and the local `RasterStrategy` both pass it, so the whole sampling→write path streams (single write path across backends). Default (no callback) still accumulates and returns the `{t_idx: slab}` dict, so existing callers/tests are unchanged.

Peak per-shard then ≈ `K × (tiles + gather) + ~1 slab`.

## Phases

- [x] **Phase 1** — bound sampling concurrency with `asyncio.Semaphore(K)`; surface `K` as `data_source.sample_concurrency` (default 4); validation + worker-helper guard; concurrency-bound test.
- [x] **Phase 2** — stream slab writes via an `on_slab` callback in `process_raster_shard`; wire it in `_handle_process_raster` and local `RasterStrategy`; streaming/interleave tests.

## How tested

- `tests/test_raster_pipeline.py::TestSampleConcurrency` — `N=10` single-item groups under `Semaphore(K)` via an instrumented fake `sample_item_async`; parametrized over `k ∈ {1, 3, 10, 12}`, asserting observed peak concurrency `== min(k, N)` (serial at `k=1`, capped in the interior, and reaching `N` when `k≥N`).
- `TestOwnership::test_on_slab_streams_and_matches_dict` — streaming mode returns an empty `slabs` (nothing accumulated) yet the per-timestep slabs handed to the sink match the buffered dict-mode output exactly.
- `test_lambda_raster_handler.py::test_handler_streams_slabs_incrementally` — a fake worker drives the sink per timestep; asserts the handler writes one slab per timestep in stream order with never more than one slab alive (`live["max"] == 1`), and writes coords once after.
- Config: `sample_concurrency` default/override + rejection of `0/-1/True/2.0` at both `validate_config` and the worker helper.
- Existing raster suites stay green — the default (no-callback) path is byte-identical.

Local: `ruff check` / `ruff format --check` clean on changed files; `pytest` green on `test_raster_pipeline.py`, `test_raster_runner.py`, `test_lambda_raster_handler.py`, `test_config.py`, `test_runner.py`.

## Questions for review

1. **Default `K` value.** Chose **4** to mirror `granule_workers`. The issue suggests 4–8; the empirical clean point was client-side datatake batch 5 at 4096 MB (a different axis, but adjacent). Happy to bump to 6/8 if you'd rather trade a little more peak memory for overlap at coarse orders.
2. **Knob placement / name.** Put it on `data_source.sample_concurrency` alongside `read_workers`/`granule_workers`. Alternative: a dedicated worker-config field, or a `*_workers` name for consistency (`timestep_workers`). Preference?
3. **Streaming write in the loop.** The `on_slab` write runs synchronously inside the sampling event loop (single-writer, so a completed slab is written+freed before the next group is drained). This serializes each slab write against the other groups' in-flight COG fetches. That's the intended memory/throughput trade at coarse orders (writes are the ~1-slab tail); flag if you'd prefer offloading the write to an executor (which would relax the ~1-slab bound).
4. Pre-existing, not touched here: `ruff check src tests` flags `N818` on `src/zagg/registry.py`; and `config.py` is ~1978 lines (both predate this PR). Flagging per §4, not fixing.
