### PR TITLE
morton-hive/2 temporal machinery: windowed leaves, temporal manifest block, time-range stamps, coverage full (issue #246)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -625,12 +625,16 @@ def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
     try:
         config = load_config_from_dict(event["config"])
         if get_store_layout(config) == "hive":
+            from zagg.config import get_windowing
             from zagg.hive import build_manifest, ensure_manifest
 
             grid = from_config(config, parent_order=event.get("parent_order"))
             ensure_manifest(
                 event["store_path"],
-                build_manifest(grid, dataset=event.get("dataset")),
+                # Windowed stores (issue #246) declare morton-hive/2 + the
+                # temporal block, derived from the SAME forwarded config the
+                # dispatcher fanned out on — no extra event key to drift.
+                build_manifest(grid, dataset=event.get("dataset"), windowing=get_windowing(config)),
                 overwrite=event.get("overwrite", False),
                 **_output_store_kwargs(event),
             )
@@ -1106,6 +1110,13 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 handoff=handoff,
                 aoi_payload=aoi_payload,
                 profile=profile,
+                # Temporal window unit (issue #246): {"label", "start", "end"}
+                # in dataset units, absent on unwindowed runs. The shared
+                # write path selects the windowed leaf, injects the
+                # time_field filter, and stamps window + ISO time_range; the
+                # response body (this metadata) then carries time_range back
+                # for the dispatcher's root-summary union.
+                window=event.get("window"),
             )
         else:
             # Flat layout: lazy store + one-time template check, opened on the

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -1,11 +1,13 @@
-# Hive store layout (morton-hive/1)
+# Hive store layout (morton-hive/1, /2)
 
 zagg can write each dispatch shard as its **own self-describing leaf zarr**
 under a morton digit tree, instead of into one shared flat store. The layout is
 the write-side half of the sparse-coverage design record
 ([`docs/design/sparse_coverage.md`](design/sparse_coverage.md) §2–§3, decisions
 D1–D6); the convention itself is owned by the mortie spec and versioned as
-`morton-hive/1`.
+`morton-hive/1`. A store that declares a **time-window schedule** (D13–D15,
+[Time windows](#time-windows-morton-hive2) below) is `morton-hive/2` — a
+strict superset: a `/1` store *is* a `/2` store with `schedule: none`.
 
 It is opt-in (default `flat`, today's single shared store) and wired to
 **both backends** — the local runner and the Lambda handler share the same
@@ -18,6 +20,7 @@ per-shard write path (see [Status](#status)).
   morton_hive.json               <- static manifest (root-only exception)
   {sign+base}/{d1}/.../{d_n}/    <- one decimal digit per level (D2)
     {full_id}.zarr/              <- vanilla zarr v3 leaf, one per shard (D3)
+    {full_id}_{window}.zarr/     <- time-windowed leaf (D13, morton-hive/2)
 ```
 
 - **Ids are morton decimal strings** (D1): sign + base digit (`1..6` /
@@ -79,6 +82,73 @@ digits) and with `consolidate_metadata: true` (there is no store-root zarr
 hierarchy to consolidate — D5/D12). (The manifest's `shard_order` field below
 records the dispatch/tree order — it is not a config knob.)
 
+## Time windows (morton-hive/2)
+
+A store may partition each shard's time series into **one write-once leaf per
+window** ([issue #246](https://github.com/englacial/zagg/issues/246), design
+D13–D15; grammar and boundary semantics frozen on the
+[mortie spec page](https://github.com/espg/mortie/issues/62#issuecomment-4986809092)).
+Windowed leaves keep full D4/D5 semantics — stamped, binary debris, zero
+shared state — so **backfill** is just a new earlier-window leaf, concurrent
+runs on different windows share no object, and the window is the unit of
+idempotent reprocessing (re-dispatching a window replaces its leaf wholesale).
+
+```yaml
+output:
+  store_layout: hive
+  windowing:                        # absent = schedule none = morton-hive/1
+    schedule: yearly                # none | yearly | monthly | daily | explicit
+    time_field: delta_time          # per-observation timestamp column
+                                    #   (a declared data_source column)
+    epoch: "2018-01-01T00:00:00Z"   # dataset zero as an ISO-8601 UTC instant
+    scale: gps                      # utc (default) | gps | tai
+    units: seconds                  # seconds (default) | days
+    windows:                        # explicit schedule only:
+      - {label: melt-2019, start: "2019-06-01", end: "2019-09-01"}
+      - {label: melt-2020, start: "2020-06-01", end: "2020-09-01"}
+```
+
+- **Leaf naming is frozen**: `{full_id}_{window}.zarr`, underscore separator,
+  parse by splitting on the FIRST `_`. Generative labels are ISO-derived and
+  hyphen-free (`2025`, `202511`, `20251103`), so lexicographic order =
+  chronological order; explicit labels are opaque (`[0-9A-Za-z-]{1,32}`) and
+  decode only through the declared list. `quarterly` is grammar-reserved but
+  not implemented (validation rejects it).
+- **Boundaries are UTC calendar terms, half-open `[start, end)`.** Window
+  bounds are converted to dataset units once at dispatch, using the declared
+  `epoch`/`scale`/`units` and a fixed scale offset (`GPS−UTC = 18 s`,
+  `TAI−UTC = 37 s`; stdlib `datetime` has no leap-second table) — boundaries
+  are accurate to ≤ 1 leap second, none declared since 2017.
+- **Dispatch fans one work unit per (shard, window).** The ShardMap's
+  per-granule `time_start`/`time_end` subset granules per window; inside the
+  worker an observation-level filter on `time_field` (a pair of structured
+  `ge`/`lt` predicates riding the ordinary filter machinery) splits
+  boundary-straddling granules exactly — an observation on a boundary instant
+  belongs to the *later* window. Legacy shardmaps without granule times
+  dispatch every granule to every window (the filter keeps it correct) and
+  need `bounds.temporal` to enumerate generative windows.
+- **Stamps carry the truth, the manifest the schema** (D15): each windowed
+  leaf's commit stamp records its `window` label and the ACTUAL written
+  `time_range` as ISO-8601 UTC strings; the root `coverage.moc` summary
+  carries the run's time-range union (cache, regenerable); temporal *extent*
+  never lives in the manifest, which stays write-once. Appending a new year
+  to a `yearly` store adds leaves the schedule already describes — no
+  manifest touch; the explicit list is the noted exception (appending outside
+  it re-templates).
+- **Coverage gains `encoding: "full"`** (D14): a popcount at stamp time marks
+  a fully-occupied subtree — no bitmap sidecar object is written, and readers
+  short-circuit the exact intersection through the shard's own MOC
+  membership. Partial shards keep the bitmap sidecar.
+
+Validation: `output.windowing` requires the hive layout on a healpix grid;
+`time_field` must be a declared `data_source` column (the worker can only
+filter what it reads); explicit windows must be well-formed (frozen label
+grammar, `start < end`, unique labels, disjoint ranges). Raster pipelines
+reject the block
+([issue #247](https://github.com/englacial/zagg/issues/247) tracks raster
+windowing). Changing the windowing of an existing store fails the frozen-key
+manifest check like an orders change — clear the root first.
+
 ## The manifest (`morton_hive.json`)
 
 Written **once at template time**, before any shard dispatches; never touched
@@ -102,9 +172,15 @@ order) but recorded explicitly for forward compatibility. `pyramid` is
 declared-only in round one: overview zarrs are generated by a later
 post-process sweep (D11), never at fan-out time.
 
+A windowed store ([Time windows](#time-windows-morton-hive2)) additionally
+declares `spec: "morton-hive/2"` and a `temporal` block — schedule,
+`time_field`, `epoch`/`scale`/`units`/`calendar`, the explicit windows list,
+and the append policy. Temporal *extent* is deliberately not manifest data
+(D15): actual ranges live on leaf stamps (truth) and the root summary (cache).
+
 A rerun into an existing root verifies the manifest's **frozen keys** match
 the run's own configuration (`spec`, `dataset`, `cell_order`, `shard_order`,
-`split_schedule`) and fails loudly on a mismatch — the hive analogue of the
+`split_schedule`, `temporal`) and fails loudly on a mismatch — the hive analogue of the
 flat layout's shard-map signature guard. The sweep-mutable `pyramid` block and
 the `generated_at` timestamp are deliberately excluded, so a swept store still
 resumes (and the sweep's pyramid declaration is preserved, not clobbered).
@@ -147,6 +223,9 @@ leaf is created lazily on the first chunk write).
 The stamp also carries the shard's **coverage envelope** — see
 [Coverage](#coverage) below. The sidecar it points to is written before the
 stamp, so coverage shares the debris semantics: no stamp, no visible coverage.
+A windowed leaf's stamp ([Time windows](#time-windows-morton-hive2)) declares
+`spec: "morton-hive/2"` and adds `window` (the label) plus `time_range` — the
+actual `[t_min, t_max]` written, as ISO-8601 UTC strings.
 
 ## Coverage
 

--- a/src/zagg/__init__.py
+++ b/src/zagg/__init__.py
@@ -51,6 +51,7 @@ def __getattr__(name):
         return getattr(mod, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
 __all__ = [
     "HealpixGrid",
     "OutputGrid",

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -51,10 +51,14 @@ def _granule_entry(rec: dict) -> dict:
 
     The canonical single-asset trio is always present; multi-asset records
     (raster sources, #218) additionally carry ``assets`` (per-band hrefs) and
-    ``datetime`` (ISO acquisition time).
+    ``datetime`` (ISO acquisition time). ``time_start``/``time_end`` (issue
+    #246) are the granule's ISO acquisition range on any record whose catalog
+    carries STAC ``start_datetime``/``end_datetime`` — the metadata the
+    dispatcher uses to subset granules per time window; absent on maps built
+    from pre-#246 catalogs (the fan-out then degrades conservatively).
     """
     entry = {"id": rec["id"], "s3": rec["s3"], "https": rec["https"]}
-    for key in ("assets", "datetime", "time_key"):
+    for key in ("assets", "datetime", "time_key", "time_start", "time_end"):
         if rec.get(key) is not None:
             entry[key] = rec[key]
     return entry

--- a/src/zagg/catalog/sources.py
+++ b/src/zagg/catalog/sources.py
@@ -441,7 +441,10 @@ class Catalog:
             catalog's ``time_key`` metadata, when present); any
             record with a ``data``/``data_s3`` asset -- every CMR record,
             including ``preserve_thumbnails=True`` -- keeps its exact pre-#218
-            shape.
+            shape, except that any record whose catalog carries STAC
+            ``start_datetime``/``end_datetime`` also gains ``time_start``/
+            ``time_end`` (ISO acquisition range, issue #246) for the
+            per-window dispatch subsetting.
         """
         import shapely
 
@@ -453,6 +456,19 @@ class Catalog:
             if "datetime" in self.table.column_names
             else [None] * len(ids)
         )
+
+        # Per-granule acquisition range (issue #246): STAC items carry
+        # start_datetime/end_datetime properties (every CMR granule does),
+        # flattened to columns by stac-geoparquet. Surfaced on EVERY record so
+        # the ShardMap can subset granules per time window at dispatch;
+        # catalogs without the columns (or null rows) simply omit the keys —
+        # the fan-out then degrades to its conservative every-window path.
+        def _col(name):
+            if name in self.table.column_names:
+                return self.table.column(name).to_pylist()
+            return [None] * len(ids)
+
+        t_starts, t_ends = _col("start_datetime"), _col("end_datetime")
         # Acquisition-group property (issue #218): the source records its item
         # property name in the catalog metadata; stac-geoparquet flattens item
         # properties to top-level columns, so it reads straight off the table.
@@ -463,7 +479,9 @@ class Catalog:
             else [None] * len(ids)
         )
         records = []
-        for gid, asset_map, wkb, dt, tk in zip(ids, assets, geoms, dts, tks):
+        for gid, asset_map, wkb, dt, tk, ts, te in zip(
+            ids, assets, geoms, dts, tks, t_starts, t_ends
+        ):
             geom = shapely.from_wkb(wkb)
             if geom.is_empty or geom.geom_type not in ("Polygon", "MultiPolygon"):
                 continue
@@ -479,6 +497,15 @@ class Catalog:
                 "lats": np.asarray(y),
                 "lons": np.asarray(x),
             }
+            # Acquisition range keys (issue #246), on any record whose catalog
+            # carries them (unlike the raster-only extras below): newly built
+            # ShardMaps gain per-granule time metadata; pre-#246 manifests
+            # without the keys keep reading (the dispatcher degrades
+            # conservatively).
+            if ts is not None:
+                rec["time_start"] = ts.isoformat() if hasattr(ts, "isoformat") else str(ts)
+            if te is not None:
+                rec["time_end"] = te.isoformat() if hasattr(te, "isoformat") else str(te)
             # Only records with no canonical data asset (raster sources) grow
             # the extra keys; any record carrying data/data_s3 -- every CMR
             # record, including preserve_thumbnails -- stays byte-identical

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -683,8 +683,11 @@ def _validate_windowing(config: PipelineConfig) -> None:
     page but NOT implemented — rejected with a pointed message. The explicit
     windows list must be well-formed: frozen label grammar, half-open
     ``start < end``, unique labels, non-overlapping ranges. ``time_field``
-    must name a declared ``data_source`` column so the worker actually reads
-    the membership timestamps it filters on.
+    must name a declared BASE-RATE ``data_source`` variable (a flat
+    ``variables`` entry or the base level's ``variables``) — a coordinate or
+    a non-base (segment-rate) level column is rejected, since the stamp
+    ``time_range`` is pooled from read variable columns and window membership
+    is decided per observation.
     """
     from zagg import windows as _windows
 
@@ -729,21 +732,37 @@ def _validate_windowing(config: PipelineConfig) -> None:
             "output.windowing.time_field is required: the per-observation "
             "timestamp column that decides window membership"
         )
-    # The worker can only filter on columns it actually reads: the flat
-    # data_source coordinates/variables plus any readable segment-level
-    # variable a hierarchical level declares (issue #30 mapping form,
-    # ``_segment_variable_names``). The check is unconditional — a windowing
-    # store that declares no columns cannot filter on ``time_field`` at all.
-    declared = (
-        set((config.data_source or {}).get("coordinates", {}))
-        | set((config.data_source or {}).get("variables", {}))
-        | _segment_variable_names(config.data_source or {})
-    )
+    # ``time_field`` must be a BASE-RATE variable column, i.e. a
+    # ``data_source.variables`` entry (the base level reads its columns from
+    # there too — ``_validate_levels`` forbids a base-level ``variables``
+    # mapping). The stamp ``time_range`` (a windowed leaf's headline truth) is
+    # pooled from the read VARIABLE columns (``col_arrays`` in the worker),
+    # never from ``coordinates`` — so a coordinate ``time_field`` would filter
+    # yet silently drop the stamp, and a lat/lon coordinate is not a timestamp
+    # anyway. A non-base (segment-rate) level column is rejected too: window
+    # membership would be decided per whole segment, not per observation,
+    # which is not supported this round (see ``window_time_filters``).
+    ds = config.data_source or {}
+    declared = set(ds.get("variables") or {})
     if time_field not in declared:
+        if time_field in set(ds.get("coordinates") or {}):
+            raise ValueError(
+                f"output.windowing.time_field {time_field!r} is a data_source "
+                f"coordinate; the stamp time_range is pooled from read variable "
+                f"columns and a coordinate is not read as a timestamp. Declare it "
+                f"under data_source.variables (or the base level's variables)."
+            )
+        if time_field in _segment_variable_names(ds):
+            raise ValueError(
+                f"output.windowing.time_field {time_field!r} is declared on a "
+                f"non-base (segment-rate) level; segment-rate window membership is "
+                f"not supported yet (whole segments would be kept or dropped). "
+                f"Declare it on the base level or data_source.variables."
+            )
         raise ValueError(
             f"output.windowing.time_field {time_field!r} is not a declared "
-            f"data_source column (one of {sorted(declared)}); the worker can "
-            f"only filter on columns it reads"
+            f"base-rate data_source column (one of {sorted(declared)}); the "
+            f"worker filters per observation on variable columns it reads"
         )
     epoch = block.get("epoch")
     if epoch is None:
@@ -2032,39 +2051,28 @@ def window_time_filters(config: PipelineConfig, start: float, end: float) -> lis
     predicates on the declared ``time_field`` — ``ge start`` / ``lt end`` in
     DATASET units (converted once at dispatch) — so it rides the existing,
     pushdown-eligible filter machinery (issue #43) on every backend instead
-    of a bespoke row filter. The field's dataset path resolves from
-    ``variables``/``coordinates`` (base level) or a hierarchical ``levels``
-    entry (the filter then carries that level and expands to base rate, the
-    Phase-B path). Appended to :func:`filters_from_data_source`'s normalized
-    output by the hive write path, preserving any declared filters.
+    of a bespoke row filter. ``_validate_windowing`` restricts ``time_field``
+    to a base-rate ``data_source.variables`` entry (the base level reads its
+    columns from there too), so the predicate always filters at base rate
+    (``level=None``, per observation); a coordinate or non-base/segment-rate
+    ``time_field`` is rejected at validation and never reaches here. Appended
+    to :func:`filters_from_data_source`'s normalized output by the hive write
+    path, preserving any declared filters.
     """
     windowing = get_windowing(config)
     if windowing is None:
         raise ValueError("window_time_filters requires a windowed config (output.windowing)")
     field = windowing["time_field"]
-    ds = config.data_source or {}
-    path, level = None, None
-    for key in ("variables", "coordinates"):
-        p = (ds.get(key) or {}).get(field)
-        if isinstance(p, str) and p:
-            path = p
-            break
-    if path is None:
-        for lname, spec in (get_levels(config) or {}).items():
-            lvars = spec.get("variables") if isinstance(spec, dict) else None
-            if isinstance(lvars, dict) and isinstance(lvars.get(field), str):
-                # The base level's columns filter at base rate (level None).
-                path, level = lvars[field], (None if lname == get_base_level(config) else lname)
-                break
-    if path is None:
+    path = ((config.data_source or {}).get("variables") or {}).get(field)
+    if not (isinstance(path, str) and path):
         raise ValueError(
-            f"windowing time_field {field!r} has no dataset path in "
-            f"data_source.variables/coordinates/levels — validate_config should "
-            f"have rejected this configuration"
+            f"windowing time_field {field!r} has no base-rate dataset path in "
+            f"data_source.variables — validate_config should have rejected "
+            f"this configuration"
         )
     return [
-        {"level": level, "dataset": path, "op": "ge", "value": float(start)},
-        {"level": level, "dataset": path, "op": "lt", "value": float(end)},
+        {"level": None, "dataset": path, "op": "ge", "value": float(start)},
+        {"level": None, "dataset": path, "op": "lt", "value": float(end)},
     ]
 
 

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -381,6 +381,12 @@ def validate_config(config: PipelineConfig) -> None:
                 "hive root to bootstrap from)"
             )
 
+    # Temporal windowing block (issue #246, morton-hive/2): nested
+    # output.windowing declares the window schedule + time encoding. Absent =
+    # schedule none = today's behavior; the block itself is hive-only (windowed
+    # leaves are a hive-layout convention), mirroring coverage_moc's posture.
+    _validate_windowing(config)
+
     # Validate bounds structure (optional)
     if config.bounds is not None:
         allowed_keys = {"temporal", "spatial"}
@@ -654,6 +660,135 @@ def _validate_raster_config(config: PipelineConfig) -> None:
             "raster templates do not support sharded: true yet (issue #218); "
             "chunks are (1, cells_per_chunk) — one object per timestep-chunk"
         )
+    # Time-windowed hive leaves are a point-pipeline capability in this round;
+    # the raster (time, cells) product's windowing is its own design (issue
+    # #247). Reject pointedly rather than silently ignoring the block —
+    # extending the early-return validation posture from issue #239.
+    if config.output.get("windowing"):
+        raise ValueError(
+            "raster pipelines do not support output.windowing yet (issue #247); "
+            "drop the block — raster output is a (time, cells) cube, not "
+            "windowed hive leaves"
+        )
+
+
+def _validate_windowing(config: PipelineConfig) -> None:
+    """Validate the ``output.windowing`` block (issue #246, morton-hive/2).
+
+    ``{schedule, time_field, epoch, scale?, units?, windows?}`` — the nested
+    form ratified on the #246 thread. Absent/null is schedule ``none``
+    (today's behavior). A present block requires the hive store layout on a
+    healpix grid (windowed leaf names are a morton-hive convention, like
+    ``coverage_moc``). ``quarterly`` is grammar-reserved on the mortie spec
+    page but NOT implemented — rejected with a pointed message. The explicit
+    windows list must be well-formed: frozen label grammar, half-open
+    ``start < end``, unique labels, non-overlapping ranges. ``time_field``
+    must name a declared ``data_source`` column so the worker actually reads
+    the membership timestamps it filters on.
+    """
+    from zagg import windows as _windows
+
+    block = config.output.get("windowing")
+    if block is None:
+        return
+    if not isinstance(block, dict):
+        raise ValueError(
+            f"output.windowing must be a mapping "
+            f"{{schedule, time_field, epoch, ...}} (got {block!r})"
+        )
+    try:
+        schedule = _windows.check_schedule(block.get("schedule", "none"))
+    except ValueError as e:
+        raise ValueError(f"output.windowing.schedule: {e}") from e
+    grid = config.output.get("grid") or {}
+    if (grid.get("type", "healpix")) != "healpix":
+        raise ValueError(
+            "output.windowing requires a healpix grid (windowed leaves are a "
+            f"morton-hive convention; grid type is {grid.get('type')!r})"
+        )
+    if (config.output.get("store_layout") or "flat") != "hive":
+        raise ValueError(
+            "output.windowing requires output.store_layout: hive (window leaves "
+            "are hive leaf zarrs; the flat shared store has no leaves to window)"
+        )
+    if schedule == "none":
+        return
+    time_field = block.get("time_field")
+    if not isinstance(time_field, str) or not time_field:
+        raise ValueError(
+            "output.windowing.time_field is required: the per-observation "
+            "timestamp column that decides window membership"
+        )
+    declared = {
+        **(config.data_source or {}).get("coordinates", {}),
+        **(config.data_source or {}).get("variables", {}),
+    }
+    if declared and time_field not in declared:
+        raise ValueError(
+            f"output.windowing.time_field {time_field!r} is not a declared "
+            f"data_source column (one of {sorted(declared)}); the worker can "
+            f"only filter on columns it reads"
+        )
+    epoch = block.get("epoch")
+    if epoch is None:
+        raise ValueError(
+            "output.windowing.epoch is required: the dataset's zero time as an "
+            "ISO-8601 UTC instant (e.g. '2018-01-01T00:00:00Z' for ICESat-2 "
+            "delta_time)"
+        )
+    try:
+        _windows.parse_utc(epoch)
+    except ValueError as e:
+        raise ValueError(f"output.windowing.epoch: {e}") from e
+    scale = block.get("scale") or "utc"
+    if scale not in _windows.EPOCH_SCALES:
+        raise ValueError(
+            f"output.windowing.scale must be one of {_windows.EPOCH_SCALES} (got {scale!r})"
+        )
+    units = block.get("units") or "seconds"
+    if units not in _windows.UNIT_SECONDS:
+        raise ValueError(
+            f"output.windowing.units must be one of {tuple(_windows.UNIT_SECONDS)} (got {units!r})"
+        )
+    declared_windows = block.get("windows")
+    if schedule != "explicit":
+        if declared_windows is not None:
+            raise ValueError(
+                f"output.windowing.windows only applies to schedule: explicit "
+                f"(the {schedule} schedule derives its windows from labels)"
+            )
+        return
+    if not isinstance(declared_windows, list) or not declared_windows:
+        raise ValueError(
+            "output.windowing.windows is required for schedule: explicit — a "
+            "non-empty list of {label, start, end} entries"
+        )
+    seen: dict = {}
+    for entry in declared_windows:
+        if not isinstance(entry, dict) or not {"label", "start", "end"} <= set(entry):
+            raise ValueError(
+                f"each explicit window must be a {{label, start, end}} mapping (got {entry!r})"
+            )
+        try:
+            label = _windows.validate_label(entry["label"], "explicit")
+            start, end = _windows.parse_utc(entry["start"]), _windows.parse_utc(entry["end"])
+        except ValueError as e:
+            raise ValueError(f"output.windowing.windows: {e}") from e
+        if not start < end:
+            raise ValueError(
+                f"explicit window {label!r} is not half-open: start "
+                f"{entry['start']!r} must precede end {entry['end']!r}"
+            )
+        if label in seen:
+            raise ValueError(f"explicit window label {label!r} is declared twice")
+        seen[label] = (start, end)
+    ordered = sorted(seen.items(), key=lambda kv: kv[1][0])
+    for (a, (_sa, ea)), (b, (sb, _eb)) in zip(ordered, ordered[1:]):
+        if ea > sb:
+            raise ValueError(
+                f"explicit windows {a!r} and {b!r} overlap; windows must be "
+                f"disjoint half-open ranges"
+            )
 
 
 def get_raster_bands(config: PipelineConfig) -> dict:
@@ -1832,6 +1967,46 @@ def get_coverage_moc(config: PipelineConfig) -> bool:
     if flag is None:
         return get_store_layout(config) == "hive"
     return bool(flag)
+
+
+def get_windowing(config: PipelineConfig) -> dict | None:
+    """The normalized temporal windowing declaration, or ``None`` (issue #246).
+
+    ``None`` — absent block, null block, or an explicit ``schedule: none`` —
+    is today's unwindowed behavior (bare leaf names, ``morton-hive/1``).
+    Otherwise a normalized dict with defaults resolved::
+
+        {"schedule", "time_field", "epoch", "scale", "units", "windows"}
+
+    ``epoch`` and explicit-window boundaries are canonicalized to ISO-8601
+    UTC strings; ``windows`` is ``None`` except for ``schedule: explicit``.
+    The same dict feeds the manifest temporal block
+    (:func:`zagg.hive.build_manifest`) and the dispatch fan-out, so the two
+    can never disagree.
+    """
+    from zagg import windows as _windows
+
+    block = config.output.get("windowing")
+    if not block or block.get("schedule", "none") == "none":
+        return None
+    declared = None
+    if block["schedule"] == "explicit":
+        declared = [
+            {
+                "label": w["label"],
+                "start": _windows.iso_utc(_windows.parse_utc(w["start"])),
+                "end": _windows.iso_utc(_windows.parse_utc(w["end"])),
+            }
+            for w in block["windows"]
+        ]
+    return {
+        "schedule": block["schedule"],
+        "time_field": block["time_field"],
+        "epoch": _windows.iso_utc(_windows.parse_utc(block["epoch"])),
+        "scale": block.get("scale") or "utc",
+        "units": block.get("units") or "seconds",
+        "windows": declared,
+    }
 
 
 def get_aoi_mask(config: PipelineConfig) -> bool:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -2025,6 +2025,75 @@ def get_windowing(config: PipelineConfig) -> dict | None:
     }
 
 
+def window_time_filters(config: PipelineConfig, start: float, end: float) -> list[dict]:
+    """Structured filters implementing one window's ``[start, end)`` (issue #246).
+
+    The observation-level window filter is exactly a pair of structured
+    predicates on the declared ``time_field`` — ``ge start`` / ``lt end`` in
+    DATASET units (converted once at dispatch) — so it rides the existing,
+    pushdown-eligible filter machinery (issue #43) on every backend instead
+    of a bespoke row filter. The field's dataset path resolves from
+    ``variables``/``coordinates`` (base level) or a hierarchical ``levels``
+    entry (the filter then carries that level and expands to base rate, the
+    Phase-B path). Appended to :func:`filters_from_data_source`'s normalized
+    output by the hive write path, preserving any declared filters.
+    """
+    windowing = get_windowing(config)
+    if windowing is None:
+        raise ValueError("window_time_filters requires a windowed config (output.windowing)")
+    field = windowing["time_field"]
+    ds = config.data_source or {}
+    path, level = None, None
+    for key in ("variables", "coordinates"):
+        p = (ds.get(key) or {}).get(field)
+        if isinstance(p, str) and p:
+            path = p
+            break
+    if path is None:
+        for lname, spec in (get_levels(config) or {}).items():
+            lvars = spec.get("variables") if isinstance(spec, dict) else None
+            if isinstance(lvars, dict) and isinstance(lvars.get(field), str):
+                # The base level's columns filter at base rate (level None).
+                path, level = lvars[field], (None if lname == get_base_level(config) else lname)
+                break
+    if path is None:
+        raise ValueError(
+            f"windowing time_field {field!r} has no dataset path in "
+            f"data_source.variables/coordinates/levels — validate_config should "
+            f"have rejected this configuration"
+        )
+    return [
+        {"level": level, "dataset": path, "op": "ge", "value": float(start)},
+        {"level": level, "dataset": path, "op": "lt", "value": float(end)},
+    ]
+
+
+def windowed_cell_config(config: PipelineConfig, window: dict) -> tuple[PipelineConfig, dict]:
+    """One work unit's config with its window filter injected (issue #246).
+
+    Returns ``(config, windowing)``: a per-unit config copy whose normalized
+    filter list gains the :func:`window_time_filters` pair for ``window``'s
+    dataset-unit ``[start, end)`` (declared filters preserved — the explicit
+    list wins over ``quality_filter`` sugar, so normalize-then-append), plus
+    the normalized windowing declaration. Raises if the config declares no
+    ``output.windowing`` — a dispatched window without one is dispatcher/
+    config drift, never guessed around.
+    """
+    from dataclasses import replace
+
+    windowing = get_windowing(config)
+    if windowing is None:
+        raise ValueError(
+            "a window was dispatched but the config declares no output.windowing "
+            "block — dispatcher/config drift, refusing to guess the time_field"
+        )
+    ds = dict(config.data_source)
+    ds["filters"] = filters_from_data_source(ds) + window_time_filters(
+        config, window["start"], window["end"]
+    )
+    return replace(config, data_source=ds), windowing
+
+
 def get_aoi_mask(config: PipelineConfig) -> bool:
     """Whether the optional strict-AOI cell mask is enabled (issue #101).
 

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -700,6 +700,18 @@ def _validate_windowing(config: PipelineConfig) -> None:
         schedule = _windows.check_schedule(block.get("schedule", "none"))
     except ValueError as e:
         raise ValueError(f"output.windowing.schedule: {e}") from e
+    if schedule == "none":
+        # An inert ``schedule: none`` block is equivalent to an absent block
+        # (``get_windowing`` returns ``None``, no windowed output), so it must
+        # NOT require the hive/healpix layout — this early return precedes the
+        # layout guards. A stray ``windows`` key is still rejected, mirroring
+        # the generative-schedule check below (validation symmetry).
+        if block.get("windows") is not None:
+            raise ValueError(
+                "output.windowing.windows only applies to schedule: explicit "
+                "(schedule: none produces no windowed output)"
+            )
+        return
     grid = config.output.get("grid") or {}
     if (grid.get("type", "healpix")) != "healpix":
         raise ValueError(
@@ -711,19 +723,23 @@ def _validate_windowing(config: PipelineConfig) -> None:
             "output.windowing requires output.store_layout: hive (window leaves "
             "are hive leaf zarrs; the flat shared store has no leaves to window)"
         )
-    if schedule == "none":
-        return
     time_field = block.get("time_field")
     if not isinstance(time_field, str) or not time_field:
         raise ValueError(
             "output.windowing.time_field is required: the per-observation "
             "timestamp column that decides window membership"
         )
-    declared = {
-        **(config.data_source or {}).get("coordinates", {}),
-        **(config.data_source or {}).get("variables", {}),
-    }
-    if declared and time_field not in declared:
+    # The worker can only filter on columns it actually reads: the flat
+    # data_source coordinates/variables plus any readable segment-level
+    # variable a hierarchical level declares (issue #30 mapping form,
+    # ``_segment_variable_names``). The check is unconditional — a windowing
+    # store that declares no columns cannot filter on ``time_field`` at all.
+    declared = (
+        set((config.data_source or {}).get("coordinates", {}))
+        | set((config.data_source or {}).get("variables", {}))
+        | _segment_variable_names(config.data_source or {})
+    )
+    if time_field not in declared:
         raise ValueError(
             f"output.windowing.time_field {time_field!r} is not a declared "
             f"data_source column (one of {sorted(declared)}); the worker can "

--- a/src/zagg/coverage.py
+++ b/src/zagg/coverage.py
@@ -35,6 +35,7 @@ from zagg.hive import (
     read_manifest,
     read_root_coverage,
     root_coverage_words,
+    union_time_range,
 )
 from zagg.store import open_object_store
 from zagg.windows import split_leaf_name
@@ -108,20 +109,35 @@ def box_and(coverage: dict, aoi) -> np.ndarray:
 
 
 def bitmap_and(leaf_root: str, aoi, **store_kwargs) -> np.ndarray | None:
-    """Exact cell-level intersection via a leaf's bitmap sidecar.
+    """Exact cell-level intersection via a leaf's coverage (bitmap or full).
 
-    One opt-in sidecar GET (:func:`zagg.hive.read_coverage_bitmap`), then
-    ``moc_and`` against ``aoi``. ``None`` when the leaf carries no bitmap
-    (box-only phase-1 stamp, depth-0 config, debris, absent leaf) — the
-    caller falls back to the box verdict; a present-but-corrupt sidecar
-    raises (the decoder's posture). An empty array is a definitive miss:
-    the bitmap is exact, not conservative.
+    Reads the stamp envelope once. ``encoding: "full"`` (issue #246, D14 —
+    whole-subtree coverage, no sidecar object exists) short-circuits to the
+    shard's own MOC membership: ``moc_and`` against the shard id resolves
+    containment exactly, with no bitmap GET and no cell expansion. The
+    ``"bitmap"`` path pays the one opt-in sidecar GET
+    (:func:`zagg.hive.read_coverage_bitmap`, envelope reused). ``None`` when
+    the leaf carries neither (box-only phase-1 stamp, depth-0 config, debris,
+    absent leaf) — the caller falls back to the box verdict; a
+    present-but-corrupt sidecar raises (the decoder's posture). An empty
+    array is a definitive miss: both encodings are exact, not conservative.
     """
-    occupied = read_coverage_bitmap(leaf_root, **store_kwargs)
-    if occupied is None:
+    from zagg.hive import read_coverage
+    from zagg.store import open_store
+
+    coverage = read_coverage(open_store(leaf_root, **store_kwargs))
+    if not coverage:
         return None
     from mortie import moc_and
 
+    if coverage.get("encoding") == "full":
+        from zagg.grids.morton import morton_word
+
+        word = morton_word(split_leaf_name(leaf_root.rstrip("/").rsplit("/", 1)[-1])[0])
+        return moc_and(np.asarray([word], dtype=np.uint64), np.asarray(aoi, dtype=np.uint64))
+    occupied = read_coverage_bitmap(leaf_root, coverage=coverage, **store_kwargs)
+    if occupied is None:
+        return None
     return moc_and(occupied, np.asarray(aoi, dtype=np.uint64))
 
 
@@ -222,7 +238,8 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     order = int(manifest["shard_order"])
     store = open_object_store(store_root, **store_kwargs)
     root = store_root.rstrip("/")
-    keys = []
+    keys: list = []
+    time_ranges: list = []
     stack = [""]
     while stack:
         prefix = stack.pop()
@@ -243,7 +260,8 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
                         f"listed in {ROOT_COVERAGE_NAME}"
                     )
                     continue
-                if read_commit(open_store(f"{root}/{rel}", **store_kwargs)) is None:
+                stamp = read_commit(open_store(f"{root}/{rel}", **store_kwargs))
+                if stamp is None:
                     continue  # unstamped debris (D4)
                 if _decimal_order(decimal) != order:
                     # A fixed-order ranges MOC cannot represent this leaf:
@@ -259,6 +277,10 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
                     )
                     continue
                 keys.append(morton_word(decimal))
+                # D15: windowed stamps carry the leaf's actual time range;
+                # the rebuilt root summary re-derives the union from this
+                # walk's stamps (truth), superseding any cached value.
+                time_ranges.append(stamp.get("time_range"))
                 continue
             is_digit_node = (
                 _is_base_component(name) if prefix == "" else len(name) == 1 and name in "1234"
@@ -272,7 +294,9 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
         except (FileNotFoundError, NotFoundError):
             pass
         return None
-    envelope = build_root_coverage(keys, order, source="refresh")
+    envelope = build_root_coverage(
+        keys, order, source="refresh", time_range=union_time_range(*time_ranges)
+    )
     obstore.put(store, ROOT_COVERAGE_NAME, json.dumps(envelope, indent=1).encode())
     return envelope
 

--- a/src/zagg/coverage.py
+++ b/src/zagg/coverage.py
@@ -223,8 +223,9 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     the ranges envelope has no empty form). Windowed leaves (issue #246)
     classify as data via the frozen first-``_`` name split; several stamped
     windows of one shard are one covered shard (the MOC is spatial — the
-    builder de-duplicates words), and a malformed window label is skipped
-    with a warning, like the foreign-order carve-out.
+    builder de-duplicates words), and a malformed window label on a STAMPED
+    leaf is skipped with a warning, like the foreign-order carve-out —
+    unstamped malformed debris stays silent, as ordinary debris does.
     """
     import obstore
     from obstore.exceptions import NotFoundError
@@ -248,21 +249,30 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
             rel = child.rstrip("/")
             name = rel.split("/")[-1]
             if name.endswith(".zarr"):
+                # Read the commit stamp FIRST — it opens the full rel path, not
+                # the decimal, so it needs no name split. Unstamped debris drops
+                # SILENTLY here, malformed name or not, exactly as valid-named
+                # debris (D4) and the foreign-order carve-out below do: only real
+                # data ever earns a warning.
+                stamp = read_commit(open_store(f"{root}/{rel}", **store_kwargs))
+                if stamp is None:
+                    continue  # unstamped debris (D4)
                 # Windowed leaves (issue #246, D13): `{full_id}_{window}.zarr`
                 # names split on the first `_` (frozen parse rule); several
                 # windows of one shard collapse to one coverage entry below.
                 try:
                     decimal, _window = split_leaf_name(name)
                 except ValueError:
+                    # A STAMPED leaf (real data) whose name breaks the frozen
+                    # grammar — warn only past the stamp gate, the same "only
+                    # complain about real data" posture as the foreign-order
+                    # branch. The escape hatch stays alive on it either way.
                     logger.warning(
-                        f"refresh: skipping leaf {name!r} with a malformed window "
-                        f"label (frozen grammar, mortie#62) — it will NOT be "
+                        f"refresh: skipping STAMPED leaf {name!r} with a malformed "
+                        f"window label (frozen grammar, mortie#62) — it will NOT be "
                         f"listed in {ROOT_COVERAGE_NAME}"
                     )
                     continue
-                stamp = read_commit(open_store(f"{root}/{rel}", **store_kwargs))
-                if stamp is None:
-                    continue  # unstamped debris (D4)
                 if _decimal_order(decimal) != order:
                     # A fixed-order ranges MOC cannot represent this leaf:
                     # either corruption (old-config data surviving a partial

--- a/src/zagg/coverage.py
+++ b/src/zagg/coverage.py
@@ -37,6 +37,7 @@ from zagg.hive import (
     root_coverage_words,
 )
 from zagg.store import open_object_store
+from zagg.windows import split_leaf_name
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +204,11 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     :func:`warn_if_stale` once-per-episode latch for this store. Returns the
     envelope written, or ``None`` — deleting any existing root object — when
     no stamped leaf exists (absence is truthful, a stale cache is not, and
-    the ranges envelope has no empty form).
+    the ranges envelope has no empty form). Windowed leaves (issue #246)
+    classify as data via the frozen first-``_`` name split; several stamped
+    windows of one shard are one covered shard (the MOC is spatial — the
+    builder de-duplicates words), and a malformed window label is skipped
+    with a warning, like the foreign-order carve-out.
     """
     import obstore
     from obstore.exceptions import NotFoundError
@@ -226,7 +231,18 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
             rel = child.rstrip("/")
             name = rel.split("/")[-1]
             if name.endswith(".zarr"):
-                decimal = name.removesuffix(".zarr")
+                # Windowed leaves (issue #246, D13): `{full_id}_{window}.zarr`
+                # names split on the first `_` (frozen parse rule); several
+                # windows of one shard collapse to one coverage entry below.
+                try:
+                    decimal, _window = split_leaf_name(name)
+                except ValueError:
+                    logger.warning(
+                        f"refresh: skipping leaf {name!r} with a malformed window "
+                        f"label (frozen grammar, mortie#62) — it will NOT be "
+                        f"listed in {ROOT_COVERAGE_NAME}"
+                    )
+                    continue
                 if read_commit(open_store(f"{root}/{rel}", **store_kwargs)) is None:
                     continue  # unstamped debris (D4)
                 if _decimal_order(decimal) != order:

--- a/src/zagg/coverage.py
+++ b/src/zagg/coverage.py
@@ -35,10 +35,9 @@ from zagg.hive import (
     read_manifest,
     read_root_coverage,
     root_coverage_words,
-    union_time_range,
 )
 from zagg.store import open_object_store
-from zagg.windows import split_leaf_name
+from zagg.windows import split_leaf_name, union_time_range
 
 logger = logging.getLogger(__name__)
 

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -62,6 +62,10 @@ logger = logging.getLogger(__name__)
 
 #: Convention version recorded in the manifest and the commit stamp (D6).
 HIVE_SPEC = "morton-hive/1"
+#: The temporal superset convention (issue #246, D13/D15): declared iff the
+#: manifest carries a temporal block; a ``/1`` store *is* a ``/2`` store with
+#: ``schedule: none``, so ``/1`` stays the spec written for unwindowed stores.
+HIVE_SPEC_V2 = "morton-hive/2"
 #: Root manifest object name (the root-only exception to the node invariant).
 MANIFEST_NAME = "morton_hive.json"
 #: Root-group attrs key carrying the commit stamp (D4).
@@ -129,7 +133,7 @@ def check_node_invariant(rel_path: str) -> None:
         raise ValueError(f"path {rel_path!r} violates the hive node invariant (D5)")
 
 
-def build_manifest(grid, dataset: dict | None = None) -> dict:
+def build_manifest(grid, dataset: dict | None = None, windowing: dict | None = None) -> dict:
     """Build the static ``morton_hive.json`` payload for one store (§3, D6).
 
     ``grid`` supplies the orders; ``dataset`` (typically the ShardMap's
@@ -138,10 +142,19 @@ def build_manifest(grid, dataset: dict | None = None) -> dict:
     to the shard order) but recorded explicitly for forward compatibility; the
     ``pyramid`` block is declared-only in round one (D11: overviews are a
     second-pass sweep, never written at fan-out time).
+
+    ``windowing`` (issue #246) is the normalized declaration from
+    :func:`zagg.config.get_windowing`; when given, the manifest declares
+    ``spec: "morton-hive/2"`` and carries the D15 **temporal block** — the
+    STATIC schema half of the temporal split (schedule, time encoding, the
+    membership ``time_field``, the explicit windows list, and the append
+    policy). Temporal EXTENT deliberately never lives here: actual ranges are
+    leaf-stamp truth and root-summary cache. ``None`` writes the ``/1``
+    manifest byte-identical to pre-windowing runs.
     """
     dataset = dataset or {}
-    return {
-        "spec": HIVE_SPEC,
+    manifest = {
+        "spec": HIVE_SPEC_V2 if windowing else HIVE_SPEC,
         "dataset": {
             "short_name": dataset.get("short_name"),
             "version": dataset.get("version"),
@@ -152,6 +165,24 @@ def build_manifest(grid, dataset: dict | None = None) -> dict:
         "pyramid": {"orders": [], "aggregation": {}},
         "generated_at": _utcnow(),
     }
+    if windowing:
+        temporal = {
+            "schedule": windowing["schedule"],
+            "time_field": windowing["time_field"],
+            "epoch": windowing["epoch"],
+            "scale": windowing["scale"],
+            "units": windowing["units"],
+            # Generative schedules append by adding leaves the schedule already
+            # describes (manifest untouched); the explicit list is the noted
+            # D15 exception — appending outside it re-templates the manifest.
+            "append_policy": (
+                "re-template" if windowing["schedule"] == "explicit" else "new-window"
+            ),
+        }
+        if windowing.get("windows"):
+            temporal["windows"] = windowing["windows"]
+        manifest["temporal"] = temporal
+    return manifest
 
 
 def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False, **store_kwargs):
@@ -204,10 +235,20 @@ def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False,
     return manifest
 
 
-#: Manifest keys the resume match-check compares (orders + identity + schedule).
-#: ``generated_at`` (a timestamp) and ``pyramid`` (populated by the §7 sweep,
-#: D11) are mutable by design and excluded.
-_FROZEN_MANIFEST_KEYS = ("spec", "dataset", "cell_order", "shard_order", "split_schedule")
+#: Manifest keys the resume match-check compares (orders + identity + split
+#: and temporal schedules — a windowing change re-partitions the leaf names,
+#: so it must refuse resume exactly like an orders change). ``generated_at``
+#: (a timestamp) and ``pyramid`` (populated by the §7 sweep, D11) are mutable
+#: by design and excluded. ``temporal`` projects to ``None`` on both sides for
+#: pre-#246 manifests, so existing stores resume unchanged.
+_FROZEN_MANIFEST_KEYS = (
+    "spec",
+    "dataset",
+    "cell_order",
+    "shard_order",
+    "split_schedule",
+    "temporal",
+)
 
 
 def _frozen(manifest: dict) -> dict:
@@ -847,6 +888,7 @@ __all__ = [
     "COVERAGE_SIDECAR",
     "COVERAGE_SPEC",
     "HIVE_SPEC",
+    "HIVE_SPEC_V2",
     "MANIFEST_NAME",
     "ROOT_COVERAGE_NAME",
     "build_coverage",

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -184,6 +184,11 @@ def build_manifest(grid, dataset: dict | None = None, windowing: dict | None = N
             "epoch": windowing["epoch"],
             "scale": windowing["scale"],
             "units": windowing["units"],
+            # D15 records calendar alongside encoding/units/epoch. Only
+            # proleptic_gregorian is supported this round: the three scales
+            # (utc/gps/tai) all derive from stdlib datetime, which is proleptic
+            # Gregorian.
+            "calendar": "proleptic_gregorian",
             # Generative schedules append by adding leaves the schedule already
             # describes (manifest untouched); the explicit list is the noted
             # D15 exception — appending outside it re-templates the manifest.

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -284,7 +284,9 @@ def read_manifest(store_root: str, **store_kwargs) -> dict | None:
     return _read_json(open_object_store(store_root, **store_kwargs), MANIFEST_NAME)
 
 
-def build_coverage(shard_key, occupied, cell_order: int, *, bitmap: bytes | None = None) -> dict:
+def build_coverage(
+    shard_key, occupied, cell_order: int, *, bitmap: bytes | None = None, full: bool = False
+) -> dict:
     """Coverage payload for one shard's commit stamp (§4, issue #200).
 
     ``occupied`` is the shard's occupied cell words (mixed order allowed —
@@ -309,7 +311,18 @@ def build_coverage(shard_key, occupied, cell_order: int, *, bitmap: bytes | None
     reader treats their absence as "box only". Raises ``ValueError`` if the
     box escapes the shard's subtree (occupied cells from another shard are
     an upstream bug, never stamped).
+
+    ``full`` (issue #246, D14) marks whole-subtree coverage: the ``encoding``
+    discriminator becomes ``"full"`` and NO sidecar is written or pointed to
+    — the shard id itself is the exact MOC, so readers skip the sidecar GET
+    entirely. Decided by one popcount at stamp time (the caller's job);
+    mutually exclusive with ``bitmap``.
     """
+    if full and bitmap is not None:
+        raise ValueError(
+            "full=True and a bitmap payload are mutually exclusive: a fully "
+            "occupied subtree writes no sidecar (D14)"
+        )
     from zagg.grids.morton import morton_box, morton_decimal
 
     shard = morton_decimal(shard_key)
@@ -329,7 +342,9 @@ def build_coverage(shard_key, occupied, cell_order: int, *, bitmap: bytes | None
         "cell_order": int(cell_order),
         "source": "worker",
     }
-    if bitmap is not None:
+    if full:
+        coverage["encoding"] = "full"
+    elif bitmap is not None:
         n_bits = 4 ** (int(cell_order) - _decimal_order(shard))
         coverage.update(
             encoding="bitmap",
@@ -458,14 +473,19 @@ def write_coverage_sidecar(leaf_root: str, payload: bytes, **store_kwargs) -> No
     obstore.put(open_object_store(leaf_root, **store_kwargs), COVERAGE_SIDECAR, payload)
 
 
-def read_coverage_bitmap(leaf_root: str, **store_kwargs) -> np.ndarray | None:
+def read_coverage_bitmap(
+    leaf_root: str, *, coverage: dict | None = None, **store_kwargs
+) -> np.ndarray | None:
     """A leaf's exact occupied cell words from its sidecar, or ``None``.
 
     Gates on the committed stamp's envelope (:func:`read_coverage`): no
     stamp, a box-only phase-1 payload (no ``encoding``/``sidecar`` keys), an
     unknown encoding, or a missing sidecar object all read ``None`` — the
     box is then the only index and readers degrade per D9, never to wrong
-    answers. A PRESENT-but-corrupt sidecar raises instead (see
+    answers. An ``encoding: "full"`` envelope (issue #246, D14) also reads
+    ``None`` here — there IS no sidecar; the shard id itself is the exact
+    MOC and :func:`zagg.coverage.bitmap_and` short-circuits on it. Pass an
+    already-read ``coverage`` envelope to skip the stamp GET. A PRESENT-but-corrupt sidecar raises instead (see
     :func:`decode_coverage_bitmap` — degrading a corrupt payload would be
     indistinguishable from healthy box-only coverage). The shard id comes
     from the leaf basename — ``{full_id}.zarr``, or the windowed
@@ -479,7 +499,8 @@ def read_coverage_bitmap(leaf_root: str, **store_kwargs) -> np.ndarray | None:
     from zagg.grids.morton import morton_word
     from zagg.store import open_store
 
-    coverage = read_coverage(open_store(leaf_root, **store_kwargs))
+    if coverage is None:
+        coverage = read_coverage(open_store(leaf_root, **store_kwargs))
     if not coverage or coverage.get("encoding") != "bitmap" or not coverage.get("sidecar"):
         return None
     # Windowed leaves (issue #246) carry `{full_id}_{window}.zarr` basenames;
@@ -494,7 +515,13 @@ def read_coverage_bitmap(leaf_root: str, **store_kwargs) -> np.ndarray | None:
 
 
 def stamp_commit(
-    leaf_store, *, cells_with_data: int, granule_count: int, coverage: dict | None = None
+    leaf_store,
+    *,
+    cells_with_data: int,
+    granule_count: int,
+    coverage: dict | None = None,
+    window: str | None = None,
+    time_range: tuple | list | None = None,
 ) -> None:
     """Stamp a shard leaf complete — the shard's FINAL write (D4).
 
@@ -504,15 +531,32 @@ def stamp_commit(
     overwrite the prefix wholesale. ``coverage`` (issue #200) attaches the
     tier-0 payload from :func:`build_coverage`; ``None`` writes the
     pre-coverage stamp unchanged.
+
+    ``window``/``time_range`` (issue #246, D15): a windowed leaf's stamp is
+    the TRUTH half of the temporal split — it records the window label and
+    the actual ``[t_min, t_max]`` written, as ISO-8601 UTC strings (ratified
+    on the #246 thread; the manifest keeps only the static schedule). A
+    windowed stamp declares ``spec: "morton-hive/2"``; unwindowed stamps stay
+    ``/1``, byte-identical to pre-windowing runs. ``time_range`` without a
+    ``window`` is rejected — unwindowed leaf extent stays data-plane only.
     """
+    if window is None and time_range is not None:
+        raise ValueError(
+            "time_range rides windowed stamps only (D15: unwindowed leaves make "
+            "no extent claim in the stamp); pass window= as well"
+        )
     group = zarr.open_group(leaf_store, path="", mode="r+", zarr_format=3)
     stamp: dict = {
-        "spec": HIVE_SPEC,
+        "spec": HIVE_SPEC if window is None else HIVE_SPEC_V2,
         "complete": True,
         "cells_with_data": int(cells_with_data),
         "granule_count": int(granule_count),
         "written_at": _utcnow(),
     }
+    if window is not None:
+        stamp["window"] = str(window)
+        if time_range is not None:
+            stamp["time_range"] = [str(t) for t in time_range]
     if coverage is not None:
         stamp["coverage"] = coverage
     group.attrs[COMMIT_ATTR] = stamp
@@ -578,7 +622,9 @@ def _rank_tail(rank: int, depth: int) -> str:
     return "".join(reversed(digits))
 
 
-def build_root_coverage(shard_keys, order: int, *, source: str = "dispatcher") -> dict:
+def build_root_coverage(
+    shard_keys, order: int, *, source: str = "dispatcher", time_range: tuple | list | None = None
+) -> dict:
     """Store-root coverage envelope from completed shard keys (issue #200 phase 3).
 
     The O1 serialization: JSON ranges under the ``morton-moc/1`` envelope,
@@ -591,6 +637,12 @@ def build_root_coverage(shard_keys, order: int, *, source: str = "dispatcher") -
     packed-word order — the bitmap's rank convention at the root). Endpoints
     are D1 decimal STRINGS: packed u64 words exceed 2^53, so raw JSON
     numbers would be silently mangled by any float-based parser (O1).
+
+    ``time_range`` (issue #246, D15): the root summary optionally carries the
+    ``[min, max]`` ISO-8601 UTC union of the run's leaf-stamp time ranges —
+    CACHE, never truth (the per-leaf stamps are the truth; the walk and the
+    sweep regenerate this). Omitted for unwindowed stores, keeping their root
+    object byte-identical to pre-#246 runs.
     """
     from zagg.grids.morton import to_morton_array
 
@@ -616,7 +668,7 @@ def build_root_coverage(shard_keys, order: int, *, source: str = "dispatcher") -
         ranges.append([start, prev])
         start = prev = dec
     ranges.append([start, prev])
-    return {
+    envelope = {
         "spec": COVERAGE_SPEC,
         "encoding": "ranges",
         "order": int(order),
@@ -624,6 +676,9 @@ def build_root_coverage(shard_keys, order: int, *, source: str = "dispatcher") -
         "generated_at": _utcnow(),
         "ranges": ranges,
     }
+    if time_range is not None:
+        envelope["time_range"] = [str(t) for t in time_range]
+    return envelope
 
 
 def root_coverage_words(envelope: dict) -> np.ndarray:
@@ -654,6 +709,31 @@ def root_coverage_words(envelope: dict) -> np.ndarray:
             raise ValueError(f"malformed coverage range [{lo}, {hi}] at order {order}")
         words.extend(morton_word(base + _rank_tail(r, order)) for r in range(lo_rank, hi_rank + 1))
     return np.unique(np.asarray(words, dtype=np.uint64))
+
+
+def union_time_range(*ranges) -> list | None:
+    """The ``[min, max]`` ISO-UTC union of time ranges; ``None``s drop out.
+
+    Malformed entries (non-2-sequences, unparsable instants) are DROPPED with
+    a warning rather than raised: the union feeds cache carriers (the root
+    summary, D15) whose write paths are fail-open — a bad cached range must
+    not fail the run, and the leaf stamps remain the truth.
+    """
+    from zagg.windows import iso_utc, parse_utc
+
+    starts, ends = [], []
+    for r in ranges:
+        if r is None:
+            continue
+        try:
+            lo, hi = r
+            starts.append(parse_utc(lo))
+            ends.append(parse_utc(hi))
+        except (TypeError, ValueError) as e:
+            logger.warning(f"dropping malformed time_range {r!r} from the union ({e})")
+    if not starts:
+        return None
+    return [iso_utc(min(starts)), iso_utc(max(ends))]
 
 
 def write_root_coverage(store_root: str, envelope: dict, **store_kwargs) -> dict:
@@ -694,7 +774,14 @@ def write_root_coverage(store_root: str, envelope: dict, **store_kwargs) -> dict
             try:
                 union = np.union1d(root_coverage_words(existing), root_coverage_words(envelope))
                 merged = build_root_coverage(
-                    union, int(envelope["order"]), source=envelope.get("source", "dispatcher")
+                    union,
+                    int(envelope["order"]),
+                    source=envelope.get("source", "dispatcher"),
+                    # D15: incremental runs accumulate the time union too —
+                    # cache semantics identical to the spatial ranges.
+                    time_range=union_time_range(
+                        existing.get("time_range"), envelope.get("time_range")
+                    ),
                 )
             except (KeyError, TypeError, ValueError) as e:
                 logger.warning(
@@ -928,6 +1015,7 @@ __all__ = [
     "root_coverage_words",
     "shard_leaf_path",
     "stamp_commit",
+    "union_time_range",
     "write_coverage_sidecar",
     "write_root_coverage",
 ]

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -57,6 +57,7 @@ import zarr
 from zarr.errors import GroupNotFoundError
 
 from zagg.store import open_object_store
+from zagg.windows import leaf_name, split_leaf_name
 
 logger = logging.getLogger(__name__)
 
@@ -90,13 +91,16 @@ _ZSTD_LEVEL = 3
 ROOT_COVERAGE_NAME = "coverage.moc"
 
 
-def shard_leaf_path(store_root: str, shard_key) -> str:
+def shard_leaf_path(store_root: str, shard_key, window: str | None = None) -> str:
     """Absolute path of a shard's leaf zarr under ``store_root`` (D2/D3).
 
     Computed by mortie's ``hive_path`` — the layout convention is owned by the
     mortie spec — and re-checked against the node invariant (D5) so a future
     drift in either side fails loudly instead of writing a stray prefix.
-    Raises ``ValueError`` on an invalid shard key.
+    ``window`` (issue #246, D13) selects the shard's time-windowed leaf,
+    ``{full_id}_{window}.zarr``, at the same node; ``None`` is the bare
+    schedule-``none`` leaf, byte-identical to pre-windowing paths. Raises
+    ``ValueError`` on an invalid shard key or window label.
     """
     from mortie import MortonIndexArray
 
@@ -107,6 +111,9 @@ def shard_leaf_path(store_root: str, shard_key) -> str:
             f"id with zagg.grids.morton.morton_word first"
         )
     rel = MortonIndexArray.from_words(np.asarray([word], dtype=np.uint64)).hive_path()[0]
+    if window is not None:
+        node, _sep, bare = rel.rpartition("/")
+        rel = f"{node}/{leaf_name(bare.removesuffix('.zarr'), window)}"
     check_node_invariant(rel)
     return f"{store_root.rstrip('/')}/{rel}"
 
@@ -116,19 +123,24 @@ def check_node_invariant(rel_path: str) -> None:
 
     Below the root only digit components are allowed — ``{sign+base}``
     (optional ``-``, one digit ``1..6``) at the first level, one ``1..4`` digit
-    per level after — terminating in ``{full_id}.zarr`` whose id equals the
-    concatenated components. This is the walker's contract: any other name
-    under the root (bar the manifest and the future ``coverage.moc``) breaks
-    child classification.
+    per level after — terminating in ``{full_id}.zarr`` (or the windowed
+    ``{full_id}_{window}.zarr``, issue #246: split on the first ``_``, window
+    label per the frozen grammar) whose id equals the concatenated components.
+    This is the walker's contract: any other name under the root (bar the
+    manifest and the root ``coverage.moc``) breaks child classification.
     """
     parts = rel_path.strip("/").split("/")
     leaf = parts[-1]
     ok = len(parts) >= 2 and leaf.endswith(".zarr")
     if ok:
         head, digits = parts[0], parts[1:-1]
+        try:
+            full_id, _window = split_leaf_name(leaf)
+        except ValueError:
+            full_id = None  # malformed window label -> not a legal leaf
         ok = _is_base_component(head)
         ok = ok and all(len(d) == 1 and d in "1234" for d in digits)
-        ok = ok and leaf[: -len(".zarr")] == head + "".join(digits)
+        ok = ok and full_id == head + "".join(digits)
     if not ok:
         raise ValueError(f"path {rel_path!r} violates the hive node invariant (D5)")
 
@@ -450,9 +462,11 @@ def read_coverage_bitmap(leaf_root: str, **store_kwargs) -> np.ndarray | None:
     box is then the only index and readers degrade per D9, never to wrong
     answers. A PRESENT-but-corrupt sidecar raises instead (see
     :func:`decode_coverage_bitmap` — degrading a corrupt payload would be
-    indistinguishable from healthy box-only coverage). The shard id comes from the leaf's ``{full_id}.zarr`` basename;
-    ``cell_order`` from the envelope. One GET, paid only by readers that
-    want cell-level filtering.
+    indistinguishable from healthy box-only coverage). The shard id comes
+    from the leaf basename — ``{full_id}.zarr``, or the windowed
+    ``{full_id}_{window}.zarr`` (issue #246) — via the frozen first-``_``
+    split; ``cell_order`` from the envelope. One GET, paid only by readers
+    that want cell-level filtering.
     """
     import obstore
     from obstore.exceptions import NotFoundError
@@ -463,8 +477,9 @@ def read_coverage_bitmap(leaf_root: str, **store_kwargs) -> np.ndarray | None:
     coverage = read_coverage(open_store(leaf_root, **store_kwargs))
     if not coverage or coverage.get("encoding") != "bitmap" or not coverage.get("sidecar"):
         return None
-    leaf_name = leaf_root.rstrip("/").rsplit("/", 1)[-1]
-    shard = morton_word(leaf_name.removesuffix(".zarr"))
+    # Windowed leaves (issue #246) carry `{full_id}_{window}.zarr` basenames;
+    # the shard id is the part before the first `_` (the frozen parse rule).
+    shard = morton_word(split_leaf_name(leaf_root.rstrip("/").rsplit("/", 1)[-1])[0])
     store = open_object_store(leaf_root, **store_kwargs)
     try:
         data = obstore.get(store, str(coverage["sidecar"])).bytes()

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -555,6 +555,27 @@ def stamp_commit(
     if window is not None:
         stamp["window"] = str(window)
         if time_range is not None:
+            # The stamp is the D15 TRUTH half — it fails CLOSED on a bad range
+            # (unlike the fail-open cache union). Validate a 2-sequence of
+            # parseable UTC instants with t_min <= t_max before it becomes
+            # durable truth; the production path already builds this via
+            # windows.iso_time_range (worker min/max, ordered), so this guards
+            # direct callers. (review finding, PR #248)
+            from zagg.windows import parse_utc
+
+            try:
+                lo, hi = time_range
+                lo_dt, hi_dt = parse_utc(lo), parse_utc(hi)
+            except (TypeError, ValueError) as e:
+                raise ValueError(
+                    f"time_range must be a 2-sequence of parseable UTC instants "
+                    f"[t_min, t_max]; got {time_range!r} ({e})"
+                ) from e
+            if lo_dt > hi_dt:
+                raise ValueError(
+                    f"time_range is reversed: t_min {lo!r} follows t_max {hi!r} "
+                    f"(the D15 stamp is truth and must fail closed on a bad range)"
+                )
             stamp["time_range"] = [str(t) for t in time_range]
     if coverage is not None:
         stamp["coverage"] = coverage

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -57,7 +57,7 @@ import zarr
 from zarr.errors import GroupNotFoundError
 
 from zagg.store import open_object_store
-from zagg.windows import leaf_name, split_leaf_name
+from zagg.windows import leaf_name, split_leaf_name, union_time_range
 
 logger = logging.getLogger(__name__)
 
@@ -533,12 +533,11 @@ def stamp_commit(
     pre-coverage stamp unchanged.
 
     ``window``/``time_range`` (issue #246, D15): a windowed leaf's stamp is
-    the TRUTH half of the temporal split — it records the window label and
-    the actual ``[t_min, t_max]`` written, as ISO-8601 UTC strings (ratified
-    on the #246 thread; the manifest keeps only the static schedule). A
-    windowed stamp declares ``spec: "morton-hive/2"``; unwindowed stamps stay
-    ``/1``, byte-identical to pre-windowing runs. ``time_range`` without a
-    ``window`` is rejected — unwindowed leaf extent stays data-plane only.
+    the TRUTH half of the temporal split — the window label plus the actual
+    ``[t_min, t_max]`` written, as ISO-8601 UTC strings (ratified #246 Q2;
+    the manifest keeps only the static schedule). A windowed stamp declares
+    ``spec: "morton-hive/2"``; unwindowed stamps stay ``/1`` byte-identical.
+    ``time_range`` without ``window`` is rejected (no unwindowed extent claim).
     """
     if window is None and time_range is not None:
         raise ValueError(
@@ -711,31 +710,6 @@ def root_coverage_words(envelope: dict) -> np.ndarray:
     return np.unique(np.asarray(words, dtype=np.uint64))
 
 
-def union_time_range(*ranges) -> list | None:
-    """The ``[min, max]`` ISO-UTC union of time ranges; ``None``s drop out.
-
-    Malformed entries (non-2-sequences, unparsable instants) are DROPPED with
-    a warning rather than raised: the union feeds cache carriers (the root
-    summary, D15) whose write paths are fail-open — a bad cached range must
-    not fail the run, and the leaf stamps remain the truth.
-    """
-    from zagg.windows import iso_utc, parse_utc
-
-    starts, ends = [], []
-    for r in ranges:
-        if r is None:
-            continue
-        try:
-            lo, hi = r
-            starts.append(parse_utc(lo))
-            ends.append(parse_utc(hi))
-        except (TypeError, ValueError) as e:
-            logger.warning(f"dropping malformed time_range {r!r} from the union ({e})")
-    if not starts:
-        return None
-    return [iso_utc(min(starts)), iso_utc(max(ends))]
-
-
 def write_root_coverage(store_root: str, envelope: dict, **store_kwargs) -> dict:
     """GET-union-PUT the store-root ``coverage.moc`` (issue #200 phase 3).
 
@@ -828,6 +802,7 @@ def process_and_write_hive(
     handoff="arrow",
     aoi_payload=None,
     profile=False,
+    window=None,
 ):
     """Process one shard into its own hive leaf store (issue #199 phase 2).
 
@@ -850,6 +825,16 @@ def process_and_write_hive(
     ``profile`` forwards to ``process_shard`` (issue #100); the write phase is
     interleaved with the stream (or a single post-stream pass when sharded),
     so no separate ``write`` timing is recorded.
+
+    ``window`` (issue #246, D13/D15) is one dispatch unit's time window:
+    ``{"label", "start", "end"}``, bounds half-open in DATASET units
+    (converted once at dispatch). It selects the windowed leaf name, injects
+    the observation-level ``time_field`` filter (the temporal analog of
+    ``aoi_mask`` — see :func:`zagg.config.windowed_cell_config`), stamps the
+    window label + the ACTUAL written ISO-UTC time range (also returned as
+    ``metadata["time_range"]`` for the root-summary union), and arms the D14
+    popcount (``encoding: "full"``). ``None`` is byte-identical to
+    pre-windowing behavior.
     """
     from zagg.processing import (
         process_shard,
@@ -859,7 +844,17 @@ def process_and_write_hive(
     )
     from zagg.store import open_store
 
-    leaf_path = shard_leaf_path(store_root, shard_key)
+    windowing = None
+    time_range_of = None
+    if window is not None:
+        from zagg.config import windowed_cell_config
+
+        # Inject the window's observation filter into a per-unit config copy
+        # (the issue #43 machinery — see windowed_cell_config).
+        config, windowing = windowed_cell_config(config, window)
+        time_range_of = windowing["time_field"]
+
+    leaf_path = shard_leaf_path(store_root, shard_key, window=window["label"] if window else None)
     box: dict = {}
 
     def _leaf():
@@ -932,8 +927,18 @@ def process_and_write_hive(
         chunk_results=chunk_results,
         write_chunk=None if sharded else _write_chunk,
         occupied_out=occupied,
+        time_range_of=time_range_of,
         profile=profile,
     )
+    # Windowed stamp truth (D15): convert the worker's dataset-unit extent to
+    # ISO-8601 UTC once, here — the same strings feed the stamp below and the
+    # dispatcher's root-summary union (via the returned metadata).
+    time_range = None
+    if window is not None and metadata.get("time_range") is not None:
+        from zagg.windows import iso_time_range
+
+        time_range = iso_time_range(metadata["time_range"], windowing)
+        metadata["time_range"] = time_range
     # Sharded leaf: ONE whole-leaf write per array (dense + ragged together,
     # issue #236), after the stream. The leaf template is emitted here (still
     # lazily, via ``_leaf``), so a shard that produced no chunks never creates
@@ -956,19 +961,27 @@ def process_and_write_hive(
         if words is not None and words.size == 0:
             words = None
         bitmap = None
+        # D14 popcount (issue #246): a fully-occupied subtree stamps
+        # ``encoding: "full"``, no sidecar. Gated on windowing (/2 stores
+        # only) so schedule-none output stays object-for-object identical to
+        # pre-#246 runs (the mortie spec files "full" under /2).
+        depth = int(grid.child_order) - int(grid.parent_order)
+        full = window is not None and words is not None and np.unique(words).size == 4**depth
         # Depth 0 (child_order == parent_order, a legal one-cell-per-shard
         # config) skips the sidecar: a 1-bit bitmap says nothing the stamp
         # itself doesn't, and encode would raise AFTER the chunk writes,
         # leaving the shard permanently unstampable debris (review finding,
         # PR #208 round 2). The envelope simply omits the pointer — box only.
-        if words is not None and int(grid.child_order) > int(grid.parent_order):
+        if words is not None and not full and depth > 0:
             bitmap = encode_coverage_bitmap(shard_key, words, grid.child_order)
             write_coverage_sidecar(leaf_path, bitmap, **store_kwargs)
         stamp_commit(
             box["store"],
             cells_with_data=metadata.get("cells_with_data", 0),
             granule_count=metadata.get("granule_count", 0),
-            coverage=build_coverage(shard_key, words, grid.child_order, bitmap=bitmap),
+            coverage=build_coverage(shard_key, words, grid.child_order, bitmap=bitmap, full=full),
+            window=window["label"] if window else None,
+            time_range=time_range,
         )
     return metadata
 
@@ -1015,7 +1028,6 @@ __all__ = [
     "root_coverage_words",
     "shard_leaf_path",
     "stamp_commit",
-    "union_time_range",
     "write_coverage_sidecar",
     "write_root_coverage",
 ]

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -101,6 +101,7 @@ def process_shard(
     aoi_payload=None,
     write_chunk: Callable | None = None,
     occupied_out: list | None = None,
+    time_range_of: str | None = None,
     profile: bool = False,
 ) -> Tuple[pd.DataFrame, ProcessingMetadata]:
     """Process one shard: read granules, filter to this shard, aggregate, return df.
@@ -193,6 +194,17 @@ def process_shard(
         appended after the shard's reads are grouped. The hive write path uses
         it to derive the commit stamp's coverage payload; ``None`` (default)
         records nothing — byte-for-byte unchanged.
+    time_range_of : str, optional
+        Column name whose observed ``[min, max]`` is reported as
+        ``metadata["time_range"]`` (issue #246): the ACTUAL dataset-unit time
+        extent of the shard's surviving observations, which the hive write
+        path converts to the windowed stamp's ISO-UTC ``time_range`` (D15
+        truth). Read AFTER all filters, off the pooled column arrays — so it
+        reflects exactly what was written. ``None`` (default) records nothing
+        — byte-for-byte unchanged. The streaming buffered path (issue #148)
+        does not pool columns, so the key is omitted there; the column must
+        be a read column (declared, e.g. the windowing ``time_field``) or the
+        key is likewise omitted.
     profile : bool, optional
         Opt-in per-phase timing (issue #100 phase 2). When ``True``, fills
         ``metadata["phase_timings"]`` with ``read`` / ``index`` / ``aggregate``
@@ -545,6 +557,14 @@ def process_shard(
     else:
         col_arrays, cell_to_slice, n_obs_total = _concat_and_group(all_reads, grid, handoff)
         logger.info(f"  Read {n_obs_total:,} observations")
+
+    # Actual time extent (issue #246): min/max of the declared time column
+    # over the pooled (post-filter) observations — two reductions on an array
+    # already in hand. The buffered/streaming path holds no pooled columns, so
+    # windowed streaming stamps simply omit their time_range (documented).
+    if time_range_of is not None and time_range_of in col_arrays and n_obs_total:
+        col = col_arrays[time_range_of]
+        metadata["time_range"] = [float(col.min()), float(col.max())]
 
     # Occupied-cell sink (issue #200): both paths already key per-cell state by
     # the packed cell word — ``cell_to_slice`` pooled, ``buffered.counts``

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -45,6 +45,7 @@ from zagg.config import (
     get_pipeline_type,
     get_store_layout,
     get_store_path,
+    get_windowing,
 )
 from zagg.dispatch import (
     LAMBDA_MEMORY_GB,
@@ -1384,6 +1385,95 @@ def _aoi_payload_map(catalog_data: dict) -> dict:
     return {int(k): payload for k, payload in zip(catalog_data["shard_keys"], aoi)}
 
 
+def _granule_time_span(record: dict):
+    """A granule record's ``(start, end)`` UTC instants, or ``None`` (issue #246).
+
+    New shardmaps carry ``time_start``/``time_end`` (from the catalog's STAC
+    ``start_datetime``/``end_datetime``); raster records carry the instant
+    ``datetime``. A record with neither (a legacy shardmap) returns ``None``
+    — the fan-out then treats it as intersecting EVERY window (conservative:
+    the worker's observation-level filter enforces correctness) and window
+    enumeration falls back to ``bounds.temporal``.
+    """
+    from zagg.windows import parse_utc
+
+    start = record.get("time_start") or record.get("datetime")
+    if start is None:
+        return None
+    end = record.get("time_end") or start
+    return parse_utc(start), parse_utc(end)
+
+
+def _windowed_units(cells: list[tuple], windowing: dict, bounds_temporal: dict | None) -> list:
+    """Expand ``(shard, records)`` pairs into ``(shard, records, window)`` units.
+
+    One work unit per (shard, window) with a non-empty granule subset (issue
+    #246 phase 5): the run's window labels come from the declared explicit
+    list, or — for generative schedules — from the union of the granules'
+    time spans (legacy shardmaps without per-granule times fall back to
+    ``bounds.temporal``, or fail with a pointed remedy). Each unit's
+    ``window`` dict carries the label plus its half-open ``[start, end)``
+    bounds converted ONCE to dataset units (the ratified fixed-offset
+    conversion); granules subset per window by span intersection, spans
+    unknown → every window (the worker filter decides membership).
+    """
+    from zagg.windows import parse_utc, utc_to_offset, window_range, windows_intersecting
+
+    schedule, declared = windowing["schedule"], windowing.get("windows")
+    spans = {id(r): _granule_time_span(r) for _k, records in cells for r in records}
+    if schedule == "explicit":
+        labels = [w["label"] for w in declared]
+    else:
+        found: set = set()
+        for span in spans.values():
+            if span is not None:
+                found.update(windows_intersecting(*span, schedule))
+        if any(span is None for span in spans.values()):
+            if not bounds_temporal:
+                raise ValueError(
+                    "windowing with a generative schedule needs per-granule time "
+                    "metadata to enumerate windows, but this shardmap predates it "
+                    "(no time_start/time_end on its granule records) — rebuild the "
+                    "shardmap with `python -m zagg.catalog`, or set bounds.temporal "
+                    "{start_date, end_date} on the run config"
+                )
+            found.update(
+                windows_intersecting(
+                    parse_utc(bounds_temporal["start_date"]),
+                    parse_utc(f"{bounds_temporal['end_date']}T23:59:59"),
+                    schedule,
+                )
+            )
+        labels = sorted(found)
+    to_dataset = {
+        "epoch": windowing["epoch"],
+        "scale": windowing["scale"],
+        "units": windowing["units"],
+    }
+    windows = []
+    for label in labels:
+        lo, hi = window_range(label, schedule, declared)
+        payload = {
+            "label": label,
+            "start": utc_to_offset(lo, **to_dataset),
+            "end": utc_to_offset(hi, **to_dataset),
+        }
+        windows.append((payload, lo, hi))
+    # Shard-major expansion: the incoming cell order (the issue #197 shuffle,
+    # the lambda biggest-first buckets) is preserved, windows fan out within it.
+    units = []
+    for shard_key, records in cells:
+        for payload, lo, hi in windows:
+            subset = [
+                r
+                for r in records
+                if (span := spans[id(r)]) is None or (span[0] < hi and span[1] >= lo)
+            ]
+            if subset:
+                units.append((shard_key, subset, payload))
+    return units
+
+
 def _resolve_source_credentials(config) -> dict:
     """S3 read credentials for the source datasets, provider-selected.
 
@@ -1597,6 +1687,7 @@ def _run_local(
         "credentials": output_credentials,
         "endpoint_url": output_endpoint_url,
     }
+    windowing = get_windowing(config)
     if store_layout == "hive":
         # Hive layout (issue #199 phase 2): no shared zarr template — zero
         # metadata above the leaves (D5). Template time writes only the root
@@ -1607,11 +1698,16 @@ def _run_local(
 
         ensure_manifest(
             store_path,
-            build_manifest(grid, dataset=catalog_data.get("metadata")),
+            build_manifest(grid, dataset=catalog_data.get("metadata"), windowing=windowing),
             overwrite=overwrite,
             **store_kwargs,
         )
         zarr_store = None
+        # Temporal fan-out (issue #246 phase 5): one work unit per (shard,
+        # window). None (schedule none/absent) keeps the (shard, records)
+        # pairs — dispatch byte-identical to pre-windowing runs.
+        if windowing is not None:
+            cells = _windowed_units(cells, windowing, (config.bounds or {}).get("temporal"))
     else:
         zarr_store = open_store(store_path, **store_kwargs)
         zarr_store = grid.emit_template(zarr_store, overwrite=overwrite)
@@ -1621,13 +1717,18 @@ def _run_local(
     # outcome is tagged in a private envelope the accumulator unpacks; on the
     # error path nothing is appended to ``results``, matching the old behavior.
     def _cell_work(payload):
-        shard_key, records = payload
+        # (shard, records) pairs, or (shard, records, window) triples when a
+        # window schedule fanned the dispatch (issue #246).
+        shard_key, records = payload[0], payload[1]
+        window = payload[2] if len(payload) > 2 else None
         # Only thread aoi_payload when the manifest actually carries a mask (flag
         # on); otherwise omit the kwarg entirely so the flag-off call is identical
-        # to the pre-feature signature.
+        # to the pre-feature signature. Same posture for the window unit.
         extra = {}
         if aoi_by_shard:
             extra["aoi_payload"] = aoi_by_shard.get(int(shard_key))
+        if window is not None:
+            extra["window"] = window
         # Per-cell granule_workers clamp (issue #184): min(K, n_granules), so
         # a small cell doesn't spin idle reader threads; unclamped cells pass
         # the shared config through untouched. Count the RESOLVED urls — what
@@ -1722,13 +1823,22 @@ def _run_local(
     # failed write costs readers one walk, never a wrong answer.
     if store_layout == "hive" and get_coverage_moc(config):
         from zagg.hive import build_root_coverage, write_root_coverage
+        from zagg.windows import union_time_range
 
         try:
             # Inside the try so the fail-open claim survives result-envelope
             # refactors (review finding, PR #208 round 3).
-            done = [m["shard_key"] for m in report.results if not m.get("error")]
+            ok_results = [m for m in report.results if not m.get("error")]
+            done = [m["shard_key"] for m in ok_results]
             if done:
-                envelope = build_root_coverage(done, int(grid.parent_order))
+                # D15: windowed runs union the leaf stamps' ISO time ranges
+                # into the root summary; unwindowed metas carry no time_range,
+                # the union is None, and the envelope stays byte-identical.
+                envelope = build_root_coverage(
+                    done,
+                    int(grid.parent_order),
+                    time_range=union_time_range(*(m.get("time_range") for m in ok_results)),
+                )
                 write_root_coverage(store_path, envelope, **store_kwargs)
                 logger.info(f"Wrote root coverage.moc ({len(envelope['ranges'])} ranges)")
         except Exception as e:
@@ -1808,6 +1918,13 @@ def _run_lambda(
 
     if dry_run:
         return _dry_run_summary(cells, store_path)
+
+    # Temporal fan-out (issue #246 phase 5): one work unit per (shard,
+    # window); the biggest-first bucket order above survives (shard-major
+    # expansion). None keeps the pairs — dispatch byte-identical.
+    windowing = get_windowing(config)
+    if windowing is not None:
+        cells = _windowed_units(cells, windowing, (config.bounds or {}).get("temporal"))
 
     # Authenticate (for per-cell source reads inside the Lambda)
     s3_creds = _resolve_source_credentials(config)
@@ -1902,7 +2019,10 @@ def _run_lambda(
     # the executor submits one payload per cell. Mirrors the kwargs the old
     # inline ``executor.submit(_invoke_lambda_cell, ...)`` passed.
     def _cell_work(payload):
-        shard_key, records = payload
+        # (shard, records) pairs, or (shard, records, window) triples when a
+        # window schedule fanned the dispatch (issue #246).
+        shard_key, records = payload[0], payload[1]
+        window = payload[2] if len(payload) > 2 else None
         # Rendered once per cell: the status-object name (below) and the
         # payload-cap error message in _invoke_lambda_cell both carry it
         # (issue #199). On ASYNC runs the label becomes a path component (the
@@ -1920,6 +2040,8 @@ def _run_lambda(
         extra = {}
         if aoi_by_shard:
             extra["aoi_payload"] = aoi_by_shard.get(int(shard_key))
+        if window is not None:
+            extra["window"] = window
         # Async dispatch (issue #151): where the worker writes this shard's
         # result, how to poll for it, and how long before giving up (function
         # timeout + queue/write margin). Sync runs pass none of these, keeping
@@ -1927,7 +2049,10 @@ def _run_lambda(
         if result_prefix is not None:
             # Status objects are named by the shard label — the decimal morton
             # string for HEALPix (issue #199) — not the raw packed word.
-            key = f"{label}.json"
+            # Windowed units suffix the window label (mirroring the leaf
+            # naming) so two windows of one shard cannot clobber each other's
+            # status object (issue #246).
+            key = f"{label}.json" if window is None else f"{label}_{window['label']}.json"
             extra["result_url"] = f"{result_prefix}/{key}"
             extra["result_fetch"] = _result_fetcher(
                 result_box, result_prefix, output_creds_event, region, key
@@ -2089,16 +2214,25 @@ def _run_lambda(
     if get_store_layout(config) == "hive" and get_coverage_moc(config):
         try:
             from zagg.hive import build_root_coverage
+            from zagg.windows import union_time_range
 
             # Inside the try so the fail-open claim survives result-envelope
             # refactors (review finding, PR #208 round 3).
-            done = [
-                r["shard_key"]
-                for r in report.results
-                if r.get("status_code") == 200 and not r.get("error")
+            ok_results = [
+                r for r in report.results if r.get("status_code") == 200 and not r.get("error")
             ]
+            done = [r["shard_key"] for r in ok_results]
             if done:
-                envelope = build_root_coverage(done, int(parent_order))
+                # D15: union the windowed workers' stamped time ranges (each
+                # body mirrors its leaf stamp's ISO strings); unwindowed
+                # bodies carry none and the envelope stays byte-identical.
+                envelope = build_root_coverage(
+                    done,
+                    int(parent_order),
+                    time_range=union_time_range(
+                        *(r.get("body", {}).get("time_range") for r in ok_results)
+                    ),
+                )
                 # An OLD deployment has no coverage mode: the event falls
                 # through to its process handler, which returns a LOGGED 400
                 # (missing shard_key/granule_urls...) — no writes, no result
@@ -2885,6 +3019,7 @@ def _invoke_lambda_cell(
     handoff="arrow",
     profile=False,
     aoi_payload=None,
+    window=None,
     result_url=None,
     result_fetch=None,
     poll_timeout_s=None,
@@ -2944,6 +3079,11 @@ def _invoke_lambda_cell(
     # to the pre-feature event (issue #101).
     if aoi_payload is not None:
         event["aoi_payload"] = aoi_payload
+    # Temporal window unit (issue #246): {"label", "start", "end"} with the
+    # half-open bounds in dataset units, converted once at dispatch. Absent
+    # (schedule none) keeps the event byte-identical to pre-windowing runs.
+    if window is not None:
+        event["window"] = window
     # Add the key for the arrow carrier (the default); an explicit pandas run omits
     # it, staying byte-identical to the pre-handoff path (#130).
     if handoff and handoff != "pandas":

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1437,10 +1437,16 @@ def _windowed_units(cells: list[tuple], windowing: dict, bounds_temporal: dict |
                     "shardmap with `python -m zagg.catalog`, or set bounds.temporal "
                     "{start_date, end_date} on the run config"
                 )
+            # A bare ``YYYY-MM-DD`` end_date means end-of-day; a full ISO
+            # instant is parsed verbatim (appending the suffix unconditionally
+            # would corrupt e.g. ``2020-12-31T00:00:00Z`` into a parse error).
+            end_date = bounds_temporal["end_date"]
+            if isinstance(end_date, str) and len(end_date) == 10 and "T" not in end_date:
+                end_date = f"{end_date}T23:59:59"
             found.update(
                 windows_intersecting(
                     parse_utc(bounds_temporal["start_date"]),
-                    parse_utc(f"{bounds_temporal['end_date']}T23:59:59"),
+                    parse_utc(end_date),
                     schedule,
                 )
             )

--- a/src/zagg/viz/crs.py
+++ b/src/zagg/viz/crs.py
@@ -20,6 +20,7 @@ client-side -- so the headless render core is unchanged.
 Everything here is pure Python (no ipyleaflet): the bbox helper and the picker
 are unit-testable with just the core deps.
 """
+
 from __future__ import annotations
 
 from zagg.viz.shardmap import grid_from_signature
@@ -146,8 +147,7 @@ def pick_crs(shardmap, override=None) -> str:
     if override is not None:
         if override not in _CRS_INFO:
             raise ValueError(
-                f"unsupported crs override {override!r}; "
-                f"expected one of {sorted(_CRS_INFO)}"
+                f"unsupported crs override {override!r}; expected one of {sorted(_CRS_INFO)}"
             )
         return override
 
@@ -172,9 +172,7 @@ def crs_info(crs: str) -> dict:
         If ``crs`` is not a supported code.
     """
     if crs not in _CRS_INFO:
-        raise ValueError(
-            f"unsupported crs {crs!r}; expected one of {sorted(_CRS_INFO)}"
-        )
+        raise ValueError(f"unsupported crs {crs!r}; expected one of {sorted(_CRS_INFO)}")
     return _CRS_INFO[crs]
 
 

--- a/src/zagg/windows.py
+++ b/src/zagg/windows.py
@@ -75,10 +75,13 @@ _OFFSET_ERA = datetime(2017, 1, 1, tzinfo=timezone.utc)
 #: Explicit-list label charset (frozen): opaque, no ``_`` by construction —
 #: the superset grammar every window label (generative included) satisfies.
 _LABEL_RE = re.compile(r"^[0-9A-Za-z-]{1,32}$")
+#: ASCII ``[0-9]`` (not ``\d``, which also matches Unicode digits) — keeps the
+#: generative labels a strict subset of the frozen ``_LABEL_RE`` charset, so an
+#: externally supplied label round-trips through ``leaf_name``/``split_leaf_name``.
 _GENERATIVE_RE = {
-    "yearly": re.compile(r"^\d{4}$"),
-    "monthly": re.compile(r"^\d{6}$"),
-    "daily": re.compile(r"^\d{8}$"),
+    "yearly": re.compile(r"^[0-9]{4}$"),
+    "monthly": re.compile(r"^[0-9]{6}$"),
+    "daily": re.compile(r"^[0-9]{8}$"),
 }
 
 
@@ -95,7 +98,7 @@ def check_schedule(schedule: str) -> str:
     return schedule
 
 
-def parse_utc(value) -> datetime:
+def parse_utc(value: str | datetime) -> datetime:
     """Parse an ISO-8601 string (or pass through a ``datetime``) as aware UTC.
 
     A naive input is taken AS UTC (window boundaries are UTC-defined); an
@@ -149,7 +152,9 @@ def validate_label(label: str, schedule: str = "explicit") -> str:
     return label
 
 
-def window_range(label: str, schedule: str, windows: list[dict] | None = None):
+def window_range(
+    label: str, schedule: str, windows: list[dict] | None = None
+) -> tuple[datetime, datetime]:
     """The half-open UTC ``[start, end)`` of one window.
 
     Generative labels decode arithmetically. Explicit labels are OPAQUE: they
@@ -268,6 +273,14 @@ def utc_to_offset(dt: datetime, *, epoch, scale: str = "utc", units: str = "seco
     ``datetime``). See the module docstring for the fixed-offset semantics
     and tolerance; e.g. ICESat-2 ``delta_time`` is
     ``scale="gps", epoch="2018-01-01T00:00:00Z"`` (the ATLAS SDP epoch).
+
+    The <= 1 s guarantee holds only when ``epoch`` **and** ``dt`` lie on the
+    same side of 2017-01-01 (the current constant-offset era): the branch keys
+    on ``epoch`` alone and assumes the scale-UTC offset is identical at ``dt``,
+    so a post-2017 epoch with a pre-2017 ``dt`` (or an arbitrary pre-2017
+    *non-native* epoch, offset-at-epoch taken as 0) can carry up to the full
+    current offset as error. Legitimate ICESat-2/native-epoch use is exact; no
+    runtime guard is imposed.
     """
     epoch_dt = parse_utc(epoch)
     offset = epoch_offset(scale)  # validates the scale even when it cancels
@@ -278,7 +291,12 @@ def utc_to_offset(dt: datetime, *, epoch, scale: str = "utc", units: str = "seco
 
 
 def offset_to_utc(value: float, *, epoch, scale: str = "utc", units: str = "seconds") -> datetime:
-    """Inverse of :func:`utc_to_offset`: dataset time -> aware UTC instant."""
+    """Inverse of :func:`utc_to_offset`: dataset time -> aware UTC instant.
+
+    Same fixed-offset caveat as :func:`utc_to_offset`: the <= 1 s guarantee
+    holds only when ``epoch`` and the resulting instant are on the same side of
+    2017-01-01; no runtime guard is imposed.
+    """
     epoch_dt = parse_utc(epoch)
     offset = epoch_offset(scale)  # validates the scale even when it cancels
     seconds = float(value) * _unit_seconds(units)

--- a/src/zagg/windows.py
+++ b/src/zagg/windows.py
@@ -1,0 +1,310 @@
+"""Temporal window primitives for ``morton-hive/2`` (issue #246, D13/D15).
+
+Pure functions implementing the FROZEN window-label grammar and boundary
+semantics recorded on the mortie spec page
+(https://github.com/espg/mortie/issues/62#issuecomment-4986809092):
+
+- Windowed leaf names are ``{full_id}_{window}.zarr`` — underscore separator,
+  **parse rule: split on the first** ``_``. The underscore never appears in
+  morton decimal ids (sign + digits) nor in window labels (charset below), so
+  the split is unambiguous.
+- Generative schedules have fixed ISO-derived, hyphen-free labels —
+  ``yearly`` = ``YYYY``, ``monthly`` = ``YYYYMM``, ``daily`` = ``YYYYMMDD`` —
+  so **lexicographic order = chronological order** within a store.
+  ``quarterly`` (``YYYYQ[1-4]``) is grammar-reserved, NOT implemented.
+- Explicit-list labels are opaque, ``[0-9A-Za-z-]{1,32}`` (no ``_`` by
+  construction); their ranges are declared per label in the store manifest and
+  never parsed out of the label itself.
+- **Window boundaries are UTC calendar terms, half-open** ``[start, end)``,
+  regardless of the store's native time encoding.
+
+UTC <-> dataset-time conversion (ratified on the #246 thread): stdlib
+``datetime`` has no leap-second support (it cannot even represent ``:60``),
+and an exact conversion needs a maintained leap-second table (astropy-sized —
+rejected as a dependency). Instead :func:`utc_to_offset` /
+:func:`offset_to_utc` use the fixed current scale offsets
+(:data:`GPS_MINUS_UTC` / :data:`TAI_MINUS_UTC`, correct since 2017-01-01):
+
+- ``scale: "utc"`` — the field counts (nominal) UTC seconds since the epoch;
+  the naive ``datetime`` difference is the value.
+- ``scale: "gps"`` / ``"tai"`` — the field counts CONTINUOUS scale seconds
+  since a UTC-labeled epoch instant. For an epoch **on/after 2017-01-01**
+  (e.g. the ICESat-2 ATLAS SDP epoch, 2018-01-01T00:00:00Z) the scale-UTC
+  offset is identical at both ends and cancels — the naive difference is
+  exact until a future leap second is declared. For an epoch **before**
+  2017-01-01 the scale offset at the epoch is taken as 0 — exact for the
+  scales' own epochs (GPS: 1980-01-06, TAI: 1958-01-01), where the offset is
+  0 by definition; an arbitrary pre-2017 epoch inherits up to the full
+  current offset as error.
+
+**Documented tolerance**: window boundaries are accurate to <= 1 leap second
+(none declared since 2017-01-01; a future one shifts a boundary by 1 s —
+negligible against daily/monthly/yearly windows). If exact second-scale
+boundaries are ever needed, these two functions are the contained swap point
+for an astropy-backed conversion.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+
+#: Generative window schedules: labels derive from the boundary instant and
+#: the manifest stays static as data accrues (D15).
+GENERATIVE_SCHEDULES = ("yearly", "monthly", "daily")
+#: All implemented schedules (``none`` = no temporal partitioning, bare leaf
+#: names — a ``morton-hive/1`` store *is* a ``/2`` store with this schedule).
+SCHEDULES = ("none", *GENERATIVE_SCHEDULES, "explicit")
+#: Grammar-reserved on the mortie spec page (``YYYYQ[1-4]``), NOT implemented:
+#: validation rejects it with a pointed message rather than half-supporting it.
+RESERVED_SCHEDULES = ("quarterly",)
+
+#: GPS - UTC in seconds — constant since the 2017-01-01 leap second.
+GPS_MINUS_UTC = 18
+#: TAI - UTC in seconds (TAI = GPS + 19 s, a fixed relation).
+TAI_MINUS_UTC = GPS_MINUS_UTC + 19
+#: Supported dataset time scales for the epoch conversion.
+EPOCH_SCALES = ("utc", "gps", "tai")
+#: Supported dataset time units -> seconds multiplier.
+UNIT_SECONDS = {"seconds": 1.0, "days": 86400.0}
+
+#: First instant of the current constant-offset era (the 2017-01-01 leap
+#: second is the most recent one declared).
+_OFFSET_ERA = datetime(2017, 1, 1, tzinfo=timezone.utc)
+
+#: Explicit-list label charset (frozen): opaque, no ``_`` by construction —
+#: the superset grammar every window label (generative included) satisfies.
+_LABEL_RE = re.compile(r"^[0-9A-Za-z-]{1,32}$")
+_GENERATIVE_RE = {
+    "yearly": re.compile(r"^\d{4}$"),
+    "monthly": re.compile(r"^\d{6}$"),
+    "daily": re.compile(r"^\d{8}$"),
+}
+
+
+def check_schedule(schedule: str) -> str:
+    """Validate a schedule name; returns it. Reserved names get a pointed reject."""
+    if schedule in RESERVED_SCHEDULES:
+        raise ValueError(
+            f"schedule {schedule!r} is grammar-reserved on the morton-hive/2 spec "
+            f"but not implemented; use one of {GENERATIVE_SCHEDULES} or an explicit "
+            f"windows list"
+        )
+    if schedule not in SCHEDULES:
+        raise ValueError(f"unknown window schedule {schedule!r} (one of {SCHEDULES})")
+    return schedule
+
+
+def parse_utc(value) -> datetime:
+    """Parse an ISO-8601 string (or pass through a ``datetime``) as aware UTC.
+
+    A naive input is taken AS UTC (window boundaries are UTC-defined); an
+    aware input is converted. ``Z`` suffixes are accepted.
+    """
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        try:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError as e:
+            raise ValueError(f"{value!r} is not an ISO-8601 datetime: {e}") from e
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def iso_utc(dt: datetime) -> str:
+    """Canonical ISO-8601 UTC rendering (seconds precision, ``+00:00`` offset)."""
+    return dt.astimezone(timezone.utc).isoformat(timespec="seconds")
+
+
+def window_label(dt: datetime, schedule: str) -> str:
+    """The generative-schedule label of the window containing ``dt`` (UTC)."""
+    check_schedule(schedule)
+    dt = parse_utc(dt)
+    if schedule == "yearly":
+        return f"{dt.year:04d}"
+    if schedule == "monthly":
+        return f"{dt.year:04d}{dt.month:02d}"
+    if schedule == "daily":
+        return f"{dt.year:04d}{dt.month:02d}{dt.day:02d}"
+    raise ValueError(f"schedule {schedule!r} has no generative labels")
+
+
+def validate_label(label: str, schedule: str = "explicit") -> str:
+    """Validate a window label against its schedule's grammar; returns it.
+
+    Generative labels must match their fixed-width digit form (and decode to a
+    real calendar instant — checked by :func:`window_range`); explicit labels
+    the frozen opaque charset ``[0-9A-Za-z-]{1,32}`` (``_`` excluded by
+    construction, so the leaf-name split stays unambiguous).
+    """
+    check_schedule(schedule)
+    pattern = _GENERATIVE_RE.get(schedule, _LABEL_RE)
+    if not isinstance(label, str) or not pattern.match(label):
+        raise ValueError(
+            f"window label {label!r} does not match the {schedule} schedule's "
+            f"grammar ({pattern.pattern}; frozen on the morton-hive/2 spec)"
+        )
+    return label
+
+
+def window_range(label: str, schedule: str, windows: list[dict] | None = None):
+    """The half-open UTC ``[start, end)`` of one window.
+
+    Generative labels decode arithmetically. Explicit labels are OPAQUE: they
+    resolve only through ``windows`` — the manifest/config-declared
+    ``[{label, start, end}, ...]`` list — never by parsing the label.
+    """
+    validate_label(label, schedule)
+    if schedule == "yearly":
+        start = datetime(int(label), 1, 1, tzinfo=timezone.utc)
+        return start, datetime(start.year + 1, 1, 1, tzinfo=timezone.utc)
+    if schedule == "monthly":
+        y, m = int(label[:4]), int(label[4:6])
+        start = datetime(y, m, 1, tzinfo=timezone.utc)  # raises on month 0/13+
+        y2, m2 = (y + 1, 1) if m == 12 else (y, m + 1)
+        return start, datetime(y2, m2, 1, tzinfo=timezone.utc)
+    if schedule == "daily":
+        start = datetime(int(label[:4]), int(label[4:6]), int(label[6:8]), tzinfo=timezone.utc)
+        return start, start + timedelta(days=1)
+    if schedule == "explicit":
+        for w in windows or []:
+            if w.get("label") == label:
+                return parse_utc(w["start"]), parse_utc(w["end"])
+        raise ValueError(
+            f"explicit window label {label!r} is not declared (labels are opaque; "
+            f"their ranges come only from the declared windows list)"
+        )
+    raise ValueError(f"schedule {schedule!r} has no windows")
+
+
+def windows_intersecting(
+    start: datetime, end: datetime, schedule: str, windows: list[dict] | None = None
+) -> list[str]:
+    """Labels of every window intersecting the CLOSED instant range [start, end].
+
+    ``start``/``end`` are observation-range endpoints (instants, both
+    included); windows are half-open ``[w_start, w_end)``, so an instant
+    sitting exactly on a boundary belongs to the LATER window only.
+    Generative results are chronological (= lexicographic); explicit results
+    keep the declared order.
+    """
+    check_schedule(schedule)
+    start, end = parse_utc(start), parse_utc(end)
+    if end < start:
+        raise ValueError(f"end {iso_utc(end)} precedes start {iso_utc(start)}")
+    if schedule == "explicit":
+        return [
+            w["label"]
+            for w in windows or []
+            if parse_utc(w["start"]) <= end and start < parse_utc(w["end"])
+        ]
+    if schedule not in GENERATIVE_SCHEDULES:
+        raise ValueError(f"schedule {schedule!r} has no windows to intersect")
+    labels = []
+    label = window_label(start, schedule)
+    last = window_label(end, schedule)
+    while True:
+        labels.append(label)
+        if label == last:
+            return labels
+        _lo, hi = window_range(label, schedule)
+        label = window_label(hi, schedule)
+
+
+def leaf_name(full_id: str, window: str | None = None) -> str:
+    """The leaf zarr basename: ``{full_id}_{window}.zarr``, or bare (D13).
+
+    ``window`` is validated against the frozen superset charset (no ``_``),
+    so the name always splits back unambiguously.
+    """
+    if window is None:
+        return f"{full_id}.zarr"
+    validate_label(window)
+    return f"{full_id}_{window}.zarr"
+
+
+def split_leaf_name(name: str) -> tuple[str, str | None]:
+    """``(full_id, window-or-None)`` from a leaf basename — split on the FIRST ``_``.
+
+    The frozen parse rule: morton decimal ids never contain ``_`` and window
+    labels cannot (charset), so the first underscore is the one separator.
+    Raises on a non-``.zarr`` name or a malformed window label.
+    """
+    if not name.endswith(".zarr"):
+        raise ValueError(f"{name!r} is not a leaf zarr name")
+    stem = name.removesuffix(".zarr")
+    if "_" not in stem:
+        return stem, None
+    full_id, window = stem.split("_", 1)
+    validate_label(window)
+    return full_id, window
+
+
+def epoch_offset(scale: str) -> int:
+    """The CURRENT ``scale - UTC`` offset in seconds (0 / 18 / 37).
+
+    Frozen constants, correct since 2017-01-01 (the most recent leap second);
+    see the module docstring for the conversion semantics and the <= 1
+    leap-second tolerance. A new scale (the "TAI hook") is one more entry.
+    """
+    offsets = {"utc": 0, "gps": GPS_MINUS_UTC, "tai": TAI_MINUS_UTC}
+    if scale not in offsets:
+        raise ValueError(f"unknown time scale {scale!r} (one of {EPOCH_SCALES})")
+    return offsets[scale]
+
+
+def _unit_seconds(units: str) -> float:
+    if units not in UNIT_SECONDS:
+        raise ValueError(f"unknown time units {units!r} (one of {tuple(UNIT_SECONDS)})")
+    return UNIT_SECONDS[units]
+
+
+def utc_to_offset(dt: datetime, *, epoch, scale: str = "utc", units: str = "seconds") -> float:
+    """A UTC instant as dataset time: ``units`` on ``scale`` since ``epoch``.
+
+    ``epoch`` is the dataset's zero as a UTC instant (ISO string or
+    ``datetime``). See the module docstring for the fixed-offset semantics
+    and tolerance; e.g. ICESat-2 ``delta_time`` is
+    ``scale="gps", epoch="2018-01-01T00:00:00Z"`` (the ATLAS SDP epoch).
+    """
+    epoch_dt = parse_utc(epoch)
+    offset = epoch_offset(scale)  # validates the scale even when it cancels
+    seconds = (parse_utc(dt) - epoch_dt).total_seconds()
+    if scale != "utc" and epoch_dt < _OFFSET_ERA:
+        seconds += offset
+    return seconds / _unit_seconds(units)
+
+
+def offset_to_utc(value: float, *, epoch, scale: str = "utc", units: str = "seconds") -> datetime:
+    """Inverse of :func:`utc_to_offset`: dataset time -> aware UTC instant."""
+    epoch_dt = parse_utc(epoch)
+    offset = epoch_offset(scale)  # validates the scale even when it cancels
+    seconds = float(value) * _unit_seconds(units)
+    if scale != "utc" and epoch_dt < _OFFSET_ERA:
+        seconds -= offset
+    return epoch_dt + timedelta(seconds=seconds)
+
+
+__all__ = [
+    "EPOCH_SCALES",
+    "GENERATIVE_SCHEDULES",
+    "GPS_MINUS_UTC",
+    "RESERVED_SCHEDULES",
+    "SCHEDULES",
+    "TAI_MINUS_UTC",
+    "UNIT_SECONDS",
+    "check_schedule",
+    "epoch_offset",
+    "iso_utc",
+    "leaf_name",
+    "offset_to_utc",
+    "parse_utc",
+    "split_leaf_name",
+    "utc_to_offset",
+    "validate_label",
+    "window_label",
+    "window_range",
+    "windows_intersecting",
+]

--- a/src/zagg/windows.py
+++ b/src/zagg/windows.py
@@ -46,8 +46,11 @@ for an astropy-backed conversion.
 
 from __future__ import annotations
 
+import logging
 import re
 from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
 
 #: Generative window schedules: labels derive from the boundary instant and
 #: the manifest stays static as data accrues (D15).
@@ -247,6 +250,46 @@ def split_leaf_name(name: str) -> tuple[str, str | None]:
     return full_id, window
 
 
+def union_time_range(*ranges) -> list | None:
+    """The ``[min, max]`` ISO-UTC union of time ranges; ``None``s drop out.
+
+    Malformed entries (non-2-sequences, unparsable instants) are DROPPED with
+    a warning rather than raised: the union feeds cache carriers (the root
+    summary, D15) whose write paths are fail-open — a bad cached range must
+    not fail the run, and the leaf stamps remain the truth.
+    """
+    starts, ends = [], []
+    for r in ranges:
+        if r is None:
+            continue
+        try:
+            lo, hi = r
+            starts.append(parse_utc(lo))
+            ends.append(parse_utc(hi))
+        except (TypeError, ValueError) as e:
+            logger.warning(f"dropping malformed time_range {r!r} from the union ({e})")
+    if not starts:
+        return None
+    return [iso_utc(min(starts)), iso_utc(max(ends))]
+
+
+def iso_time_range(time_range, windowing: dict) -> list:
+    """Dataset-unit ``[lo, hi]`` -> ISO-8601 UTC strings (issue #246, D15).
+
+    ``windowing`` is the normalized declaration (``epoch``/``scale``/``units``)
+    the conversion is defined by — the same one the manifest records, so the
+    stamp truth and the schema can never disagree.
+    """
+    return [
+        iso_utc(
+            offset_to_utc(
+                t, epoch=windowing["epoch"], scale=windowing["scale"], units=windowing["units"]
+            )
+        )
+        for t in time_range
+    ]
+
+
 def epoch_offset(scale: str) -> int:
     """The CURRENT ``scale - UTC`` offset in seconds (0 / 18 / 37).
 
@@ -315,11 +358,13 @@ __all__ = [
     "UNIT_SECONDS",
     "check_schedule",
     "epoch_offset",
+    "iso_time_range",
     "iso_utc",
     "leaf_name",
     "offset_to_utc",
     "parse_utc",
     "split_leaf_name",
+    "union_time_range",
     "utc_to_offset",
     "validate_label",
     "window_label",

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -42,8 +42,10 @@ class TestLoadPolygon:
             json.dump(geojson, f)
 
     def test_bare_polygon(self, tmp_path):
-        geojson = {"type": "Polygon",
-                   "coordinates": [[[0, -70], [10, -70], [10, -80], [0, -80], [0, -70]]]}
+        geojson = {
+            "type": "Polygon",
+            "coordinates": [[[0, -70], [10, -70], [10, -80], [0, -80], [0, -70]]],
+        }
         path = tmp_path / "poly.geojson"
         self._write(geojson, path)
         parts = load_polygon(str(path))
@@ -53,9 +55,14 @@ class TestLoadPolygon:
         assert lats.max() == pytest.approx(-70)
 
     def test_feature(self, tmp_path):
-        geojson = {"type": "Feature", "properties": {},
-                   "geometry": {"type": "Polygon",
-                                "coordinates": [[[0, -70], [10, -70], [10, -80], [0, -80], [0, -70]]]}}
+        geojson = {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[0, -70], [10, -70], [10, -80], [0, -80], [0, -70]]],
+            },
+        }
         path = tmp_path / "feat.geojson"
         self._write(geojson, path)
         assert len(load_polygon(str(path))) == 1
@@ -63,24 +70,34 @@ class TestLoadPolygon:
     def test_feature_collection(self, tmp_path):
         def feat(x):
             ring = [[x, -70], [x + 10, -70], [x + 10, -80], [x, -80], [x, -70]]
-            return {"type": "Feature", "properties": {},
-                    "geometry": {"type": "Polygon", "coordinates": [ring]}}
+            return {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Polygon", "coordinates": [ring]},
+            }
+
         geojson = {"type": "FeatureCollection", "features": [feat(0), feat(20)]}
         path = tmp_path / "fc.geojson"
         self._write(geojson, path)
         assert len(load_polygon(str(path))) == 2
 
     def test_multipolygon(self, tmp_path):
-        geojson = {"type": "MultiPolygon", "coordinates": [
-            [[[0, -70], [10, -70], [10, -80], [0, -80], [0, -70]]],
-            [[[20, -70], [30, -70], [30, -80], [20, -80], [20, -70]]]]}
+        geojson = {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [[[0, -70], [10, -70], [10, -80], [0, -80], [0, -70]]],
+                [[[20, -70], [30, -70], [30, -80], [20, -80], [20, -70]]],
+            ],
+        }
         path = tmp_path / "multi.geojson"
         self._write(geojson, path)
         assert len(load_polygon(str(path))) == 2
 
     def test_lat_lon_order(self, tmp_path):
-        geojson = {"type": "Polygon",
-                   "coordinates": [[[100, -65], [110, -65], [110, -75], [100, -75], [100, -65]]]}
+        geojson = {
+            "type": "Polygon",
+            "coordinates": [[[100, -65], [110, -65], [110, -75], [100, -75], [100, -65]]],
+        }
         path = tmp_path / "order.geojson"
         self._write(geojson, path)
         lats, lons = load_polygon(str(path))[0]
@@ -94,8 +111,10 @@ class TestPolygonToBbox:
         assert polygon_to_bbox(parts) == (0.0, -80.0, 10.0, -70.0)
 
     def test_multi_part(self):
-        parts = [(np.array([-70, -80]), np.array([0, 10])),
-                 (np.array([-60, -90]), np.array([20, 30]))]
+        parts = [
+            (np.array([-70, -80]), np.array([0, 10])),
+            (np.array([-60, -90]), np.array([20, 30])),
+        ]
         assert polygon_to_bbox(parts) == (0.0, -90.0, 30.0, -60.0)
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -166,7 +166,7 @@ def test_run_extraction_local_prefix(tmp_path, monkeypatch):
 
     beams = {"gt1l": _beam(2 * CHUNK)}
     monkeypatch.setattr(
-        ext, "_resolve_h5coro_driver", lambda driver: (lambda *a, **k: None), raising=True
+        ext, "_resolve_h5coro_driver", lambda driver: lambda *a, **k: None, raising=True
     )
 
     class _FakeH5Coro:

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -1,0 +1,311 @@
+"""Time-windowed morton-hive stores (morton-hive/2) — issue #246.
+
+Covers the ``output.windowing`` config block (phase 2), the manifest temporal
+block + spec bump, windowed leaf naming/walking (phase 3), the stamp/coverage
+extensions (phase 4), and the dispatch fan-out (phase 5). The primitives
+themselves are pinned in ``tests/test_windows.py``; the frozen grammar lives
+on the mortie spec page (mortie#62).
+"""
+
+import pytest
+
+from zagg import hive
+from zagg.config import default_config, get_windowing, validate_config
+from zagg.grids import HealpixGrid
+
+
+@pytest.fixture
+def cfg():
+    c = default_config("atl06")
+    # The membership timestamp column must be a declared read column.
+    c.data_source["variables"]["delta_time"] = "/{group}/land_ice_segments/delta_time"
+    return c
+
+
+def _windowed(cfg, schedule="yearly", **over):
+    cfg.output["store_layout"] = "hive"
+    block = {
+        "schedule": schedule,
+        "time_field": "delta_time",
+        # ICESat-2 ATLAS SDP epoch: GPS seconds since 2018-01-01T00:00:00Z.
+        "epoch": "2018-01-01T00:00:00Z",
+        "scale": "gps",
+    }
+    if schedule == "explicit":
+        block["windows"] = [
+            {"label": "melt-2019", "start": "2019-06-01", "end": "2019-09-01"},
+            {"label": "melt-2020", "start": "2020-06-01", "end": "2020-09-01"},
+        ]
+    block.update(over)
+    cfg.output["windowing"] = block
+    return cfg
+
+
+# ── config block (phase 2) ───────────────────────────────────────────────────
+
+
+class TestWindowingConfig:
+    def test_absent_is_none(self, cfg):
+        assert get_windowing(cfg) is None
+        validate_config(cfg)
+
+    def test_null_block_is_none(self, cfg):
+        cfg.output["windowing"] = None
+        assert get_windowing(cfg) is None
+        validate_config(cfg)
+
+    def test_schedule_none_is_inert(self, cfg):
+        cfg.output["store_layout"] = "hive"
+        cfg.output["windowing"] = {"schedule": "none"}
+        validate_config(cfg)
+        assert get_windowing(cfg) is None
+
+    def test_yearly_normalized(self, cfg):
+        _windowed(cfg)
+        validate_config(cfg)
+        got = get_windowing(cfg)
+        assert got == {
+            "schedule": "yearly",
+            "time_field": "delta_time",
+            "epoch": "2018-01-01T00:00:00+00:00",
+            "scale": "gps",
+            "units": "seconds",
+            "windows": None,
+        }
+
+    def test_explicit_normalized(self, cfg):
+        _windowed(cfg, schedule="explicit")
+        validate_config(cfg)
+        got = get_windowing(cfg)
+        assert got["windows"] == [
+            {
+                "label": "melt-2019",
+                "start": "2019-06-01T00:00:00+00:00",
+                "end": "2019-09-01T00:00:00+00:00",
+            },
+            {
+                "label": "melt-2020",
+                "start": "2020-06-01T00:00:00+00:00",
+                "end": "2020-09-01T00:00:00+00:00",
+            },
+        ]
+
+    def test_non_mapping_rejected(self, cfg):
+        cfg.output["store_layout"] = "hive"
+        cfg.output["windowing"] = "yearly"
+        with pytest.raises(ValueError, match="mapping"):
+            validate_config(cfg)
+
+    def test_quarterly_reserved(self, cfg):
+        _windowed(cfg, schedule="quarterly")
+        with pytest.raises(ValueError, match="reserved"):
+            validate_config(cfg)
+
+    def test_unknown_schedule(self, cfg):
+        _windowed(cfg, schedule="weekly")
+        with pytest.raises(ValueError, match="unknown window schedule"):
+            validate_config(cfg)
+
+    def test_requires_hive_layout(self, cfg):
+        _windowed(cfg)
+        cfg.output["store_layout"] = "flat"
+        with pytest.raises(ValueError, match="store_layout: hive"):
+            validate_config(cfg)
+
+    def test_requires_healpix(self, cfg):
+        _windowed(cfg)
+        cfg.output["grid"] = {
+            "type": "rectilinear",
+            "crs": "EPSG:3031",
+            "resolution": 100,
+            "bounds": [0, 0, 1000, 1000],
+        }
+        cfg.output["store_layout"] = "hive"
+        with pytest.raises(ValueError, match="healpix"):
+            validate_config(cfg)
+
+    def test_requires_time_field(self, cfg):
+        _windowed(cfg, time_field=None)
+        with pytest.raises(ValueError, match="time_field"):
+            validate_config(cfg)
+
+    def test_time_field_must_be_declared(self, cfg):
+        _windowed(cfg, time_field="not_a_column")
+        with pytest.raises(ValueError, match="declared data_source column"):
+            validate_config(cfg)
+
+    def test_requires_epoch(self, cfg):
+        _windowed(cfg, epoch=None)
+        with pytest.raises(ValueError, match="epoch"):
+            validate_config(cfg)
+
+    def test_bad_epoch_rejected(self, cfg):
+        _windowed(cfg, epoch="the beginning")
+        with pytest.raises(ValueError, match="ISO-8601"):
+            validate_config(cfg)
+
+    def test_bad_scale_and_units(self, cfg):
+        _windowed(cfg, scale="tt")
+        with pytest.raises(ValueError, match="scale"):
+            validate_config(cfg)
+        _windowed(cfg, scale="gps", units="fortnights")
+        with pytest.raises(ValueError, match="units"):
+            validate_config(cfg)
+
+    def test_windows_only_for_explicit(self, cfg):
+        _windowed(cfg, windows=[{"label": "x", "start": "2019-01-01", "end": "2020-01-01"}])
+        with pytest.raises(ValueError, match="schedule: explicit"):
+            validate_config(cfg)
+
+    def test_explicit_requires_windows(self, cfg):
+        _windowed(cfg, schedule="explicit", windows=None)
+        with pytest.raises(ValueError, match="non-empty list"):
+            validate_config(cfg)
+
+    def test_explicit_bad_label(self, cfg):
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[{"label": "melt_2019", "start": "2019-06-01", "end": "2019-09-01"}],
+        )
+        with pytest.raises(ValueError, match="grammar"):
+            validate_config(cfg)
+
+    def test_explicit_reversed_range(self, cfg):
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[{"label": "w", "start": "2019-09-01", "end": "2019-06-01"}],
+        )
+        with pytest.raises(ValueError, match="half-open"):
+            validate_config(cfg)
+
+    def test_explicit_duplicate_label(self, cfg):
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "w", "start": "2019-01-01", "end": "2019-02-01"},
+                {"label": "w", "start": "2019-03-01", "end": "2019-04-01"},
+            ],
+        )
+        with pytest.raises(ValueError, match="twice"):
+            validate_config(cfg)
+
+    def test_explicit_overlap(self, cfg):
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "a", "start": "2019-01-01", "end": "2019-03-01"},
+                {"label": "b", "start": "2019-02-01", "end": "2019-04-01"},
+            ],
+        )
+        with pytest.raises(ValueError, match="overlap"):
+            validate_config(cfg)
+
+    def test_explicit_touching_ranges_allowed(self, cfg):
+        # Half-open ranges may share a boundary instant without overlapping.
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "a", "start": "2019-01-01", "end": "2019-02-01"},
+                {"label": "b", "start": "2019-02-01", "end": "2019-03-01"},
+            ],
+        )
+        validate_config(cfg)
+
+    def test_raster_rejects_windowing_pointing_at_247(self):
+        c = default_config("atl06")
+        c.data_source = {
+            "reader": "raster",
+            "bands": {"red": {"asset": "red", "dtype": "uint16"}},
+        }
+        c.aggregation = {}
+        c.output["grid"] = {"type": "healpix", "parent_order": 6, "child_order": 12}
+        c.output["windowing"] = {"schedule": "yearly"}
+        with pytest.raises(ValueError, match="issue #247"):
+            validate_config(c)
+
+
+# ── manifest temporal block + spec bump (phase 2) ────────────────────────────
+
+
+class TestManifestTemporal:
+    def _grid(self, cfg):
+        return HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+
+    def test_unwindowed_manifest_is_v1_and_unchanged(self, cfg):
+        m = hive.build_manifest(self._grid(cfg), dataset={"short_name": "ATL06", "version": "007"})
+        assert m["spec"] == "morton-hive/1"
+        assert "temporal" not in m
+        # The exact pre-#246 key set: no new keys leak into unwindowed stores.
+        assert set(m) == {
+            "spec",
+            "dataset",
+            "cell_order",
+            "shard_order",
+            "split_schedule",
+            "pyramid",
+            "generated_at",
+        }
+
+    def test_yearly_manifest_declares_v2_temporal(self, cfg):
+        _windowed(cfg)
+        m = hive.build_manifest(self._grid(cfg), windowing=get_windowing(cfg))
+        assert m["spec"] == "morton-hive/2"
+        assert m["temporal"] == {
+            "schedule": "yearly",
+            "time_field": "delta_time",
+            "epoch": "2018-01-01T00:00:00+00:00",
+            "scale": "gps",
+            "units": "seconds",
+            "append_policy": "new-window",
+        }
+
+    def test_explicit_manifest_carries_windows_and_retemplate_policy(self, cfg):
+        _windowed(cfg, schedule="explicit")
+        m = hive.build_manifest(self._grid(cfg), windowing=get_windowing(cfg))
+        assert m["spec"] == "morton-hive/2"
+        assert m["temporal"]["append_policy"] == "re-template"
+        assert [w["label"] for w in m["temporal"]["windows"]] == ["melt-2019", "melt-2020"]
+
+    def test_windowed_rerun_resumes(self, cfg, tmp_path):
+        _windowed(cfg)
+        root = str(tmp_path / "store")
+        grid = self._grid(cfg)
+        hive.ensure_manifest(root, hive.build_manifest(grid, windowing=get_windowing(cfg)))
+        again = hive.build_manifest(grid, windowing=get_windowing(cfg))
+        assert hive.ensure_manifest(root, again)["spec"] == "morton-hive/2"
+
+    def test_adding_windowing_to_v1_store_refuses(self, cfg, tmp_path):
+        # A windowing change re-partitions leaf NAMES — it must refuse resume
+        # exactly like an orders change (frozen-key posture).
+        root = str(tmp_path / "store")
+        grid = self._grid(cfg)
+        hive.ensure_manifest(root, hive.build_manifest(grid))
+        _windowed(cfg)
+        with pytest.raises(ValueError, match="clear the store root"):
+            hive.ensure_manifest(root, hive.build_manifest(grid, windowing=get_windowing(cfg)))
+
+    def test_changing_schedule_refuses(self, cfg, tmp_path):
+        _windowed(cfg)
+        root = str(tmp_path / "store")
+        grid = self._grid(cfg)
+        hive.ensure_manifest(root, hive.build_manifest(grid, windowing=get_windowing(cfg)))
+        cfg.output["windowing"]["schedule"] = "monthly"
+        with pytest.raises(ValueError, match="clear the store root"):
+            hive.ensure_manifest(root, hive.build_manifest(grid, windowing=get_windowing(cfg)))
+
+    def test_both_specs_read_back(self, cfg, tmp_path):
+        grid = self._grid(cfg)
+        hive.ensure_manifest(str(tmp_path / "v1"), hive.build_manifest(grid))
+        assert hive.read_manifest(str(tmp_path / "v1"))["spec"] == "morton-hive/1"
+        _windowed(cfg)
+        hive.ensure_manifest(
+            str(tmp_path / "v2"), hive.build_manifest(grid, windowing=get_windowing(cfg))
+        )
+        m = hive.read_manifest(str(tmp_path / "v2"))
+        assert m["spec"] == "morton-hive/2"
+        assert m["temporal"]["schedule"] == "yearly"

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -1296,3 +1296,191 @@ class TestShardMapTimeMetadata:
         # Legacy records without the keys stay byte-identical.
         legacy = {"id": "g", "s3": "s3://b/g.h5", "https": "https://h/g.h5"}
         assert _granule_entry(legacy) == legacy
+
+
+# ── yearly end-to-end: real read path, observation-level split (phase 6) ─────
+
+
+class _FakeH5:
+    """Stub h5coro object (the ``test_processing`` filter-fixture pattern):
+    ``readDatasets`` returns canned arrays by path, honoring hyperslices."""
+
+    def __init__(self, arrays):
+        self._arrays = arrays
+
+    def readDatasets(self, datasets):  # noqa: N802 (mirror real h5coro API)
+        out = {}
+        for d in datasets:
+            if isinstance(d, str):
+                out[d] = self._arrays[d]
+                continue
+            arr = self._arrays[d["dataset"]]
+            hs = d["hyperslice"]
+            if hs:
+                lo, hi = hs[0]
+                arr = arr[lo:hi]
+            out[d["dataset"]] = arr
+        return out
+
+
+class TestYearlyEndToEnd:
+    """The acceptance fixture (issue #246): a yearly windowed run over three
+    granules — one per year plus a boundary straddler — driven through the
+    REAL read path (``_read_group`` applies the injected window filters; only
+    the h5coro transport is faked), asserting observation-level splitting,
+    stamp truth, backfill, idempotent re-run, and the root time union."""
+
+    DAY = 86400.0
+    SHARD_DECIMAL = "-5112333"
+
+    def _cfg(self):
+        cfg = default_config("atl06")
+        cfg.data_source = {
+            "reader": "h5coro",
+            "driver": "s3",
+            "groups": ["g1"],
+            "coordinates": {"latitude": "/lat", "longitude": "/lon"},
+            "variables": {"h_li": "/h", "s_li": "/s", "delta_time": "/dt"},
+        }
+        cfg.output["store_layout"] = "hive"
+        cfg.output["windowing"] = {
+            "schedule": "yearly",
+            "time_field": "delta_time",
+            "epoch": "2018-01-01T00:00:00Z",  # ATLAS SDP epoch
+            "scale": "gps",
+        }
+        validate_config(cfg)
+        return cfg
+
+    def _fakes(self):
+        """Three granules in dataset units (GPS days since 2018-01-01):
+
+        - gA: [300, 400, 401, 402] — one 2018 obs (backfill bait) + three 2019
+        - gB: [800, 801, 802] — all 2020
+        - gC: [729.5, 729.75, 730.25, 730.5] — straddles the 2019/2020 boundary
+          (2020-01-01 = day 730)
+        """
+        import numpy as np
+
+        def h5(days):
+            n = len(days)
+            return _FakeH5(
+                {
+                    "/lat": np.full(n, -78.5),
+                    "/lon": np.full(n, -132.0),
+                    "/h": np.arange(n, dtype=np.float32),
+                    "/s": np.ones(n, dtype=np.float32),
+                    "/dt": np.asarray(days, dtype=np.float64) * self.DAY,
+                }
+            )
+
+        return {
+            "s3://bucket/granuleA.h5": h5([300.0, 400.0, 401.0, 402.0]),
+            "s3://bucket/granuleB.h5": h5([800.0, 801.0, 802.0]),
+            "s3://bucket/granuleC.h5": h5([729.5, 729.75, 730.25, 730.5]),
+        }
+
+    def _records(self):
+        return [
+            _timed_rec("A", "2018-10-28T00:00:00Z", "2019-02-07T00:00:00Z"),
+            _timed_rec("B", "2020-03-10T00:00:00Z", "2020-03-13T00:00:00Z"),
+            _timed_rec("C", "2019-12-31T12:00:00Z", "2020-01-01T12:00:00Z"),
+        ]
+
+    def _patch(self, monkeypatch, fakes):
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda path, *a, **k: fakes[path])
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
+
+    def _run_units(self, monkeypatch, cfg, root, labels=None):
+        from zagg.config import get_windowing
+        from zagg.runner import _windowed_units
+
+        grid = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        shard = _shard_word()
+        self._patch(monkeypatch, self._fakes())
+        units = _windowed_units([(shard, self._records())], get_windowing(cfg), None)
+        results = {}
+        for shard_key, records, window in units:
+            if labels is not None and window["label"] not in labels:
+                continue
+            urls = [r["s3"] for r in records]
+            results[window["label"]] = hive.process_and_write_hive(
+                shard_key, urls, grid, {}, root, cfg, store_kwargs={}, window=window
+            )
+        return grid, shard, results
+
+    def _leaf_obs(self, root, shard, label, grid):
+        import numpy as np
+        import zarr
+
+        from zagg.store import open_store
+
+        leaf = hive.shard_leaf_path(root, shard, window=label)
+        grp = zarr.open_group(open_store(leaf), path=grid.group_path, mode="r", zarr_format=3)
+        return int(np.asarray(grp["count"][:]).sum())
+
+    def test_boundary_straddling_observations_split_exactly(self, monkeypatch, cfg, tmp_path):
+        from zagg.store import open_store
+
+        root = str(tmp_path / "store")
+        c = self._cfg()
+        grid, shard, results = self._run_units(monkeypatch, c, root)
+        # Enumerated from the granule spans: 2018 (gA's early obs), 2019, 2020.
+        assert sorted(results) == ["2018", "2019", "2020"]
+
+        # Observation-level split on delta_time (the injected ge/lt filters):
+        # 2018 gets gA's single early obs; 2019 gets gA's three + gC's two
+        # pre-boundary obs; 2020 gets gB's three + gC's two post-boundary obs.
+        assert self._leaf_obs(root, shard, "2018", grid) == 1
+        assert self._leaf_obs(root, shard, "2019", grid) == 5
+        assert self._leaf_obs(root, shard, "2020", grid) == 5
+
+        # Stamp truth (D15): window label + the ACTUAL ISO-UTC extent of what
+        # was written, strictly inside the window's half-open range.
+        stamp = hive.read_commit(open_store(hive.shard_leaf_path(root, shard, window="2019")))
+        assert stamp["spec"] == "morton-hive/2"
+        assert stamp["window"] == "2019"
+        # day 400 = 2019-02-05; day 729.75 = 2019-12-31T18:00 (gC's last 2019 obs).
+        assert stamp["time_range"] == ["2019-02-05T00:00:00+00:00", "2019-12-31T18:00:00+00:00"]
+        # Boundary membership: the 2020 leaf STARTS at day 730.25 (06:00), not
+        # at the boundary instant — half-open windows, no double-counting.
+        stamp20 = hive.read_commit(open_store(hive.shard_leaf_path(root, shard, window="2020")))
+        assert stamp20["time_range"][0] == "2020-01-01T06:00:00+00:00"
+        # Per-unit granule subsetting reached the worker: 2019 read gA + gC.
+        assert stamp["granule_count"] == 2
+
+    def test_backfill_then_root_union_and_idempotent_rerun(self, monkeypatch, cfg, tmp_path):
+        import os
+
+        from zagg.coverage import refresh_root_coverage
+        from zagg.store import open_store
+
+        root = str(tmp_path / "store")
+        c = self._cfg()
+        # Later windows land first...
+        grid, shard, _ = self._run_units(monkeypatch, c, root, labels={"2019", "2020"})
+        leaf_2019 = hive.shard_leaf_path(root, shard, window="2019")
+        stamped_at = hive.read_commit(open_store(leaf_2019))["written_at"]
+        # ...then BACKFILL the earlier window: a new leaf appears next to the
+        # committed ones, which are untouched (D13 — no resize, no rewrite).
+        grid, shard, _ = self._run_units(monkeypatch, c, root, labels={"2018"})
+        assert os.path.exists(hive.shard_leaf_path(root, shard, window="2018"))
+        assert hive.read_commit(open_store(leaf_2019))["written_at"] == stamped_at
+
+        # Idempotent window re-run (D13): same window again is wholesale
+        # replacement, same content.
+        grid, shard, _ = self._run_units(monkeypatch, c, root, labels={"2019"})
+        assert self._leaf_obs(root, shard, "2019", grid) == 5
+
+        # The rebuilt root summary unions the three stamps' time ranges:
+        # day 300 = 2018-10-28 .. day 802 = 2020-03-13.
+        from zagg.config import get_windowing
+
+        hive.ensure_manifest(root, hive.build_manifest(grid, windowing=get_windowing(c)))
+        env = refresh_root_coverage(root)
+        assert env["time_range"] == ["2018-10-28T00:00:00+00:00", "2020-03-13T00:00:00+00:00"]

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -732,7 +732,7 @@ class TestRootTimeUnion:
     def test_union_drops_malformed_with_warning(self, caplog):
         import logging
 
-        with caplog.at_level(logging.WARNING, logger="zagg.hive"):
+        with caplog.at_level(logging.WARNING, logger="zagg.windows"):
             got = hive.union_time_range(
                 ["garbage", "2024-01-01"],
                 ["2024-06-01T00:00:00+00:00", "2024-07-01T00:00:00+00:00"],
@@ -814,3 +814,382 @@ class TestRootTimeUnion:
             )
         env = refresh_root_coverage(root)
         assert env["time_range"] == ["2024-02-01T00:00:00+00:00", "2025-03-01T00:00:00+00:00"]
+
+
+# ── dispatch fan-out + worker window wiring (phase 5) ────────────────────────
+
+
+def _timed_rec(n, start, end):
+    return {
+        "id": f"g{n}",
+        "s3": f"s3://bucket/granule{n}.h5",
+        "https": f"https://h/g{n}.h5",
+        "time_start": start,
+        "time_end": end,
+    }
+
+
+class TestWindowedUnits:
+    """``runner._windowed_units``: one work unit per (shard, window), granules
+    subset by their shardmap time spans, bounds in dataset units."""
+
+    def _windowing(self, cfg, **over):
+        from zagg.config import get_windowing
+
+        _windowed(cfg, **over)
+        return get_windowing(cfg)
+
+    def test_yearly_fanout_and_subsetting(self, cfg):
+        from zagg.runner import _windowed_units
+
+        g19 = _timed_rec(1, "2019-03-01T00:00:00Z", "2019-03-01T00:05:00Z")
+        g20 = _timed_rec(2, "2020-07-01T00:00:00Z", "2020-07-01T00:05:00Z")
+        straddle = _timed_rec(3, "2019-12-31T23:58:00Z", "2020-01-01T00:02:00Z")
+        units = _windowed_units([(11, [g19, g20, straddle])], self._windowing(cfg), None)
+        # Shard-major, chronological labels; the straddler rides BOTH windows.
+        assert [(k, w["label"], [r["id"] for r in recs]) for k, recs, w in units] == [
+            (11, "2019", ["g1", "g3"]),
+            (11, "2020", ["g2", "g3"]),
+        ]
+        # Bounds are dataset units: GPS seconds since the ATLAS SDP epoch
+        # (2018-01-01Z; post-2017 epoch -> the naive difference, exactly).
+        w2019 = units[0][2]
+        assert w2019["start"] == 365 * 86400.0
+        assert w2019["end"] == (365 + 365) * 86400.0
+
+    def test_untimed_granule_rides_every_window_with_bounds(self, cfg):
+        from zagg.runner import _windowed_units
+
+        legacy = {"id": "g0", "s3": "s3://b/g0.h5", "https": None}
+        units = _windowed_units(
+            [(11, [legacy])],
+            self._windowing(cfg),
+            {"start_date": "2019-01-01", "end_date": "2020-12-31"},
+        )
+        assert [w["label"] for _k, _r, w in units] == ["2019", "2020"]
+        assert all(recs == [legacy] for _k, recs, _w in units)
+
+    def test_untimed_granule_without_bounds_is_a_pointed_error(self, cfg):
+        from zagg.runner import _windowed_units
+
+        legacy = {"id": "g0", "s3": "s3://b/g0.h5", "https": None}
+        with pytest.raises(ValueError, match="bounds.temporal"):
+            _windowed_units([(11, [legacy])], self._windowing(cfg), None)
+
+    def test_explicit_schedule_uses_declared_windows(self, cfg):
+        from zagg.runner import _windowed_units
+
+        w = self._windowing(cfg, schedule="explicit")
+        inside = _timed_rec(1, "2019-07-01T00:00:00Z", "2019-07-01T01:00:00Z")
+        outside = _timed_rec(2, "2021-07-01T00:00:00Z", "2021-07-01T01:00:00Z")
+        units = _windowed_units([(11, [inside, outside])], w, None)
+        # Only the declared melt seasons dispatch; the 2021 granule matches
+        # neither, and the empty melt-2020 subset is skipped entirely.
+        assert [(w_["label"], [r["id"] for r in recs]) for _k, recs, w_ in units] == [
+            ("melt-2019", ["g1"])
+        ]
+
+    def test_shard_with_no_matching_granules_dispatches_nothing(self, cfg):
+        from zagg.runner import _windowed_units
+
+        g = _timed_rec(1, "2019-03-01T00:00:00Z", "2019-03-01T01:00:00Z")
+        units = _windowed_units([(11, [g]), (22, [])], self._windowing(cfg), None)
+        assert [(k, w["label"]) for k, _r, w in units] == [(11, "2019")]
+
+    def test_raster_instant_datetime_is_honored(self, cfg):
+        from zagg.runner import _windowed_units
+
+        rec = {"id": "r1", "s3": None, "https": None, "datetime": "2019-06-15T10:00:00Z"}
+        units = _windowed_units([(11, [rec])], self._windowing(cfg), None)
+        assert [w["label"] for _k, _r, w in units] == ["2019"]
+
+
+class TestWindowedCellConfig:
+    def test_injects_ge_lt_filters_on_the_time_field(self, cfg):
+        from zagg.config import windowed_cell_config
+
+        _windowed(cfg)
+        unit_cfg, windowing = windowed_cell_config(cfg, {"label": "2019", "start": 1.5, "end": 9.5})
+        got = unit_cfg.data_source["filters"]
+        # The ATL06 quality_filter sugar is normalized FIRST, then the window
+        # pair appends — declared filtering is preserved.
+        assert got[0]["dataset"] == "/{group}/land_ice_segments/atl06_quality_summary"
+        assert got[-2:] == [
+            {
+                "level": None,
+                "dataset": "/{group}/land_ice_segments/delta_time",
+                "op": "ge",
+                "value": 1.5,
+            },
+            {
+                "level": None,
+                "dataset": "/{group}/land_ice_segments/delta_time",
+                "op": "lt",
+                "value": 9.5,
+            },
+        ]
+        assert windowing["time_field"] == "delta_time"
+        # The original config is untouched (per-unit copy).
+        assert "filters" not in cfg.data_source
+
+    def test_unwindowed_config_refuses(self, cfg):
+        from zagg.config import windowed_cell_config
+
+        with pytest.raises(ValueError, match="drift"):
+            windowed_cell_config(cfg, {"label": "2019", "start": 0.0, "end": 1.0})
+
+
+class TestProcessAndWriteHiveWindowed:
+    """The shared write path threads the window end to end: leaf name, filter
+    injection, ISO time_range stamp, and the D14 popcount."""
+
+    def _grid(self, cfg):
+        return HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+
+    def _carrier(self, grid, shard):
+        import numpy as np
+        import pandas as pd
+
+        from zagg.config import get_agg_fields, get_data_vars, get_output_signature
+
+        coords = grid.chunk_coords(shard)
+        n = len(coords["cell_ids"])
+        agg = get_agg_fields(grid.config)
+        df = pd.DataFrame(
+            {
+                var: np.zeros(n, dtype=np.int32 if var == "count" else np.float32)
+                for var in get_data_vars(grid.config)
+                if get_output_signature(agg[var])["kind"] != "ragged"
+            }
+        )
+        for name, vals in coords.items():
+            df[name] = vals
+        return df
+
+    def _run(self, monkeypatch, cfg, tmp_path, *, occupied, time_range=None):
+        import numpy as np
+        import pandas as pd
+
+        import zagg.processing as processing
+
+        _windowed(cfg)
+        grid = self._grid(cfg)
+        shard = _shard_word()
+        root = str(tmp_path / "store")
+        seen: dict = {}
+
+        def fake(g, shard_key, urls, **kwargs):
+            seen["config"] = kwargs["config"]
+            seen["time_range_of"] = kwargs.get("time_range_of")
+            kwargs["write_chunk"](
+                grid.block_index(int(shard_key)), self._carrier(grid, shard_key), {}
+            )
+            if kwargs.get("occupied_out") is not None:
+                kwargs["occupied_out"].append(np.asarray(occupied, dtype=np.uint64))
+            meta = {
+                "shard_key": int(shard_key),
+                "cells_with_data": len(occupied),
+                "total_obs": 7,
+                "granule_count": 1,
+                "files_processed": 1,
+                "duration_s": 0.0,
+                "error": None,
+            }
+            if time_range is not None:
+                meta["time_range"] = time_range
+            return pd.DataFrame(), meta
+
+        monkeypatch.setattr(processing, "process_shard", fake)
+        # One year window: [2019-01-01, 2020-01-01) as GPS seconds since the
+        # ATLAS SDP epoch (2018-01-01Z).
+        window = {"label": "2019", "start": 365 * 86400.0, "end": 730 * 86400.0}
+        meta = hive.process_and_write_hive(
+            shard, ["s3://b/g1.h5"], grid, {}, root, cfg, store_kwargs={}, window=window
+        )
+        return grid, shard, root, meta, seen
+
+    def test_windowed_leaf_filter_and_stamp(self, monkeypatch, cfg, tmp_path):
+        import os
+
+        from zagg.store import open_store
+
+        grid, shard, root, meta, seen = self._run(
+            monkeypatch,
+            cfg,
+            tmp_path,
+            occupied=self._grid(cfg).children(_shard_word())[:3],
+            # Dataset-unit extent from the worker: ~2019-03-02 .. ~2019-11-27.
+            time_range=[425 * 86400.0, 695 * 86400.0],
+        )
+        leaf = hive.shard_leaf_path(root, shard, window="2019")
+        assert os.path.exists(leaf)
+        # The per-unit config the worker saw carries the injected window
+        # filter pair and the time-extent sink on the declared time_field.
+        assert seen["time_range_of"] == "delta_time"
+        assert [f["op"] for f in seen["config"].data_source["filters"][-2:]] == ["ge", "lt"]
+        # The stamp is the D15 truth: window label + ACTUAL ISO-UTC extent.
+        stamp = hive.read_commit(open_store(leaf))
+        assert stamp["spec"] == "morton-hive/2"
+        assert stamp["window"] == "2019"
+        assert stamp["time_range"] == ["2019-03-02T00:00:00+00:00", "2019-11-27T00:00:00+00:00"]
+        # The dispatcher sees the SAME strings for the root-summary union.
+        assert meta["time_range"] == stamp["time_range"]
+        # Partial occupancy: the bitmap sidecar path is unchanged.
+        assert stamp["coverage"]["encoding"] == "bitmap"
+        assert os.path.exists(os.path.join(leaf, hive.COVERAGE_SIDECAR))
+
+    def test_full_popcount_skips_the_sidecar(self, monkeypatch, cfg, tmp_path):
+        import os
+
+        from zagg.store import open_store
+
+        grid, shard, root, _meta, _seen = self._run(
+            monkeypatch, cfg, tmp_path, occupied=self._grid(cfg).children(_shard_word())
+        )
+        leaf = hive.shard_leaf_path(root, shard, window="2019")
+        stamp = hive.read_commit(open_store(leaf))
+        # D14: full subtree -> encoding "full", NO sidecar object written.
+        assert stamp["coverage"]["encoding"] == "full"
+        assert "sidecar" not in stamp["coverage"]
+        assert not os.path.exists(os.path.join(leaf, hive.COVERAGE_SIDECAR))
+
+    def test_window_rerun_is_idempotent_replacement(self, monkeypatch, cfg, tmp_path):
+        from zagg.store import open_store
+
+        grid, shard, root, _m, _s = self._run(
+            monkeypatch, cfg, tmp_path, occupied=self._grid(cfg).children(_shard_word())[:2]
+        )
+        # Re-dispatching the same window overwrites the leaf wholesale (D13).
+        grid, shard, root, _m, _s = self._run(
+            monkeypatch, cfg, tmp_path, occupied=self._grid(cfg).children(_shard_word())[:2]
+        )
+        leaf = hive.shard_leaf_path(root, shard, window="2019")
+        assert hive.read_commit(open_store(leaf))["complete"] is True
+
+
+class TestWindowedRunnerWiring:
+    """Both dispatchers fan (shard, window) units into the shared write path."""
+
+    def _catalog(self, tmp_path):
+        import json as _json
+
+        shard = _shard_word()
+        catalog = {
+            "metadata": {"short_name": "ATL06", "version": "007"},
+            "grid_signature": {
+                "type": "healpix",
+                "indexing_scheme": "nested",
+                "parent_order": 6,
+                "child_order": 12,
+                "layout": "fullsphere",
+            },
+            "shard_keys": [shard],
+            "granules": [
+                [
+                    _timed_rec(1, "2019-03-01T00:00:00Z", "2019-03-01T00:05:00Z"),
+                    _timed_rec(2, "2020-07-01T00:00:00Z", "2020-07-01T00:05:00Z"),
+                    _timed_rec(3, "2019-12-31T23:58:00Z", "2020-01-01T00:02:00Z"),
+                ]
+            ],
+        }
+        p = tmp_path / "catalog.json"
+        p.write_text(_json.dumps(catalog))
+        return str(p), shard
+
+    def test_local_windowed_fanout_manifest_and_root_union(self, monkeypatch, cfg, tmp_path):
+        from zagg import runner
+        from zagg.runner import agg
+
+        _windowed(cfg)
+        catalog_path, shard = self._catalog(tmp_path)
+        root = str(tmp_path / "out")
+        calls = []
+
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "a"})
+
+        def fake_hive_write(shard_key, granule_urls, grid, s3_creds, store_root, config, **kw):
+            w = kw["window"]
+            calls.append((int(shard_key), w["label"], len(granule_urls)))
+            return {
+                "shard_key": int(shard_key),
+                "error": None,
+                "total_obs": 1,
+                "time_range": [
+                    f"{w['label']}-03-01T00:00:00+00:00",
+                    f"{w['label']}-11-01T00:00:00+00:00",
+                ],
+            }
+
+        monkeypatch.setattr(hive, "process_and_write_hive", fake_hive_write)
+        agg(cfg, catalog=catalog_path, store=root, backend="local")
+
+        # One unit per (shard, window); the straddler rides both years.
+        assert sorted(calls) == [(shard, "2019", 2), (shard, "2020", 2)]
+        # The manifest declares /2 + the temporal block.
+        m = hive.read_manifest(root)
+        assert m["spec"] == "morton-hive/2"
+        assert m["temporal"]["schedule"] == "yearly"
+        # The root summary carries the run's time-range union (D15 cache).
+        env = hive.read_root_coverage(root)
+        assert env["time_range"] == ["2019-03-01T00:00:00+00:00", "2020-11-01T00:00:00+00:00"]
+
+    def test_lambda_cell_event_carries_window(self, cfg):
+        import json as _json
+        from unittest.mock import MagicMock
+
+        from zagg.runner import _invoke_lambda_cell
+
+        payload_box = MagicMock()
+        payload_box.read.return_value = _json.dumps(
+            {"statusCode": 200, "body": _json.dumps({"total_obs": 1})}
+        ).encode()
+        client = MagicMock()
+        client.invoke.return_value = {"Payload": payload_box, "FunctionError": None}
+
+        creds = {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"}
+        window = {"label": "2019", "start": 365 * 86400.0, "end": 730 * 86400.0}
+        _invoke_lambda_cell(
+            client,
+            (0,),
+            _shard_word(),
+            6,
+            12,
+            ["s3://b/g1.h5"],
+            "s3://out/store",
+            creds,
+            function_name="process-shard",
+            config_dict=None,
+            window=window,
+        )
+        event = _json.loads(client.invoke.call_args.kwargs["Payload"])
+        assert event["window"] == window
+
+        # Unwindowed invoke: no "window" key — the event stays byte-identical
+        # to the pre-#246 payload.
+        _invoke_lambda_cell(
+            client,
+            (0,),
+            _shard_word(),
+            6,
+            12,
+            ["s3://b/g1.h5"],
+            "s3://out/store",
+            creds,
+            function_name="process-shard",
+            config_dict=None,
+        )
+        event = _json.loads(client.invoke.call_args.kwargs["Payload"])
+        assert "window" not in event
+
+
+class TestShardMapTimeMetadata:
+    def test_granule_entry_carries_time_range(self):
+        from zagg.catalog.shardmap import _granule_entry
+
+        rec = _timed_rec(1, "2019-03-01T00:00:00+00:00", "2019-03-01T00:05:00+00:00")
+        entry = _granule_entry(rec)
+        assert entry["time_start"] == "2019-03-01T00:00:00+00:00"
+        assert entry["time_end"] == "2019-03-01T00:05:00+00:00"
+        # Legacy records without the keys stay byte-identical.
+        legacy = {"id": "g", "s3": "s3://b/g.h5", "https": "https://h/g.h5"}
+        assert _granule_entry(legacy) == legacy

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -499,3 +499,251 @@ class TestWindowedWalkerAndSidecar:
         )
         # The shard id parses out of the WINDOWED basename (first-`_` split).
         np.testing.assert_array_equal(hive.read_coverage_bitmap(leaf), occupied)
+
+
+# ── windowed stamps + coverage "full" + root time union (phase 4) ────────────
+
+
+class TestWindowedStamp:
+    def _leaf(self, cfg):
+        from zarr.storage import MemoryStore
+
+        grid = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        store = MemoryStore()
+        grid.emit_shard_template(store, overwrite=True)
+        return store
+
+    def test_windowed_stamp_round_trip(self, cfg):
+        store = self._leaf(cfg)
+        hive.stamp_commit(
+            store,
+            cells_with_data=5,
+            granule_count=2,
+            window="2025",
+            time_range=["2025-03-01T06:00:00+00:00", "2025-11-20T18:30:00+00:00"],
+        )
+        stamp = hive.read_commit(store)
+        # D15 truth half: the stamp carries the window label + the ACTUAL
+        # written range as ISO-8601 UTC strings (ratified #246 Q2), spec /2.
+        assert stamp["spec"] == "morton-hive/2"
+        assert stamp["window"] == "2025"
+        assert stamp["time_range"] == ["2025-03-01T06:00:00+00:00", "2025-11-20T18:30:00+00:00"]
+
+    def test_unwindowed_stamp_unchanged(self, cfg):
+        store = self._leaf(cfg)
+        hive.stamp_commit(store, cells_with_data=5, granule_count=2)
+        stamp = hive.read_commit(store)
+        assert stamp["spec"] == "morton-hive/1"
+        # Pin the exact pre-#246 key set: no new keys leak into unwindowed stamps.
+        assert set(stamp) == {
+            "spec",
+            "complete",
+            "cells_with_data",
+            "granule_count",
+            "written_at",
+        }
+
+    def test_time_range_requires_window(self, cfg):
+        store = self._leaf(cfg)
+        with pytest.raises(ValueError, match="windowed stamps only"):
+            hive.stamp_commit(
+                store,
+                cells_with_data=1,
+                granule_count=1,
+                time_range=["2025-01-01T00:00:00+00:00", "2025-02-01T00:00:00+00:00"],
+            )
+
+
+class TestCoverageFull:
+    def _grid(self, cfg):
+        return HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+
+    def test_full_envelope_shape(self, cfg):
+        import numpy as np
+
+        word = _shard_word()
+        occupied = np.asarray(self._grid(cfg).children(word), dtype=np.uint64)
+        cov = hive.build_coverage(word, occupied, 8, full=True)
+        assert cov["encoding"] == "full"
+        # No sidecar is written or pointed to (D14): the pointer keys are absent.
+        assert "sidecar" not in cov and "nbytes" not in cov and "raw_nbytes" not in cov
+        # The tier-0 box is carried unconditionally — full occupancy collapses
+        # it to the shard's own id (the trivial 1-member cover).
+        from zagg.grids.morton import morton_decimal
+
+        assert cov["box"][0] == morton_decimal(word)
+
+    def test_full_and_bitmap_mutually_exclusive(self, cfg):
+        word = _shard_word()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            hive.build_coverage(word, None, 8, bitmap=b"x", full=True)
+
+    def _stamped_leaf(self, cfg, tmp_path, *, full):
+        import numpy as np
+
+        from zagg.store import open_store
+
+        grid = self._grid(cfg)
+        word = _shard_word()
+        root = str(tmp_path / "store")
+        leaf = hive.shard_leaf_path(root, word, window="2025")
+        store = open_store(leaf)
+        grid.emit_shard_template(store, overwrite=True)
+        if full:
+            occupied = np.asarray(grid.children(word), dtype=np.uint64)
+            cov = hive.build_coverage(word, occupied, grid.child_order, full=True)
+        else:
+            occupied = np.sort(np.asarray(grid.children(word)[:3], dtype=np.uint64))
+            bitmap = hive.encode_coverage_bitmap(word, occupied, grid.child_order)
+            hive.write_coverage_sidecar(leaf, bitmap)
+            cov = hive.build_coverage(word, occupied, grid.child_order, bitmap=bitmap)
+        hive.stamp_commit(
+            store, cells_with_data=len(occupied), granule_count=1, window="2025", coverage=cov
+        )
+        return grid, word, leaf, occupied
+
+    def test_full_leaf_writes_no_sidecar_and_short_circuits(self, cfg, tmp_path):
+        import os
+
+        import numpy as np
+
+        from zagg.coverage import bitmap_and
+
+        grid, word, leaf, _occ = self._stamped_leaf(cfg, tmp_path, full=True)
+        # The whole point of "full": NO sidecar object exists in the leaf.
+        assert not os.path.exists(os.path.join(leaf, hive.COVERAGE_SIDECAR))
+        assert hive.read_coverage_bitmap(leaf) is None  # nothing to GET
+        # bitmap_and short-circuits via the shard's own MOC membership: an AOI
+        # of two child cells intersects exactly those cells.
+        aoi = np.asarray(grid.children(word)[5:7], dtype=np.uint64)
+        np.testing.assert_array_equal(np.sort(bitmap_and(leaf, aoi)), np.sort(aoi))
+
+    def test_partial_leaf_keeps_the_bitmap_path(self, cfg, tmp_path):
+        import numpy as np
+
+        from zagg.coverage import bitmap_and
+
+        grid, word, leaf, occupied = self._stamped_leaf(cfg, tmp_path, full=False)
+        children = np.asarray(grid.children(word), dtype=np.uint64)
+        aoi = children[1:5]  # overlaps occupied[1:3] only
+        got = bitmap_and(leaf, aoi)
+        np.testing.assert_array_equal(np.sort(got), np.sort(np.intersect1d(occupied, aoi)))
+        # A miss is definitive (exact encoding).
+        assert bitmap_and(leaf, children[5:7]).size == 0
+
+    def test_box_only_stamp_degrades_to_none(self, cfg, tmp_path):
+        import numpy as np
+
+        from zagg.coverage import bitmap_and
+        from zagg.store import open_store
+
+        grid = self._grid(cfg)
+        word = _shard_word()
+        leaf = hive.shard_leaf_path(str(tmp_path / "store"), word)
+        store = open_store(leaf)
+        grid.emit_shard_template(store, overwrite=True)
+        occupied = np.asarray(grid.children(word)[:2], dtype=np.uint64)
+        hive.stamp_commit(
+            store,
+            cells_with_data=2,
+            granule_count=1,
+            coverage=hive.build_coverage(word, occupied, grid.child_order),
+        )
+        assert bitmap_and(leaf, occupied) is None  # box-only: fall back to box
+
+
+class TestRootTimeUnion:
+    def test_union_time_range(self):
+        assert hive.union_time_range(None, None) is None
+        got = hive.union_time_range(
+            ["2024-06-01T00:00:00+00:00", "2024-09-01T00:00:00+00:00"],
+            None,
+            ["2024-01-01T00:00:00+00:00", "2024-07-01T00:00:00+00:00"],
+        )
+        assert got == ["2024-01-01T00:00:00+00:00", "2024-09-01T00:00:00+00:00"]
+
+    def test_union_drops_malformed_with_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="zagg.hive"):
+            got = hive.union_time_range(
+                ["garbage", "2024-01-01"],
+                ["2024-06-01T00:00:00+00:00", "2024-07-01T00:00:00+00:00"],
+            )
+        assert got == ["2024-06-01T00:00:00+00:00", "2024-07-01T00:00:00+00:00"]
+        assert any("malformed time_range" in r.message for r in caplog.records)
+
+    def test_envelope_carries_time_range_only_when_given(self):
+        import numpy as np
+
+        word = _shard_word()
+        keys = np.asarray([word], dtype=np.uint64)
+        assert "time_range" not in hive.build_root_coverage(keys, 6)
+        env = hive.build_root_coverage(
+            keys, 6, time_range=["2024-01-01T00:00:00+00:00", "2025-01-01T00:00:00+00:00"]
+        )
+        assert env["time_range"] == ["2024-01-01T00:00:00+00:00", "2025-01-01T00:00:00+00:00"]
+
+    def test_write_root_coverage_unions_time_ranges(self, tmp_path):
+        import numpy as np
+
+        root = str(tmp_path / "store")
+        word = _shard_word()
+        keys = np.asarray([word], dtype=np.uint64)
+        hive.write_root_coverage(
+            root,
+            hive.build_root_coverage(
+                keys, 6, time_range=["2024-01-01T00:00:00+00:00", "2024-06-01T00:00:00+00:00"]
+            ),
+        )
+        merged = hive.write_root_coverage(
+            root,
+            hive.build_root_coverage(
+                keys, 6, time_range=["2024-03-01T00:00:00+00:00", "2025-01-01T00:00:00+00:00"]
+            ),
+        )
+        assert merged["time_range"] == ["2024-01-01T00:00:00+00:00", "2025-01-01T00:00:00+00:00"]
+        # One-sided: a later run without a range keeps the accumulated union.
+        merged = hive.write_root_coverage(root, hive.build_root_coverage(keys, 6))
+        assert merged["time_range"] == ["2024-01-01T00:00:00+00:00", "2025-01-01T00:00:00+00:00"]
+
+    def test_load_coverage_tolerates_time_range(self, tmp_path):
+        import numpy as np
+
+        from zagg.coverage import load_coverage
+
+        root = str(tmp_path / "store")
+        keys = np.asarray([_shard_word()], dtype=np.uint64)
+        hive.write_root_coverage(
+            root,
+            hive.build_root_coverage(
+                keys, 6, time_range=["2024-01-01T00:00:00+00:00", "2025-01-01T00:00:00+00:00"]
+            ),
+        )
+        env = load_coverage(root)
+        assert env is not None
+        assert env["time_range"] == ["2024-01-01T00:00:00+00:00", "2025-01-01T00:00:00+00:00"]
+
+    def test_refresh_rebuilds_time_union_from_stamps(self, cfg, tmp_path):
+        from zagg.coverage import refresh_root_coverage
+        from zagg.store import open_store
+
+        _windowed(cfg)
+        from zagg.config import get_windowing
+
+        grid = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        root = str(tmp_path / "store")
+        hive.ensure_manifest(root, hive.build_manifest(grid, windowing=get_windowing(cfg)))
+        word = _shard_word()
+        for label, lo, hi in [
+            ("2024", "2024-02-01T00:00:00+00:00", "2024-11-01T00:00:00+00:00"),
+            ("2025", "2025-01-15T00:00:00+00:00", "2025-03-01T00:00:00+00:00"),
+        ]:
+            leaf = hive.shard_leaf_path(root, word, window=label)
+            store = open_store(leaf)
+            grid.emit_shard_template(store, overwrite=True)
+            hive.stamp_commit(
+                store, cells_with_data=1, granule_count=1, window=label, time_range=[lo, hi]
+            )
+        env = refresh_root_coverage(root)
+        assert env["time_range"] == ["2024-02-01T00:00:00+00:00", "2025-03-01T00:00:00+00:00"]

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -60,6 +60,24 @@ class TestWindowingConfig:
         validate_config(cfg)
         assert get_windowing(cfg) is None
 
+    def test_schedule_none_inert_on_flat_layout(self, cfg):
+        # A ``schedule: none`` block is equivalent to an absent block, so it
+        # must validate on a flat/non-healpix store — the layout guards run
+        # only for a live (generative) schedule.
+        cfg.output["windowing"] = {"schedule": "none"}
+        validate_config(cfg)
+        assert get_windowing(cfg) is None
+
+    def test_schedule_none_rejects_stray_windows(self, cfg):
+        # Validation symmetry: a stray ``windows`` list is rejected under
+        # ``schedule: none`` just as it is under a generative schedule.
+        cfg.output["windowing"] = {
+            "schedule": "none",
+            "windows": [{"label": "x", "start": "2019-01-01", "end": "2020-01-01"}],
+        }
+        with pytest.raises(ValueError, match="schedule: explicit"):
+            validate_config(cfg)
+
     def test_yearly_normalized(self, cfg):
         _windowed(cfg)
         validate_config(cfg)
@@ -133,6 +151,41 @@ class TestWindowingConfig:
         _windowed(cfg, time_field="not_a_column")
         with pytest.raises(ValueError, match="declared data_source column"):
             validate_config(cfg)
+
+    def test_time_field_rejected_when_no_columns_declared(self, cfg):
+        # An empty read set is itself rejected: a store reading no columns
+        # cannot filter on ``time_field`` (the check is unconditional).
+        _windowed(cfg)
+        cfg.data_source["coordinates"] = {}
+        cfg.data_source["variables"] = {}
+        with pytest.raises(ValueError, match="declared data_source column"):
+            validate_config(cfg)
+
+    def test_time_field_from_level_declared_variable_accepted(self, cfg):
+        # A readable segment-level variable declared on a non-base level
+        # (issue #30 mapping form) is a valid ``time_field``: it broadcasts to
+        # a per-photon column the worker reads.
+        _windowed(cfg, time_field="seg_time")
+        cfg.data_source["base_level"] = "photons"
+        cfg.data_source["levels"] = {
+            "photons": {
+                "path": "/{group}/heights",
+                "coordinates": ["lat_ph", "lon_ph"],
+                "variables": ["h_ph"],
+            },
+            "segments": {
+                "path": "/{group}/geolocation",
+                "coordinates": ["reference_photon_lat"],
+                "variables": {"seg_time": "/{group}/geolocation/delta_time"},
+                "link": {
+                    "to": "photons",
+                    "index_beg": "/{group}/geolocation/ph_index_beg",
+                    "count": "/{group}/geolocation/segment_ph_cnt",
+                },
+            },
+        }
+        validate_config(cfg)
+        assert get_windowing(cfg)["time_field"] == "seg_time"
 
     def test_requires_epoch(self, cfg):
         _windowed(cfg, epoch=None)
@@ -261,6 +314,7 @@ class TestManifestTemporal:
             "epoch": "2018-01-01T00:00:00+00:00",
             "scale": "gps",
             "units": "seconds",
+            "calendar": "proleptic_gregorian",
             "append_policy": "new-window",
         }
 

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -467,17 +467,84 @@ class TestWindowedWalkerAndSidecar:
         import logging
 
         from zagg.coverage import refresh_root_coverage
+        from zagg.store import open_store
 
-        root, word, _grid = self._windowed_store(cfg, tmp_path, labels=("2024",))
-        # A leaf-shaped name whose window part breaks the frozen charset: the
-        # walk warns and skips it instead of dying (escape-hatch posture).
-        bad = tmp_path / "store" / "-5" / "1" / "1" / "2" / "3" / "3" / "3"
-        (bad / "-5112333_bad_label.zarr").mkdir()
-        (bad / "-5112333_bad_label.zarr" / "zarr.json").write_text("{}")
+        root, word, grid = self._windowed_store(cfg, tmp_path, labels=("2024",))
+        node = tmp_path / "store" / "-5" / "1" / "1" / "2" / "3" / "3" / "3"
+        # (a) An UNSTAMPED leaf whose name breaks the frozen charset is ordinary
+        # D4 debris: read_commit returns None first, so it is dropped SILENTLY,
+        # no noisier than a valid-named unstamped leaf or the foreign-order
+        # carve-out — only real data earns a warning.
+        grid.emit_shard_template(open_store(str(node / "-5112333_bad_label.zarr")), overwrite=True)
+        with caplog.at_level(logging.WARNING, logger="zagg.coverage"):
+            env = refresh_root_coverage(root)
+        assert env is not None and len(env["ranges"]) == 1
+        assert not any("malformed window label" in r.message for r in caplog.records)
+        # (b) A STAMPED leaf with the same malformed name is real (misnamed)
+        # data: the walk warns and skips it instead of dying (escape-hatch
+        # posture), and the conforming leaf still carries the coverage.
+        stamped = open_store(str(node / "-5112333_bad_label2.zarr"))
+        grid.emit_shard_template(stamped, overwrite=True)
+        hive.stamp_commit(stamped, cells_with_data=1, granule_count=1)
+        caplog.clear()
         with caplog.at_level(logging.WARNING, logger="zagg.coverage"):
             env = refresh_root_coverage(root)
         assert env is not None and len(env["ranges"]) == 1
         assert any("malformed window label" in r.message for r in caplog.records)
+
+    def test_refresh_trusts_basename_id_over_path_node(self, cfg, tmp_path):
+        # The walker keys off `split_leaf_name(name)[0]`, never re-checking
+        # `check_node_invariant`, so a stamped windowed leaf parked at the WRONG
+        # digit node is listed at its basename id, not the path's. This mirrors
+        # pre-#246 behavior for bare leaves (the walk always trusted the basename
+        # over the path); pinning it as the intended contract, not a regression.
+        import numpy as np
+
+        from zagg.config import get_windowing
+        from zagg.coverage import refresh_root_coverage
+        from zagg.store import open_store
+
+        _windowed(cfg)
+        grid = self._grid(cfg)
+        root = str(tmp_path / "store")
+        hive.ensure_manifest(root, hive.build_manifest(grid, windowing=get_windowing(cfg)))
+        word = _shard_word()  # basename id -5112333, correct node .../3/3/3
+        # Same basename, planted one digit off (.../3/3/4): the walker descends
+        # any valid digit node and trusts the basename it finds.
+        wrong = open_store(f"{root}/-5/1/1/2/3/3/4/-5112333_2025.zarr")
+        grid.emit_shard_template(wrong, overwrite=True)
+        hive.stamp_commit(wrong, cells_with_data=1, granule_count=1, window="2025")
+        env = refresh_root_coverage(root)
+        np.testing.assert_array_equal(
+            hive.root_coverage_words(env), np.asarray([word], dtype=np.uint64)
+        )
+
+    def test_refresh_dedupes_bare_and_windowed_siblings(self, cfg, tmp_path):
+        # The spec forbids mixing a bare and a windowed leaf of one id in a
+        # single store (WRITE side), but the walk must survive it: both stamp to
+        # the same shard word, so `build_root_coverage`'s np.unique dedupe lists
+        # the shard exactly once (read-side dedupe across the two name shapes).
+        import numpy as np
+
+        from zagg.config import get_windowing
+        from zagg.coverage import refresh_root_coverage
+        from zagg.store import open_store
+
+        _windowed(cfg)
+        grid = self._grid(cfg)
+        root = str(tmp_path / "store")
+        hive.ensure_manifest(root, hive.build_manifest(grid, windowing=get_windowing(cfg)))
+        word = _shard_word()
+        for label in (None, "2025"):
+            store = open_store(hive.shard_leaf_path(root, word, window=label))
+            grid.emit_shard_template(store, overwrite=True)
+            hive.stamp_commit(
+                store, cells_with_data=1, granule_count=1, **({"window": label} if label else {})
+            )
+        env = refresh_root_coverage(root)
+        np.testing.assert_array_equal(
+            hive.root_coverage_words(env), np.asarray([word], dtype=np.uint64)
+        )
 
     def test_bitmap_sidecar_round_trip_on_windowed_leaf(self, cfg, tmp_path):
         import numpy as np

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -620,6 +620,38 @@ class TestWindowedStamp:
                 time_range=["2025-01-01T00:00:00+00:00", "2025-02-01T00:00:00+00:00"],
             )
 
+    def test_reversed_time_range_rejected(self, cfg):
+        # D15 truth half fails CLOSED: a [t_max, t_min] pair never becomes
+        # durable truth (review finding, PR #248).
+        store = self._leaf(cfg)
+        with pytest.raises(ValueError, match="reversed"):
+            hive.stamp_commit(
+                store,
+                cells_with_data=1,
+                granule_count=1,
+                window="2025",
+                time_range=["2025-11-20T18:30:00+00:00", "2025-03-01T06:00:00+00:00"],
+            )
+
+    def test_wrong_length_time_range_rejected(self, cfg):
+        store = self._leaf(cfg)
+        for bad in (["2025-01-01T00:00:00+00:00"], ["a", "b", "c"]):
+            with pytest.raises(ValueError, match="2-sequence"):
+                hive.stamp_commit(
+                    store, cells_with_data=1, granule_count=1, window="2025", time_range=bad
+                )
+
+    def test_garbage_time_range_rejected(self, cfg):
+        store = self._leaf(cfg)
+        with pytest.raises(ValueError, match="2-sequence"):
+            hive.stamp_commit(
+                store,
+                cells_with_data=1,
+                granule_count=1,
+                window="2025",
+                time_range=["not-a-date", "also-not"],
+            )
+
 
 class TestCoverageFull:
     def _grid(self, cfg):
@@ -697,6 +729,48 @@ class TestCoverageFull:
         np.testing.assert_array_equal(np.sort(got), np.sort(np.intersect1d(occupied, aoi)))
         # A miss is definitive (exact encoding).
         assert bitmap_and(leaf, children[5:7]).size == 0
+
+    def _full_bitmap_leaf(self, cfg, tmp_path):
+        """A leaf with ALL children occupied but encoded as a BITMAP (not
+        "full") — the representation the "full" short-circuit claims
+        moc_and-equivalence to."""
+        import numpy as np
+
+        from zagg.store import open_store
+
+        grid = self._grid(cfg)
+        word = _shard_word()
+        leaf = hive.shard_leaf_path(str(tmp_path / "bmp"), word, window="2025")
+        store = open_store(leaf)
+        grid.emit_shard_template(store, overwrite=True)
+        occupied = np.sort(np.asarray(grid.children(word), dtype=np.uint64))
+        bitmap = hive.encode_coverage_bitmap(word, occupied, grid.child_order)
+        hive.write_coverage_sidecar(leaf, bitmap)
+        cov = hive.build_coverage(word, occupied, grid.child_order, bitmap=bitmap)
+        hive.stamp_commit(
+            store, cells_with_data=len(occupied), granule_count=1, window="2025", coverage=cov
+        )
+        return leaf
+
+    def test_full_short_circuit_matches_bitmap_for_coarse_aoi(self, cfg, tmp_path):
+        # The "full" short-circuit is `moc_and([shard], aoi)`; the bitmap path
+        # is `moc_and(all_children_at_cell_order, aoi)`. Their equality rests on
+        # moc_and COMPACTING fine children up to a coarser AOI cell. Every other
+        # "full" test here uses child-order AOIs where both trivially agree and
+        # no normalization runs; here the AOI is the shard's own order-6 word —
+        # COARSER than cell_order 8 — so the bitmap path must compact its 4^2
+        # children up to match the short-circuit. A future moc_and that stopped
+        # compacting would break this (review finding, PR #248).
+        import numpy as np
+
+        from zagg.coverage import bitmap_and
+
+        _grid, word, full_leaf, _occ = self._stamped_leaf(cfg, tmp_path, full=True)
+        bmp_leaf = self._full_bitmap_leaf(cfg, tmp_path)
+        aoi = np.asarray([word], dtype=np.uint64)  # coarser than cell_order
+        full_res, bmp_res = bitmap_and(full_leaf, aoi), bitmap_and(bmp_leaf, aoi)
+        assert full_res is not None and bmp_res is not None
+        np.testing.assert_array_equal(np.sort(full_res), np.sort(bmp_res))
 
     def test_box_only_stamp_degrades_to_none(self, cfg, tmp_path):
         import numpy as np
@@ -966,14 +1040,14 @@ class TestProcessAndWriteHiveWindowed:
             df[name] = vals
         return df
 
-    def _run(self, monkeypatch, cfg, tmp_path, *, occupied, time_range=None):
+    def _run(self, monkeypatch, cfg, tmp_path, *, occupied, time_range=None, grid=None):
         import numpy as np
         import pandas as pd
 
         import zagg.processing as processing
 
         _windowed(cfg)
-        grid = self._grid(cfg)
+        grid = grid if grid is not None else self._grid(cfg)
         shard = _shard_word()
         root = str(tmp_path / "store")
         seen: dict = {}
@@ -1052,6 +1126,35 @@ class TestProcessAndWriteHiveWindowed:
         assert stamp["coverage"]["encoding"] == "full"
         assert "sidecar" not in stamp["coverage"]
         assert not os.path.exists(os.path.join(leaf, hive.COVERAGE_SIDECAR))
+
+    def test_depth0_full_popcount_short_circuits(self, monkeypatch, cfg, tmp_path):
+        import os
+
+        import numpy as np
+
+        from zagg.coverage import bitmap_and
+        from zagg.store import open_store
+
+        # Depth-0 config: child_order == parent_order, so a shard IS one cell and
+        # the popcount threshold is 4**0 == 1 (review finding, PR #248).
+        grid0 = HealpixGrid(parent_order=6, child_order=6, layout="fullsphere", config=cfg)
+        _grid, shard, root, _meta, _seen = self._run(
+            monkeypatch,
+            cfg,
+            tmp_path,
+            grid=grid0,
+            occupied=grid0.children(_shard_word()),  # the single order-6 cell
+        )
+        leaf = hive.shard_leaf_path(root, shard, window="2019")
+        stamp = hive.read_commit(open_store(leaf))
+        # The one occupied cell is a FULL subtree: stamps "full", no sidecar, and
+        # bitmap_and short-circuits — unlike an UNWINDOWED depth-0 leaf, which
+        # stays box-only (full is gated on windowing).
+        assert stamp["coverage"]["encoding"] == "full"
+        assert "sidecar" not in stamp["coverage"]
+        assert not os.path.exists(os.path.join(leaf, hive.COVERAGE_SIDECAR))
+        aoi = np.asarray([shard], dtype=np.uint64)
+        np.testing.assert_array_equal(np.sort(bitmap_and(leaf, aoi)), np.sort(aoi))
 
     def test_window_rerun_is_idempotent_replacement(self, monkeypatch, cfg, tmp_path):
         from zagg.store import open_store

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -309,3 +309,139 @@ class TestManifestTemporal:
         m = hive.read_manifest(str(tmp_path / "v2"))
         assert m["spec"] == "morton-hive/2"
         assert m["temporal"]["schedule"] == "yearly"
+
+
+# ── windowed leaf paths + node invariant + walker (phase 3) ──────────────────
+
+
+def _shard_word(order=6):
+    """A real southern packed shard word (decimal form ``-5112333`` at order 6)."""
+    import numpy as np
+    from mortie import geo2mort
+
+    return int(geo2mort(np.array([-78.5]), np.array([-132.0]), order=order)[0])
+
+
+class TestWindowedLeafPath:
+    def test_windowed_leaf_at_the_shard_node(self):
+        # D13: the windowed leaf sits at the SAME digit node as the bare leaf,
+        # basename `{full_id}_{window}.zarr` (frozen naming, mortie#62).
+        word = _shard_word()
+        assert (
+            hive.shard_leaf_path("root", word, window="2025")
+            == "root/-5/1/1/2/3/3/3/-5112333_2025.zarr"
+        )
+        assert (
+            hive.shard_leaf_path("root", word, window="melt-2019")
+            == "root/-5/1/1/2/3/3/3/-5112333_melt-2019.zarr"
+        )
+
+    def test_bare_path_byte_identical(self):
+        word = _shard_word()
+        assert hive.shard_leaf_path("root", word) == hive.shard_leaf_path("root", word, window=None)
+
+    def test_bad_window_label_raises(self):
+        with pytest.raises(ValueError, match="grammar"):
+            hive.shard_leaf_path("root", _shard_word(), window="melt_2019")
+
+
+class TestWindowedNodeInvariant:
+    @pytest.mark.parametrize(
+        "ok",
+        [
+            "-5/1/1/2/3/3/3/-5112333_2025.zarr",
+            "-4/2/-42_melt-2019.zarr",
+            "-4/2/-42_20251103.zarr",
+            "-4/2/-42.zarr",  # bare stays legal
+        ],
+    )
+    def test_accepts(self, ok):
+        hive.check_node_invariant(ok)
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "-4/2/-43_2025.zarr",  # leaf id does not match the digit chain
+            "-4/2/-42_mel_t.zarr",  # `_` inside the window label
+            "-4/2/-42_.zarr",  # empty window label
+            "-4/2/-42_" + "a" * 33 + ".zarr",  # label too long
+        ],
+    )
+    def test_rejects(self, bad):
+        with pytest.raises(ValueError, match="node invariant"):
+            hive.check_node_invariant(bad)
+
+
+class TestWindowedWalkerAndSidecar:
+    def _grid(self, cfg):
+        return HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+
+    def _windowed_store(self, cfg, tmp_path, labels, debris=()):
+        from zagg.store import open_store
+
+        _windowed(cfg)
+        grid = self._grid(cfg)
+        root = str(tmp_path / "store")
+        from zagg.config import get_windowing
+
+        hive.ensure_manifest(root, hive.build_manifest(grid, windowing=get_windowing(cfg)))
+        word = _shard_word()
+        for label in (*labels, *debris):
+            leaf = hive.shard_leaf_path(root, word, window=label)
+            store = open_store(leaf)
+            grid.emit_shard_template(store, overwrite=True)
+            if label not in debris:
+                hive.stamp_commit(store, cells_with_data=1, granule_count=1)
+        return root, word, grid
+
+    def test_refresh_walks_windowed_leaves_and_dedupes(self, cfg, tmp_path):
+        import numpy as np
+
+        from zagg.coverage import refresh_root_coverage
+
+        # Two stamped windows + one debris window of the SAME shard: the root
+        # MOC is spatial, so the shard is listed exactly once.
+        root, word, _grid = self._windowed_store(
+            cfg, tmp_path, labels=("2024", "2025"), debris=("2026",)
+        )
+        env = refresh_root_coverage(root)
+        np.testing.assert_array_equal(
+            hive.root_coverage_words(env), np.asarray([word], dtype=np.uint64)
+        )
+
+    def test_refresh_skips_malformed_window_label(self, cfg, tmp_path, caplog):
+        import logging
+
+        from zagg.coverage import refresh_root_coverage
+
+        root, word, _grid = self._windowed_store(cfg, tmp_path, labels=("2024",))
+        # A leaf-shaped name whose window part breaks the frozen charset: the
+        # walk warns and skips it instead of dying (escape-hatch posture).
+        bad = tmp_path / "store" / "-5" / "1" / "1" / "2" / "3" / "3" / "3"
+        (bad / "-5112333_bad_label.zarr").mkdir()
+        (bad / "-5112333_bad_label.zarr" / "zarr.json").write_text("{}")
+        with caplog.at_level(logging.WARNING, logger="zagg.coverage"):
+            env = refresh_root_coverage(root)
+        assert env is not None and len(env["ranges"]) == 1
+        assert any("malformed window label" in r.message for r in caplog.records)
+
+    def test_bitmap_sidecar_round_trip_on_windowed_leaf(self, cfg, tmp_path):
+        import numpy as np
+
+        from zagg.store import open_store
+
+        root, word, grid = self._windowed_store(cfg, tmp_path, labels=())
+        leaf = hive.shard_leaf_path(root, word, window="2025")
+        store = open_store(leaf)
+        grid.emit_shard_template(store, overwrite=True)
+        occupied = np.sort(np.asarray(grid.children(word)[:3], dtype=np.uint64))
+        bitmap = hive.encode_coverage_bitmap(word, occupied, grid.child_order)
+        hive.write_coverage_sidecar(leaf, bitmap)
+        hive.stamp_commit(
+            store,
+            cells_with_data=3,
+            granule_count=1,
+            coverage=hive.build_coverage(word, occupied, grid.child_order, bitmap=bitmap),
+        )
+        # The shard id parses out of the WINDOWED basename (first-`_` split).
+        np.testing.assert_array_equal(hive.read_coverage_bitmap(leaf), occupied)

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -1407,8 +1407,9 @@ class TestYearlyEndToEnd:
 
         - gA: [300, 400, 401, 402] — one 2018 obs (backfill bait) + three 2019
         - gB: [800, 801, 802] — all 2020
-        - gC: [729.5, 729.75, 730.25, 730.5] — straddles the 2019/2020 boundary
-          (2020-01-01 = day 730)
+        - gC: [729.5, 729.75, 730.0, 730.25, 730.5] — straddles the 2019/2020
+          boundary (2020-01-01 = day 730); the 730.0 obs lands EXACTLY on the
+          boundary instant and (half-open [start, end): ge start) belongs to 2020
         """
         import numpy as np
 
@@ -1427,7 +1428,7 @@ class TestYearlyEndToEnd:
         return {
             "s3://bucket/granuleA.h5": h5([300.0, 400.0, 401.0, 402.0]),
             "s3://bucket/granuleB.h5": h5([800.0, 801.0, 802.0]),
-            "s3://bucket/granuleC.h5": h5([729.5, 729.75, 730.25, 730.5]),
+            "s3://bucket/granuleC.h5": h5([729.5, 729.75, 730.0, 730.25, 730.5]),
         }
 
     def _records(self):
@@ -1474,7 +1475,7 @@ class TestYearlyEndToEnd:
         grp = zarr.open_group(open_store(leaf), path=grid.group_path, mode="r", zarr_format=3)
         return int(np.asarray(grp["count"][:]).sum())
 
-    def test_boundary_straddling_observations_split_exactly(self, monkeypatch, cfg, tmp_path):
+    def test_boundary_straddling_observations_split_exactly(self, monkeypatch, tmp_path):
         from zagg.store import open_store
 
         root = str(tmp_path / "store")
@@ -1485,10 +1486,11 @@ class TestYearlyEndToEnd:
 
         # Observation-level split on delta_time (the injected ge/lt filters):
         # 2018 gets gA's single early obs; 2019 gets gA's three + gC's two
-        # pre-boundary obs; 2020 gets gB's three + gC's two post-boundary obs.
+        # pre-boundary obs; 2020 gets gB's three + gC's three at-and-post-boundary
+        # obs (the day-730.0 obs lands ON the boundary → 2020 by ge start).
         assert self._leaf_obs(root, shard, "2018", grid) == 1
         assert self._leaf_obs(root, shard, "2019", grid) == 5
-        assert self._leaf_obs(root, shard, "2020", grid) == 5
+        assert self._leaf_obs(root, shard, "2020", grid) == 6
 
         # Stamp truth (D15): window label + the ACTUAL ISO-UTC extent of what
         # was written, strictly inside the window's half-open range.
@@ -1497,14 +1499,16 @@ class TestYearlyEndToEnd:
         assert stamp["window"] == "2019"
         # day 400 = 2019-02-05; day 729.75 = 2019-12-31T18:00 (gC's last 2019 obs).
         assert stamp["time_range"] == ["2019-02-05T00:00:00+00:00", "2019-12-31T18:00:00+00:00"]
-        # Boundary membership: the 2020 leaf STARTS at day 730.25 (06:00), not
-        # at the boundary instant — half-open windows, no double-counting.
+        # Boundary membership: gC's day-730.0 obs sits EXACTLY on the boundary
+        # instant, so the 2020 leaf STARTS at 2020-01-01T00:00:00 — half-open
+        # [start, end) puts the boundary tie in 2020, with no double-counting
+        # (it is absent from 2019, whose lt end excludes it).
         stamp20 = hive.read_commit(open_store(hive.shard_leaf_path(root, shard, window="2020")))
-        assert stamp20["time_range"][0] == "2020-01-01T06:00:00+00:00"
+        assert stamp20["time_range"][0] == "2020-01-01T00:00:00+00:00"
         # Per-unit granule subsetting reached the worker: 2019 read gA + gC.
         assert stamp["granule_count"] == 2
 
-    def test_backfill_then_root_union_and_idempotent_rerun(self, monkeypatch, cfg, tmp_path):
+    def test_backfill_then_root_union_and_idempotent_rerun(self, monkeypatch, tmp_path):
         import os
 
         from zagg.coverage import refresh_root_coverage

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -149,7 +149,7 @@ class TestWindowingConfig:
 
     def test_time_field_must_be_declared(self, cfg):
         _windowed(cfg, time_field="not_a_column")
-        with pytest.raises(ValueError, match="declared data_source column"):
+        with pytest.raises(ValueError, match="base-rate data_source column"):
             validate_config(cfg)
 
     def test_time_field_rejected_when_no_columns_declared(self, cfg):
@@ -158,13 +158,22 @@ class TestWindowingConfig:
         _windowed(cfg)
         cfg.data_source["coordinates"] = {}
         cfg.data_source["variables"] = {}
-        with pytest.raises(ValueError, match="declared data_source column"):
+        with pytest.raises(ValueError, match="base-rate data_source column"):
             validate_config(cfg)
 
-    def test_time_field_from_level_declared_variable_accepted(self, cfg):
-        # A readable segment-level variable declared on a non-base level
-        # (issue #30 mapping form) is a valid ``time_field``: it broadcasts to
-        # a per-photon column the worker reads.
+    def test_time_field_coordinate_rejected(self, cfg):
+        # A coordinate ``time_field`` is rejected: the stamp time_range is
+        # pooled from read VARIABLE columns, never coordinates (a lat/lon
+        # coordinate is not a timestamp), so it would filter yet silently drop
+        # the stamp. It must be declared as a variable.
+        _windowed(cfg, time_field="latitude")
+        with pytest.raises(ValueError, match="coordinate"):
+            validate_config(cfg)
+
+    def test_time_field_from_non_base_level_rejected(self, cfg):
+        # A segment-rate (non-base) level column is rejected this round: window
+        # membership would be decided per whole segment, not per observation,
+        # so the per-observation split process_and_write_hive promises fails.
         _windowed(cfg, time_field="seg_time")
         cfg.data_source["base_level"] = "photons"
         cfg.data_source["levels"] = {
@@ -184,8 +193,36 @@ class TestWindowingConfig:
                 },
             },
         }
+        with pytest.raises(ValueError, match="segment-rate window membership"):
+            validate_config(cfg)
+
+    def test_time_field_base_rate_accepted_in_hierarchical_config(self, cfg):
+        # In a hierarchical (levels) config the base level reads its columns
+        # from ``data_source.variables`` (a base-level ``variables`` mapping is
+        # forbidden). A base-rate ``time_field`` declared there filters at base
+        # rate (level None) — per-observation membership — so it is accepted
+        # even alongside a segment-level link.
+        _windowed(cfg, time_field="delta_time")
+        cfg.data_source["base_level"] = "photons"
+        cfg.data_source["levels"] = {
+            "photons": {
+                "path": "/{group}/heights",
+                "coordinates": ["lat_ph", "lon_ph"],
+                "variables": ["h_ph"],
+            },
+            "segments": {
+                "path": "/{group}/geolocation",
+                "coordinates": ["reference_photon_lat"],
+                "variables": {"seg_h": "/{group}/geolocation/h"},
+                "link": {
+                    "to": "photons",
+                    "index_beg": "/{group}/geolocation/ph_index_beg",
+                    "count": "/{group}/geolocation/segment_ph_cnt",
+                },
+            },
+        }
         validate_config(cfg)
-        assert get_windowing(cfg)["time_field"] == "seg_time"
+        assert get_windowing(cfg)["time_field"] == "delta_time"
 
     def test_requires_epoch(self, cfg):
         _windowed(cfg, epoch=None)
@@ -942,6 +979,19 @@ class TestWindowedUnits:
         )
         assert [w["label"] for _k, _r, w in units] == ["2019", "2020"]
         assert all(recs == [legacy] for _k, recs, _w in units)
+
+    def test_bounds_full_iso_end_date_accepted(self, cfg):
+        from zagg.runner import _windowed_units
+
+        # A full ISO end_date must parse as-is (not get a T23:59:59 suffix
+        # appended, which would corrupt it into a parse error).
+        legacy = {"id": "g0", "s3": "s3://b/g0.h5", "https": None}
+        units = _windowed_units(
+            [(11, [legacy])],
+            self._windowing(cfg),
+            {"start_date": "2019-01-01", "end_date": "2020-12-31T00:00:00Z"},
+        )
+        assert [w["label"] for _k, _r, w in units] == ["2019", "2020"]
 
     def test_untimed_granule_without_bounds_is_a_pointed_error(self, cfg):
         from zagg.runner import _windowed_units

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -60,27 +60,35 @@ def test_dense_fullsphere_equivalence(mock_dataframe_factory):
 
     # Dense store
     dense_grid = HealpixGrid(
-        parent_order=parent_order, child_order=child_order, layout="dense",
-        config=cfg, populated_shards=parents,
+        parent_order=parent_order,
+        child_order=child_order,
+        layout="dense",
+        config=cfg,
+        populated_shards=parents,
     )
     dense_store = MemoryStore()
     dense_grid.emit_template(dense_store)
     for parent, df in zip(parents, frames):
         write_dataframe_to_zarr(
-            df, dense_store,
+            df,
+            dense_store,
             grid=dense_grid,
             chunk_idx=dense_grid.block_index(parent),
         )
 
     # Fullsphere store
     full_grid = HealpixGrid(
-        parent_order=parent_order, child_order=child_order, layout="fullsphere", config=cfg,
+        parent_order=parent_order,
+        child_order=child_order,
+        layout="fullsphere",
+        config=cfg,
     )
     full_store = MemoryStore()
     full_grid.emit_template(full_store)
     for parent, df in zip(parents, frames):
         write_dataframe_to_zarr(
-            df, full_store,
+            df,
+            full_store,
             grid=full_grid,
             chunk_idx=full_grid.block_index(parent),
         )
@@ -101,7 +109,8 @@ def test_dense_fullsphere_equivalence(mock_dataframe_factory):
             dense_vals = dense_group[col][dense_min : dense_max + 1]
             full_vals = full_group[col][full_min : full_max + 1]
             np.testing.assert_array_equal(
-                dense_vals, full_vals,
+                dense_vals,
+                full_vals,
                 err_msg=f"layout mismatch in {col} for parent {parent}",
             )
 
@@ -117,9 +126,11 @@ def test_rectilinear_end_to_end():
     cfg = default_config("atl06_polar")
     # Small grid for test speed: 32 x 32 cells, 8x8 chunks → 4x4 chunk grid.
     grid = RectilinearGrid(
-        crs="EPSG:3031", resolution=200_000,  # large resolution → small grid
+        crs="EPSG:3031",
+        resolution=200_000,  # large resolution → small grid
         bounds=(-3_200_000, -3_200_000, 3_200_000, 3_200_000),
-        chunk_shape=(8, 8), config=cfg,
+        chunk_shape=(8, 8),
+        config=cfg,
     )
     assert grid.array_shape == (32, 32)
     assert grid.n_row_blocks == 4 and grid.n_col_blocks == 4
@@ -130,24 +141,25 @@ def test_rectilinear_end_to_end():
     # Write known values to one chunk.
     shard = grid._pack(1, 2)
     n_cells = grid.chunk_h * grid.chunk_w
-    df = pd.DataFrame({
-        "count": np.arange(n_cells, dtype=np.int32),
-        "h_min": np.linspace(-100, 100, n_cells, dtype=np.float32),
-        "h_max": np.linspace(0, 200, n_cells, dtype=np.float32),
-        "h_mean": np.linspace(-50, 150, n_cells, dtype=np.float32),
-        "h_sigma": np.full(n_cells, 0.5, dtype=np.float32),
-        "h_variance": np.full(n_cells, 1.0, dtype=np.float32),
-    })
+    df = pd.DataFrame(
+        {
+            "count": np.arange(n_cells, dtype=np.int32),
+            "h_min": np.linspace(-100, 100, n_cells, dtype=np.float32),
+            "h_max": np.linspace(0, 200, n_cells, dtype=np.float32),
+            "h_mean": np.linspace(-50, 150, n_cells, dtype=np.float32),
+            "h_sigma": np.full(n_cells, 0.5, dtype=np.float32),
+            "h_variance": np.full(n_cells, 1.0, dtype=np.float32),
+        }
+    )
     from zagg.processing import write_dataframe_to_zarr
+
     write_dataframe_to_zarr(df, store, grid=grid, chunk_idx=grid.block_index(shard))
 
     # Read back. Block (1, 2) covers rows [8, 16) and cols [16, 24).
     group = zarr.open_group(store, path=grid.group_path, mode="r")
     block = group["count"][8:16, 16:24]
     assert block.shape == (8, 8)
-    np.testing.assert_array_equal(
-        block, np.arange(n_cells, dtype=np.int32).reshape(8, 8)
-    )
+    np.testing.assert_array_equal(block, np.arange(n_cells, dtype=np.int32).reshape(8, 8))
 
     # Confirm other chunks are still fill-value (NaN for float arrays).
     assert np.all(np.isnan(group["h_mean"][0:8, 0:8]))

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1156,8 +1156,23 @@ class TestProcessHiveWindowed:
         resp = handler_mod._handle_process(event, _context())
         assert resp["statusCode"] == 200, resp["body"]
 
-        # The injected window filter pair reached the worker's config.
-        assert [f["op"] for f in seen["filters"][-2:]] == ["ge", "lt"]
+        # The injected window filter pair reached the worker's config — full
+        # dicts (level/dataset/op/value), matching how test_hive_windows.py's
+        # TestWindowedCellConfig pins the ge/lt pair off the time field.
+        assert seen["filters"][-2:] == [
+            {
+                "level": None,
+                "dataset": "/{group}/land_ice_segments/delta_time",
+                "op": "ge",
+                "value": 365 * 86400.0,
+            },
+            {
+                "level": None,
+                "dataset": "/{group}/land_ice_segments/delta_time",
+                "op": "lt",
+                "value": 730 * 86400.0,
+            },
+        ]
         assert seen["time_range_of"] == "delta_time"
         # The leaf is the WINDOWED name; its stamp carries the D15 truth.
         leaf = hive.shard_leaf_path(event["store_path"], TestProcessHive._WORD, window="2019")

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1100,6 +1100,117 @@ class TestProcessHive:
         assert not os.path.exists(hive.shard_leaf_path(event["store_path"], self._WORD))
 
 
+class TestProcessHiveWindowed:
+    """Issue #246: a windowed hive event threads ``window`` through the shared
+    ``process_and_write_hive`` path — windowed leaf, filter injection, ISO
+    ``time_range`` in the response body — and the setup invoke declares the
+    ``morton-hive/2`` manifest from the same forwarded config."""
+
+    @staticmethod
+    def _windowed_config_dict():
+        cfg_dict = TestProcessHive._hive_config_dict()
+        cfg_dict["data_source"]["variables"]["delta_time"] = "/{group}/land_ice_segments/delta_time"
+        cfg_dict["output"]["windowing"] = {
+            "schedule": "yearly",
+            "time_field": "delta_time",
+            "epoch": "2018-01-01T00:00:00Z",
+            "scale": "gps",
+        }
+        return cfg_dict
+
+    def test_windowed_event_writes_windowed_leaf_with_time_range(
+        self, handler_mod, monkeypatch, tmp_path
+    ):
+        import zagg.processing as processing
+        from zagg import hive
+        from zagg.config import load_config_from_dict
+        from zagg.store import open_store
+
+        cfg_dict = self._windowed_config_dict()
+        grid = from_config(load_config_from_dict(cfg_dict))
+        seen = {}
+
+        def fake(g, shard_key, urls, **kwargs):
+            seen["filters"] = kwargs["config"].data_source["filters"]
+            seen["time_range_of"] = kwargs.get("time_range_of")
+            carrier = TestProcessHive._carrier(grid, shard_key)
+            kwargs["write_chunk"](grid.block_index(int(shard_key)), carrier, {})
+            return pd.DataFrame(), {
+                "shard_key": int(shard_key),
+                "cells_with_data": 5,
+                "total_obs": 7,
+                "granule_count": 1,
+                "files_processed": 1,
+                "duration_s": 0.0,
+                "error": None,
+                # Dataset units (GPS s since 2018-01-01): days 425 and 695.
+                "time_range": [425 * 86400.0, 695 * 86400.0],
+            }
+
+        monkeypatch.setattr(processing, "process_shard", fake)
+        event = _base_event(cfg_dict)
+        event["shard_key"] = TestProcessHive._WORD
+        event["child_order"] = 12
+        event["store_path"] = str(tmp_path / "hive-out")
+        event["window"] = {"label": "2019", "start": 365 * 86400.0, "end": 730 * 86400.0}
+        resp = handler_mod._handle_process(event, _context())
+        assert resp["statusCode"] == 200, resp["body"]
+
+        # The injected window filter pair reached the worker's config.
+        assert [f["op"] for f in seen["filters"][-2:]] == ["ge", "lt"]
+        assert seen["time_range_of"] == "delta_time"
+        # The leaf is the WINDOWED name; its stamp carries the D15 truth.
+        leaf = hive.shard_leaf_path(event["store_path"], TestProcessHive._WORD, window="2019")
+        stamp = hive.read_commit(open_store(leaf))
+        assert stamp["window"] == "2019"
+        assert stamp["time_range"] == [
+            "2019-03-02T00:00:00+00:00",
+            "2019-11-27T00:00:00+00:00",
+        ]
+        # The response body mirrors the ISO strings for the dispatcher's
+        # root-summary union.
+        assert json.loads(resp["body"])["time_range"] == stamp["time_range"]
+
+    def test_unwindowed_event_stays_bare(self, handler_mod, monkeypatch, tmp_path):
+        import zagg.processing as processing
+        from zagg import hive
+        from zagg.store import open_store
+
+        grid = TestProcessHive._grid()
+        monkeypatch.setattr(
+            processing,
+            "process_shard",
+            TestProcessHive()._streaming_fake(grid),
+        )
+        event = TestProcessHive()._event(tmp_path)
+        resp = handler_mod._handle_process(event, _context())
+        assert resp["statusCode"] == 200, resp["body"]
+        stamp = hive.read_commit(
+            open_store(hive.shard_leaf_path(event["store_path"], TestProcessHive._WORD))
+        )
+        assert stamp["spec"] == "morton-hive/1"
+        assert "window" not in stamp and "time_range" not in stamp
+        assert "time_range" not in json.loads(resp["body"])
+
+    def test_setup_declares_v2_manifest(self, handler_mod, tmp_path):
+        from zagg import hive
+
+        event = {
+            "mode": "setup",
+            "store_path": str(tmp_path / "hive-out"),
+            "parent_order": 6,
+            "overwrite": False,
+            "config": self._windowed_config_dict(),
+            "dataset": {"short_name": "ATL06", "version": "007"},
+        }
+        resp = handler_mod._handle_setup(event)
+        assert resp["statusCode"] == 200, resp["body"]
+        manifest = hive.read_manifest(event["store_path"])
+        assert manifest["spec"] == "morton-hive/2"
+        assert manifest["temporal"]["schedule"] == "yearly"
+        assert manifest["temporal"]["time_field"] == "delta_time"
+
+
 class TestSetupHive:
     """Issue #199 phase 3: for a hive config, setup mode writes ONLY the
     ``morton_hive.json`` manifest — no global zarr template (D5) — with the

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -55,6 +55,10 @@ class TestGoldenVectors:
         assert w.window_label(_dt(2025, 6, 15, 12), "yearly") == "2025"
         assert w.window_range("2025", "yearly") == (_dt(2025, 1, 1), _dt(2026, 1, 1))
         assert w.leaf_name("-31123", "2025") == "-31123_2025.zarr"
+        # Width-valid but not a real year: the raise comes from datetime(), not
+        # the regex (calendar validity is deferred to window_range).
+        with pytest.raises(ValueError):
+            w.window_range("0000", "yearly")
 
     def test_monthly(self):
         # | monthly | YYYYMM | -31123_202511.zarr | calendar month |
@@ -63,6 +67,11 @@ class TestGoldenVectors:
         assert w.leaf_name("-31123", "202511") == "-31123_202511.zarr"
         # December rolls the year.
         assert w.window_range("202512", "monthly") == (_dt(2025, 12, 1), _dt(2026, 1, 1))
+        # Width-valid but out-of-range month: raised by datetime(), not the regex.
+        with pytest.raises(ValueError):
+            w.window_range("202513", "monthly")
+        with pytest.raises(ValueError):
+            w.window_range("202500", "monthly")
 
     def test_daily(self):
         # | daily | YYYYMMDD | -31123_20251103.zarr | calendar day |
@@ -247,6 +256,15 @@ class TestEpochConversion:
         naive = (_dt(2020, 1, 1) - _dt(1980, 1, 6)).total_seconds()
         assert w.utc_to_offset(_dt(2020, 1, 1), epoch=epoch, scale="gps") == naive + 18
         assert w.offset_to_utc(naive + 18, epoch=epoch, scale="gps") == _dt(2020, 1, 1)
+
+    def test_tai_native_epoch(self):
+        # TAI seconds since the TAI epoch (1958-01-01, offset 0 by definition):
+        # the full current TAI-UTC offset (+37) applies — the pre-2017 branch,
+        # symmetric with the GPS +18 case above.
+        epoch = "1958-01-01T00:00:00Z"
+        naive = (_dt(2020, 1, 1) - _dt(1958, 1, 1)).total_seconds()
+        assert w.utc_to_offset(_dt(2020, 1, 1), epoch=epoch, scale="tai") == naive + 37
+        assert w.offset_to_utc(naive + 37, epoch=epoch, scale="tai") == _dt(2020, 1, 1)
 
     def test_utc_scale_is_naive_difference(self):
         epoch = "2000-01-01T00:00:00Z"

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,0 +1,288 @@
+"""Window primitives for morton-hive/2 — issue #246 phase 1.
+
+Golden vectors are pinned to the FROZEN convention table on the mortie spec
+page (https://github.com/espg/mortie/issues/62#issuecomment-4986809092):
+label grammar, example leaves, UTC half-open boundaries, split-on-first-``_``
+parse rule, and the lexicographic = chronological ordering property.
+"""
+
+import random
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from zagg import windows as w
+
+UTC = timezone.utc
+
+
+def _dt(*args):
+    return datetime(*args, tzinfo=UTC)
+
+
+# ── schedules ────────────────────────────────────────────────────────────────
+
+
+class TestSchedules:
+    def test_implemented_set(self):
+        assert w.SCHEDULES == ("none", "yearly", "monthly", "daily", "explicit")
+        for s in w.SCHEDULES:
+            assert w.check_schedule(s) == s
+
+    def test_quarterly_is_reserved_not_implemented(self):
+        # Grammar-reserved on the spec page (YYYYQ[1-4]); this round rejects it
+        # pointedly instead of half-supporting the grammar.
+        with pytest.raises(ValueError, match="reserved"):
+            w.check_schedule("quarterly")
+        with pytest.raises(ValueError, match="reserved"):
+            w.window_label(_dt(2025, 7, 1), "quarterly")
+        with pytest.raises(ValueError, match="reserved"):
+            w.windows_intersecting(_dt(2025, 1, 1), _dt(2025, 2, 1), "quarterly")
+
+    def test_unknown_schedule_rejected(self):
+        with pytest.raises(ValueError, match="unknown window schedule"):
+            w.check_schedule("weekly")
+
+
+# ── golden vectors: the frozen mortie table ──────────────────────────────────
+
+
+class TestGoldenVectors:
+    """One row per spec-table row: label grammar, example leaf, window range."""
+
+    def test_yearly(self):
+        # | yearly | YYYY | -31123_2025.zarr | [2025-01-01T00:00Z, 2026-01-01T00:00Z) |
+        assert w.window_label(_dt(2025, 6, 15, 12), "yearly") == "2025"
+        assert w.window_range("2025", "yearly") == (_dt(2025, 1, 1), _dt(2026, 1, 1))
+        assert w.leaf_name("-31123", "2025") == "-31123_2025.zarr"
+
+    def test_monthly(self):
+        # | monthly | YYYYMM | -31123_202511.zarr | calendar month |
+        assert w.window_label(_dt(2025, 11, 3), "monthly") == "202511"
+        assert w.window_range("202511", "monthly") == (_dt(2025, 11, 1), _dt(2025, 12, 1))
+        assert w.leaf_name("-31123", "202511") == "-31123_202511.zarr"
+        # December rolls the year.
+        assert w.window_range("202512", "monthly") == (_dt(2025, 12, 1), _dt(2026, 1, 1))
+
+    def test_daily(self):
+        # | daily | YYYYMMDD | -31123_20251103.zarr | calendar day |
+        assert w.window_label(_dt(2025, 11, 3, 23, 59, 59), "daily") == "20251103"
+        assert w.window_range("20251103", "daily") == (_dt(2025, 11, 3), _dt(2025, 11, 4))
+        assert w.leaf_name("-31123", "20251103") == "-31123_20251103.zarr"
+        # Leap day decodes; a non-date of the right width does not.
+        assert w.window_range("20240229", "daily")[0] == _dt(2024, 2, 29)
+        with pytest.raises(ValueError):
+            w.window_range("20230229", "daily")
+
+    def test_none_bare_leaf(self):
+        # | none | (no label; bare name) | -31123.zarr |
+        assert w.leaf_name("-31123") == "-31123.zarr"
+        assert w.split_leaf_name("-31123.zarr") == ("-31123", None)
+
+    def test_explicit_opaque_label(self):
+        # | explicit list | opaque, [0-9A-Za-z-]{1,32} | -31123_melt-2019.zarr |
+        declared = [{"label": "melt-2019", "start": "2019-06-01", "end": "2019-09-01"}]
+        assert w.leaf_name("-31123", "melt-2019") == "-31123_melt-2019.zarr"
+        assert w.window_range("melt-2019", "explicit", declared) == (
+            _dt(2019, 6, 1),
+            _dt(2019, 9, 1),
+        )
+        # Labels are opaque: undeclared labels never decode.
+        with pytest.raises(ValueError, match="not declared"):
+            w.window_range("melt-2020", "explicit", declared)
+
+
+# ── label grammar ────────────────────────────────────────────────────────────
+
+
+class TestLabelGrammar:
+    @pytest.mark.parametrize(
+        "label,schedule",
+        [
+            ("2025", "yearly"),
+            ("202511", "monthly"),
+            ("20251103", "daily"),
+            ("melt-2019", "explicit"),
+            ("a", "explicit"),
+            ("A" * 32, "explicit"),
+        ],
+    )
+    def test_valid(self, label, schedule):
+        assert w.validate_label(label, schedule) == label
+
+    @pytest.mark.parametrize(
+        "label,schedule",
+        [
+            ("25", "yearly"),  # wrong width
+            ("2025-11", "monthly"),  # hyphen in a generative label
+            ("2025", "monthly"),  # wrong width for the schedule
+            ("melt_2019", "explicit"),  # underscore excluded by construction
+            ("", "explicit"),  # empty
+            ("A" * 33, "explicit"),  # too long
+            ("melt 2019", "explicit"),  # space
+        ],
+    )
+    def test_invalid(self, label, schedule):
+        with pytest.raises(ValueError, match="grammar"):
+            w.validate_label(label, schedule)
+
+
+# ── leaf-name split (frozen parse rule) ──────────────────────────────────────
+
+
+class TestLeafNameSplit:
+    def test_split_on_first_underscore(self):
+        assert w.split_leaf_name("-31123_2025.zarr") == ("-31123", "2025")
+        assert w.split_leaf_name("41123_melt-2019.zarr") == ("41123", "melt-2019")
+
+    def test_round_trip(self):
+        for full_id, window in [("-31123", "2025"), ("41123", "melt-2019"), ("-5112333", None)]:
+            assert w.split_leaf_name(w.leaf_name(full_id, window)) == (full_id, window)
+
+    def test_rejects_non_zarr(self):
+        with pytest.raises(ValueError, match="leaf zarr"):
+            w.split_leaf_name("-31123_2025")
+
+    def test_rejects_malformed_window(self):
+        # A second underscore lands IN the window part and fails the charset —
+        # the one-separator property the frozen charset guarantees.
+        with pytest.raises(ValueError, match="grammar"):
+            w.split_leaf_name("-31123_2025_x.zarr")
+
+    def test_leaf_name_rejects_bad_window(self):
+        with pytest.raises(ValueError, match="grammar"):
+            w.leaf_name("-31123", "melt_2019")
+
+
+# ── windows_intersecting ─────────────────────────────────────────────────────
+
+
+class TestWindowsIntersecting:
+    def test_yearly_straddle(self):
+        got = w.windows_intersecting(_dt(2024, 11, 2), _dt(2025, 2, 3), "yearly")
+        assert got == ["2024", "2025"]
+
+    def test_monthly_run(self):
+        got = w.windows_intersecting(_dt(2025, 11, 30), _dt(2026, 1, 1), "monthly")
+        assert got == ["202511", "202512", "202601"]
+
+    def test_instant_on_boundary_belongs_to_the_later_window(self):
+        # Half-open [start, end): the boundary instant is in the LATER window.
+        assert w.windows_intersecting(_dt(2026, 1, 1), _dt(2026, 1, 1), "yearly") == ["2026"]
+
+    def test_daily_single_instant(self):
+        assert w.windows_intersecting(_dt(2025, 11, 3, 5), _dt(2025, 11, 3, 6), "daily") == [
+            "20251103"
+        ]
+
+    def test_explicit_overlap_and_boundary(self):
+        declared = [
+            {"label": "melt-2019", "start": "2019-06-01", "end": "2019-09-01"},
+            {"label": "melt-2020", "start": "2020-06-01", "end": "2020-09-01"},
+        ]
+        assert w.windows_intersecting(_dt(2019, 8, 1), _dt(2020, 7, 1), "explicit", declared) == [
+            "melt-2019",
+            "melt-2020",
+        ]
+        # A range starting exactly at a window's half-open END misses it.
+        assert w.windows_intersecting(_dt(2019, 9, 1), _dt(2019, 10, 1), "explicit", declared) == []
+
+    def test_reversed_range_rejected(self):
+        with pytest.raises(ValueError, match="precedes"):
+            w.windows_intersecting(_dt(2025, 2, 1), _dt(2025, 1, 1), "yearly")
+
+
+# ── lexicographic = chronological (property, per generative schedule) ────────
+
+
+class TestLexicographicIsChronological:
+    @pytest.mark.parametrize("schedule", w.GENERATIVE_SCHEDULES)
+    def test_property(self, schedule):
+        rng = random.Random(f"issue-246-{schedule}")
+        span = _dt(1990, 1, 1), _dt(2120, 12, 31)
+        seconds = int((span[1] - span[0]).total_seconds())
+        instants = [span[0] + timedelta(seconds=rng.randrange(seconds)) for _ in range(300)]
+        labels = [w.window_label(t, schedule) for t in instants]
+        starts = {lab: w.window_range(lab, schedule)[0] for lab in labels}
+        assert sorted(set(labels)) == sorted(set(labels), key=starts.__getitem__)
+        # And label order matches the instants' own order window-wise.
+        for t, lab in zip(instants, labels):
+            lo, hi = w.window_range(lab, schedule)
+            assert lo <= t < hi
+
+    @pytest.mark.parametrize("schedule", w.GENERATIVE_SCHEDULES)
+    def test_contiguity(self, schedule):
+        # Consecutive windows tile time: each window's end is the next's start.
+        t = _dt(2023, 11, 27)
+        for _ in range(50):
+            lab = w.window_label(t, schedule)
+            lo, hi = w.window_range(lab, schedule)
+            assert w.window_label(hi, schedule) != lab
+            assert w.window_range(w.window_label(hi, schedule), schedule)[0] == hi
+            t = hi
+
+
+# ── UTC <-> dataset time (fixed-offset conversion, ratified #246) ────────────
+
+
+class TestEpochConversion:
+    def test_offsets(self):
+        assert w.epoch_offset("utc") == 0
+        assert w.epoch_offset("gps") == 18
+        assert w.epoch_offset("tai") == 37  # TAI = GPS + 19 s
+        with pytest.raises(ValueError, match="scale"):
+            w.epoch_offset("tt")
+
+    def test_icesat2_atlas_sdp_epoch(self):
+        # ICESat-2 delta_time: GPS seconds since 2018-01-01T00:00:00Z (post-2017
+        # epoch -> the constant offset cancels; naive difference is exact).
+        epoch = "2018-01-01T00:00:00Z"
+        assert w.utc_to_offset(_dt(2019, 1, 1), epoch=epoch, scale="gps") == 365 * 86400.0
+        assert w.offset_to_utc(365 * 86400.0, epoch=epoch, scale="gps") == _dt(2019, 1, 1)
+
+    def test_gps_native_epoch(self):
+        # GPS seconds since the GPS epoch (1980-01-06, offset 0 by definition):
+        # the full current GPS-UTC offset applies.
+        epoch = "1980-01-06T00:00:00Z"
+        naive = (_dt(2020, 1, 1) - _dt(1980, 1, 6)).total_seconds()
+        assert w.utc_to_offset(_dt(2020, 1, 1), epoch=epoch, scale="gps") == naive + 18
+        assert w.offset_to_utc(naive + 18, epoch=epoch, scale="gps") == _dt(2020, 1, 1)
+
+    def test_utc_scale_is_naive_difference(self):
+        epoch = "2000-01-01T00:00:00Z"
+        assert w.utc_to_offset(_dt(2000, 1, 2), epoch=epoch) == 86400.0
+
+    def test_days_units(self):
+        epoch = "2018-01-01T00:00:00Z"
+        assert w.utc_to_offset(_dt(2018, 1, 31), epoch=epoch, units="days") == 30.0
+        assert w.offset_to_utc(30, epoch=epoch, units="days") == _dt(2018, 1, 31)
+        with pytest.raises(ValueError, match="units"):
+            w.utc_to_offset(_dt(2018, 1, 2), epoch=epoch, units="fortnights")
+
+    def test_round_trip(self):
+        epoch = "2018-01-01T00:00:00Z"
+        for scale in w.EPOCH_SCALES:
+            v = w.utc_to_offset(_dt(2024, 7, 15, 6, 30), epoch=epoch, scale=scale)
+            assert w.offset_to_utc(v, epoch=epoch, scale=scale) == _dt(2024, 7, 15, 6, 30)
+
+
+# ── parse/format helpers ─────────────────────────────────────────────────────
+
+
+class TestParseUtc:
+    def test_z_suffix_and_offset(self):
+        assert w.parse_utc("2025-01-01T00:00:00Z") == _dt(2025, 1, 1)
+        assert w.parse_utc("2025-01-01T02:00:00+02:00") == _dt(2025, 1, 1)
+
+    def test_naive_is_utc(self):
+        assert w.parse_utc("2025-01-01") == _dt(2025, 1, 1)
+
+    def test_datetime_passthrough(self):
+        assert w.parse_utc(_dt(2025, 1, 1)) == _dt(2025, 1, 1)
+
+    def test_garbage_rejected(self):
+        with pytest.raises(ValueError, match="ISO-8601"):
+            w.parse_utc("not-a-date")
+
+    def test_iso_utc_rendering(self):
+        assert w.iso_utc(_dt(2025, 1, 1, 12, 30, 15)) == "2025-01-01T12:30:15+00:00"


### PR DESCRIPTION
Closes #246

Implements the `morton-hive/2` temporal machinery ratified on #237 (design registry D13/D14/D15, merged in #243) and planned + ratified on the #246 thread: time-windowed leaves, the manifest temporal block, window/time-range stamps, the coverage `"full"` fast path, per-(shard, window) dispatch fan-out, and the worker-side observation time filter. The window-label grammar and boundary semantics are FROZEN on the [mortie spec page](https://github.com/espg/mortie/issues/62#issuecomment-4986809092); golden-vector tests pin that table.

## Approach

- **New `src/zagg/windows.py` module** (pure functions, stdlib only): label grammar + validation, `window_label` / `window_range` / `windows_intersecting` (UTC half-open `[start, end)`), the split-on-first-`_` leaf-name parser, and the fixed-offset UTC↔dataset-time conversion (`epoch_offset` with `GPS_MINUS_UTC = 18`, TAI hook included, documented ≤1-leap-second tolerance) per the ratified Q3 answer, plus `union_time_range`/`iso_time_range`.
- **Config**: the ratified nested `output.windowing: {schedule, time_field, epoch, scale, units, windows}` block; absent (or `schedule: none`) = today's behavior, byte-identical. Hive-only, healpix-only; `time_field` must be a base-rate `data_source.variables` column (segment-rate membership deferred — review fold); raster configs rejected pointing at #247. `quarterly` is grammar-reserved and rejected pointedly; the explicit windows list ships in this round. `window_time_filters`/`windowed_cell_config` implement the observation filter as a pair of structured `ge`/`lt` predicates riding the issue #43 machinery — the temporal analog of `aoi_mask`.
- **Manifest** gains the D15 temporal block (`schedule`/`time_field`/`epoch`/`scale`/`units`/`calendar`/`append_policy`/`windows`) and bumps `spec` to `"morton-hive/2"` iff windowing is configured; `temporal` joins the frozen resume keys (a windowing change refuses resume like an orders change); `/1` manifests keep reading. **Stamps** (truth) carry the window label + the actual written `time_range` as ISO-8601 UTC strings (ratified Q2), validated fail-closed. The **root summary** (cache) carries the time-range union, accumulated by `write_root_coverage` and rebuilt by `refresh_root_coverage` from the stamps.
- **Coverage `"full"`** (D14): a popcount at stamp time short-circuits a fully-occupied subtree to `encoding: "full"` with no bitmap sidecar PUT; `bitmap_and` short-circuits reads via the shard's own MOC membership (exact, one fewer GET).
- **Dispatch** fans one work unit per (shard, window) (`runner._windowed_units`, shard-major so the #197 shuffle and biggest-first buckets survive): the shardmap's new per-granule `time_start`/`time_end` subset granules per window; legacy shardmaps degrade conservatively (every granule → every window; `bounds.temporal` enumerates generative windows, with a pointed error otherwise). Window bounds convert to dataset units once at dispatch. Async status keys become `{label}_{window}.json` so windowed units of one shard cannot collide. Both dispatchers ride the shared `process_and_write_hive` worker path; the Lambda event gains an optional `window` key (absent = byte-identical), and the worker response body returns the stamped ISO `time_range` for the root union.

## Phases

- [x] Phase 1 — window primitives (`src/zagg/windows.py`) + golden-vector tests pinned to the frozen mortie table, lexicographic=chronological property test per generative schedule
- [x] Phase 2 — config `output.windowing` block (validation + accessor) + manifest temporal block / `morton-hive/2` spec bump
- [x] Phase 3 — windowed leaf naming (`shard_leaf_path`), node-invariant + walker acceptance of windowed leaves
- [x] Phase 4 — stamp `window`/`time_range`, coverage `encoding: "full"` write + read sides, root-summary time union
- [x] Phase 5 — per-(shard, window) dispatch fan-out (local + Lambda), shardmap per-granule time metadata, worker time filter
- [x] Phase 6 — end-to-end tests + `docs/hive_layout.md` windowing section

All six adversarial self-review rounds are folded (one review + one fold pass per phase; every inline thread carries a reply).

## Testing

- `tests/test_windows.py` (55): golden vectors for every row of the frozen grammar table, split-parser round trips, half-open boundary membership, the lexicographic=chronological property over 300 random instants per generative schedule, window contiguity, epoch conversion (ATLAS SDP exactness, GPS-1980 +18 s, TAI-1958 +37 s, round trips).
- `tests/test_hive_windows.py` (90): config validation (including raster→#247, quarterly, explicit-list well-formedness, base-rate time_field), manifest `/2` + frozen-key resume semantics, windowed leaf paths + node invariant + walker (dedupe, malformed-label skip, bare+windowed siblings), windowed stamps (fail-closed `time_range`), coverage `"full"` both ways (popcount through `process_and_write_hive`, full-vs-bitmap exactness at coarse AOIs, depth-0), root time union (build/write-union/refresh/load), dispatch fan-out units (subsetting, straddler, legacy fallback, explicit), `_invoke_lambda_cell` event shape (windowed + unwindowed-byte-identical), and **`TestYearlyEndToEnd`** — the acceptance fixture through the REAL read path (`_FakeH5` h5coro stub + real `_read_group`, so the injected filters actually run): exact 1/5/6 observation splits including an obs exactly on the boundary instant (later window only), stamp ISO ranges strictly inside the window, backfill leaving committed leaves untouched, idempotent window re-run, root time union.
- `tests/test_lambda_handler.py`: windowed event → windowed leaf + injected filter values + ISO `time_range` in stamp and body; unwindowed event stays bare (spec `/1`, no new keys); setup declares the `/2` manifest.
- `none`-identity pins: unwindowed manifest/stamp/root-envelope key sets pinned exactly; unwindowed dispatch payloads/events byte-identical; all pre-existing hive/#241 parity tests green.
- Local green: `ruff format --check src tests`, `pytest -v` — 2100+ passed. `ruff check src tests` reports one **pre-existing** N818 on `src/zagg/registry.py` (`UnknownCapability`), present on main and untouched here (the CI lint bot selects E,F,W,I). `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` also fails on a clean main checkout in this environment (build-environment dependent) — both flagged rather than "fixed" per §4.

## Questions for review

- **`hive.py` is now ~1030 lines**, over the ~1000 §4 guidance (871 pre-change). The temporal machinery itself lives in `windows.py` (pure) and `config.py` (filter injection) by design, and this PR moved `union_time_range`/`iso_time_range` out — the remaining growth is the windowed-stamp/coverage-full/manifest wiring that belongs with the write path. Raising per §4 instead of splitting unilaterally: the natural follow-up split is the read-side bitmap accessors (`decode_coverage_bitmap`/`read_coverage_bitmap`, ~75 lines) into `coverage.py` ("hive owns the write side; coverage owns consumption"), if that is preferred.
- **Coverage `"full"` is gated on windowing being configured** (only `/2` stores emit it). D14 does not literally condition it on a schedule, but emitting `"full"` on schedule-none stores would break the acceptance criterion that schedule-absent output stays object-for-object identical to pre-change (a fully-occupied shard would drop its sidecar object). The mortie spec files the `"full"` discriminator under the `/2` stamp-envelope change, so gating on `/2` reads consistent — flagging the choice explicitly.
- **Per-granule temporal metadata**: ShardMap granule entries gain `time_start`/`time_end` on newly built maps (from STAC `start_datetime`/`end_datetime`). Legacy shardmaps degrade conservatively (every granule to every window; the worker filter enforces correctness) and need `bounds.temporal` for generative window enumeration — the error message says exactly that. Windowed production runs will want rebuilt shardmaps to avoid the read amplification.
- **Streaming (`aggregation.streaming`) windowed stamps omit `time_range`** (the buffered path pools no columns to min/max). The stamp field is optional by design; if streaming+windowing becomes a production combination, a running min/max in the buffered aggregator is a small follow-up.
