### PR TITLE
raster worker: store + pull-NN geometry caches (issue #244)

### DIFF
--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -231,6 +231,14 @@ async def _sample_one(
         # compute-and-store is atomic on the loop and each source grid is
         # computed exactly once per invoke — no locks needed. If this compute
         # ever moves off-loop (``to_thread``), add per-key async locks.
+        # INVARIANT (issue #244 thread): the key ``(epsg, transform, shape)``
+        # is complete only because ``cells`` and ``grid`` are constants of the
+        # invoke — ``cells = grid.children(shard_key)`` is computed once (see
+        # ``process_raster_shard``) and threaded unchanged into every
+        # ``_sample_one``, and ``geom_cache`` is allocated fresh per
+        # ``process_raster_shard`` call. A future refactor that varies
+        # ``cells`` (or ``grid``) per item/group within one invoke MUST fold
+        # them into the key or drop the cache, else it returns a stale mapping.
         geom = grid.sample(cells, f"EPSG:{epsg}", transform, shape)
         if geom_cache is not None:
             geom_cache[geom_key] = geom

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -77,6 +77,29 @@ def _geo_from_ifd(ifd) -> tuple[int, tuple[float, float, float, float, float, fl
 # pattern. Lock-guarded because the running-loop fallback in ``sample_asset``
 # and hand-rolled callers can construct from other threads; construction runs
 # under the lock deliberately (single-flight per key).
+#
+# Credential lifetime (issue #244 review): every key deployed today is
+# anonymous (``sentinel2_l2a.yaml`` sets ``anonymous: true``; runner.py:676
+# and ``sample_asset*`` default it True), so the cached ``S3Store`` carries
+# ``skip_signature=True`` and signs nothing — credentials never enter the
+# picture and warm-caching a store cannot go stale. If a *signed* store
+# (``anonymous=False``) were ever cached, sandbox-lifetime caching would only
+# be safe because of how async-tiff's Rust ``object_store``-backed ``S3Store``
+# resolves credentials, and that splits by environment:
+#   - On AWS Lambda the execution-role credentials arrive as static env vars
+#     valid for the whole sandbox lifetime and do NOT rotate mid-sandbox, so a
+#     sandbox-lifetime store cannot outlive its creds — safe by construction.
+#   - Off-Lambda (EC2 instance profile / IMDS, SSO), object_store resolves
+#     through a caching credential *provider* that refreshes on expiry per
+#     request rather than freezing a token at construction, so a warm store
+#     keeps working across rotation.
+# (The Lambda case is directly grounded; the off-Lambda refresh behavior
+# reflects object_store's documented provider design — ``S3Store`` exposes a
+# ``credential_provider`` slot — and was not source-verified against the
+# installed binary wheel.) Caveat: no explicit-credential store exists here
+# (the raster path is anonymous); do NOT add one to the cache without
+# revisiting this, since a statically-supplied token would be frozen at
+# construction and eventually go stale on a warm worker.
 _STORE_CACHE: dict = {}
 _STORE_LOCK = threading.Lock()
 

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -170,9 +170,18 @@ async def _sample_one(
     region: str | None = None,
     anonymous: bool = True,
     fill=0,
+    geom_cache: dict | None = None,
 ):
     """:func:`sample_asset_async` body, also returning the raster's center
-    ``(lon, lat)`` — the ownership rule's tile-center input (#218)."""
+    ``(lon, lat)`` — the ownership rule's tile-center input (#218).
+
+    ``geom_cache`` (issue #244) memoizes the pull-NN mapping ``(rows, cols,
+    valid)`` per ``(epsg, transform, shape)``: the mapping is invariant across
+    every timestep and band that shares a source grid, so a shard invoke
+    computes it once per distinct grid (~175 ms at o9) instead of once per
+    asset-sample. ``None`` (the default, and the public ``sample_asset*``
+    path) computes per call, unchanged.
+    """
     from async_tiff import TIFF
 
     store, path = _store_and_path(href, region=region, anonymous=anonymous)
@@ -191,7 +200,18 @@ async def _sample_one(
     epsg, transform = _geo_from_ifd(ifd)
     shape = (ifd.image_height, ifd.image_width)
     center = _raster_center_lonlat(epsg, transform, shape)
-    rows, cols, valid = grid.sample(cells, f"EPSG:{epsg}", transform, shape)
+    geom_key = (epsg, transform, shape)
+    geom = geom_cache.get(geom_key) if geom_cache is not None else None
+    if geom is None:
+        # INVARIANT (issue #244 thread): no ``await`` between this check and
+        # the store below. asyncio interleaves only at await points, so the
+        # compute-and-store is atomic on the loop and each source grid is
+        # computed exactly once per invoke — no locks needed. If this compute
+        # ever moves off-loop (``to_thread``), add per-key async locks.
+        geom = grid.sample(cells, f"EPSG:{epsg}", transform, shape)
+        if geom_cache is not None:
+            geom_cache[geom_key] = geom
+    rows, cols, valid = geom
 
     th, tw = ifd.tile_height, ifd.tile_width
     vr, vc = rows[valid], cols[valid]
@@ -271,6 +291,7 @@ async def sample_item_async(
     nodata=None,
     region: str | None = None,
     anonymous: bool = True,
+    geom_cache: dict | None = None,
 ):
     """Sample every configured band of one STAC item, concurrently.
 
@@ -313,6 +334,7 @@ async def sample_item_async(
                 region=region,
                 anonymous=anonymous,
                 fill=bands[f]["fill_value"],
+                geom_cache=geom_cache,
             )
             for f in fields
         ]
@@ -508,6 +530,12 @@ def process_raster_shard(
     # orders.
     k = _shard_workers(config)
     wb = _write_buffer(config)
+    # Pull-NN geometry memo (issue #244), scoped to THIS invoke: the (rows,
+    # cols, valid) mapping embeds the shard's cells, so per-invoke scoping
+    # makes cross-shard collisions impossible by construction. A full-year
+    # Sentinel-2 shard has exactly two distinct source grids (10 m bands,
+    # 20 m scl) — this turns 425 geometry computations into 2.
+    geom_cache: dict = {}
 
     async def _run_all():
         sem = asyncio.Semaphore(k)
@@ -524,6 +552,7 @@ def process_raster_shard(
                             nodata=nodata,
                             region=region,
                             anonymous=anonymous,
+                            geom_cache=geom_cache,
                         )
                         for e in items
                     ]

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import os
 import re
+import threading
 from urllib.parse import urlparse
 
 import numpy as np
@@ -66,33 +68,67 @@ def _geo_from_ifd(ifd) -> tuple[int, tuple[float, float, float, float, float, fl
     return int(epsg), (sx, 0.0, x - i * sx, 0.0, -sy, y + j * sy)
 
 
+# Store cache (issue #244): one obspec store per (kind, bucket-or-host-or-dir,
+# region, anonymous) per PROCESS. A fresh S3Store per asset-sample cost ~300 ms
+# of client/TLS setup and made every tile GET ride a cold connection (425
+# clients per full-year o9 invoke — the measured breakdown on the issue).
+# Module lifetime == sandbox lifetime (espg-ratified): warm Lambda invocations
+# keep their connection pools, matching the issue #171 sandbox-lifetime
+# pattern. Lock-guarded because the running-loop fallback in ``sample_asset``
+# and hand-rolled callers can construct from other threads; construction runs
+# under the lock deliberately (single-flight per key).
+_STORE_CACHE: dict = {}
+_STORE_LOCK = threading.Lock()
+
+
 def _store_and_path(href: str, *, region: str | None = None, anonymous: bool = True):
     """obspec store + in-store path for an asset href.
 
     Handles ``s3://bucket/key``, virtual-hosted S3 HTTPS
     (``https://bucket.s3.region.amazonaws.com/key`` -- what Earth Search
-    asset hrefs look like), plain HTTPS, and local paths.
+    asset hrefs look like), plain HTTPS, and local paths. Stores are cached
+    per ``(kind, location, region, anonymous)`` for the life of the process
+    (issue #244) — the returned store is shared, never per-call.
     """
-    from async_tiff.store import HTTPStore, LocalStore, S3Store
-
     u = urlparse(href)
     if u.scheme == "s3":
-        kw: dict = {"skip_signature": True} if anonymous else {}
-        if region:
-            kw["region"] = region
-        return S3Store(u.netloc, **kw), u.path.lstrip("/")
-    if u.scheme in ("http", "https"):
+        key = ("s3", u.netloc, region, anonymous)
+        path = u.path.lstrip("/")
+    elif u.scheme in ("http", "https"):
         m = _S3_VHOST.match(u.netloc)
         if m:
-            kw = {"region": region or m["region"]}
-            if anonymous:
-                kw["skip_signature"] = True
-            return S3Store(m["bucket"], **kw), u.path.lstrip("/")
-        return HTTPStore(f"{u.scheme}://{u.netloc}"), u.path.lstrip("/")
-    import os
+            key = ("s3", m["bucket"], region or m["region"], anonymous)
+            path = u.path.lstrip("/")
+        else:
+            key = ("http", f"{u.scheme}://{u.netloc}", None, None)
+            path = u.path.lstrip("/")
+    else:
+        d, name = os.path.split(href)
+        key = ("local", d or ".", None, None)
+        path = name
+    with _STORE_LOCK:
+        store = _STORE_CACHE.get(key)
+        if store is None:
+            store = _build_store(key)
+            _STORE_CACHE[key] = store
+    return store, path
 
-    d, name = os.path.split(href)
-    return LocalStore(d or "."), name
+
+def _build_store(key):
+    """Construct the obspec store for a cache key (see ``_STORE_CACHE``)."""
+    from async_tiff.store import HTTPStore, LocalStore, S3Store
+
+    kind, loc, region, anonymous = key
+    if kind == "s3":
+        kw: dict = {}
+        if anonymous:
+            kw["skip_signature"] = True
+        if region:
+            kw["region"] = region
+        return S3Store(loc, **kw)
+    if kind == "http":
+        return HTTPStore(loc)
+    return LocalStore(loc)
 
 
 async def sample_asset_async(

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -347,6 +347,55 @@ class TestSampleAsset:
 
 
 class TestStoreAndPath:
+    @pytest.fixture(autouse=True)
+    def _fresh_cache(self, monkeypatch):
+        # The store cache is process-lifetime (issue #244); isolate per test.
+        from zagg.processing import raster as raster_mod
+
+        monkeypatch.setattr(raster_mod, "_STORE_CACHE", {})
+
+    def test_same_href_reuses_store(self):
+        s1, _ = _store_and_path("s3://bkt/a.tif", region="us-west-2")
+        s2, _ = _store_and_path("s3://bkt/b.tif", region="us-west-2")
+        assert s1 is s2  # one client per (bucket, region, anonymous) — issue #244
+
+    def test_vhost_and_scheme_key_separately_but_cache(self):
+        v1, _ = _store_and_path("https://bkt.s3.us-west-2.amazonaws.com/a/B04.tif")
+        v2, _ = _store_and_path("https://bkt.s3.us-west-2.amazonaws.com/b/B08.tif")
+        assert v1 is v2
+
+    def test_distinct_keys_get_distinct_stores(self):
+        a, _ = _store_and_path("s3://bkt/a.tif", region="us-west-2")
+        b, _ = _store_and_path("s3://bkt/a.tif", region="us-west-2", anonymous=False)
+        c, _ = _store_and_path("s3://other/a.tif", region="us-west-2")
+        assert a is not b and a is not c and b is not c
+
+    def test_constructor_called_once_per_key(self, monkeypatch):
+        import async_tiff.store as ats
+
+        from zagg.processing import raster as raster_mod
+
+        calls = {"n": 0}
+        real = ats.S3Store
+
+        class _Counting:
+            def __new__(cls, *a, **k):
+                calls["n"] += 1
+                return real(*a, **k)
+
+        monkeypatch.setattr(raster_mod, "_STORE_CACHE", {})
+        monkeypatch.setattr(ats, "S3Store", _Counting)
+        for _ in range(5):
+            _store_and_path("s3://bkt/x.tif", region="us-west-2")
+        assert calls["n"] == 1
+
+    def test_local_store_reused_per_directory(self, tmp_path):
+        (tmp_path / "a.tif").write_bytes(b"x")
+        (tmp_path / "b.tif").write_bytes(b"x")
+        sa, pa = _store_and_path(str(tmp_path / "a.tif"))
+        sb, pb = _store_and_path(str(tmp_path / "b.tif"))
+        assert sa is sb and (pa, pb) == ("a.tif", "b.tif")
+
     def test_s3_scheme(self):
         store, path = _store_and_path("s3://bkt/some/key.tif", region="us-west-2")
         assert type(store).__name__ == "S3Store"

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -189,7 +189,7 @@ class TestSampleConcurrency:
         lock = _asyncio.Lock()
 
         async def _fake_sample_item(
-            grid, cells, assets, bands, *, nodata=None, region=None, anonymous=True
+            grid, cells, assets, bands, *, nodata=None, region=None, anonymous=True, **_kw
         ):
             async with lock:
                 state["cur"] += 1
@@ -592,3 +592,63 @@ class TestTemplateAndSlabs:
         got = red[0, start:stop]
         np.testing.assert_array_equal(got[valid], data[rows[valid], cols[valid]])
         assert (got[~valid] == 0).all()  # fill outside the raster footprint
+
+
+class TestGeometryCache:
+    """Issue #244: the pull-NN mapping is memoized per (epsg, transform, shape)
+    within a shard invoke — once per distinct source grid, not once per
+    asset-sample — with output byte-identical to the uncached path."""
+
+    def _run_counting(self, tmp_path, monkeypatch, n_timesteps=4, second_grid=False):
+        vals = [11, 22, 33, 44][:n_timesteps]
+        granules = []
+        for i, v in enumerate(vals):
+            _write_tiff(tmp_path / f"s{i}.tif", np.full((96, 96), v, dtype=np.uint16))
+            assets = {"red": str(tmp_path / f"s{i}.tif")}
+            if second_grid:
+                # A second, differently-shaped source grid (48x48 @ 20 m).
+                _write_tiff(tmp_path / f"c{i}.tif", np.full((48, 48), 4, dtype=np.uint16), res=20.0)
+                assets["scl"] = str(tmp_path / f"c{i}.tif")
+            granules.append(
+                _entry(f"g{i}", assets, f"2026-07-{13 + i:02d}T16:02:20+00:00", time_key=f"dt-{i}")
+            )
+        bands = {"red": {"asset": "red", "dtype": "uint16"}}
+        if second_grid:
+            bands["scl"] = {"asset": "scl", "dtype": "uint16"}
+        grid = _rect_grid([ORIGIN[0], ORIGIN[1] - 960.0, ORIGIN[0] + 960.0, ORIGIN[1]], [96, 96])
+        cfg = _raster_config(bands=bands, nodata=None)
+        index, _ = raster_time_index([granules])
+
+        calls = {"n": 0}
+        real = type(grid).sample
+
+        def _counting(self_, *a, **k):
+            calls["n"] += 1
+            return real(self_, *a, **k)
+
+        monkeypatch.setattr(type(grid), "sample", _counting)
+        slabs, meta = process_raster_shard(grid, 0, granules, cfg, index)
+        return slabs, calls["n"]
+
+    def test_one_compute_per_source_grid(self, tmp_path, monkeypatch):
+        _slabs, n = self._run_counting(tmp_path, monkeypatch, n_timesteps=4)
+        assert n == 1  # 4 timesteps x 1 band, one shared source grid
+
+    def test_two_computes_for_two_grids(self, tmp_path, monkeypatch):
+        _slabs, n = self._run_counting(tmp_path, monkeypatch, n_timesteps=3, second_grid=True)
+        assert n == 2  # 3 timesteps x 2 bands over exactly two source grids
+
+    def test_cached_output_matches_uncached(self, tmp_path):
+        _write_tiff(tmp_path / "t0.tif", _index_raster())
+        grid = _rect_grid([ORIGIN[0], ORIGIN[1] - 960.0, ORIGIN[0] + 960.0, ORIGIN[1]], [96, 96])
+        bands = get_raster_bands(_raster_config(bands={"red": {"asset": "red", "dtype": "uint16"}}))
+        assets = {"red": str(tmp_path / "t0.tif")}
+        cells = np.arange(96 * 96)
+        uncached = _run_sync(sample_item_async(grid, cells, assets, bands))
+        shared: dict = {}
+        cached1 = _run_sync(sample_item_async(grid, cells, assets, bands, geom_cache=shared))
+        cached2 = _run_sync(sample_item_async(grid, cells, assets, bands, geom_cache=shared))
+        assert len(shared) == 1
+        for got in (cached1, cached2):
+            np.testing.assert_array_equal(got[0]["red"], uncached[0]["red"])
+            np.testing.assert_array_equal(got[1], uncached[1])


### PR DESCRIPTION
Closes #244. Refs #218, PR #232 (measurement threads), #228, #235.

## What / approach

The raster worker paid per-asset costs that should be per-invoke — measured on the SERC full-year o9 runs at ~300 ms of S3 client construction + ~175 ms of redundant pull-NN geometry per asset-sample, × 425 samples per invoke, with every tile GET riding cold connections ([breakdown on the issue](https://github.com/englacial/zagg/issues/244)). Two pure-memoization fixes in `processing/raster.py`, no config surface, no new deps; handler and local runner benefit transparently.

**Phase 1 — store cache.** `_store_and_path` resolves a cache key `(kind, bucket-or-host-or-dir, region, anonymous)` and consults a lock-guarded module-level cache; construction is single-flight under the lock. Module lifetime = sandbox lifetime (espg-ratified Q1 on #244): warm invocations keep their connection pools, the issue-#171 pattern.

**Phase 2 — geometry cache.** `process_raster_shard` allocates one `geom_cache` per invoke (per-invoke scoping makes cross-shard collisions structurally impossible) and threads it through `sample_item_async` → `_sample_one`, memoizing `(rows, cols, valid)` per `(epsg, transform, shape)`. Exactly-once population is guaranteed by loop atomicity — no `await` between check and store — per the [Q2 resolution](https://github.com/englacial/zagg/issues/244#issuecomment-4986824702); the invariant is documented at the site with the upgrade path (per-key async locks) if the compute ever moves off-loop. Public `sample_asset`/`sample_asset_async` behavior unchanged (default `None` = compute per call).

## Phases

- [x] **Phase 1** — store cache (`_STORE_CACHE`/`_build_store`), key semantics, single-flight construction.
- [x] **Phase 2** — per-invoke `geom_cache` threaded through the sample path; atomicity invariant documented.
- [ ] **Phase 3** — fleet A/B after the next bundled release (espg-ratified Q3): rerun the [PR #232 protocol](https://github.com/englacial/zagg/pull/232#issuecomment-4986626775), post before/after here, refresh #228 calibration. Target: full-year o9 wall ≤ ~300 s (estimate ~150–250 s vs today's 578 s).

## How tested

`tests/test_raster.py::TestStoreAndPath` — per-test cache isolation (autouse fixture); same-href/same-vhost store identity; distinct `(bucket, anonymous)` keys distinct; constructor-count-of-one via a counting `S3Store` shim (no wall-clock assertions); LocalStore per-directory reuse. `tests/test_raster_pipeline.py::TestGeometryCache` — `grid.sample` call-count == 1 for 4 timesteps × 1 band on one source grid, == 2 for 3 timesteps × 2 bands over two grids (the SERC shape: 10 m + 20 m); cached output byte-equal to uncached. Full raster suites: 91 passed; existing golden/e2e tests unchanged (memoization has no semantic surface).

## Questions for review

- Pre-existing, untouched: `ruff` N818 on `registry.py` (long-flagged).
