### PR TITLE
Make sharded: true the default for HEALPix output

### DIFF
--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1721,16 +1721,18 @@ def get_layout(config: PipelineConfig) -> str:
     return config.output.get("grid", {}).get("layout", "fullsphere")
 
 
-def get_sharded(config: PipelineConfig) -> bool:
+def get_sharded(config: PipelineConfig, default: bool = False) -> bool:
     """Return whether the output grid uses ShardingCodec storage (issue #108).
 
     The ``sharded`` knob lives on the grid/chunk block next to ``chunk_inner``
-    (mirroring its accessor), default ``False``. When ``True`` the grid bundles a
-    dispatch shard's K inner chunks into one zarr shard object instead of K
-    independent regular chunk objects; it is only valid when ``chunk_inner`` gives
-    K>1 (the grid raises otherwise, validated before deployment).
+    (mirroring its accessor). When ``True`` the grid bundles a dispatch shard's K
+    inner chunks into one zarr shard object instead of K independent regular chunk
+    objects; a K==1 grid has nothing to bundle, so the grid silently no-ops it
+    (issue #215). ``default`` is the value returned when the flag is omitted —
+    ``False`` here, but ``from_config`` passes ``True`` for HEALPix flat-layout
+    output (issue #215: a missing flag should not cost the ~K-fold object blow-up).
     """
-    return bool(config.output.get("grid", {}).get("sharded", False))
+    return bool(config.output.get("grid", {}).get("sharded", default))
 
 
 def get_shard_order(config: PipelineConfig) -> int | None:

--- a/src/zagg/grids/__init__.py
+++ b/src/zagg/grids/__init__.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import warnings
 
-from zagg.config import PipelineConfig, get_child_order, get_shard_order, get_sharded
+from zagg.config import (
+    PipelineConfig,
+    get_child_order,
+    get_shard_order,
+    get_sharded,
+    get_store_layout,
+)
 from zagg.grids.base import InconsistentShardError, OutputGrid, ShardKey
 from zagg.grids.healpix import HEALPIX_BASE_CELLS, HealpixGrid
 from zagg.grids.rectilinear import OOB_SENTINEL, RectilinearGrid
@@ -46,6 +52,13 @@ def from_config(
         resolved_parent = grid_cfg.get("parent_order", parent_order)
         if resolved_parent is None:
             raise ValueError("output.grid.parent_order is required for HEALPix grids")
+        # issue #215: HEALPix flat-layout output defaults to sharded — a missing
+        # flag should not silently cost the ~K-fold object blow-up (one object per
+        # inner chunk instead of one per shard). Hive is inherently unsharded (each
+        # leaf is a vanilla zarr v3 store — D3), so it keeps the False default; an
+        # explicit sharded:true with hive is rejected by ``validate_config``. The
+        # grid no-ops sharding when K==1, so single-chunk grids stay unaffected.
+        sharded_default = get_store_layout(config) != "hive"
         return HealpixGrid(
             parent_order=resolved_parent,
             child_order=get_child_order(config),
@@ -53,7 +66,7 @@ def from_config(
             config=config,
             populated_shards=populated_shards,
             chunk_inner=grid_cfg.get("chunk_inner"),
-            sharded=get_sharded(config),
+            sharded=get_sharded(config, default=sharded_default),
             shard_order=get_shard_order(config),
         )
     if grid_type == "rectilinear":

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -74,7 +74,7 @@ class HealpixGrid:
         config: PipelineConfig | None = None,
         populated_shards: list[int] | None = None,
         chunk_inner: int | None = None,
-        sharded: bool = False,
+        sharded: bool = True,
         shard_order: int | None = None,
     ):
         if child_order < parent_order:
@@ -121,17 +121,13 @@ class HealpixGrid:
         # Sharded storage (issue #108): bundle the shard's K inner chunks into one
         # zarr ShardingCodec shard object instead of K independent regular chunk
         # objects. Only meaningful when K > 1 (a finer ``chunk_inner`` gives the
-        # shard multiple inner chunks); sharding a K==1 shard is a no-op shard of
-        # one chunk, so reject it with a clear message (validated pre-deployment,
-        # matching the grid-mismatch errors). HEALPix lands first (issue #108).
-        if sharded and self.chunks_per_shard <= 1:
-            raise ValueError(
-                "sharded output requires chunk_inner to give more than one inner "
-                f"chunk per shard (K>1), but chunk_order ({chunk_order}) == "
-                f"parent_order ({parent_order}) gives K=1; set chunk_inner finer "
-                "than parent_order (e.g. chunk_inner=13 for the 64x64 read chunk) "
-                "or disable sharded"
-            )
+        # shard multiple inner chunks). ``sharded`` defaults True (issue #215 — a
+        # missing flag should not silently cost the ~K-fold object blow-up), so a
+        # K==1 shard (no ``chunk_inner``) has nothing to bundle: sharding is a no-op
+        # there and is silently disabled, leaving single-chunk grids byte-identical
+        # to a pre-#215 unsharded write. HEALPix lands first (issue #108).
+        if self.chunks_per_shard <= 1:
+            sharded = False
         self.sharded = bool(sharded)
         # shard_order (issue #133 phase 8): decouple the sharding OBJECT from the
         # dispatch shard. A ShardingCodec object normally spans the whole dispatch

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -123,9 +123,10 @@ class HealpixGrid:
         # objects. Only meaningful when K > 1 (a finer ``chunk_inner`` gives the
         # shard multiple inner chunks). ``sharded`` defaults True (issue #215 — a
         # missing flag should not silently cost the ~K-fold object blow-up), so a
-        # K==1 shard (no ``chunk_inner``) has nothing to bundle: sharding is a no-op
-        # there and is silently disabled, leaving single-chunk grids byte-identical
-        # to a pre-#215 unsharded write. HEALPix lands first (issue #108).
+        # K==1 shard (``chunk_inner`` unset, or no finer than ``parent_order``) has
+        # nothing to bundle: sharding is a no-op there and is silently disabled,
+        # leaving single-chunk grids byte-identical to a pre-#215 unsharded write.
+        # HEALPix lands first (issue #108).
         if self.chunks_per_shard <= 1:
             sharded = False
         self.sharded = bool(sharded)

--- a/tests/data/benchmark/configs/atl03_gain_bias_healpix_o10.yaml
+++ b/tests/data/benchmark/configs/atl03_gain_bias_healpix_o10.yaml
@@ -127,4 +127,5 @@ output:
     indexing_scheme: nested
     parent_order: 10             # shard / dispatch unit: 4^(19-10) = 512x512 cells
     chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=16 per shard)
+    sharded: true                # issue #215: explicit (also the new HEALPix default); one object/shard
     child_order: 19              # leaf cell resolution (~10 m)

--- a/tests/data/benchmark/configs/atl03_gain_bias_healpix_o11.yaml
+++ b/tests/data/benchmark/configs/atl03_gain_bias_healpix_o11.yaml
@@ -127,4 +127,5 @@ output:
     indexing_scheme: nested
     parent_order: 11             # shard / dispatch unit: 4^(19-11) = 256x256 cells
     chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=16 per shard)
+    sharded: true                # issue #215: explicit (also the new HEALPix default); one object/shard
     child_order: 19              # leaf cell resolution (~10 m)

--- a/tests/data/benchmark/configs/atl03_scalar_healpix_o11.yaml
+++ b/tests/data/benchmark/configs/atl03_scalar_healpix_o11.yaml
@@ -81,4 +81,5 @@ output:
     indexing_scheme: nested
     parent_order: 11             # shard / dispatch unit: 4^(19-11) = 256x256 cells
     chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=16 per shard)
+    sharded: true                # issue #215: explicit (also the new HEALPix default); one object/shard
     child_order: 19              # leaf cell resolution (~10 m)

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o10_cached.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o10_cached.yaml
@@ -80,4 +80,5 @@ output:
     indexing_scheme: nested
     parent_order: 10             # shard / dispatch unit: 4^(19-10) = 512x512 cells
     chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=64 per shard)
+    sharded: true                # issue #215: explicit (also the new HEALPix default); one object/shard
     child_order: 19              # leaf cell resolution (~10 m)

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o11.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o11.yaml
@@ -93,4 +93,5 @@ output:
     indexing_scheme: nested
     parent_order: 11             # shard / dispatch unit: 4^(19-11) = 256x256 cells
     chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=16 per shard)
+    sharded: true                # issue #215: explicit (also the new HEALPix default); one object/shard
     child_order: 19              # leaf cell resolution (~10 m)

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o11_cached.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o11_cached.yaml
@@ -80,4 +80,5 @@ output:
     indexing_scheme: nested
     parent_order: 11             # shard / dispatch unit: 4^(19-11) = 256x256 cells
     chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=16 per shard)
+    sharded: true                # issue #215: explicit (also the new HEALPix default); one object/shard
     child_order: 19              # leaf cell resolution (~10 m)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -330,9 +330,30 @@ class TestFromConfig:
         with pytest.raises(ValueError, match="Unknown output.grid.type"):
             from_config(cfg, parent_order=6)
 
-    def test_sharded_default_off(self, cfg):
-        # The knob is absent by default -> regular (non-sharded) storage (issue #108).
+    def test_sharded_default_on_for_multichunk(self, cfg):
+        # issue #215: with chunk_inner giving K>1, a HEALPix flat-layout config that
+        # OMITS the flag now defaults to sharded — the safe state, so a missing line
+        # no longer silently costs the ~K-fold object blow-up.
+        cfg.output["grid"]["chunk_inner"] = 8
         g = from_config(cfg, parent_order=6)
+        assert g.sharded is True
+        assert g.chunks_per_shard > 1
+
+    def test_sharded_default_noop_for_single_chunk(self, cfg):
+        # No chunk_inner -> K==1 -> nothing to bundle, so the default is a no-op:
+        # single-chunk grids stay unsharded and byte-identical (issue #215).
+        g = from_config(cfg, parent_order=6)
+        assert g.chunks_per_shard == 1
+        assert g.sharded is False
+
+    def test_sharded_default_off_for_hive(self, cfg):
+        # issue #215: hive is inherently unsharded (each leaf is a vanilla zarr v3
+        # store — D3), so the sharded default stays False there even at K>1,
+        # matching validate_config's hive+sharded rejection.
+        cfg.output["grid"]["chunk_inner"] = 8
+        cfg.output["store_layout"] = "hive"
+        g = from_config(cfg, parent_order=6)
+        assert g.chunks_per_shard > 1
         assert g.sharded is False
 
     def test_sharded_flag_threads_through(self, cfg):
@@ -343,21 +364,31 @@ class TestFromConfig:
         assert g.sharded is True
         assert g.chunks_per_shard > 1
 
-    def test_sharded_k1_validated_pre_deployment(self, cfg):
-        # sharded without chunk_inner (K==1) is meaningless -> error at construction
-        # (validated before lambda deployment, matching the grid-mismatch errors).
-        cfg.output["grid"]["sharded"] = True
-        with pytest.raises(ValueError, match="K>1"):
-            from_config(cfg, parent_order=6)
-
-    def test_sharded_off_byte_identical_template(self, cfg):
-        # Flag off must reproduce the regular template byte-for-byte even when
-        # chunk_inner is set (sharding is purely opt-in storage form).
+    def test_sharded_explicit_off_disables(self, cfg):
+        # An explicit sharded:false opts out even at K>1 (the one-release explicit
+        # opt-out — issue #215): storage stays regular per-inner-chunk.
         cfg.output["grid"]["chunk_inner"] = 8
-        g_off = from_config(cfg, parent_order=6)
         cfg.output["grid"]["sharded"] = False
-        g_explicit_off = from_config(cfg, parent_order=6)
-        assert g_off._spec().model_dump() == g_explicit_off._spec().model_dump()
+        g = from_config(cfg, parent_order=6)
+        assert g.chunks_per_shard > 1
+        assert g.sharded is False
+
+    def test_sharded_k1_noop_not_rejected(self, cfg):
+        # sharded without chunk_inner (K==1) has nothing to bundle; the grid
+        # silently disables it rather than raising (issue #215 — the default is
+        # True, so a K==1 grid must not blow up at construction).
+        cfg.output["grid"]["sharded"] = True
+        g = from_config(cfg, parent_order=6)
+        assert g.sharded is False
+
+    def test_sharded_default_matches_explicit_true(self, cfg):
+        # The omitted-flag default now produces the SAME template as an explicit
+        # sharded:true (both collapse the K>1 inner chunks to one object; issue #215).
+        cfg.output["grid"]["chunk_inner"] = 8
+        g_default = from_config(cfg, parent_order=6)
+        cfg.output["grid"]["sharded"] = True
+        g_explicit = from_config(cfg, parent_order=6)
+        assert g_default._spec().model_dump() == g_explicit._spec().model_dump()
 
 
 class TestBackcompatWrapper:
@@ -1133,11 +1164,13 @@ class TestSharded:
             sharded=sharded,
         )
 
-    def test_k1_sharded_rejected(self):
+    def test_k1_sharded_noop(self):
         cfg = default_config("atl06")
-        # No chunk_inner -> K == 1 -> sharding is a no-op shard of one chunk.
-        with pytest.raises(ValueError, match="K>1"):
-            HealpixGrid(4, 8, layout="fullsphere", config=cfg, sharded=True)
+        # No chunk_inner -> K == 1 -> nothing to bundle: sharding is silently
+        # disabled rather than rejected, so the True default is safe on a
+        # single-chunk grid (issue #215).
+        g = HealpixGrid(4, 8, layout="fullsphere", config=cfg, sharded=True)
+        assert g.sharded is False
 
     def test_template_emits_sharding_codec(self):
         g = self._grid()
@@ -1154,10 +1187,12 @@ class TestSharded:
             assert any("sharding" in type(c).__name__.lower() for c in arr.metadata.codecs), name
 
     def test_flag_off_byte_identical_to_regular(self):
-        # Sharded OFF must reproduce the existing regular template exactly.
+        # Sharded OFF must reproduce the existing regular per-inner-chunk template
+        # exactly. Both sides pass sharded=False explicitly (the constructor default
+        # is now True — issue #215), isolating the opt-out storage form.
         g_off = self._grid(sharded=False)
         g_reg = HealpixGrid(
-            4, 8, layout="fullsphere", config=default_config("atl06"), chunk_inner=6
+            4, 8, layout="fullsphere", config=default_config("atl06"), chunk_inner=6, sharded=False
         )
         assert g_off._spec().model_dump() == g_reg._spec().model_dump()
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -104,7 +104,7 @@ class TestWriteShardToZarr:
 
         kw = dict(layout="fullsphere", config=cfg, chunk_inner=7)
         sharded = HealpixGrid(6, 8, sharded=True, **kw)
-        regular = HealpixGrid(6, 8, **kw)
+        regular = HealpixGrid(6, 8, sharded=False, **kw)
         shard_key = int(geo2mort(-78.5, -132.0, order=6)[0])
         return sharded, regular, shard_key
 
@@ -1399,8 +1399,11 @@ class TestRaggedVlenLayout:
         grid, shard_key, chunk_results, payloads = self._sharded_setup()
         flat = self._write(grid, shard_key, chunk_results)
 
-        # Same config/geometry, hive-legal (unsharded) grid for the leaf.
-        leaf_grid = HealpixGrid(4, 8, layout="fullsphere", config=grid.config, chunk_inner=6)
+        # Same config/geometry, hive-legal (unsharded) grid for the leaf. sharded is
+        # explicit False now that the constructor default is True (issue #215).
+        leaf_grid = HealpixGrid(
+            4, 8, layout="fullsphere", config=grid.config, chunk_inner=6, sharded=False
+        )
         leaf = MemoryStore()
         leaf_grid.emit_shard_template(leaf)
         shard_block = grid.block_index(shard_key)[0]
@@ -1754,7 +1757,9 @@ class TestMultiChunkWorker:
         from zagg.config import default_config
 
         cfg = default_config("atl06")
-        grid = {"type": "healpix", "parent_order": 6, "child_order": 8}
+        # sharded:false pins the unsharded per-inner-chunk worker path this class
+        # exercises (issue #30 item 3) now that sharded defaults True (issue #215).
+        grid = {"type": "healpix", "parent_order": 6, "child_order": 8, "sharded": False}
         if chunk_inner is not None:
             grid["chunk_inner"] = chunk_inner
         cfg.output["grid"] = grid
@@ -1896,6 +1901,7 @@ class TestMultiChunkWorker:
             "parent_order": 6,
             "chunk_inner": 7,
             "child_order": 8,
+            "sharded": False,  # unsharded per-inner-chunk path (issue #215 default is True)
         }
         cfg.aggregation["chunk_precompute"] = {
             "anchor": {"expression": "np.float32(np.min(h_li))", "source": "h_li"}
@@ -1981,6 +1987,7 @@ class TestMultiChunkWorker:
             "parent_order": 6,
             "chunk_inner": 7,
             "child_order": 8,
+            "sharded": False,  # unsharded per-inner-chunk path (issue #215 default is True)
         }
         # gain/offset basis case: the anchor is min(h_li) over the chunk.
         cfg.aggregation["chunk_precompute"] = {
@@ -2049,6 +2056,7 @@ class TestMultiChunkWorker:
             "parent_order": 6,
             "chunk_inner": 7,
             "child_order": 8,
+            "sharded": False,  # unsharded per-inner-chunk path (issue #215 default is True)
         }
         cfg.aggregation["chunk_precompute"] = {
             "anchor": {"expression": "np.float32(np.min(h_li))", "source": "h_li"}


### PR DESCRIPTION
Closes #215

## What / approach

`sharded` defaulted **False** for HEALPix output, so a config that omitted the flag wrote **one object per inner chunk** (~K per shard) instead of collapsing to **one object per shard** via the `ShardingCodec` — a silent ~K-fold object blow-up (e.g. ~250× at the o9 `chunk_inner: 13` geometry) driven by a *missing line*. This flips the safe default to sharded, scoped to **HEALPix only** (rectilinear default untouched — see Questions for review).

Changes:

- **`HealpixGrid.__init__`**: constructor default `sharded=False → True`.
- **The K==1 guard becomes a no-op instead of an error.** Previously `sharded=True` with `chunks_per_shard <= 1` raised; now that the default is True, a single-chunk grid (no `chunk_inner`) has nothing to bundle, so sharding is silently disabled there. This keeps single-chunk grids byte-identical to a pre-#215 unsharded write — the default "only bites when there's something to collapse."
- **`get_sharded(config, default=False)`** gains a `default` parameter. Its own default stays `False` (so a bare `get_sharded(config)` is unchanged), but `from_config` passes the HEALPix default in.
- **`from_config`** (HEALPix branch): the omitted-flag default is now `True` for **flat** layout. **Hive stays unsharded** (`store_layout: hive` → default False): each hive leaf is a vanilla zarr v3 store (D3) and `emit_shard_template` rejects sharded output, and `validate_config` already rejects an *explicit* `sharded: true` + hive. Without this carve-out a hive config that omitted the flag would validate but crash at write. Rectilinear branch left on the `False` default (scope: HEALPix).
- **Benchmark configs**: added an explicit `sharded: true` to the 6 HEALPix configs that still omitted it (see checklist). The new default already covers them, but the explicit line documents intent (matching #193) and doesn't rely on the default.

### Reader compatibility (confirmed before flipping)

- **Dense-array reads** go through plain zarr indexing; the `ShardingCodec` is recorded in the array metadata, so zarr reads sharded and regular arrays through the same path.
- **T-digest / ragged reads** (`readers/tdigest_tensor.py`) are explicitly sharding-agnostic: the read plan derives its span from `arr.shards or arr.chunks` (self-describing metadata), "so the sharded and per-inner-chunk layouts share this path" (#209/#211).
- Existing unsharded stores stay readable; only *new writes* change.

## Phases

- [x] **Phase 1** — flip the HEALPix default (constructor + `from_config`), make the K==1 guard a no-op, keep hive unsharded, add/update tests.
- [x] **Phase 2** — add explicit `sharded: true` to the 6 HEALPix benchmark configs that omitted it; confirm reader compatibility (above).

## Configs touched (Phase 2)

Added `sharded: true` (HEALPix, K>1, flat):

- `atl03_gain_bias_healpix_o10.yaml`
- `atl03_gain_bias_healpix_o11.yaml`
- `atl03_scalar_healpix_o11.yaml`
- `atl03_tdigest_healpix_o10_cached.yaml`
- `atl03_tdigest_healpix_o11.yaml`
- `atl03_tdigest_healpix_o11_cached.yaml`

Note on the issue's named list: `atl03_tdigest_healpix_o8.yaml`, `o9_cached.yaml`, and the plain `o9`/`o10` already carry `sharded: true` in the current tree (added in earlier work — the o8 one is even commented "issue #215"), so they needed no change. The two rectilinear configs the issue lists (`atl03_tdigest_rect_3km.yaml`, `_6km.yaml`) are intentionally left untouched (scope: HEALPix — see Questions).

## How tested

- `ruff check` / `ruff format --check` clean on all changed files.
- Full suite green locally: **1930 passed, 28 skipped** (`pytest -q`).
- New/updated tests in `tests/test_grids.py`:
  - K>1 omitted flag now defaults sharded; K==1 omitted flag is a no-op (unsharded); hive omitted flag stays unsharded; explicit `sharded: false` still opts out; explicit `sharded: true` + K==1 no-ops (was: raised); omitted-flag default template equals explicit `sharded: true`.
- `tests/test_processing.py`: the unsharded multi-chunk worker tests and the "regular"/hive-leaf reference grids now pin `sharded: false` explicitly (that path is the opt-out now), preserving their original coverage.

## Questions for review

1. **Rectilinear default (deliberately out of scope).** I confirmed the rect engine *does* honor `sharded` (full `ShardingCodec` path in `RectilinearGrid`), but per the issue ("scope the default to HEALPix first") I left the rect default and the two rect benchmark configs unchanged. Want the rect default flipped / the rect configs' flag added in a follow-up, or fold it here?
2. **Explicit `sharded: true` + K==1 now silently no-ops** rather than raising a `ValueError`. This is what made the True default safe for single-chunk grids, and matches the issue's "the guard makes it a no-op" framing — but it does drop a config-mistake signal for someone who explicitly asks for sharding on a K==1 grid. OK, or would you prefer to keep an error only for the *explicit* opt-in case (would need a tri-state default to distinguish explicit from defaulted)?
3. **One-release opt-out warning (issue item 3, optional).** I did **not** add a warning when a multi-chunk shard is written unsharded: with the default now True the only way to hit that is an explicit `sharded: false`, and hive leaves are legitimately unsharded at K>1 (`emit_shard_template`), so a blanket warning would fire on every hive leaf. Flagging as a follow-up rather than landing something noisy — want it as a narrower flat-layout-only warning instead?


---
_Generated by [Claude Code](https://claude.ai/code/session_011vwrYZY38grfwJqtCeuM65)_