### PR TITLE
small fixes 2026-07-16

### DIFF
--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -664,7 +664,10 @@ def _validate_raster_config(config: PipelineConfig) -> None:
     # capabilities; the raster path always writes the flat (time, cells) store
     # and never consults these keys (issue #239), so an explicit request is a
     # config mistake, not a no-op — reject it pointedly.
-    if config.output.get("store_layout") == "hive":
+    store_layout = config.output.get("store_layout")
+    if store_layout is not None and store_layout not in ("flat", "hive"):
+        raise ValueError(f"output.store_layout must be 'flat' or 'hive' (got {store_layout!r})")
+    if store_layout == "hive":
         raise ValueError(
             "output.store_layout: hive is not supported on the raster path "
             "yet — see issue #237 for the design; drop the key (raster output "

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -670,7 +670,10 @@ def _validate_raster_config(config: PipelineConfig) -> None:
             "yet — see issue #237 for the design; drop the key (raster output "
             "is a flat (time, cells) store)"
         )
-    if config.output.get("coverage_moc") is True:
+    coverage_moc = config.output.get("coverage_moc")
+    if coverage_moc is not None and not isinstance(coverage_moc, bool):
+        raise ValueError(f"output.coverage_moc must be a boolean (got {coverage_moc!r})")
+    if coverage_moc:
         raise ValueError(
             "output.coverage_moc is not supported on the raster path yet — "
             "see issue #237 for the design; drop the flag (there is no hive "

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -660,6 +660,22 @@ def _validate_raster_config(config: PipelineConfig) -> None:
             "raster templates do not support sharded: true yet (issue #218); "
             "chunks are (1, cells_per_chunk) — one object per timestep-chunk"
         )
+    # The hive shard layout and its root coverage MOC are point-pipeline
+    # capabilities; the raster path always writes the flat (time, cells) store
+    # and never consults these keys (issue #239), so an explicit request is a
+    # config mistake, not a no-op — reject it pointedly.
+    if config.output.get("store_layout") == "hive":
+        raise ValueError(
+            "output.store_layout: hive is not supported on the raster path "
+            "yet — see issue #237 for the design; drop the key (raster output "
+            "is a flat (time, cells) store)"
+        )
+    if config.output.get("coverage_moc") is True:
+        raise ValueError(
+            "output.coverage_moc is not supported on the raster path yet — "
+            "see issue #237 for the design; drop the flag (there is no hive "
+            "store root to write coverage.moc to)"
+        )
     # Time-windowed hive leaves are a point-pipeline capability in this round;
     # the raster (time, cells) product's windowing is its own design (issue
     # #247). Reject pointedly rather than silently ignoring the block —

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -92,6 +92,18 @@ class TestRasterConfigValidation:
         with pytest.raises(ValueError, match="sharded"):
             validate_config(_raster_config(grid=grid))
 
+    def test_hive_store_layout_rejected(self):
+        cfg = _raster_config()
+        cfg.output["store_layout"] = "hive"
+        with pytest.raises(ValueError, match="issue #237"):
+            validate_config(cfg)
+
+    def test_coverage_moc_rejected(self):
+        cfg = _raster_config()
+        cfg.output["coverage_moc"] = True
+        with pytest.raises(ValueError, match="issue #237"):
+            validate_config(cfg)
+
     def test_rectilinear_grid_rejected_for_now(self):
         grid = {"type": "rectilinear", "crs": UTM18, "resolution": 10, "bounds": [0, 0, 1, 1]}
         with pytest.raises(ValueError, match="healpix"):

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -95,13 +95,13 @@ class TestRasterConfigValidation:
     def test_hive_store_layout_rejected(self):
         cfg = _raster_config()
         cfg.output["store_layout"] = "hive"
-        with pytest.raises(ValueError, match="issue #237"):
+        with pytest.raises(ValueError, match="store_layout"):
             validate_config(cfg)
 
     def test_coverage_moc_rejected(self):
         cfg = _raster_config()
         cfg.output["coverage_moc"] = True
-        with pytest.raises(ValueError, match="issue #237"):
+        with pytest.raises(ValueError, match="coverage_moc"):
             validate_config(cfg)
 
     def test_rectilinear_grid_rejected_for_now(self):


### PR DESCRIPTION
Closes #239

Bundled small-fix PR for 2026-07-16 (one open `small-fix` issue today).

## Checklist

- [x] #239 — raster configs silently ignore `store_layout` / `coverage_moc`

## What / approach

The raster branch of `validate_config` dispatches to `_validate_raster_config` and returns before the point-pipeline `store_layout` / `coverage_moc` checks run, and `RasterStrategy` never consults either key — so a raster config declaring `store_layout: hive` or `coverage_moc: true` validated cleanly and then silently wrote a flat store with no coverage object.

This adds two pointed rejections in `_validate_raster_config` (`src/zagg/config.py`), placed between the existing `sharded: true` rejection and the `output.windowing` rejection (which already cites this issue's posture):

- explicit `output.store_layout: hive` → `ValueError` ("not supported on the raster path yet — see issue #237 for the design; drop the key ...")
- explicit `output.coverage_moc: true` → `ValueError` (same shape; explicit `false` remains a harmless opt-out and is not rejected)

`store_layout: flat` (the actual raster behavior) still validates. Goes away naturally when #237 lands.

## How tested

Two new tests in `tests/test_raster_pipeline.py::TestRasterConfigValidation` (`test_hive_store_layout_rejected`, `test_coverage_moc_rejected`), confirmed red before the fix (both `DID NOT RAISE`) and green after. Full local bar: `ruff check` / `ruff format --check` clean on the changed files, `pytest -v` → 2153 passed, 30 skipped.

## Questions for review

- Pre-existing, unrelated to this change: `ruff check src tests` on current `main` fails with `N818` in `src/zagg/registry.py:64` (`UnknownCapability` should have an `Error` suffix). Not fixed here per the no-unrelated-fixes convention; flagging so it can be picked up separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_014suq9BRdBuMihm2XLuwRnx)_