### PR TITLE
Hive manifest hybrid lifecycle: async init write, finalize backstop (issue #252)

### DIFF
--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -66,9 +66,12 @@ RECORD_COLUMNS = [
     # Wall-time breakdown (issue #180): end-to-end AOI dispatch wall and its
     # three phases. ``runtime_s`` above is the single worker's compute;
     # ``total_wall_s`` is what the orchestrator actually waits (setup +
-    # fanout/poll + finalize). ``finalize_s`` is the zarr metadata
-    # consolidation invoke -- a ~fixed cost worth tracking for regression
-    # (issue #191). Null on rows recorded before these were surfaced.
+    # fanout/poll + finalize). ``finalize_s`` is the finalize invoke: zarr
+    # metadata consolidation on flat (issue #191); on hive it carries the
+    # morton_hive.json manifest write, folded off the setup path (issue
+    # #252) -- no longer ~0, keep it displayed. ``setup_s`` on hive rows is
+    # just the lightweight preflight ping. Null on rows recorded before
+    # these were surfaced.
     "total_wall_s",
     "setup_s",
     "fanout_s",

--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -67,11 +67,12 @@ RECORD_COLUMNS = [
     # three phases. ``runtime_s`` above is the single worker's compute;
     # ``total_wall_s`` is what the orchestrator actually waits (setup +
     # fanout/poll + finalize). ``finalize_s`` is the finalize invoke: zarr
-    # metadata consolidation on flat (issue #191); on hive it carries the
-    # morton_hive.json manifest write, folded off the setup path (issue
-    # #252) -- no longer ~0, keep it displayed. ``setup_s`` on hive rows is
-    # just the lightweight preflight ping. Null on rows recorded before
-    # these were surfaced.
+    # metadata consolidation on flat (issue #191); on hive it is the
+    # idempotent morton_hive.json backstop (issue #252 hybrid -- the primary
+    # manifest write fires as an async Event invoke at init) -- keep it
+    # displayed. ``setup_s`` on hive rows is the lightweight preflight ping
+    # plus the ~10 ms Event dispatch of the manifest write. Null on rows
+    # recorded before these were surfaced.
     "total_wall_s",
     "setup_s",
     "fanout_s",

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -43,7 +43,9 @@ Event payload (default / process mode):
 Setup mode (creates the zarr template once before per-cell fan-out; for a
 hive-layout config -- output.store_layout: hive, issue #199 -- it writes the
 morton_hive.json manifest instead, and each process-mode worker emits its own
-leaf template):
+leaf template. Current dispatchers no longer send hive setup -- the manifest
+rides finalize instead, issue #252 -- but the hive branch stays so older
+dispatchers keep working against this function):
 {
     "mode": "setup",
     "store_path": str,
@@ -58,10 +60,17 @@ leaf template):
     "output_credentials": dict (optional, same shape as process mode),
 }
 
-Finalize mode (consolidates zarr metadata after all cells complete):
+Finalize mode (after all cells complete: consolidates zarr metadata; for a
+hive-layout config -- issue #252 -- it writes the morton_hive.json manifest
+instead, folded off the pre-worker setup path):
 {
     "mode": "finalize",
     "store_path": str,
+    "config": dict (optional, hive only) -- same single-source config as setup;
+        its presence + store_layout selects the manifest write. With it ride
+        "parent_order", "overwrite", and the optional "dataset" identity
+        block, mirroring the hive setup event. Absent on flat runs (their
+        event is byte-identical to pre-#252).
     "output_credentials": dict (optional, same shape as process mode),
 }
 
@@ -672,11 +681,42 @@ def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _handle_finalize(event: Dict[str, Any]) -> Dict[str, Any]:
-    """Consolidate zarr metadata for the store at ``event['store_path']``."""
-    from zarr import consolidate_metadata
+    """Finalize the store at ``event['store_path']``.
 
-    logger.info(f"Finalize mode: consolidating metadata at {event.get('store_path')}")
+    Flat: consolidate zarr metadata (byte-identical to before). Hive (issue
+    #252): write the root ``morton_hive.json`` manifest instead — folded off
+    the setup path so no pre-worker invoke blocks the fan-out. Order-correct
+    because the manifest is reader-facing only: workers write self-describing
+    leaves (D3) and readers arrive after the run. The manifest inputs mirror
+    the hive setup event (``config``/``parent_order``/``dataset``/
+    ``overwrite``); there is no zarr hierarchy above the leaves to
+    consolidate (D5), so the hive branch returns without touching zarr. The
+    success body echoes ``"layout": "hive"``, matching setup's echo.
+    """
+    logger.info(f"Finalize mode: finalizing store at {event.get('store_path')}")
     try:
+        if "config" in event:
+            config = load_config_from_dict(event["config"])
+            if get_store_layout(config) == "hive":
+                from zagg.config import get_windowing
+                from zagg.grids import from_config
+                from zagg.hive import build_manifest, ensure_manifest
+
+                grid = from_config(config, parent_order=event.get("parent_order"))
+                ensure_manifest(
+                    event["store_path"],
+                    build_manifest(
+                        grid, dataset=event.get("dataset"), windowing=get_windowing(config)
+                    ),
+                    overwrite=event.get("overwrite", False),
+                    **_output_store_kwargs(event),
+                )
+                return {
+                    "statusCode": 200,
+                    "body": json.dumps({"ok": True, "mode": "finalize", "layout": "hive"}),
+                }
+        from zarr import consolidate_metadata
+
         store = open_store(event["store_path"], **_output_store_kwargs(event))
         consolidate_metadata(store, zarr_format=3)
         return {"statusCode": 200, "body": json.dumps({"ok": True, "mode": "finalize"})}

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -764,7 +764,9 @@ def _handle_ping(event: Dict[str, Any]) -> Dict[str, Any]:
     into a store templated for different orders/identity refuses up front
     (the D2 mixed-order footgun) instead of after the fan-out — the writer-
     side guard the manifest fold would otherwise defer to finalize (PR #255
-    review fold). Kept while flat exists (issue #251): once flat is removed,
+    review fold). This covers sequential reruns; two concurrent runs into the
+    same fresh root both see no manifest and only collide at the losing run's
+    finalize. Kept while flat exists (issue #251): once flat is removed,
     a stale function simply errors and the ping can be dropped.
     """
     logger.info(f"Ping mode: hive preflight for {event.get('store_path')}")

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -642,9 +642,12 @@ def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
     For a hive-layout config (issue #199 phase 3) template time writes ONLY
     the ``morton_hive.json`` manifest — no global zarr template exists (zero
     metadata above the leaves, D5); each worker emits its own leaf template.
-    The optional ``dataset`` event key carries the manifest's identity block
-    (the orchestrator sources it from the ShardMap metadata, same as the local
-    path). The flat path below is byte-identical to before, bar one addition:
+    Current dispatchers no longer send hive setup (the manifest rides finalize
+    since issue #252); this branch stays so OLDER dispatchers keep working
+    against a redeployed function. The optional ``dataset`` event key carries
+    the manifest's identity block (the orchestrator sources it from the
+    ShardMap metadata, same as the local path).
+    The flat path below is byte-identical to before, bar one addition:
     the success body now ECHOES the layout it acted on (``"layout"``) — a
     stale deployment without the hive branch returns the old echo-less body,
     which the dispatcher rejects for hive runs instead of silently letting old

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -74,6 +74,25 @@ instead, folded off the pre-worker setup path):
     "output_credentials": dict (optional, same shape as process mode),
 }
 
+Ping mode (hive pre-fan-out preflight, issue #252 — writes nothing; kept while
+flat exists, issue #251):
+{
+    "mode": "ping",
+    "store_path": str,
+    "config": dict,             # same manifest inputs as hive finalize; with it
+    "parent_order": int,        #   ride "overwrite" and the optional "dataset"
+    "overwrite": bool,          #   identity block
+    "dataset": dict (optional),
+    "output_credentials": dict (optional, same shape as process mode),
+}
+Answering 200 at all is the versioning half of the guard: a function deployed
+before the issue #252 manifest-in-finalize lifecycle doesn't know the mode, so
+the event falls through to the process handler's 400 (zero writes) and the
+dispatcher fails fast with a redeploy message before any worker runs. The body
+echoes the deployed zagg version; the handler also runs the READ-ONLY
+zagg.hive.validate_manifest against any existing root so an incompatible rerun
+refuses up front (D2).
+
 Extract mode (chunk-boundary geometry extraction, issue #148 — one parquet per
 granule under an S3 prefix; a batch of granules per invocation for the fan-out):
 {
@@ -453,6 +472,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
     Default ``mode`` (or no mode) runs per-cell processing. ``mode="setup"``
     creates the zarr template; ``mode="finalize"`` consolidates metadata;
+    ``mode="ping"`` is the hive pre-fan-out preflight (issue #252);
     ``mode="coverage"`` writes the store-root ``coverage.moc`` (issue #200);
     ``mode="extract"`` extracts chunk-boundary geometry parquets (issue #148);
     ``mode="process_event"`` runs the temporal/event worker (issue #12).
@@ -468,6 +488,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         return _handle_setup(event)
     if mode == "finalize":
         return _handle_finalize(event)
+    if mode == "ping":
+        return _handle_ping(event)
     if mode == "coverage":
         return _handle_coverage(event)
     # Extract mode returns directly: the result_url mirror below is for the
@@ -723,6 +745,52 @@ def _handle_finalize(event: Dict[str, Any]) -> Dict[str, Any]:
     except Exception as e:
         logger.exception(e)
         return {"statusCode": 500, "body": json.dumps({"error": str(e), "mode": "finalize"})}
+
+
+def _handle_ping(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Hive pre-fan-out preflight (issue #252) — writes nothing.
+
+    Answering 200 at all is the versioning half of the guard: a function that
+    predates the manifest-in-finalize lifecycle doesn't know ``mode="ping"``,
+    so the event falls through to its process handler's 400 (zero writes) and
+    the dispatcher fails fast with a redeploy message before any worker is
+    dispatched. The body echoes the deployed zagg version for observability.
+
+    The store half mirrors finalize's manifest inputs and runs the READ-ONLY
+    :func:`zagg.hive.validate_manifest` against any existing root, so a run
+    into a store templated for different orders/identity refuses up front
+    (the D2 mixed-order footgun) instead of after the fan-out — the writer-
+    side guard the manifest fold would otherwise defer to finalize (PR #255
+    review fold). Kept while flat exists (issue #251): once flat is removed,
+    a stale function simply errors and the ping can be dropped.
+    """
+    logger.info(f"Ping mode: hive preflight for {event.get('store_path')}")
+    try:
+        import zagg
+
+        if "config" in event:
+            config = load_config_from_dict(event["config"])
+            if get_store_layout(config) == "hive":
+                from zagg.config import get_windowing
+                from zagg.grids import from_config
+                from zagg.hive import build_manifest, validate_manifest
+
+                grid = from_config(config, parent_order=event.get("parent_order"))
+                validate_manifest(
+                    event["store_path"],
+                    build_manifest(
+                        grid, dataset=event.get("dataset"), windowing=get_windowing(config)
+                    ),
+                    overwrite=event.get("overwrite", False),
+                    **_output_store_kwargs(event),
+                )
+        return {
+            "statusCode": 200,
+            "body": json.dumps({"ok": True, "mode": "ping", "zagg_version": zagg.__version__}),
+        }
+    except Exception as e:
+        logger.exception(e)
+        return {"statusCode": 500, "body": json.dumps({"error": str(e), "mode": "ping"})}
 
 
 def _handle_coverage(event: Dict[str, Any]) -> Dict[str, Any]:

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -43,9 +43,9 @@ Event payload (default / process mode):
 Setup mode (creates the zarr template once before per-cell fan-out; for a
 hive-layout config -- output.store_layout: hive, issue #199 -- it writes the
 morton_hive.json manifest instead, and each process-mode worker emits its own
-leaf template. Current dispatchers no longer send hive setup -- the manifest
-rides finalize instead, issue #252 -- but the hive branch stays so older
-dispatchers keep working against this function):
+leaf template. Current dispatchers send hive setup as a fire-and-forget Event
+invoke right after the ping -- the primary manifest write, issue #252 hybrid
+-- and older synchronous dispatchers keep working against this function):
 {
     "mode": "setup",
     "store_path": str,
@@ -61,8 +61,8 @@ dispatchers keep working against this function):
 }
 
 Finalize mode (after all cells complete: consolidates zarr metadata; for a
-hive-layout config -- issue #252 -- it writes the morton_hive.json manifest
-instead, folded off the pre-worker setup path):
+hive-layout config -- issue #252 hybrid -- it re-ensures the morton_hive.json
+manifest instead, the idempotent backstop for the async init-time setup write):
 {
     "mode": "finalize",
     "store_path": str,
@@ -86,7 +86,7 @@ flat exists, issue #251):
     "output_credentials": dict (optional, same shape as process mode),
 }
 Answering 200 at all is the versioning half of the guard: a function deployed
-before the issue #252 manifest-in-finalize lifecycle doesn't know the mode, so
+before the issue #252 hive dispatch lifecycle doesn't know the mode, so
 the event falls through to the process handler's 400 (zero writes) and the
 dispatcher fails fast with a redeploy message before any worker runs. The body
 echoes the deployed zagg version; the handler also runs the READ-ONLY
@@ -642,9 +642,11 @@ def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
     For a hive-layout config (issue #199 phase 3) template time writes ONLY
     the ``morton_hive.json`` manifest — no global zarr template exists (zero
     metadata above the leaves, D5); each worker emits its own leaf template.
-    Current dispatchers no longer send hive setup (the manifest rides finalize
-    since issue #252); this branch stays so OLDER dispatchers keep working
-    against a redeployed function. The optional ``dataset`` event key carries
+    Current dispatchers send hive setup as a fire-and-forget Event invoke
+    right after the ping (issue #252 hybrid) — this branch is the PRIMARY
+    manifest write, run off the critical path, with finalize as idempotent
+    backstop; older synchronous dispatchers keep working against it
+    unchanged. The optional ``dataset`` event key carries
     the manifest's identity block (the orchestrator sources it from the
     ShardMap metadata, same as the local path).
     The flat path below is byte-identical to before, bar one addition:
@@ -709,14 +711,15 @@ def _handle_finalize(event: Dict[str, Any]) -> Dict[str, Any]:
     """Finalize the store at ``event['store_path']``.
 
     Flat: consolidate zarr metadata (byte-identical to before). Hive (issue
-    #252): write the root ``morton_hive.json`` manifest instead — folded off
-    the setup path so no pre-worker invoke blocks the fan-out. Order-correct
-    because the manifest is reader-facing only: workers write self-describing
-    leaves (D3) and readers arrive after the run. The manifest inputs mirror
-    the hive setup event (``config``/``parent_order``/``dataset``/
-    ``overwrite``); there is no zarr hierarchy above the leaves to
-    consolidate (D5), so the hive branch returns without touching zarr. The
-    success body echoes ``"layout": "hive"``, matching setup's echo.
+    #252 hybrid): re-ensure the root ``morton_hive.json`` manifest — the
+    idempotent BACKSTOP for the async init-time setup invoke (a frozen-key-
+    matching manifest is accepted, no second PUT). Worker Event invokes run
+    with retries 0 (template.yaml EventInvokeConfig), so a lost async init
+    write is never redelivered — this backstop self-heals it. The manifest
+    inputs mirror the hive setup event (``config``/``parent_order``/
+    ``dataset``/``overwrite``); there is no zarr hierarchy above the leaves
+    to consolidate (D5), so the hive branch returns without touching zarr.
+    The success body echoes ``"layout": "hive"``, matching setup's echo.
     """
     logger.info(f"Finalize mode: finalizing store at {event.get('store_path')}")
     try:
@@ -754,20 +757,20 @@ def _handle_ping(event: Dict[str, Any]) -> Dict[str, Any]:
     """Hive pre-fan-out preflight (issue #252) — writes nothing.
 
     Answering 200 at all is the versioning half of the guard: a function that
-    predates the manifest-in-finalize lifecycle doesn't know ``mode="ping"``,
+    predates the issue #252 hive lifecycle doesn't know ``mode="ping"``,
     so the event falls through to its process handler's 400 (zero writes) and
     the dispatcher fails fast with a redeploy message before any worker is
     dispatched. The body echoes the deployed zagg version for observability.
 
-    The store half mirrors finalize's manifest inputs and runs the READ-ONLY
-    :func:`zagg.hive.validate_manifest` against any existing root, so a run
-    into a store templated for different orders/identity refuses up front
-    (the D2 mixed-order footgun) instead of after the fan-out — the writer-
-    side guard the manifest fold would otherwise defer to finalize (PR #255
-    review fold). This covers sequential reruns; two concurrent runs into the
-    same fresh root both see no manifest and only collide at the losing run's
-    finalize. Kept while flat exists (issue #251): once flat is removed,
-    a stale function simply errors and the ping can be dropped.
+    The store half mirrors setup/finalize's manifest inputs and runs the
+    READ-ONLY :func:`zagg.hive.validate_manifest` against any existing root,
+    so a run into a store templated for different orders/identity refuses up
+    front (the D2 mixed-order footgun) instead of after the fan-out (PR #255
+    review fold). This covers sequential reruns; two concurrent runs into
+    the same fresh root both pass here, colliding within seconds of init
+    once the async setup write lands (issue #252 hybrid). Kept while flat
+    exists (issue #251): once flat is removed, a stale function simply
+    errors and the ping can be dropped.
     """
     logger.info(f"Ping mode: hive preflight for {event.get('store_path')}")
     try:

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -117,7 +117,8 @@ leaf stores. No zarr-version coupling in either direction.
 Written **once, at finalize** (issue #252 — it rode template time before, but
 it is reader-facing only and workers never read it, so the write comes off
 the pre-dispatch critical path; a read-only frozen-key precheck keeps the
-up-front refusal). O(1); never touched again during a run. Contents:
+up-front refusal on reruns — concurrent first writes still collide only at
+finalize). O(1); never touched again during a run. Contents:
 
 - `spec`: convention version string (e.g. `"morton-hive/1"`) — the convention
   itself is versioned from day one (D6).

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -114,8 +114,10 @@ leaf stores. No zarr-version coupling in either direction.
 
 ## 3. Layer 1: the static manifest (`morton_hive.json`)
 
-Written **once at template time**, before any shard dispatches. O(1); never
-touched again during a run. Contents:
+Written **once, at finalize** (issue #252 — it rode template time before, but
+it is reader-facing only and workers never read it, so the write comes off
+the pre-dispatch critical path; a read-only frozen-key precheck keeps the
+up-front refusal). O(1); never touched again during a run. Contents:
 
 - `spec`: convention version string (e.g. `"morton-hive/1"`) — the convention
   itself is versioned from day one (D6).
@@ -404,7 +406,8 @@ write path (§2) is load-bearing; this phase is optimization.
   range + acquisition/granule count. Root summary (cache): the end-of-run
   root coverage object gains the time-range union alongside the MOC;
   sweep-regenerable, never truth. Extent never lives in the manifest, so
-  the manifest stays write-once at template time (§3); the noted exception
+  the manifest stays write-once (§3; written at finalize since issue
+  #252); the noted exception
   is the explicit-range-list schedule, where appending outside the list
   re-templates the manifest — append-heavy stores should prefer generative
   schedules. (That exception is an implication recorded from the ratified

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -114,11 +114,14 @@ leaf stores. No zarr-version coupling in either direction.
 
 ## 3. Layer 1: the static manifest (`morton_hive.json`)
 
-Written **once, at finalize** (issue #252 — it rode template time before, but
-it is reader-facing only and workers never read it, so the write comes off
-the pre-dispatch critical path; a read-only frozen-key precheck keeps the
-up-front refusal on reruns — concurrent first writes still collide only at
-finalize). O(1); never touched again during a run. Contents:
+Written **asynchronously at init** (issue #252 hybrid — the write comes off
+the synchronous pre-dispatch path: the Lambda leg posts a fire-and-forget
+setup invoke right after the fail-fast ping, so the manifest lands seconds
+into the run and readers can consume completed leaves mid-run; finalize
+keeps an idempotent backstop that self-heals a lost async write; a read-only
+frozen-key precheck keeps the up-front refusal on reruns — concurrent first
+writes now collide within seconds of init). O(1); otherwise never touched
+again during a run. Contents:
 
 - `spec`: convention version string (e.g. `"morton-hive/1"`) — the convention
   itself is versioned from day one (D6).
@@ -407,8 +410,8 @@ write path (§2) is load-bearing; this phase is optimization.
   range + acquisition/granule count. Root summary (cache): the end-of-run
   root coverage object gains the time-range union alongside the MOC;
   sweep-regenerable, never truth. Extent never lives in the manifest, so
-  the manifest stays write-once (§3; written at finalize since issue
-  #252); the noted exception
+  the manifest stays write-once (§3; written async at init with a finalize
+  backstop since issue #252); the noted exception
   is the explicit-range-list schedule, where appending outside the list
   re-templates the manifest — append-heavy stores should prefer generative
   schedules. (That exception is an implication recorded from the ratified

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -116,8 +116,11 @@ leaf stores. No zarr-version coupling in either direction.
 
 Written **asynchronously at init** (issue #252 hybrid — the write comes off
 the synchronous pre-dispatch path: the Lambda leg posts a fire-and-forget
-setup invoke right after the fail-fast ping, so the manifest lands seconds
-into the run and readers can consume completed leaves mid-run; finalize
+setup invoke right after the fail-fast ping, so the manifest typically lands
+within seconds of init (best-effort: the Event invoke shares worker
+concurrency and runs retries-0, deferring to the finalize backstop under
+throttling or a dropped invoke) and readers can consume completed leaves
+mid-run; finalize
 keeps an idempotent backstop that self-heals a lost async write; a read-only
 frozen-key precheck keeps the up-front refusal on reruns — concurrent first
 writes now collide within seconds of init). O(1); otherwise never touched

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -157,7 +157,9 @@ time before, but it is reader-facing only — workers write self-describing
 leaves and never read it, so the write is off the critical path). Never
 touched during a run (D6); a read-only frozen-key precheck
 (`zagg.hive.validate_manifest`) still runs before the fan-out so an
-incompatible existing store refuses up front. With the manifest, every shard
+incompatible existing store refuses up front on reruns (two concurrent first
+writes into a fresh root still collide only at the losing run's finalize).
+With the manifest, every shard
 path is computable arithmetically with zero requests:
 
 ```json

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -151,14 +151,21 @@ manifest check like an orders change — clear the root first.
 
 ## The manifest (`morton_hive.json`)
 
-Written **once, at finalize** — after the fan-out, before any reader arrives
-([issue #252](https://github.com/englacial/zagg/issues/252); it rode template
-time before, but it is reader-facing only — workers write self-describing
-leaves and never read it, so the write is off the critical path). Never
-touched during a run (D6); a read-only frozen-key precheck
+Written **asynchronously at init**
+([issue #252](https://github.com/englacial/zagg/issues/252) hybrid): the
+local dispatcher writes it directly before dispatch; the Lambda leg fires
+the existing `mode: "setup"` hive branch as a fire-and-forget Event invoke
+immediately after the `mode: "ping"` preflight passes, so the manifest lands
+seconds into the run and a reader can start consuming completed leaves while
+the store builds. Finalize re-ensures it as an **idempotent backstop** (a
+frozen-key-matching manifest is accepted — no second PUT): worker Event
+invokes run with retries 0, so a lost async init write self-heals at end of
+run, and a run that crashes mid-fan-out still left a manifest at init.
+Otherwise never touched during a run (D6); the read-only frozen-key precheck
 (`zagg.hive.validate_manifest`) still runs before the fan-out so an
 incompatible existing store refuses up front on reruns (two concurrent first
-writes into a fresh root still collide only at the losing run's finalize).
+writes into a fresh root now collide within seconds of init, not at the
+losing run's finalize).
 With the manifest, every shard
 path is computable arithmetically with zero requests:
 
@@ -368,10 +375,11 @@ under D9/O7). The §7 sweep remains the authoritative rebuilder.
 - **Both backends** write hive stores end-to-end through the same
   `zagg.hive.process_and_write_hive` code path. On **Lambda**
   ([issue #199](https://github.com/englacial/zagg/issues/199) phase 3)
-  the manifest write rides `mode: "finalize"`
-  ([issue #252](https://github.com/englacial/zagg/issues/252); a lightweight
-  `mode: "ping"` preflight keeps the pre-fan-out fail-fast) — the
-  orchestrator still needs no S3 access — and each worker derives its leaf
+  the manifest write fires as an async `mode: "setup"` Event invoke at init,
+  with `mode: "finalize"` as its idempotent backstop
+  ([issue #252](https://github.com/englacial/zagg/issues/252) hybrid; a
+  lightweight `mode: "ping"` preflight keeps the pre-fan-out fail-fast) —
+  the orchestrator still needs no S3 access — and each worker derives its leaf
   path from its `shard_key` + the event config's orders, emits its own leaf
   template, and stamps completion as its final PUT. The async status channel stays at the flat
   sibling prefix (`{store_root}.status/<run_id>/…`), outside the digit tree.

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -155,9 +155,12 @@ Written **asynchronously at init**
 ([issue #252](https://github.com/englacial/zagg/issues/252) hybrid): the
 local dispatcher writes it directly before dispatch; the Lambda leg fires
 the existing `mode: "setup"` hive branch as a fire-and-forget Event invoke
-immediately after the `mode: "ping"` preflight passes, so the manifest lands
-seconds into the run and a reader can start consuming completed leaves while
-the store builds. Finalize re-ensures it as an **idempotent backstop** (a
+immediately after the `mode: "ping"` preflight passes, so the manifest
+typically lands within seconds of init (best-effort: the Event invoke shares
+worker concurrency and runs retries-0, deferring to the finalize backstop
+under throttling or a dropped invoke) and a reader can start consuming
+completed leaves while the store builds. Finalize re-ensures it as an
+**idempotent backstop** (a
 frozen-key-matching manifest is accepted — no second PUT): worker Event
 invokes run with retries 0, so a lost async init write self-heals at end of
 run, and a run that crashes mid-fan-out still left a manifest at init.

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -151,9 +151,14 @@ manifest check like an orders change — clear the root first.
 
 ## The manifest (`morton_hive.json`)
 
-Written **once at template time**, before any shard dispatches; never touched
-during a run (D6). With it, every shard path is computable arithmetically with
-zero requests:
+Written **once, at finalize** — after the fan-out, before any reader arrives
+([issue #252](https://github.com/englacial/zagg/issues/252); it rode template
+time before, but it is reader-facing only — workers write self-describing
+leaves and never read it, so the write is off the critical path). Never
+touched during a run (D6); a read-only frozen-key precheck
+(`zagg.hive.validate_manifest`) still runs before the fan-out so an
+incompatible existing store refuses up front. With the manifest, every shard
+path is computable arithmetically with zero requests:
 
 ```json
 {
@@ -316,7 +321,8 @@ doesn't list, it warns once per store and suggests
 that rebuilds the root MOC from the stamped leaves (debris excluded) and
 writes it with `source: "refresh"`. No reader ever auto-walks (D10).
 
-**Deploy note** (mirrors the PR #205 setup-echo note): the Lambda leg posts
+**Deploy note** (the sync-invoke analogue is the `mode: "ping"` preflight,
+which replaced the PR #205 setup echo — issue #252): the Lambda leg posts
 one fire-and-forget `mode: "coverage"` invoke, which requires the
 redeployed function. An **older deployment 400s the event in its process
 handler** — a logged error line in CloudWatch, but no writes, no result
@@ -360,10 +366,12 @@ under D9/O7). The §7 sweep remains the authoritative rebuilder.
 - **Both backends** write hive stores end-to-end through the same
   `zagg.hive.process_and_write_hive` code path. On **Lambda**
   ([issue #199](https://github.com/englacial/zagg/issues/199) phase 3)
-  `mode: "setup"` writes only the manifest — the orchestrator still needs no
-  S3 access — and each worker derives its leaf path from its `shard_key` +
-  the event config's orders, emits its own leaf template, and stamps
-  completion as its final PUT. The async status channel stays at the flat
+  the manifest write rides `mode: "finalize"`
+  ([issue #252](https://github.com/englacial/zagg/issues/252); a lightweight
+  `mode: "ping"` preflight keeps the pre-fan-out fail-fast) — the
+  orchestrator still needs no S3 access — and each worker derives its leaf
+  path from its `shard_key` + the event config's orders, emits its own leaf
+  template, and stamps completion as its final PUT. The async status channel stays at the flat
   sibling prefix (`{store_root}.status/<run_id>/…`), outside the digit tree.
 - **Coverage ships** ([issue #200](https://github.com/englacial/zagg/issues/200)
   phases 1–4): the tier-0 morton box on the commit stamp, the exact

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -255,7 +255,14 @@ def validate_manifest(
 
 
 def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False, **store_kwargs):
-    """Write the root manifest once at template time; verify it on reruns.
+    """Write the root manifest at finalize / end of run; verify it on reruns.
+
+    Since issue #252 this write rides finalize rather than running once at
+    template time ahead of the fan-out — the manifest is reader-facing only
+    (D6), so keeping it off the critical path is safe. The fail-fast half of
+    the guard is exposed separately as :func:`validate_manifest`, which
+    dispatchers run pre-fan-out to refuse an incompatible existing store BEFORE
+    any leaf write (D2), even though this write now lands at the end.
 
     A retry into an existing hive store must be able to proceed (that is the
     D4 debris/retry model), so an existing manifest is accepted — but only if

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -202,23 +202,26 @@ def build_manifest(grid, dataset: dict | None = None, windowing: dict | None = N
     return manifest
 
 
-def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False, **store_kwargs):
-    """Write the root manifest once at template time; verify it on reruns.
+def validate_manifest(
+    store_root: str, manifest: dict, *, overwrite: bool = False, **store_kwargs
+) -> dict | None:
+    """Read-only frozen-key precheck — the fail-fast half of the manifest guard.
 
-    A retry into an existing hive store must be able to proceed (that is the
-    D4 debris/retry model), so an existing manifest is accepted — but only if
-    its FROZEN keys match the run's own (:data:`_FROZEN_MANIFEST_KEYS`: orders
-    + identity + schedule — the flat path's ``_check_signature`` analogue).
-    ``generated_at`` and ``pyramid`` are excluded: the pyramid block is
-    populated/updated by the §7 sweep by design (D11), so comparing it would
-    brick every resume after the first sweep.
+    Split out of :func:`ensure_manifest` when the manifest WRITE moved to
+    finalize (issue #252). The write folding off the critical path is fine for
+    readers (they only arrive after the run), but it dragged the writer-side
+    guard along with it — so an incompatible rerun could write mixed-order
+    leaves before the check ever fired (D2). This function is the guard on its
+    own: dispatchers call it BEFORE fan-out to refuse an incompatible existing
+    store up front, while the actual write stays off the critical path in
+    :func:`ensure_manifest` at finalize.
 
-    ``overwrite=True`` replaces the MANIFEST ONLY — it never clears data. To
-    guard against the silent-corruption footgun (committed leaves from the old
-    orders would survive a "re-template" and be indistinguishable from legal
-    mixed-order data, D2), an overwrite that CHANGES the frozen keys refuses
-    when the digit tree already has children (one delimiter-LIST); clear the
-    store root first. Returns the manifest now in effect.
+    Performs exactly the checks :func:`ensure_manifest` does and writes nothing:
+    reads the existing manifest; on an existing store whose FROZEN keys mismatch
+    (:data:`_FROZEN_MANIFEST_KEYS`) it raises — the same ``does not match this
+    run`` refusal without ``overwrite``, and the same ``list_with_delimiter``
+    shard-data refusal with ``overwrite`` (the D2 old-order-masquerade footgun).
+    Returns the existing manifest (``None`` on a fresh root).
     """
     import obstore
 
@@ -248,6 +251,33 @@ def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False,
                 f"data (e.g. {children[0]!r}/), and overwrite replaces the "
                 f"manifest only — clear the store root first"
             )
+    return existing
+
+
+def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False, **store_kwargs):
+    """Write the root manifest once at template time; verify it on reruns.
+
+    A retry into an existing hive store must be able to proceed (that is the
+    D4 debris/retry model), so an existing manifest is accepted — but only if
+    its FROZEN keys match the run's own (:data:`_FROZEN_MANIFEST_KEYS`: orders
+    + identity + schedule — the flat path's ``_check_signature`` analogue).
+    ``generated_at`` and ``pyramid`` are excluded: the pyramid block is
+    populated/updated by the §7 sweep by design (D11), so comparing it would
+    brick every resume after the first sweep.
+
+    ``overwrite=True`` replaces the MANIFEST ONLY — it never clears data. To
+    guard against the silent-corruption footgun (committed leaves from the old
+    orders would survive a "re-template" and be indistinguishable from legal
+    mixed-order data, D2), an overwrite that CHANGES the frozen keys refuses
+    when the digit tree already has children (one delimiter-LIST); clear the
+    store root first. Returns the manifest now in effect.
+    """
+    import obstore
+
+    store = open_object_store(store_root, **store_kwargs)
+    existing = validate_manifest(store_root, manifest, overwrite=overwrite, **store_kwargs)
+    if existing is not None and not overwrite:
+        return existing
     obstore.put(store, MANIFEST_NAME, json.dumps(manifest, indent=1).encode())
     return manifest
 

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -263,8 +263,11 @@ def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False,
     Lifecycle (issue #252 hybrid): the PRIMARY write runs at init — the local
     dispatcher writes directly pre-dispatch; the lambda dispatcher fires the
     ``mode="setup"`` hive branch as a fire-and-forget Event invoke right
-    after the ping — so the manifest lands seconds into the run and a reader
-    can consume completed leaves while the store builds. Finalize calls this
+    after the ping — so the manifest typically lands within seconds of init
+    (best-effort: the Event invoke shares worker concurrency and runs
+    retries-0, deferring to the finalize backstop under throttling or a
+    dropped invoke) and a reader can consume completed leaves while the store
+    builds. Finalize calls this
     again as an idempotent BACKSTOP (an existing frozen-key-matching manifest
     is accepted — no second PUT): worker Event invokes run with retries 0, so
     a lost async init write self-heals at finalize. The fail-fast half of the

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -17,9 +17,10 @@ leaf zarr** under a morton digit tree::
   ``*.zarr`` objects — zero zarr metadata above the leaf, so 2,000 workers
   share no mutable state and a delimiter-LIST with no digit children is a
   definitive "nothing finer exists".
-- **Manifest (D6)**: ``morton_hive.json`` is written once at template time and
-  never touched during a run; with it every shard path is computable with zero
-  requests. The convention is versioned (``morton-hive/1``) from day one.
+- **Manifest (D6)**: ``morton_hive.json`` is written once — at finalize since
+  issue #252 (reader-facing only; workers never read it) — and never touched
+  during a run; with it every shard path is computable with zero requests.
+  The convention is versioned (``morton-hive/1``) from day one.
 - **Commit stamp (D4)**: the shard's FINAL write is a root
   ``group.attrs.update(...)`` marking completion (plus cell count, timestamp,
   granule count). A ``.zarr/`` prefix whose root metadata lacks the stamp is

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -208,14 +208,16 @@ def validate_manifest(
 ) -> dict | None:
     """Read-only frozen-key precheck — the fail-fast half of the manifest guard.
 
-    Split out of :func:`ensure_manifest` when the manifest WRITE moved to
-    finalize (issue #252). The write folding off the critical path is fine for
-    readers (they only arrive after the run), but it dragged the writer-side
-    guard along with it — so an incompatible rerun could write mixed-order
-    leaves before the check ever fired (D2). This function is the guard on its
-    own: dispatchers call it BEFORE fan-out to refuse an incompatible existing
-    store up front, while the actual write stays off the critical path in
-    :func:`ensure_manifest` at finalize.
+    Split out of :func:`ensure_manifest` when the manifest WRITE came off the
+    synchronous pre-dispatch path (issue #252). The write moving off the
+    critical path is fine for readers, but it dragged the writer-side guard
+    along with it — so an incompatible rerun could write mixed-order leaves
+    before the check ever fired (D2). This function is the guard on its own:
+    the lambda ping runs it BEFORE fan-out to refuse an incompatible existing
+    store up front, while the write itself rides the async init-time setup
+    invoke with a finalize backstop (issue #252 hybrid; the local dispatcher
+    writes directly at init via :func:`ensure_manifest`, which calls this
+    first).
 
     Performs exactly the checks :func:`ensure_manifest` does and writes nothing:
     reads the existing manifest; on an existing store whose FROZEN keys mismatch
@@ -256,14 +258,18 @@ def validate_manifest(
 
 
 def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False, **store_kwargs):
-    """Write the root manifest at finalize / end of run; verify it on reruns.
+    """Write the root manifest; verify it on reruns (idempotent).
 
-    Since issue #252 this write rides finalize rather than running once at
-    template time ahead of the fan-out — the manifest is reader-facing only
-    (D6), so keeping it off the critical path is safe. The fail-fast half of
-    the guard is exposed separately as :func:`validate_manifest`, which
-    dispatchers run pre-fan-out to refuse an incompatible existing store BEFORE
-    any leaf write (D2), even though this write now lands at the end.
+    Lifecycle (issue #252 hybrid): the PRIMARY write runs at init — the local
+    dispatcher writes directly pre-dispatch; the lambda dispatcher fires the
+    ``mode="setup"`` hive branch as a fire-and-forget Event invoke right
+    after the ping — so the manifest lands seconds into the run and a reader
+    can consume completed leaves while the store builds. Finalize calls this
+    again as an idempotent BACKSTOP (an existing frozen-key-matching manifest
+    is accepted — no second PUT): worker Event invokes run with retries 0, so
+    a lost async init write self-heals at finalize. The fail-fast half of the
+    guard is exposed separately as :func:`validate_manifest` (the ping's
+    read-only precheck), which this function runs first.
 
     A retry into an existing hive store must be able to proceed (that is the
     D4 debris/retry model), so an existing manifest is accepted — but only if

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3057,12 +3057,23 @@ def _invoke_lambda_ping(
         raise RuntimeError(f"Lambda ping failed: {payload}")
     result = json.loads(payload)
     if result.get("statusCode") != 200:
+        try:
+            body = json.loads(result.get("body") or "{}")
+        except (TypeError, ValueError):
+            body = {}
+        if body.get("mode") == "ping":
+            # The deployed function KNOWS ping — this is validate_manifest
+            # refusing the store, not a stale deployment.
+            raise RuntimeError(
+                f"Lambda ping refused the store at {store_path}: "
+                f"{body.get('error')!r} — the store was templated for a "
+                f"different configuration; clear the store root (or pick a "
+                f"new one) before dispatching this run"
+            )
         raise RuntimeError(
-            f"Lambda ping failed (response body {result.get('body')!r}): either the "
+            f"Lambda ping failed (response body {result.get('body')!r}): the "
             f"deployed function predates the issue #252 manifest-in-finalize "
-            f"lifecycle — redeploy the function before dispatching hive runs — or "
-            f"the store at {store_path} was templated for a different "
-            f"configuration (see the body's error)"
+            f"lifecycle — redeploy the function before dispatching hive runs"
         )
     try:
         version = json.loads(result.get("body") or "{}").get("zagg_version")

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3027,7 +3027,11 @@ def _invoke_lambda_ping(
       ``zagg.hive.validate_manifest`` against the event's manifest inputs
       (same keys as hive finalize), so a frozen-key mismatch — or an
       overwrite into a root with shard data — refuses up front (D2) instead
-      of after the fan-out (PR #255 review fold).
+      of after the fan-out (PR #255 review fold). This covers sequential
+      reruns; two CONCURRENT runs racing into the same fresh root both see
+      no manifest and only collide at the losing run's finalize — a window
+      the old setup-time write closed for the second-to-arrive dispatch.
+      Same last-writer caveat the manifest write itself has always had.
 
     Kept while flat exists (issue #251): once flat is removed, a stale
     function just errors and the ping can be dropped.

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1699,28 +1699,26 @@ def _run_local(
         # metadata above the leaves (D5); each shard emits its own leaf
         # template lazily inside hive.process_and_write_hive (the leaf write
         # path lives in zagg.hive, next to the manifest/stamp machinery it
-        # exercises). The root manifest write (D6) is folded into the
-        # end-of-run finalize below (issue #252): the manifest is
-        # reader-facing only — workers write self-describing leaves (D3) and
-        # never read it — so nothing runs ahead of the dispatch, mirroring
-        # the lambda backend.
+        # exercises). The root manifest (D6) is written HERE, pre-dispatch
+        # (issue #252 hybrid): the local dispatcher writes the store
+        # directly, so the write costs ~0 wall and a reader can consume
+        # completed leaves while the run builds — mirroring the lambda
+        # backend's async init-time setup invoke.
         from zagg.hive import (
             build_manifest,
             ensure_manifest,
             process_and_write_hive,
-            validate_manifest,
         )
 
         zarr_store = None
-        # Build the manifest once, up front, and reuse it at finalize. The WRITE
-        # is folded into the end-of-run ensure_manifest (D6), but its read-only
-        # frozen-key precheck (review fold, issue #252) runs HERE — fail-fast
-        # against an incompatible existing store before any leaf write (D2), so
-        # a misdirected rerun refuses in ~0s instead of mixing new-order leaves
-        # into an old-order store and only raising afterward. The write itself
-        # stays off the critical path in the finalize block below.
+        # Build the manifest once, up front, and reuse it at finalize.
+        # ensure_manifest runs the read-only validate_manifest frozen-key
+        # precheck before its PUT, so the pre-dispatch fail-fast (review
+        # fold, issue #252) is preserved: a rerun into an incompatible
+        # existing store refuses in ~0s, before any leaf write (D2), instead
+        # of mixing new-order leaves into an old-order store.
         manifest = build_manifest(grid, dataset=catalog_data.get("metadata"), windowing=windowing)
-        validate_manifest(store_path, manifest, overwrite=overwrite, **store_kwargs)
+        ensure_manifest(store_path, manifest, overwrite=overwrite, **store_kwargs)
         # Temporal fan-out (issue #246 phase 5): one work unit per (shard,
         # window). None (schedule none/absent) keeps the (shard, records)
         # pairs — dispatch byte-identical to pre-windowing runs.
@@ -1832,11 +1830,13 @@ def _run_local(
     # skip it unless output.consolidate_metadata is true.
     if get_consolidate_metadata(config):
         consolidate_metadata(zarr_store, zarr_format=3)
-    # End-of-run manifest write (issue #252): folded out of template time —
-    # order-correct because readers only arrive after the run. Unlike the
-    # root coverage.moc below (a regenerable cache, D9), the manifest is
-    # REQUIRED reader-facing schema (D6), so a failed write — including a
-    # frozen-key mismatch against an existing store's manifest — raises.
+    # End-of-run manifest backstop (issue #252 hybrid): the manifest already
+    # landed pre-dispatch above; this idempotent re-ensure (a frozen-key-
+    # matching manifest is accepted — no second PUT) self-heals a root whose
+    # manifest was lost mid-run, mirroring the lambda path where the init
+    # write is a retries-0 Event invoke. Unlike the root coverage.moc below
+    # (a regenerable cache, D9), the manifest is REQUIRED reader-facing
+    # schema (D6), so a failed backstop raises.
     if store_layout == "hive":
         ensure_manifest(
             store_path,
@@ -2122,12 +2122,13 @@ def _run_lambda(
     # so gate the invoke dispatcher-side. When off we hand the executor a no-op
     # finalize (mirroring the temporal path's ``_run_lambda_events``, which has no
     # metadata to consolidate) so no ``mode: "finalize"`` Lambda is dispatched.
-    # Hive (issue #252): finalize ALWAYS runs — it carries the root
-    # morton_hive.json write, folded off the pre-worker setup path — so the
-    # consolidate_metadata gate stays flat-only. The manifest inputs (config
-    # + dataset identity from the ShardMap metadata, the same source as the
-    # local path) ride the finalize event; flat finalize events stay
-    # byte-identical.
+    # Hive (issue #252 hybrid): finalize ALWAYS runs — its ensure_manifest
+    # is the idempotent BACKSTOP for the async init-time manifest write (a
+    # retries-0 Event invoke is never redelivered if lost; finalize
+    # self-heals it) — so the consolidate_metadata gate stays flat-only. The
+    # manifest inputs (config + dataset identity from the ShardMap metadata,
+    # the same source as the local path) ride the finalize event; flat
+    # finalize events stay byte-identical.
     if get_store_layout(config) == "hive":
         md = catalog_data.get("metadata") or {}
         dataset = {"short_name": md.get("short_name"), "version": md.get("version")}
@@ -2175,17 +2176,29 @@ def _run_lambda(
     # calls that already happen, so no worker probe tax -- issue #100). They
     # decompose wall time into setup invoke / fan-out / finalize invoke so
     # "where did wall time go" is answerable from the summary.
-    # Hive layout (issue #252): NO manifest-writing setup invoke. The
-    # manifest is reader-facing and hive workers write self-describing leaves
-    # (D3), so the morton_hive.json write rides the finalize invoke instead —
-    # order-correct (readers arrive after the run). What remains up front is
-    # one lightweight ping, decoupled from the write: fail-fast for a stale
-    # deployment and the read-only frozen-key precheck (see
-    # _invoke_lambda_ping; kept while flat exists — issue #251). setup_s
-    # keeps bracketing the phase.
+    # Hive layout (issue #252 hybrid): NO synchronous manifest-writing setup
+    # invoke. First the lightweight ping — fail-fast for a stale deployment
+    # plus the read-only frozen-key precheck (see _invoke_lambda_ping; kept
+    # while flat exists — issue #251) — then the manifest write fires as a
+    # fire-and-forget Event invoke of the existing mode="setup" hive branch
+    # (~10 ms, the root-coverage dispatch precedent below): the manifest
+    # lands seconds into the run, so a reader can consume completed leaves
+    # while the store builds, and finalize's ensure_manifest demotes to an
+    # idempotent backstop. setup_s keeps bracketing the phase (ping + Event
+    # dispatch).
     setup_start = time.time()
     if get_store_layout(config) == "hive":
         _invoke_lambda_ping(
+            state["lambda_client"],
+            function_name,
+            store_path,
+            config_dict=config_dict,
+            dataset=dataset,
+            parent_order=parent_order,
+            overwrite=overwrite,
+            output_creds_event=output_creds_event,
+        )
+        _invoke_lambda_setup_async(
             state["lambda_client"],
             function_name,
             store_path,
@@ -2969,11 +2982,12 @@ def _invoke_lambda_setup(
 ):
     """Invoke Lambda in setup mode to create the zarr template (flat only).
 
-    Hive runs no longer dispatch setup (issue #252): the morton_hive.json
-    write is folded into the finalize invoke, so nothing runs ahead of the
-    fan-out. The flat setup event is byte-identical to the pre-#199-phase-3
-    event, so a new dispatcher keeps working against old deployed functions
-    for flat runs.
+    Hive runs no longer dispatch setup SYNCHRONOUSLY (issue #252 hybrid):
+    the morton_hive.json write fires as a fire-and-forget Event invoke of
+    the same setup mode instead (``_invoke_lambda_setup_async``), so nothing
+    but the ping runs ahead of the fan-out. The flat setup event is
+    byte-identical to the pre-#199-phase-3 event, so a new dispatcher keeps
+    working against old deployed functions for flat runs.
     """
     event = {
         "mode": "setup",
@@ -2999,6 +3013,49 @@ def _invoke_lambda_setup(
         raise RuntimeError(f"Lambda setup error: {result.get('body')}")
 
 
+def _invoke_lambda_setup_async(
+    lambda_client,
+    function_name,
+    store_path,
+    *,
+    config_dict,
+    dataset=None,
+    parent_order=None,
+    overwrite=False,
+    output_creds_event=None,
+):
+    """Fire-and-forget hive manifest write at init (issue #252 hybrid).
+
+    One ``InvocationType="Event"`` invoke of the existing ``mode="setup"``
+    hive branch (~10 ms of dispatcher wall, the root-coverage dispatch
+    precedent), posted immediately after the ping passes: the handler runs
+    ``ensure_manifest(build_manifest(...))`` in parallel with the worker
+    fan-out, so ``morton_hive.json`` lands seconds into the run and a reader
+    can start consuming completed leaves while the store builds. The event
+    carries the same manifest inputs as the ping/finalize events (``config``
+    + ``parent_order`` + ``dataset`` identity + ``overwrite`` — the retired
+    synchronous hive setup event's shape). No response is read; a lost Event
+    invoke (retries 0, issue #151 hygiene) is self-healed by finalize's
+    idempotent ensure_manifest backstop — see ``_invoke_lambda_finalize``.
+    """
+    event = {
+        "mode": "setup",
+        "store_path": store_path,
+        "parent_order": parent_order,
+        "overwrite": overwrite,
+        "config": config_dict,
+    }
+    if dataset is not None:
+        event["dataset"] = dataset
+    if output_creds_event is not None:
+        event["output_credentials"] = output_creds_event
+    lambda_client.invoke(
+        FunctionName=function_name,
+        InvocationType="Event",
+        Payload=json.dumps(event),
+    )
+
+
 def _invoke_lambda_ping(
     lambda_client,
     function_name,
@@ -3013,25 +3070,27 @@ def _invoke_lambda_ping(
     """Pre-fan-out fail-fast ping for hive dispatch (issue #252).
 
     One lightweight RequestResponse invoke, decoupled from the manifest WRITE
-    (which rides finalize). Two failure modes are caught before any worker is
-    dispatched:
+    (which fires right after this ping as an async Event invoke of the setup
+    mode — issue #252 hybrid). Two failure modes are caught before any worker
+    is dispatched:
 
-    - **Stale deployment:** a function that predates the manifest-in-finalize
+    - **Stale deployment:** a function that predates the issue #252 hive
       lifecycle has no ping mode, so the event falls through to its process
       handler's 400 with ZERO writes — strictly earlier and cheaper than the
       retired PR #205 layout-echo guard, which only fired after a
       pre-#199-phase-3 function had already written the flat GLOBAL template
-      at the hive root. This also gates out hive-capable-but-pre-fold
-      functions, whose finalize would not write the manifest.
+      at the hive root. This also gates out hive-capable-but-pre-#252
+      functions, which lack this precheck and finalize's manifest backstop.
     - **Incompatible existing store:** the handler runs the read-only
       ``zagg.hive.validate_manifest`` against the event's manifest inputs
-      (same keys as hive finalize), so a frozen-key mismatch — or an
+      (same keys as hive setup/finalize), so a frozen-key mismatch — or an
       overwrite into a root with shard data — refuses up front (D2) instead
       of after the fan-out (PR #255 review fold). This covers sequential
-      reruns; two CONCURRENT runs racing into the same fresh root both see
-      no manifest and only collide at the losing run's finalize — a window
-      the old setup-time write closed for the second-to-arrive dispatch.
-      Same last-writer caveat the manifest write itself has always had.
+      reruns; two CONCURRENT runs racing into the same fresh root both pass
+      here, but with the manifest landing seconds after init (the async
+      setup invoke) the loser's collision window shrinks from run-length to
+      seconds. Same last-writer caveat the manifest write itself has always
+      had.
 
     Kept while flat exists (issue #251): once flat is removed, a stale
     function just errors and the ping can be dropped.
@@ -3072,7 +3131,7 @@ def _invoke_lambda_ping(
             )
         raise RuntimeError(
             f"Lambda ping failed (response body {result.get('body')!r}): the "
-            f"deployed function predates the issue #252 manifest-in-finalize "
+            f"deployed function predates the issue #252 hive dispatch "
             f"lifecycle — redeploy the function before dispatching hive runs"
         )
     try:
@@ -3096,12 +3155,17 @@ def _invoke_lambda_finalize(
     """Invoke Lambda in finalize mode.
 
     Flat: consolidates zarr metadata — the event stays byte-identical to the
-    pre-#252 one. Hive (issue #252): the event additionally carries the
-    manifest inputs (``config`` + ``parent_order`` + ``dataset`` identity +
-    ``overwrite``, mirroring the old setup event) and the worker writes the
-    root ``morton_hive.json`` instead — the manifest write folded off the
-    pre-worker critical path. The manifest is REQUIRED reader-facing schema
-    (D6), so a non-200 raises — unlike the fail-open root coverage.moc (D9).
+    pre-#252 one. Hive (issue #252 hybrid): the event additionally carries
+    the manifest inputs (``config`` + ``parent_order`` + ``dataset`` identity
+    + ``overwrite``, mirroring the hive setup event) and the worker's
+    ``ensure_manifest`` acts as the idempotent BACKSTOP for the async
+    init-time write — a frozen-key-matching existing manifest is accepted, no
+    second PUT. The backstop is load-bearing: worker Event invokes run with
+    retries 0 (template.yaml EventInvokeConfig, issue #151 hygiene), so a
+    lost async init write is never redelivered — finalize self-heals it;
+    symmetrically, finalize failure is no longer load-bearing for manifest
+    existence. The manifest is REQUIRED reader-facing schema (D6), so a
+    non-200 still raises — unlike the fail-open root coverage.moc (D9).
     """
     event = {"mode": "finalize", "store_path": store_path}
     if config_dict is not None:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1696,18 +1696,16 @@ def _run_local(
     windowing = get_windowing(config)
     if store_layout == "hive":
         # Hive layout (issue #199 phase 2): no shared zarr template — zero
-        # metadata above the leaves (D5). Template time writes only the root
-        # manifest (D6); each shard emits its own leaf template lazily inside
-        # hive.process_and_write_hive (the leaf write path lives in zagg.hive,
-        # next to the manifest/stamp machinery it exercises).
+        # metadata above the leaves (D5); each shard emits its own leaf
+        # template lazily inside hive.process_and_write_hive (the leaf write
+        # path lives in zagg.hive, next to the manifest/stamp machinery it
+        # exercises). The root manifest write (D6) is folded into the
+        # end-of-run finalize below (issue #252): the manifest is
+        # reader-facing only — workers write self-describing leaves (D3) and
+        # never read it — so nothing runs ahead of the dispatch, mirroring
+        # the lambda backend.
         from zagg.hive import build_manifest, ensure_manifest, process_and_write_hive
 
-        ensure_manifest(
-            store_path,
-            build_manifest(grid, dataset=catalog_data.get("metadata"), windowing=windowing),
-            overwrite=overwrite,
-            **store_kwargs,
-        )
         zarr_store = None
         # Temporal fan-out (issue #246 phase 5): one work unit per (shard,
         # window). None (schedule none/absent) keeps the (shard, records)
@@ -1820,6 +1818,18 @@ def _run_local(
     # skip it unless output.consolidate_metadata is true.
     if get_consolidate_metadata(config):
         consolidate_metadata(zarr_store, zarr_format=3)
+    # End-of-run manifest write (issue #252): folded out of template time —
+    # order-correct because readers only arrive after the run. Unlike the
+    # root coverage.moc below (a regenerable cache, D9), the manifest is
+    # REQUIRED reader-facing schema (D6), so a failed write — including a
+    # frozen-key mismatch against an existing store's manifest — raises.
+    if store_layout == "hive":
+        ensure_manifest(
+            store_path,
+            build_manifest(grid, dataset=catalog_data.get("metadata"), windowing=windowing),
+            overwrite=overwrite,
+            **store_kwargs,
+        )
     wall_time = time.time() - start_time
 
     # End-of-run root coverage.moc (issue #200 phase 3; default-on for hive,
@@ -2098,7 +2108,28 @@ def _run_lambda(
     # so gate the invoke dispatcher-side. When off we hand the executor a no-op
     # finalize (mirroring the temporal path's ``_run_lambda_events``, which has no
     # metadata to consolidate) so no ``mode: "finalize"`` Lambda is dispatched.
-    if get_consolidate_metadata(config):
+    # Hive (issue #252): finalize ALWAYS runs — it carries the root
+    # morton_hive.json write, folded off the pre-worker setup path — so the
+    # consolidate_metadata gate stays flat-only. The manifest inputs (config
+    # + dataset identity from the ShardMap metadata, the same source as the
+    # local path) ride the finalize event; flat finalize events stay
+    # byte-identical.
+    if get_store_layout(config) == "hive":
+        md = catalog_data.get("metadata") or {}
+        dataset = {"short_name": md.get("short_name"), "version": md.get("version")}
+
+        def _finalize_fn():
+            return _invoke_lambda_finalize(
+                state["lambda_client"],
+                function_name,
+                store_path,
+                output_creds_event=output_creds_event,
+                config_dict=config_dict,
+                dataset=dataset,
+                parent_order=parent_order,
+                overwrite=overwrite,
+            )
+    elif get_consolidate_metadata(config):
 
         def _finalize_fn():
             return _invoke_lambda_finalize(
@@ -2122,36 +2153,35 @@ def _run_lambda(
     executor.preflight(len(cells))
     max_workers = state["workers"]
 
-    # Create template via Lambda. The template write happens inside the
-    # function so the orchestrator only needs lambda:InvokeFunction; no
-    # direct S3 access to the output bucket is required (works cleanly
-    # for cross-account callers like CryoCloud).
+    # Create template via Lambda (flat only). The template write happens
+    # inside the function so the orchestrator only needs
+    # lambda:InvokeFunction; no direct S3 access to the output bucket is
+    # required (works cleanly for cross-account callers like CryoCloud).
     # Orchestrator phase brackets (always-on; just time.time() deltas around
     # calls that already happen, so no worker probe tax -- issue #100). They
     # decompose wall time into setup invoke / fan-out / finalize invoke so
     # "where did wall time go" is answerable from the summary.
-    # Hive layout (issue #199 phase 3): setup mode writes morton_hive.json
-    # instead of a global template. The worker builds the manifest itself from
-    # the event's config; only the dataset identity (from the ShardMap
-    # metadata, matching the local path's source) rides in the event — flat
-    # runs omit the key, keeping their setup event byte-identical.
-    dataset = None
-    if get_store_layout(config) == "hive":
-        md = catalog_data.get("metadata") or {}
-        dataset = {"short_name": md.get("short_name"), "version": md.get("version")}
+    # Hive layout (issue #252): NO pre-worker setup invoke. The manifest is
+    # reader-facing and hive workers write self-describing leaves (D3), so
+    # the morton_hive.json write rides the finalize invoke instead —
+    # order-correct (readers arrive after the run) and a whole synchronous
+    # ~3.7 s pre-fan-out round-trip off the wall. setup_s keeps bracketing
+    # the phase.
     setup_start = time.time()
-    _invoke_lambda_setup(
-        state["lambda_client"],
-        function_name,
-        store_path,
-        parent_order=parent_order,
-        child_order=child_order,
-        n_parent_cells=len(all_shards) if grid_type == "healpix" and layout == "dense" else None,
-        overwrite=overwrite,
-        config_dict=config_dict,
-        output_creds_event=output_creds_event,
-        dataset=dataset,
-    )
+    if get_store_layout(config) != "hive":
+        _invoke_lambda_setup(
+            state["lambda_client"],
+            function_name,
+            store_path,
+            parent_order=parent_order,
+            child_order=child_order,
+            n_parent_cells=(
+                len(all_shards) if grid_type == "healpix" and layout == "dense" else None
+            ),
+            overwrite=overwrite,
+            config_dict=config_dict,
+            output_creds_event=output_creds_event,
+        )
     setup_s = time.time() - setup_start
 
     start_time = time.time()
@@ -2909,24 +2939,14 @@ def _invoke_lambda_setup(
     overwrite,
     config_dict,
     output_creds_event=None,
-    dataset=None,
 ):
-    """Invoke Lambda in setup mode to create the zarr template.
+    """Invoke Lambda in setup mode to create the zarr template (flat only).
 
-    For a hive-layout config (issue #199 phase 3) the worker writes
-    ``morton_hive.json`` instead; ``dataset`` (``{"short_name", "version"}``
-    from the ShardMap metadata) is threaded through for the manifest's
-    identity block. The key is added only when set, so flat setup events stay
-    byte-identical.
-
-    Stale-deployment guard (review finding, PR #205): a function deployed
-    before phase 3 has no hive branch — it would emit the flat GLOBAL template
-    at the hive root, return the same 200 body, and the whole run would then
-    silently write a flat store. The phase-3 handler echoes the layout it
-    acted on (``"layout"`` in the response body), and a hive dispatch REQUIRES
-    that echo — failing fast at setup with a redeploy message instead of after
-    a full fan-out. Flat dispatch does not require the echo, so a new
-    dispatcher keeps working against old deployed functions for flat runs.
+    Hive runs no longer dispatch setup (issue #252): the morton_hive.json
+    write is folded into the finalize invoke, so nothing runs ahead of the
+    fan-out. The flat setup event is byte-identical to the pre-#199-phase-3
+    event, so a new dispatcher keeps working against old deployed functions
+    for flat runs.
     """
     event = {
         "mode": "setup",
@@ -2937,8 +2957,6 @@ def _invoke_lambda_setup(
         "overwrite": overwrite,
         "config": config_dict,
     }
-    if dataset is not None:
-        event["dataset"] = dataset
     if output_creds_event is not None:
         event["output_credentials"] = output_creds_event
     response = lambda_client.invoke(
@@ -2952,24 +2970,36 @@ def _invoke_lambda_setup(
     result = json.loads(payload)
     if result.get("statusCode") != 200:
         raise RuntimeError(f"Lambda setup error: {result.get('body')}")
-    requested = ((config_dict or {}).get("output") or {}).get("store_layout") or "flat"
-    if requested == "hive":
-        try:
-            echoed = json.loads(result.get("body") or "{}").get("layout")
-        except (TypeError, ValueError):
-            echoed = None
-        if echoed != "hive":
-            raise RuntimeError(
-                f"Lambda setup did not confirm the hive store layout (response body "
-                f"{result.get('body')!r}): the deployed function predates issue #199 "
-                f"phase 3 and would write a FLAT store at the hive root — redeploy "
-                f"the function before dispatching hive runs"
-            )
 
 
-def _invoke_lambda_finalize(lambda_client, function_name, store_path, output_creds_event=None):
-    """Invoke Lambda in finalize mode to consolidate zarr metadata."""
+def _invoke_lambda_finalize(
+    lambda_client,
+    function_name,
+    store_path,
+    output_creds_event=None,
+    *,
+    config_dict=None,
+    dataset=None,
+    parent_order=None,
+    overwrite=False,
+):
+    """Invoke Lambda in finalize mode.
+
+    Flat: consolidates zarr metadata — the event stays byte-identical to the
+    pre-#252 one. Hive (issue #252): the event additionally carries the
+    manifest inputs (``config`` + ``parent_order`` + ``dataset`` identity +
+    ``overwrite``, mirroring the old setup event) and the worker writes the
+    root ``morton_hive.json`` instead — the manifest write folded off the
+    pre-worker critical path. The manifest is REQUIRED reader-facing schema
+    (D6), so a non-200 raises — unlike the fail-open root coverage.moc (D9).
+    """
     event = {"mode": "finalize", "store_path": store_path}
+    if config_dict is not None:
+        event["config"] = config_dict
+        event["parent_order"] = parent_order
+        event["overwrite"] = overwrite
+        if dataset is not None:
+            event["dataset"] = dataset
     if output_creds_event is not None:
         event["output_credentials"] = output_creds_event
     response = lambda_client.invoke(

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1704,9 +1704,23 @@ def _run_local(
         # reader-facing only — workers write self-describing leaves (D3) and
         # never read it — so nothing runs ahead of the dispatch, mirroring
         # the lambda backend.
-        from zagg.hive import build_manifest, ensure_manifest, process_and_write_hive
+        from zagg.hive import (
+            build_manifest,
+            ensure_manifest,
+            process_and_write_hive,
+            validate_manifest,
+        )
 
         zarr_store = None
+        # Build the manifest once, up front, and reuse it at finalize. The WRITE
+        # is folded into the end-of-run ensure_manifest (D6), but its read-only
+        # frozen-key precheck (review fold, issue #252) runs HERE — fail-fast
+        # against an incompatible existing store before any leaf write (D2), so
+        # a misdirected rerun refuses in ~0s instead of mixing new-order leaves
+        # into an old-order store and only raising afterward. The write itself
+        # stays off the critical path in the finalize block below.
+        manifest = build_manifest(grid, dataset=catalog_data.get("metadata"), windowing=windowing)
+        validate_manifest(store_path, manifest, overwrite=overwrite, **store_kwargs)
         # Temporal fan-out (issue #246 phase 5): one work unit per (shard,
         # window). None (schedule none/absent) keeps the (shard, records)
         # pairs — dispatch byte-identical to pre-windowing runs.
@@ -1826,7 +1840,7 @@ def _run_local(
     if store_layout == "hive":
         ensure_manifest(
             store_path,
-            build_manifest(grid, dataset=catalog_data.get("metadata"), windowing=windowing),
+            manifest,
             overwrite=overwrite,
             **store_kwargs,
         )

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2182,10 +2182,12 @@ def _run_lambda(
     # while flat exists — issue #251) — then the manifest write fires as a
     # fire-and-forget Event invoke of the existing mode="setup" hive branch
     # (~10 ms, the root-coverage dispatch precedent below): the manifest
-    # lands seconds into the run, so a reader can consume completed leaves
-    # while the store builds, and finalize's ensure_manifest demotes to an
-    # idempotent backstop. setup_s keeps bracketing the phase (ping + Event
-    # dispatch).
+    # typically lands within seconds of init (best-effort — the Event invoke
+    # shares worker concurrency and runs retries-0, so under throttling or a
+    # dropped invoke the write defers to the finalize backstop), so a reader
+    # can consume completed leaves while the store builds, and finalize's
+    # ensure_manifest demotes to an idempotent backstop. setup_s keeps
+    # bracketing the phase (ping + Event dispatch).
     setup_start = time.time()
     if get_store_layout(config) == "hive":
         _invoke_lambda_ping(
@@ -3030,8 +3032,11 @@ def _invoke_lambda_setup_async(
     hive branch (~10 ms of dispatcher wall, the root-coverage dispatch
     precedent), posted immediately after the ping passes: the handler runs
     ``ensure_manifest(build_manifest(...))`` in parallel with the worker
-    fan-out, so ``morton_hive.json`` lands seconds into the run and a reader
-    can start consuming completed leaves while the store builds. The event
+    fan-out, so ``morton_hive.json`` typically lands within seconds of init
+    (best-effort: the Event invoke shares worker concurrency and runs
+    retries-0 — under throttling or a dropped invoke the write defers to the
+    finalize backstop) and a reader can start consuming completed leaves while
+    the store builds. The event
     carries the same manifest inputs as the ping/finalize events (``config``
     + ``parent_order`` + ``dataset`` identity + ``overwrite`` — the retired
     synchronous hive setup event's shape). No response is read; a lost Event

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2175,14 +2175,27 @@ def _run_lambda(
     # calls that already happen, so no worker probe tax -- issue #100). They
     # decompose wall time into setup invoke / fan-out / finalize invoke so
     # "where did wall time go" is answerable from the summary.
-    # Hive layout (issue #252): NO pre-worker setup invoke. The manifest is
-    # reader-facing and hive workers write self-describing leaves (D3), so
-    # the morton_hive.json write rides the finalize invoke instead —
-    # order-correct (readers arrive after the run) and a whole synchronous
-    # ~3.7 s pre-fan-out round-trip off the wall. setup_s keeps bracketing
-    # the phase.
+    # Hive layout (issue #252): NO manifest-writing setup invoke. The
+    # manifest is reader-facing and hive workers write self-describing leaves
+    # (D3), so the morton_hive.json write rides the finalize invoke instead —
+    # order-correct (readers arrive after the run). What remains up front is
+    # one lightweight ping, decoupled from the write: fail-fast for a stale
+    # deployment and the read-only frozen-key precheck (see
+    # _invoke_lambda_ping; kept while flat exists — issue #251). setup_s
+    # keeps bracketing the phase.
     setup_start = time.time()
-    if get_store_layout(config) != "hive":
+    if get_store_layout(config) == "hive":
+        _invoke_lambda_ping(
+            state["lambda_client"],
+            function_name,
+            store_path,
+            config_dict=config_dict,
+            dataset=dataset,
+            parent_order=parent_order,
+            overwrite=overwrite,
+            output_creds_event=output_creds_event,
+        )
+    else:
         _invoke_lambda_setup(
             state["lambda_client"],
             function_name,
@@ -2984,6 +2997,74 @@ def _invoke_lambda_setup(
     result = json.loads(payload)
     if result.get("statusCode") != 200:
         raise RuntimeError(f"Lambda setup error: {result.get('body')}")
+
+
+def _invoke_lambda_ping(
+    lambda_client,
+    function_name,
+    store_path,
+    *,
+    config_dict,
+    dataset=None,
+    parent_order=None,
+    overwrite=False,
+    output_creds_event=None,
+):
+    """Pre-fan-out fail-fast ping for hive dispatch (issue #252).
+
+    One lightweight RequestResponse invoke, decoupled from the manifest WRITE
+    (which rides finalize). Two failure modes are caught before any worker is
+    dispatched:
+
+    - **Stale deployment:** a function that predates the manifest-in-finalize
+      lifecycle has no ping mode, so the event falls through to its process
+      handler's 400 with ZERO writes — strictly earlier and cheaper than the
+      retired PR #205 layout-echo guard, which only fired after a
+      pre-#199-phase-3 function had already written the flat GLOBAL template
+      at the hive root. This also gates out hive-capable-but-pre-fold
+      functions, whose finalize would not write the manifest.
+    - **Incompatible existing store:** the handler runs the read-only
+      ``zagg.hive.validate_manifest`` against the event's manifest inputs
+      (same keys as hive finalize), so a frozen-key mismatch — or an
+      overwrite into a root with shard data — refuses up front (D2) instead
+      of after the fan-out (PR #255 review fold).
+
+    Kept while flat exists (issue #251): once flat is removed, a stale
+    function just errors and the ping can be dropped.
+    """
+    event = {
+        "mode": "ping",
+        "store_path": store_path,
+        "parent_order": parent_order,
+        "overwrite": overwrite,
+        "config": config_dict,
+    }
+    if dataset is not None:
+        event["dataset"] = dataset
+    if output_creds_event is not None:
+        event["output_credentials"] = output_creds_event
+    response = lambda_client.invoke(
+        FunctionName=function_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(event),
+    )
+    payload = response["Payload"].read().decode("utf-8")
+    if response.get("FunctionError"):
+        raise RuntimeError(f"Lambda ping failed: {payload}")
+    result = json.loads(payload)
+    if result.get("statusCode") != 200:
+        raise RuntimeError(
+            f"Lambda ping failed (response body {result.get('body')!r}): either the "
+            f"deployed function predates the issue #252 manifest-in-finalize "
+            f"lifecycle — redeploy the function before dispatching hive runs — or "
+            f"the store at {store_path} was templated for a different "
+            f"configuration (see the body's error)"
+        )
+    try:
+        version = json.loads(result.get("body") or "{}").get("zagg_version")
+    except (TypeError, ValueError):
+        version = None
+    logger.info(f"Hive preflight OK (function zagg version {version})")
 
 
 def _invoke_lambda_finalize(

--- a/tests/test_coverage_root.py
+++ b/tests/test_coverage_root.py
@@ -327,6 +327,7 @@ class TestLambdaCoverageDispatch:
             ),
         )
         monkeypatch.setattr(runner, "_invoke_lambda_setup", lambda *a, **kw: None)
+        monkeypatch.setattr(runner, "_invoke_lambda_ping", lambda *a, **kw: None)
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
         monkeypatch.setattr(
             runner,

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -228,6 +228,27 @@ class TestManifest:
     def test_read_absent_returns_none(self, tmp_path):
         assert hive.read_manifest(str(tmp_path / "empty")) is None
 
+    def test_validate_fresh_root_returns_none_and_writes_nothing(self, cfg, tmp_path):
+        # The read-only precheck (issue #252): a fresh root has nothing to
+        # match, returns None, and must NOT write the manifest — that stays
+        # for the finalize ensure_manifest.
+        root = str(tmp_path / "store")
+        assert hive.validate_manifest(root, hive.build_manifest(self._grid(cfg))) is None
+        assert hive.read_manifest(root) is None
+
+    def test_validate_matching_returns_existing(self, cfg, tmp_path):
+        root = str(tmp_path / "store")
+        grid = self._grid(cfg)
+        written = hive.ensure_manifest(root, hive.build_manifest(grid))
+        assert hive.validate_manifest(root, hive.build_manifest(grid)) == written
+
+    def test_validate_mismatch_raises(self, cfg, tmp_path):
+        root = str(tmp_path / "store")
+        hive.ensure_manifest(root, hive.build_manifest(self._grid(cfg)))
+        other = HealpixGrid(parent_order=5, child_order=8, layout="fullsphere", config=cfg)
+        with pytest.raises(ValueError, match="does not match this run"):
+            hive.validate_manifest(root, hive.build_manifest(other))
+
 
 # ── leaf template + commit stamp (D3/D4) ─────────────────────────────────────
 
@@ -933,6 +954,36 @@ class TestRunnerWiring:
         # the only other root object.
         assert sorted(os.listdir(root)) == [hive.ROOT_COVERAGE_NAME, hive.MANIFEST_NAME]
         assert hive.read_manifest(root)["shard_order"] == 6
+
+    def test_local_hive_rerun_frozen_key_mismatch_fails_before_dispatch(
+        self, monkeypatch, cfg, tmp_path
+    ):
+        # The manifest WRITE folded to finalize (issue #252), but its read-only
+        # frozen-key precheck runs pre-dispatch (review fold): a rerun into a
+        # root templated for DIFFERENT orders (shard_order 5 vs the catalog's 6)
+        # must refuse BEFORE any cell runs — not after fan-out has already mixed
+        # new-order leaves into the old-order store (D2).
+        from zagg import runner
+        from zagg.runner import agg
+
+        cfg.output["store_layout"] = "hive"
+        catalog_path, shard = self._catalog(tmp_path)
+        root = str(tmp_path / "out")
+        other = HealpixGrid(parent_order=5, child_order=12, layout="fullsphere", config=cfg)
+        hive.ensure_manifest(root, hive.build_manifest(other))
+
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "a"})
+        calls = []
+
+        def fake_hive_write(*args, **kw):
+            calls.append(args)
+            return {"error": None, "total_obs": 1}
+
+        monkeypatch.setattr(hive, "process_and_write_hive", fake_hive_write)
+        with pytest.raises(ValueError, match="clear the store root"):
+            agg(cfg, catalog=catalog_path, store=root, backend="local")
+        # Fail-fast: the precheck raised before dispatch, so no cell ran.
+        assert calls == []
 
     def test_local_hive_sharded_leaf_single_object(self, monkeypatch, cfg, tmp_path):
         """Issue #236 through the LOCAL dispatcher: a sharded K>1 hive run

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -904,9 +904,11 @@ class TestLeafBlockIndex:
 
 class TestRunnerWiring:
     """The local backend writes the manifest (no shared template) under hive;
-    the lambda backend dispatches hive runs (issue #199 phase 3). The
-    manifest write is folded into finalize on both paths (issue #252) — no
-    pre-worker setup invoke, the dataset identity rides the finalize event."""
+    the lambda backend dispatches hive runs (issue #199 phase 3). Manifest
+    lifecycle (issue #252 hybrid): the write lands at INIT — directly on the
+    local path, as a fire-and-forget Event invoke of the setup mode right
+    after the ping on the lambda path — and finalize re-ensures it as an
+    idempotent backstop."""
 
     def _catalog(self, tmp_path):
         shard = _shard_word()
@@ -926,7 +928,7 @@ class TestRunnerWiring:
         p.write_text(json.dumps(catalog))
         return str(p), shard
 
-    def test_local_hive_writes_manifest_not_template(self, monkeypatch, cfg, tmp_path):
+    def test_local_hive_writes_manifest_before_cells(self, monkeypatch, cfg, tmp_path):
         from zagg import runner
         from zagg.runner import agg
 
@@ -938,10 +940,10 @@ class TestRunnerWiring:
         monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "a"})
 
         def fake_hive_write(shard_key, granule_urls, grid, s3_creds, store_root, config, **kw):
-            # The manifest write is folded into finalize (issue #252): while
-            # cells run, NOTHING has been written at the root — the manifest
-            # is off the critical path, not merely reordered.
-            assert not os.path.exists(os.path.join(store_root, hive.MANIFEST_NAME))
+            # The manifest lands at init (issue #252 hybrid): by the time any
+            # cell runs it is already at the root, so a reader can consume
+            # completed leaves while the store builds.
+            assert os.path.exists(os.path.join(store_root, hive.MANIFEST_NAME))
             calls.append((int(shard_key), store_root))
             return {"shard_key": int(shard_key), "error": None, "total_obs": 1}
 
@@ -949,20 +951,43 @@ class TestRunnerWiring:
         agg(cfg, catalog=catalog_path, store=root, backend="local")
 
         assert calls == [(shard, root)]
-        # End of run wrote ONLY the manifest — no shared zarr template (D5).
-        # The root coverage.moc (issue #200 phase 3, default-on for hive) is
-        # the only other root object.
+        # The run wrote ONLY the manifest at the root — no shared zarr
+        # template (D5). The root coverage.moc (issue #200 phase 3,
+        # default-on for hive) is the only other root object.
         assert sorted(os.listdir(root)) == [hive.ROOT_COVERAGE_NAME, hive.MANIFEST_NAME]
+        assert hive.read_manifest(root)["shard_order"] == 6
+
+    def test_local_hive_finalize_backstop_restores_lost_manifest(self, monkeypatch, cfg, tmp_path):
+        # Issue #252 hybrid: the init-time write is primary, but finalize
+        # keeps ensure_manifest as an idempotent backstop — a manifest lost
+        # mid-run (simulated by deleting it inside the cell) is back at the
+        # root by end of run.
+        from zagg import runner
+        from zagg.runner import agg
+
+        cfg.output["store_layout"] = "hive"
+        catalog_path, shard = self._catalog(tmp_path)
+        root = str(tmp_path / "out")
+
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "a"})
+
+        def fake_hive_write(shard_key, granule_urls, grid, s3_creds, store_root, config, **kw):
+            os.remove(os.path.join(store_root, hive.MANIFEST_NAME))
+            return {"shard_key": int(shard_key), "error": None, "total_obs": 1}
+
+        monkeypatch.setattr(hive, "process_and_write_hive", fake_hive_write)
+        agg(cfg, catalog=catalog_path, store=root, backend="local")
         assert hive.read_manifest(root)["shard_order"] == 6
 
     def test_local_hive_rerun_frozen_key_mismatch_fails_before_dispatch(
         self, monkeypatch, cfg, tmp_path
     ):
-        # The manifest WRITE folded to finalize (issue #252), but its read-only
-        # frozen-key precheck runs pre-dispatch (review fold): a rerun into a
-        # root templated for DIFFERENT orders (shard_order 5 vs the catalog's 6)
-        # must refuse BEFORE any cell runs — not after fan-out has already mixed
-        # new-order leaves into the old-order store (D2).
+        # The manifest write runs at init (issue #252 hybrid) and
+        # ensure_manifest runs the validate_manifest frozen-key precheck
+        # first: a rerun into a root templated for DIFFERENT orders
+        # (shard_order 5 vs the catalog's 6) must refuse BEFORE any cell
+        # runs — not after fan-out has already mixed new-order leaves into
+        # the old-order store (D2).
         from zagg import runner
         from zagg.runner import agg
 
@@ -1035,12 +1060,14 @@ class TestRunnerWiring:
             assert n_objects == 1, name
         assert hive.read_commit(open_store(leaf))["complete"] is True
 
-    def test_lambda_hive_folds_manifest_into_finalize(self, monkeypatch, cfg, tmp_path):
-        # Issue #252: a hive lambda run dispatches NO setup invoke — the
-        # manifest inputs (dataset identity from the ShardMap metadata, same
-        # source as the local path) ride the finalize invoke, which runs even
-        # with consolidate_metadata off (the default). Per-cell events need
-        # NO new keys — the worker derives everything from the config dict.
+    def test_lambda_hive_fires_async_setup_after_ping(self, monkeypatch, cfg, tmp_path):
+        # Issue #252 hybrid: a hive lambda run dispatches NO synchronous
+        # setup invoke. The lifecycle is ping (fail-fast, both guards) →
+        # async Event setup (the manifest write, before any worker fan-out
+        # → progressive reads) → workers → finalize (idempotent backstop,
+        # which runs even with consolidate_metadata off — the default) and
+        # carries the same manifest inputs. Per-cell events need NO new
+        # keys — the worker derives everything from the config dict.
         from unittest.mock import MagicMock
 
         import boto3
@@ -1052,6 +1079,7 @@ class TestRunnerWiring:
         cfg.output["store_layout"] = "hive"
         catalog_path, shard = self._catalog(tmp_path)
         captured: dict = {}
+        order: list = []
 
         monkeypatch.setattr(
             runner,
@@ -1074,14 +1102,21 @@ class TestRunnerWiring:
                 ),
             ),
         )
-        monkeypatch.setattr(
-            runner, "_invoke_lambda_setup", lambda *a, **kw: captured.update(setup=kw)
-        )
-        monkeypatch.setattr(
-            runner, "_invoke_lambda_finalize", lambda *a, **kw: captured.update(finalize=kw)
-        )
+
+        def _capture(name):
+            def _f(*a, **kw):
+                order.append(name)
+                captured[name] = kw
+
+            return _f
+
+        monkeypatch.setattr(runner, "_invoke_lambda_setup", _capture("setup"))
+        monkeypatch.setattr(runner, "_invoke_lambda_setup_async", _capture("setup_async"))
+        monkeypatch.setattr(runner, "_invoke_lambda_finalize", _capture("finalize"))
+        monkeypatch.setattr(runner, "_invoke_lambda_ping", _capture("ping"))
 
         def fake_cell(client, chunk_idx, shard_key, *a, **k):
+            order.append("cell")
             captured["cell_shard_key"] = shard_key
             return {
                 "status_code": 200,
@@ -1092,17 +1127,19 @@ class TestRunnerWiring:
             }
 
         monkeypatch.setattr(runner, "_invoke_lambda_cell", fake_cell)
-        monkeypatch.setattr(
-            runner, "_invoke_lambda_ping", lambda *a, **kw: captured.update(ping=kw)
-        )
         agg(cfg, catalog=catalog_path, store="s3://out/product", backend="lambda")
 
-        # NO manifest-writing setup invoke: what runs up front is the
-        # lightweight ping, carrying the same manifest inputs as finalize
-        # (fail-fast guard, issue #252 — decoupled from the write).
+        # NO synchronous setup invoke; the manifest write (async setup) fires
+        # AFTER the ping passes and BEFORE any worker — so the manifest lands
+        # seconds into the run — and finalize backstops it at the end.
         assert "setup" not in captured
+        assert order == ["ping", "setup_async", "cell", "finalize"]
         assert captured["ping"]["dataset"] == {"short_name": "ATL06", "version": "007"}
         assert captured["ping"]["config_dict"]["output"]["store_layout"] == "hive"
+        # The async setup carries the same manifest inputs as ping/finalize.
+        assert captured["setup_async"]["dataset"] == {"short_name": "ATL06", "version": "007"}
+        assert captured["setup_async"]["config_dict"]["output"]["store_layout"] == "hive"
+        assert captured["setup_async"]["parent_order"] == 6
         assert captured["finalize"]["dataset"] == {"short_name": "ATL06", "version": "007"}
         # store_layout rides in the config dict already serialized into events.
         assert captured["finalize"]["config_dict"]["output"]["store_layout"] == "hive"
@@ -1165,10 +1202,15 @@ class TestRunnerWiring:
         monkeypatch.setattr(
             runner, "_invoke_lambda_ping", lambda *a, **kw: captured.update(ping=kw)
         )
+        monkeypatch.setattr(
+            runner, "_invoke_lambda_setup_async", lambda *a, **kw: captured.update(setup_async=kw)
+        )
         agg(cfg, catalog=catalog_path, store="s3://out/x.zarr", backend="lambda")
         assert "dataset" not in captured["setup"]
         assert "finalize" not in captured
         assert "ping" not in captured
+        # The async manifest write is hive-only (issue #252 hybrid).
+        assert "setup_async" not in captured
 
 
 def _wire_client(body: dict, status_code: int = 200):
@@ -1185,10 +1227,12 @@ def _wire_client(body: dict, status_code: int = 200):
 
 
 class TestInvokeLambdaSetupEvent:
-    """Pin the ACTUAL setup event on the wire. Setup is flat-only now (issue
-    #252 folded the hive manifest into finalize and the PR #205 layout-echo
-    guard into the version ping), so what remains to pin is flat byte-identity
-    against pre-phase-3 deployed functions."""
+    """Pin the ACTUAL setup events on the wire. The synchronous invoke is
+    flat-only now (issue #252 moved the hive manifest write to an async
+    Event invoke of the same setup mode, and the PR #205 layout-echo guard
+    into the version ping): pin flat byte-identity against pre-phase-3
+    deployed functions, and the hive async event + its fire-and-forget
+    InvocationType."""
 
     @staticmethod
     def _invoke(client, config_dict):
@@ -1227,6 +1271,39 @@ class TestInvokeLambdaSetupEvent:
         # Old deployed functions return the echo-less body: flat dispatch must
         # keep working against them.
         self._invoke(_wire_client({"ok": True, "mode": "setup"}), asdict(cfg))
+
+    def test_hive_async_event_matches_baseline(self, cfg):
+        # The async init-time manifest write (issue #252 hybrid): a
+        # fire-and-forget InvocationType="Event" invoke of the hive setup
+        # branch, carrying exactly the manifest inputs the ping/finalize
+        # events pin (config + parent_order + dataset identity + overwrite).
+        from zagg.runner import _invoke_lambda_setup_async
+
+        cfg.output["store_layout"] = "hive"
+        config_dict = asdict(cfg)
+        client = _wire_client({"ok": True, "mode": "setup", "layout": "hive"})
+        _invoke_lambda_setup_async(
+            client,
+            "process-shard",
+            "s3://out/product",
+            config_dict=config_dict,
+            dataset={"short_name": "ATL06", "version": "007"},
+            parent_order=6,
+            overwrite=False,
+        )
+        kwargs = client.invoke.call_args.kwargs
+        assert kwargs["InvocationType"] == "Event"
+        assert json.loads(kwargs["Payload"]) == {
+            "mode": "setup",
+            "store_path": "s3://out/product",
+            "parent_order": 6,
+            "overwrite": False,
+            "config": config_dict,
+            "dataset": {"short_name": "ATL06", "version": "007"},
+        }
+        # Fire-and-forget: no response is read (an Event invoke returns 202
+        # with no function payload), so nothing can block on it.
+        client.invoke.return_value["Payload"].read.assert_not_called()
 
 
 class TestInvokeLambdaFinalizeEvent:

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -970,13 +970,26 @@ class TestRunnerWiring:
         root = str(tmp_path / "out")
 
         monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "a"})
+        removed = []
 
         def fake_hive_write(shard_key, granule_urls, grid, s3_creds, store_root, config, **kw):
-            os.remove(os.path.join(store_root, hive.MANIFEST_NAME))
+            # The init write is PRIMARY, so the manifest must already be at the
+            # root when a cell runs — assert THEN remove, recording it. A
+            # regressed init write (assert fails) or a swallowed
+            # FileNotFoundError leaves ``removed`` empty, so the post-run check
+            # below fails loudly instead of staying green on finalize alone
+            # (``_cell_work`` swallows cell exceptions into an error envelope).
+            path = os.path.join(store_root, hive.MANIFEST_NAME)
+            assert os.path.exists(path)
+            os.remove(path)
+            removed.append(True)
             return {"shard_key": int(shard_key), "error": None, "total_obs": 1}
 
         monkeypatch.setattr(hive, "process_and_write_hive", fake_hive_write)
         agg(cfg, catalog=catalog_path, store=root, backend="local")
+        # The cell saw the init-written manifest and removed it (init→lost);
+        # finalize restored it (lost→restored).
+        assert removed == [True]
         assert hive.read_manifest(root)["shard_order"] == 6
 
     def test_local_hive_rerun_frozen_key_mismatch_fails_before_dispatch(

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -1276,7 +1276,9 @@ class TestInvokeLambdaPingEvent:
     #252, replacing the PR #205 layout-echo guard): the ping carries the same
     manifest inputs as hive finalize, and any non-200 — a stale function's
     process-handler 400 fall-through, or the handler's validate_manifest
-    refusal — raises before a single worker is dispatched."""
+    refusal — raises before a single worker is dispatched. The two modes get
+    distinct remedies: a 400 without ``mode: "ping"`` says redeploy, a 500
+    that echoes ``mode: "ping"`` says clear the store root."""
 
     @staticmethod
     def _invoke(client, config_dict, **kw):
@@ -1321,9 +1323,11 @@ class TestInvokeLambdaPingEvent:
 
     def test_validate_refusal_fails_fast(self, cfg):
         # The handler's read-only validate_manifest refusal (frozen-key
-        # mismatch, D2) surfaces the same way: pre-fan-out, run aborted.
+        # mismatch, D2) surfaces pre-fan-out with the store remedy, not
+        # redeploy: the 500 body echoes mode="ping", so the message points at
+        # clearing the store root rather than a stale deployment.
         cfg.output["store_layout"] = "hive"
-        with pytest.raises(RuntimeError, match="Lambda ping failed"):
+        with pytest.raises(RuntimeError, match="clear the store root"):
             self._invoke(
                 _wire_client(
                     {"error": "morton_hive.json ... does not match this run", "mode": "ping"},

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -1318,6 +1318,42 @@ class TestInvokeLambdaSetupEvent:
         # with no function payload), so nothing can block on it.
         client.invoke.return_value["Payload"].read.assert_not_called()
 
+    def test_hive_async_event_threads_creds_and_overwrite(self, cfg):
+        # The async setup is the PRIMARY manifest write and fire-and-forget
+        # (no response read), so a drifted ``output_credentials`` key or
+        # ``overwrite`` flag would fail SILENTLY — the miss only surfacing as
+        # the finalize backstop doing the "primary" write. Pin the two
+        # conditional branches on the wire: overwrite=True and an
+        # output_creds_event both reach the Event payload exactly.
+        from zagg.runner import _invoke_lambda_setup_async
+
+        cfg.output["store_layout"] = "hive"
+        config_dict = asdict(cfg)
+        client = _wire_client({"ok": True, "mode": "setup", "layout": "hive"})
+        creds = {"aws_access_key_id": "AK", "aws_secret_access_key": "SK"}
+        _invoke_lambda_setup_async(
+            client,
+            "process-shard",
+            "s3://out/product",
+            config_dict=config_dict,
+            dataset={"short_name": "ATL06", "version": "007"},
+            parent_order=6,
+            overwrite=True,
+            output_creds_event=creds,
+        )
+        kwargs = client.invoke.call_args.kwargs
+        assert kwargs["InvocationType"] == "Event"
+        assert json.loads(kwargs["Payload"]) == {
+            "mode": "setup",
+            "store_path": "s3://out/product",
+            "parent_order": 6,
+            "overwrite": True,
+            "config": config_dict,
+            "dataset": {"short_name": "ATL06", "version": "007"},
+            "output_credentials": creds,
+        }
+        client.invoke.return_value["Payload"].read.assert_not_called()
+
 
 class TestInvokeLambdaFinalizeEvent:
     """Pin the ACTUAL finalize event on the wire (issue #252): hive carries

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -1092,10 +1092,17 @@ class TestRunnerWiring:
             }
 
         monkeypatch.setattr(runner, "_invoke_lambda_cell", fake_cell)
+        monkeypatch.setattr(
+            runner, "_invoke_lambda_ping", lambda *a, **kw: captured.update(ping=kw)
+        )
         agg(cfg, catalog=catalog_path, store="s3://out/product", backend="lambda")
 
-        # NO pre-worker setup invoke: hive setup is gone from the wall.
+        # NO manifest-writing setup invoke: what runs up front is the
+        # lightweight ping, carrying the same manifest inputs as finalize
+        # (fail-fast guard, issue #252 — decoupled from the write).
         assert "setup" not in captured
+        assert captured["ping"]["dataset"] == {"short_name": "ATL06", "version": "007"}
+        assert captured["ping"]["config_dict"]["output"]["store_layout"] == "hive"
         assert captured["finalize"]["dataset"] == {"short_name": "ATL06", "version": "007"}
         # store_layout rides in the config dict already serialized into events.
         assert captured["finalize"]["config_dict"]["output"]["store_layout"] == "hive"
@@ -1155,9 +1162,13 @@ class TestRunnerWiring:
                 "shard_key": shard,
             },
         )
+        monkeypatch.setattr(
+            runner, "_invoke_lambda_ping", lambda *a, **kw: captured.update(ping=kw)
+        )
         agg(cfg, catalog=catalog_path, store="s3://out/x.zarr", backend="lambda")
         assert "dataset" not in captured["setup"]
         assert "finalize" not in captured
+        assert "ping" not in captured
 
 
 def _wire_client(body: dict, status_code: int = 200):
@@ -1256,5 +1267,68 @@ class TestInvokeLambdaFinalizeEvent:
             self._invoke(
                 _wire_client({"error": "boom", "mode": "finalize"}, status_code=500),
                 config_dict={"output": {"store_layout": "hive"}},
+                parent_order=6,
+            )
+
+
+class TestInvokeLambdaPingEvent:
+    """Pin the ACTUAL ping event on the wire and the fail-fast guard (issue
+    #252, replacing the PR #205 layout-echo guard): the ping carries the same
+    manifest inputs as hive finalize, and any non-200 — a stale function's
+    process-handler 400 fall-through, or the handler's validate_manifest
+    refusal — raises before a single worker is dispatched."""
+
+    @staticmethod
+    def _invoke(client, config_dict, **kw):
+        from zagg.runner import _invoke_lambda_ping
+
+        _invoke_lambda_ping(
+            client,
+            "process-shard",
+            "s3://out/product",
+            config_dict=config_dict,
+            **kw,
+        )
+        return json.loads(client.invoke.call_args.kwargs["Payload"])
+
+    def test_event_carries_manifest_inputs(self, cfg):
+        cfg.output["store_layout"] = "hive"
+        config_dict = asdict(cfg)
+        event = self._invoke(
+            _wire_client({"ok": True, "mode": "ping", "zagg_version": "1.2.3"}),
+            config_dict,
+            dataset={"short_name": "ATL06", "version": "007"},
+            parent_order=6,
+            overwrite=False,
+        )
+        assert event["mode"] == "ping"
+        assert event["config"] == config_dict
+        assert event["dataset"] == {"short_name": "ATL06", "version": "007"}
+        assert event["parent_order"] == 6
+        assert event["overwrite"] is False
+
+    def test_stale_function_fall_through_fails_fast(self, cfg):
+        # A pre-#252 function doesn't know mode="ping": the event falls
+        # through to its process handler, which 400s the key-less event with
+        # ZERO writes — the dispatcher turns that into the redeploy message.
+        cfg.output["store_layout"] = "hive"
+        with pytest.raises(RuntimeError, match="redeploy"):
+            self._invoke(
+                _wire_client({"error": "shard_key required"}, status_code=400),
+                asdict(cfg),
+                parent_order=6,
+            )
+
+    def test_validate_refusal_fails_fast(self, cfg):
+        # The handler's read-only validate_manifest refusal (frozen-key
+        # mismatch, D2) surfaces the same way: pre-fan-out, run aborted.
+        cfg.output["store_layout"] = "hive"
+        with pytest.raises(RuntimeError, match="Lambda ping failed"):
+            self._invoke(
+                _wire_client(
+                    {"error": "morton_hive.json ... does not match this run", "mode": "ping"},
+                    status_code=500,
+                ),
+                asdict(cfg),
                 parent_order=6,
             )

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -883,8 +883,9 @@ class TestLeafBlockIndex:
 
 class TestRunnerWiring:
     """The local backend writes the manifest (no shared template) under hive;
-    the lambda backend dispatches hive runs (issue #199 phase 3), threading
-    the manifest's dataset identity through the setup invoke."""
+    the lambda backend dispatches hive runs (issue #199 phase 3). The
+    manifest write is folded into finalize on both paths (issue #252) — no
+    pre-worker setup invoke, the dataset identity rides the finalize event."""
 
     def _catalog(self, tmp_path):
         shard = _shard_word()
@@ -916,6 +917,10 @@ class TestRunnerWiring:
         monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "a"})
 
         def fake_hive_write(shard_key, granule_urls, grid, s3_creds, store_root, config, **kw):
+            # The manifest write is folded into finalize (issue #252): while
+            # cells run, NOTHING has been written at the root — the manifest
+            # is off the critical path, not merely reordered.
+            assert not os.path.exists(os.path.join(store_root, hive.MANIFEST_NAME))
             calls.append((int(shard_key), store_root))
             return {"shard_key": int(shard_key), "error": None, "total_obs": 1}
 
@@ -923,9 +928,9 @@ class TestRunnerWiring:
         agg(cfg, catalog=catalog_path, store=root, backend="local")
 
         assert calls == [(shard, root)]
-        # Template time wrote ONLY the manifest — no shared zarr template
-        # (D5). The end-of-run root coverage.moc (issue #200 phase 3,
-        # default-on for hive) is the only other root object.
+        # End of run wrote ONLY the manifest — no shared zarr template (D5).
+        # The root coverage.moc (issue #200 phase 3, default-on for hive) is
+        # the only other root object.
         assert sorted(os.listdir(root)) == [hive.ROOT_COVERAGE_NAME, hive.MANIFEST_NAME]
         assert hive.read_manifest(root)["shard_order"] == 6
 
@@ -979,10 +984,11 @@ class TestRunnerWiring:
             assert n_objects == 1, name
         assert hive.read_commit(open_store(leaf))["complete"] is True
 
-    def test_lambda_hive_dispatches_with_manifest_dataset(self, monkeypatch, cfg, tmp_path):
-        # Issue #199 phase 3: hive is wired to the lambda backend. The setup
-        # invoke carries the manifest's dataset identity (from the ShardMap
-        # metadata, same source as the local path) and the per-cell events need
+    def test_lambda_hive_folds_manifest_into_finalize(self, monkeypatch, cfg, tmp_path):
+        # Issue #252: a hive lambda run dispatches NO setup invoke — the
+        # manifest inputs (dataset identity from the ShardMap metadata, same
+        # source as the local path) ride the finalize invoke, which runs even
+        # with consolidate_metadata off (the default). Per-cell events need
         # NO new keys — the worker derives everything from the config dict.
         from unittest.mock import MagicMock
 
@@ -1020,7 +1026,9 @@ class TestRunnerWiring:
         monkeypatch.setattr(
             runner, "_invoke_lambda_setup", lambda *a, **kw: captured.update(setup=kw)
         )
-        monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
+        monkeypatch.setattr(
+            runner, "_invoke_lambda_finalize", lambda *a, **kw: captured.update(finalize=kw)
+        )
 
         def fake_cell(client, chunk_idx, shard_key, *a, **k):
             captured["cell_shard_key"] = shard_key
@@ -1035,14 +1043,18 @@ class TestRunnerWiring:
         monkeypatch.setattr(runner, "_invoke_lambda_cell", fake_cell)
         agg(cfg, catalog=catalog_path, store="s3://out/product", backend="lambda")
 
-        assert captured["setup"]["dataset"] == {"short_name": "ATL06", "version": "007"}
+        # NO pre-worker setup invoke: hive setup is gone from the wall.
+        assert "setup" not in captured
+        assert captured["finalize"]["dataset"] == {"short_name": "ATL06", "version": "007"}
         # store_layout rides in the config dict already serialized into events.
-        assert captured["setup"]["config_dict"]["output"]["store_layout"] == "hive"
+        assert captured["finalize"]["config_dict"]["output"]["store_layout"] == "hive"
         # The per-cell event schema is unchanged: shard_key stays the packed int.
         assert captured["cell_shard_key"] == shard
 
-    def test_lambda_flat_setup_omits_dataset(self, monkeypatch, cfg, tmp_path):
-        # Flat runs keep their setup call byte-identical: dataset stays None.
+    def test_lambda_flat_setup_and_finalize_unchanged(self, monkeypatch, cfg, tmp_path):
+        # Flat runs keep the pre-#252 lifecycle: the setup invoke still runs
+        # (no dataset threading — that was hive-only and left with the fold)
+        # and finalize stays gated on consolidate_metadata (off by default).
         from unittest.mock import MagicMock
 
         import boto3
@@ -1078,7 +1090,9 @@ class TestRunnerWiring:
         monkeypatch.setattr(
             runner, "_invoke_lambda_setup", lambda *a, **kw: captured.update(setup=kw)
         )
-        monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: None)
+        monkeypatch.setattr(
+            runner, "_invoke_lambda_finalize", lambda *a, **kw: captured.update(finalize=kw)
+        )
         monkeypatch.setattr(
             runner,
             "_invoke_lambda_cell",
@@ -1091,30 +1105,31 @@ class TestRunnerWiring:
             },
         )
         agg(cfg, catalog=catalog_path, store="s3://out/x.zarr", backend="lambda")
-        assert captured["setup"]["dataset"] is None
+        assert "dataset" not in captured["setup"]
+        assert "finalize" not in captured
+
+
+def _wire_client(body: dict, status_code: int = 200):
+    """Mocked boto3 lambda client capturing ``Payload`` on the wire."""
+    from unittest.mock import MagicMock
+
+    payload = MagicMock()
+    payload.read.return_value = json.dumps(
+        {"statusCode": status_code, "body": json.dumps(body)}
+    ).encode()
+    client = MagicMock()
+    client.invoke.return_value = {"Payload": payload, "FunctionError": None}
+    return client
 
 
 class TestInvokeLambdaSetupEvent:
-    """Pin the ACTUAL setup event on the wire and the stale-deployment guard
-    (review findings, PR #205). The dispatch tests above monkeypatch
-    ``_invoke_lambda_setup`` at kwarg level, so the event-shaping conditional
-    (``dataset`` added only when set) and the layout-echo assertion are
-    exercised here directly, with a mocked boto3 client capturing ``Payload``."""
+    """Pin the ACTUAL setup event on the wire. Setup is flat-only now (issue
+    #252 folded the hive manifest into finalize and the PR #205 layout-echo
+    guard into the version ping), so what remains to pin is flat byte-identity
+    against pre-phase-3 deployed functions."""
 
     @staticmethod
-    def _client(body: dict):
-        from unittest.mock import MagicMock
-
-        payload = MagicMock()
-        payload.read.return_value = json.dumps(
-            {"statusCode": 200, "body": json.dumps(body)}
-        ).encode()
-        client = MagicMock()
-        client.invoke.return_value = {"Payload": payload, "FunctionError": None}
-        return client
-
-    @staticmethod
-    def _invoke(client, config_dict, dataset=None):
+    def _invoke(client, config_dict):
         from zagg.runner import _invoke_lambda_setup
 
         _invoke_lambda_setup(
@@ -1126,21 +1141,14 @@ class TestInvokeLambdaSetupEvent:
             n_parent_cells=None,
             overwrite=False,
             config_dict=config_dict,
-            dataset=dataset,
         )
         return json.loads(client.invoke.call_args.kwargs["Payload"])
 
-    def test_hive_event_carries_dataset(self, cfg):
-        cfg.output["store_layout"] = "hive"
-        client = self._client({"ok": True, "mode": "setup", "layout": "hive"})
-        event = self._invoke(client, asdict(cfg), dataset={"short_name": "ATL06", "version": "007"})
-        assert event["dataset"] == {"short_name": "ATL06", "version": "007"}
-
-    def test_flat_event_omits_dataset_and_matches_baseline(self, cfg):
+    def test_flat_event_matches_baseline(self, cfg):
         # The byte-identity claim, pinned on the wire: no "dataset" key, and
         # the event is exactly the pre-phase-3 flat setup event.
         config_dict = asdict(cfg)
-        client = self._client({"ok": True, "mode": "setup", "layout": "flat"})
+        client = _wire_client({"ok": True, "mode": "setup", "layout": "flat"})
         event = self._invoke(client, config_dict)
         assert "dataset" not in event
         assert event == {
@@ -1156,21 +1164,46 @@ class TestInvokeLambdaSetupEvent:
     def test_flat_without_layout_echo_unaffected(self, cfg):
         # Old deployed functions return the echo-less body: flat dispatch must
         # keep working against them.
-        self._invoke(self._client({"ok": True, "mode": "setup"}), asdict(cfg))
+        self._invoke(_wire_client({"ok": True, "mode": "setup"}), asdict(cfg))
 
-    @pytest.mark.parametrize(
-        "body",
-        [
-            {"ok": True, "mode": "setup"},  # pre-phase-3 function: no echo
-            {"ok": True, "mode": "setup", "layout": "flat"},  # wrong layout acted on
-        ],
-    )
-    def test_hive_without_hive_echo_fails_fast(self, cfg, body):
-        # Stale-deployment guard: an old function would emit the flat GLOBAL
-        # template at the hive root and return a 200 the dispatcher couldn't
-        # tell apart — the layout echo makes that fail at setup, pre-fan-out.
+
+class TestInvokeLambdaFinalizeEvent:
+    """Pin the ACTUAL finalize event on the wire (issue #252): hive carries
+    the manifest inputs (mirroring the retired hive setup event); flat stays
+    byte-identical to the pre-fold finalize event."""
+
+    @staticmethod
+    def _invoke(client, **kw):
+        from zagg.runner import _invoke_lambda_finalize
+
+        _invoke_lambda_finalize(client, "process-shard", "s3://out/product", **kw)
+        return json.loads(client.invoke.call_args.kwargs["Payload"])
+
+    def test_flat_event_matches_baseline(self):
+        event = self._invoke(_wire_client({"ok": True, "mode": "finalize"}))
+        assert event == {"mode": "finalize", "store_path": "s3://out/product"}
+
+    def test_hive_event_carries_manifest_inputs(self, cfg):
         cfg.output["store_layout"] = "hive"
-        with pytest.raises(RuntimeError, match="redeploy"):
+        config_dict = asdict(cfg)
+        event = self._invoke(
+            _wire_client({"ok": True, "mode": "finalize", "layout": "hive"}),
+            config_dict=config_dict,
+            dataset={"short_name": "ATL06", "version": "007"},
+            parent_order=6,
+            overwrite=False,
+        )
+        assert event["config"] == config_dict
+        assert event["dataset"] == {"short_name": "ATL06", "version": "007"}
+        assert event["parent_order"] == 6
+        assert event["overwrite"] is False
+
+    def test_non_200_raises(self):
+        # The manifest is REQUIRED reader-facing schema (D6): a failed hive
+        # finalize must raise, unlike the fail-open root coverage.moc (D9).
+        with pytest.raises(RuntimeError, match="Lambda finalize error"):
             self._invoke(
-                self._client(body), asdict(cfg), dataset={"short_name": "A", "version": "1"}
+                _wire_client({"error": "boom", "mode": "finalize"}, status_code=500),
+                config_dict={"output": {"store_layout": "hive"}},
+                parent_order=6,
             )

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1277,10 +1277,12 @@ class TestSetupHive:
 
 
 class TestFinalizeHive:
-    """Issue #252: for a hive config, finalize mode writes the root
-    ``morton_hive.json`` — the manifest folded off the pre-worker setup path —
-    with the same frozen-key resume semantics as setup had; a flat finalize
-    event (no ``config`` key) still goes down the consolidation path."""
+    """Issue #252 (hybrid): for a hive config, finalize mode re-ensures the
+    root ``morton_hive.json`` — the idempotent backstop for the async
+    init-time setup write, so a manifest absent at finalize (a lost retries-0
+    Event invoke) still ends up written — with the same frozen-key resume
+    semantics as setup; a flat finalize event (no ``config`` key) still goes
+    down the consolidation path."""
 
     def _event(self, tmp_path, config_dict, **extra):
         return {

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1276,6 +1276,83 @@ class TestSetupHive:
         assert handler_mod._handle_setup(self._event(tmp_path, cfg))["statusCode"] == 200
 
 
+class TestFinalizeHive:
+    """Issue #252: for a hive config, finalize mode writes the root
+    ``morton_hive.json`` — the manifest folded off the pre-worker setup path —
+    with the same frozen-key resume semantics as setup had; a flat finalize
+    event (no ``config`` key) still goes down the consolidation path."""
+
+    def _event(self, tmp_path, config_dict, **extra):
+        return {
+            "mode": "finalize",
+            "store_path": str(tmp_path / "hive-out"),
+            "parent_order": 6,
+            "overwrite": False,
+            "config": config_dict,
+            "dataset": {"short_name": "ATL06", "version": "007"},
+            **extra,
+        }
+
+    def test_finalize_writes_manifest_only(self, handler_mod, tmp_path):
+        import os
+
+        from zagg import hive
+
+        event = self._event(tmp_path, TestProcessHive._hive_config_dict())
+        resp = handler_mod._handle_finalize(event)
+        assert resp["statusCode"] == 200, resp["body"]
+        # The success body echoes the layout acted on, matching setup's echo.
+        assert json.loads(resp["body"])["layout"] == "hive"
+
+        manifest = hive.read_manifest(event["store_path"])
+        assert manifest["spec"] == "morton-hive/1"
+        assert manifest["dataset"] == {"short_name": "ATL06", "version": "007"}
+        assert manifest["shard_order"] == 6
+        assert manifest["cell_order"] == 12
+        # The manifest is the ONLY object: no consolidated zarr metadata.
+        assert sorted(os.listdir(event["store_path"])) == [hive.MANIFEST_NAME]
+
+    def test_finalize_windowed_declares_v2_manifest(self, handler_mod, tmp_path):
+        from zagg import hive
+
+        event = self._event(tmp_path, TestProcessHiveWindowed._windowed_config_dict())
+        resp = handler_mod._handle_finalize(event)
+        assert resp["statusCode"] == 200, resp["body"]
+        manifest = hive.read_manifest(event["store_path"])
+        assert manifest["spec"] == "morton-hive/2"
+        assert manifest["temporal"]["schedule"] == "yearly"
+
+    def test_finalize_frozen_key_mismatch_is_500(self, handler_mod, tmp_path):
+        cfg = TestProcessHive._hive_config_dict()
+        assert handler_mod._handle_finalize(self._event(tmp_path, cfg))["statusCode"] == 200
+        # A re-finalize with different orders must fail with the pointed
+        # remedy, matching ensure_manifest's semantics at setup time.
+        other = TestProcessHive._hive_config_dict()
+        other["output"]["grid"]["parent_order"] = 5
+        resp = handler_mod._handle_finalize(self._event(tmp_path, other))
+        assert resp["statusCode"] == 500
+        assert "clear the store root" in json.loads(resp["body"])["error"]
+
+    def test_finalize_rerun_with_matching_config_resumes(self, handler_mod, tmp_path):
+        cfg = TestProcessHive._hive_config_dict()
+        assert handler_mod._handle_finalize(self._event(tmp_path, cfg))["statusCode"] == 200
+        assert handler_mod._handle_finalize(self._event(tmp_path, cfg))["statusCode"] == 200
+
+    def test_flat_event_still_consolidates(self, handler_mod, monkeypatch, tmp_path):
+        # No "config" key -> the pre-#252 consolidation path, untouched.
+        import zarr
+
+        calls = []
+        monkeypatch.setattr(handler_mod, "open_store", lambda *a, **k: object())
+        monkeypatch.setattr(zarr, "consolidate_metadata", lambda store, **k: calls.append(store))
+        resp = handler_mod._handle_finalize(
+            {"mode": "finalize", "store_path": str(tmp_path / "flat.zarr")}
+        )
+        assert resp["statusCode"] == 200, resp["body"]
+        assert "layout" not in json.loads(resp["body"])
+        assert len(calls) == 1
+
+
 class TestSetupTemplate:
     """Issue #99: the setup handler used to hand-build the HEALPix grid and drop
     ``chunk_inner``, so the template was chunked at ``parent_order`` while workers

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1353,6 +1353,74 @@ class TestFinalizeHive:
         assert len(calls) == 1
 
 
+class TestPingMode:
+    """Issue #252: the hive pre-fan-out preflight. Answering 200 at all gates
+    the deployment generation (a pre-fold function 400s the unknown mode via
+    its process handler — zero writes); the body echoes the zagg version; and
+    the read-only validate_manifest refuses an incompatible existing store
+    BEFORE the fan-out (PR #255 review fold)."""
+
+    def _event(self, tmp_path, config_dict, **extra):
+        return {
+            "mode": "ping",
+            "store_path": str(tmp_path / "hive-out"),
+            "parent_order": 6,
+            "overwrite": False,
+            "config": config_dict,
+            "dataset": {"short_name": "ATL06", "version": "007"},
+            **extra,
+        }
+
+    def test_ping_fresh_root_is_200_and_writes_nothing(self, handler_mod, tmp_path):
+        import os
+
+        import zagg
+        from zagg import hive
+
+        event = self._event(tmp_path, TestProcessHive._hive_config_dict())
+        resp = handler_mod._handle_ping(event)
+        assert resp["statusCode"] == 200, resp["body"]
+        body = json.loads(resp["body"])
+        assert body["mode"] == "ping"
+        assert body["zagg_version"] == zagg.__version__
+        # Read-only: the preflight never writes the manifest (or anything).
+        assert not os.path.exists(os.path.join(event["store_path"], hive.MANIFEST_NAME))
+
+    def test_ping_matching_existing_store_resumes(self, handler_mod, tmp_path):
+        cfg = TestProcessHive._hive_config_dict()
+        assert handler_mod._handle_finalize(self._event(tmp_path, cfg))["statusCode"] == 200
+        assert handler_mod._handle_ping(self._event(tmp_path, cfg))["statusCode"] == 200
+
+    def test_ping_frozen_key_mismatch_is_500(self, handler_mod, tmp_path):
+        # The D2 writer-side guard, now firing BEFORE the fan-out: a store
+        # templated for different orders refuses at ping time.
+        cfg = TestProcessHive._hive_config_dict()
+        assert handler_mod._handle_finalize(self._event(tmp_path, cfg))["statusCode"] == 200
+        other = TestProcessHive._hive_config_dict()
+        other["output"]["grid"]["parent_order"] = 5
+        resp = handler_mod._handle_ping(self._event(tmp_path, other))
+        assert resp["statusCode"] == 500
+        assert "does not match this run" in json.loads(resp["body"])["error"]
+
+    def test_ping_routes_from_lambda_handler(self, handler_mod):
+        # The dispatch seam: mode="ping" answers 200 with no store touched —
+        # the versioning half of the guard needs nothing but the deployment.
+        resp = handler_mod.lambda_handler({"mode": "ping"}, _context())
+        assert resp["statusCode"] == 200, resp["body"]
+        assert json.loads(resp["body"])["mode"] == "ping"
+
+    def test_ping_event_400s_on_pre_fold_process_handler(self, handler_mod, tmp_path):
+        # What a STALE deployment does with the ping: no ping branch, so the
+        # event lands in the process handler, which rejects the key-less
+        # event with a 400 and writes nothing — the dispatcher's fail-fast.
+        import os
+
+        event = self._event(tmp_path, TestProcessHive._hive_config_dict())
+        resp = handler_mod._handle_process(event, _context())
+        assert resp["statusCode"] == 400
+        assert not os.path.exists(event["store_path"])
+
+
 class TestSetupTemplate:
     """Issue #99: the setup handler used to hand-build the HEALPix grid and drop
     ``chunk_inner``, so the template was chunked at ``parent_order`` while workers


### PR DESCRIPTION
Closes #252

Takes the hive setup Lambda off the critical path per the **hybrid lifecycle ratified on the issue** ([make-it-so](https://github.com/englacial/zagg/issues/252#issuecomment-5006627722), [design comment](https://github.com/englacial/zagg/issues/252#issuecomment-5005939446)): fail-fast stays in one cheap sync ping, the `morton_hive.json` write fires as an **async Event invoke of the existing `mode="setup"` hive branch at init**, and finalize's `ensure_manifest` is demoted to an **idempotent backstop**. The ratification also explicitly rejected a dispatcher-direct S3 PUT: CI/CD runs depend on OIDC with lambda-invoke-only permissions, so the orchestrator gains no S3 write access on the lambda path. #251 phase 3 has not landed (flat still exists), so the fail-fast stale-deploy guard is preserved as the up-front version ping, decoupled from the manifest write.

## What / approach

**Lambda dispatcher (`src/zagg/runner.py`)**
- Hive runs dispatch **no synchronous manifest-writing setup invoke** — the ~3.7 s pre-worker round-trip stays gone. Lifecycle: `mode="ping"` (byte-identical to phases 1–3: stale-deploy 400 fall-through + read-only `validate_manifest` precheck) → **`_invoke_lambda_setup_async`**, a fire-and-forget `InvocationType="Event"` invoke of the existing `mode="setup"` hive branch (~10 ms, the root-coverage dispatch precedent) carrying the same manifest inputs (`config`, `parent_order`, `dataset` identity, `overwrite`) → worker fan-out → finalize.
- The manifest therefore lands **seconds into the run**: a reader can start consuming completed leaves while the store builds (progressive reads — the windowed-leaf case from issue #246 makes partial output incrementally consumable by design).
- Hive **always** invokes finalize, whose `ensure_manifest` is now the **idempotent backstop** (a frozen-key-matching manifest is accepted — no second PUT). The backstop is load-bearing: worker Event invokes run with retries 0 (`template.yaml` EventInvokeConfig, issue #151 hygiene), so a lost async init write is never redelivered — finalize self-heals it. Symmetrically, finalize failure is no longer load-bearing for manifest existence, and a run that crashes mid-fan-out still left a manifest at init. The `consolidate_metadata` gate from issue #191 stays flat-only. Flat setup and finalize events stay byte-identical (pinned on the wire in `TestInvokeLambdaSetupEvent` / `TestInvokeLambdaFinalizeEvent`).
- A failed hive finalize backstop still **raises** — the manifest is required reader-facing schema (D6), unlike the fail-open coverage.moc (D9 regenerable cache).

**Fail-fast guard: `mode="ping"` (phase 2, unchanged on the wire)** — one lightweight RequestResponse invoke replaces the PR #205 layout-echo guard, catching two failure modes pre-fan-out:
- *Stale deployment*: a function that predates the issue #252 lifecycle doesn't know the mode, falls through to the process handler's logged 400 with **zero writes**, and the dispatcher raises a redeploy message.
- *Incompatible existing store*: the handler runs the **read-only** `zagg.hive.validate_manifest` against the event's manifest inputs, so a frozen-key mismatch refuses before any leaf is written (D2). Two concurrent runs racing into the same *fresh* root both pass the ping, but with the manifest landing seconds after init the collision window shrinks from run-length to seconds (see Questions (1)).

**Lambda handler (`deployment/aws/lambda_handler.py`) — zero behavioral changes in phase 4.** The hybrid reuses `_handle_setup`'s retained hive branch (already `ensure_manifest(build_manifest(...))`) as the async write target and `_handle_finalize`'s phase-1 hive branch as the backstop, exactly as ratified. Phase 4 only corrected the handler's module/`_handle_setup`/`_handle_finalize`/`_handle_ping` docstrings, which described the phase-1 "manifest rides finalize" lifecycle — flagging this here since the file is otherwise infra-scoped.

**Local dispatcher** — the manifest write is restored to **init** (pre-dispatch `ensure_manifest`; the local path writes the store directly, matching the pre-fold model), while the finalize-time `ensure_manifest` **backstop is kept**. `ensure_manifest` runs the `validate_manifest` frozen-key precheck before its PUT, so the pre-dispatch fail-fast from the review folds is preserved: a mismatched rerun still refuses before any cell runs. Net: local = write at init + idempotent backstop at finalize.

**Benchmark accounting** — `setup_s` on hive rows is the ping plus the ~10 ms Event dispatch; `finalize_s` is now the idempotent manifest backstop (comment updates in `.github/scripts/bench_metrics.py`; lifecycle text updated in `docs/hive_layout.md`, `docs/design/sparse_coverage.md`, `hive.py` docstrings). #250 (open; no phase panel in `plot_series.py` yet) should keep `finalize` in its panel per issue #252 — noted in the column comment.

## Phases

- [x] Phase 1 — fold the manifest write into finalize on both dispatch paths (runner + Lambda handler) + tests (6d25e34)
- [x] Phase 2 — lightweight `mode="ping"` version guard (dispatcher helper + handler branch) + tests (200c6bf)
- [x] Phase 3 — benchmark-accounting comments + docs lifecycle text (136b465)
- [x] Phase 4 — ratified hybrid: async init-time manifest write (Event invoke of the hive setup branch after the ping), finalize demoted to idempotent backstop, local init write restored + backstop kept, docs/bench text updated + tests (83aab6f)

Two adversarial self-review rounds folded on phases 1–3: round 1 (validate_manifest split + local pre-dispatch precheck, 27bccc3; ensure_manifest docstring, 68119c6), round 2 (scope the ping guard claim to sequential reruns, 95fcc8e; branch the ping failure message on the response body, 2d41cbb). All inline threads answered.

## Testing

- Full `uv run pytest -q`: **2170 passed, 30 skipped** (baseline on the branch: 2168 passed, 30 skipped — the delta is phase 4's new tests). `ruff check` / `ruff format --check` on `src tests` green except one **pre-existing on origin/main** item: N818 on `src/zagg/registry.py:64` (`UnknownCapability`). `deployment/aws/invoke_lambda.py` has pre-existing format drift, also on origin/main and outside CI's `src tests` scope. Both untouched — flagged, not fixed, per repo conventions.
- Phase 4 coverage: wire-level pin of the async hive setup event (`InvocationType="Event"`, exact payload, response never read) alongside the existing flat setup/finalize/ping byte-identity pins (all still passing); dispatcher-level lifecycle order (`ping → async setup → workers → finalize`, no sync setup, flat untouched); local-path init write visible before any cell runs; local finalize backstop restores a manifest lost mid-run; mismatched rerun still refuses pre-dispatch; handler-level backstop (manifest absent at finalize still ends written — `TestFinalizeHive`, unchanged).

## Questions for review

1. **Concurrent fresh-root window — narrowed by the hybrid.** Two concurrent runs racing into the same *fresh* root both pass the read-only ping, but the async init write now lands the loser's collision within **seconds of init** instead of at the losing run's finalize (run-length). The residual seconds-wide window keeps the same last-writer caveat the manifest write has always had; closing it entirely would require a synchronous stake-out write, which the ratified hybrid deliberately avoids. Treating this as resolved unless a stricter guarantee is wanted.
2. **Hive + `consolidate_metadata`** never reaches the finalize branch: `validate_config` already rejects that combination (`test_hive_rejects_consolidate_metadata`), so the hive finalize branch writing the manifest and never consolidating is consistent with the config surface.
3. The pre-existing N818 lint error (`src/zagg/registry.py:64`) and `deployment/aws/invoke_lambda.py` format drift noted above — should those get a `small-fix` issue?