### PR TITLE
Per-stage profiling for the raster sample path (issue #249)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -876,6 +876,7 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
         from zagg.config import get_layout
         from zagg.grids import from_config
         from zagg.processing.raster import (
+            new_stage_stats,
             process_raster_shard,
             write_raster_coords,
             write_raster_slab,
@@ -906,10 +907,15 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
         # remainder — the split the PR #232 double-buffer decision needs
         # measured. Exact at write_buffer=1 (writes serialize in the loop);
         # at write_buffer>1 writes overlap sampling, so the remainder is
-        # approximate — A/B on ``duration_s`` instead. Default (no
-        # ``profile`` key) emits nothing: the body stays byte-identical.
+        # approximate — A/B on ``duration_s`` instead. ``stages`` (issue
+        # #249) splits the sample bucket into per-stage work volumes +
+        # counts — attribution, not a wall decomposition: concurrent samples
+        # overlap, so stage sums can exceed ``sample`` (see
+        # ``new_stage_stats``). Default (no ``profile`` key) emits nothing:
+        # the body stays byte-identical and the sample path times nothing.
         profile = bool(event.get("profile"))
         write_s = 0.0
+        stage_stats = new_stage_stats() if profile else None
 
         def _write_slab(t_idx: int, slab: dict) -> None:
             nonlocal wrote, write_s
@@ -928,6 +934,7 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
             region=source.get("source_region"),
             anonymous=source.get("anonymous", True),
             on_slab=_write_slab,
+            stage_stats=stage_stats,
         )
         if wrote:
             write_raster_coords(store, grid, shard_key)
@@ -945,7 +952,11 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
         }
         if profile:
             total = time.time() - start_time
-            body["phase_timings"] = {"sample": total - write_s, "write": write_s}
+            body["phase_timings"] = {
+                "sample": total - write_s,
+                "write": write_s,
+                "stages": stage_stats,
+            }
         return {"statusCode": 200, "body": json.dumps(body)}
     except Exception as e:
         logger.error(f"raster worker failed: {e}", exc_info=True)

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import warnings
 from datetime import datetime, timezone
 
@@ -843,9 +844,15 @@ def process_and_write_hive(
     the K carriers accumulate and the whole leaf is written once
     (``write_leaf_to_zarr`` — one ShardingCodec object per array), mirroring
     the flat sharded switch in ``runner._process_and_write``.
-    ``profile`` forwards to ``process_shard`` (issue #100); the write phase is
-    interleaved with the stream (or a single post-stream pass when sharded),
-    so no separate ``write`` timing is recorded.
+    ``profile`` forwards to ``process_shard`` (issue #100), which fills
+    ``metadata["phase_timings"]`` with read/index/aggregate; the leaf write
+    work — interleaved with the stream (or a single post-stream pass when
+    sharded), plus the ragged/coverage/stamp finalize — accumulates into an
+    additive ``write`` phase alongside them (issue #249). Unlike the flat
+    path, the lazy leaf template emission counts as write: in hive the worker
+    owns its leaf's template PUTs (there is no dispatcher-side template), so
+    excluding them would hide real write-out cost. Default ``False`` makes
+    zero timing calls and leaves ``metadata`` unchanged — no probe tax.
 
     ``window`` (issue #246, D13/D15) is one dispatch unit's time window:
     ``{"label", "start", "end"}``, bounds half-open in DATASET units
@@ -877,6 +884,7 @@ def process_and_write_hive(
 
     leaf_path = shard_leaf_path(store_root, shard_key, window=window["label"] if window else None)
     box: dict = {}
+    _write_elapsed = 0.0
 
     def _leaf():
         if "store" not in box:
@@ -927,11 +935,15 @@ def process_and_write_hive(
     ragged_chunks: list = []
 
     def _write_chunk(block_index, carrier, ragged):
+        nonlocal _write_elapsed
+        _t0 = time.time() if profile else None
         store = _leaf()
         local = leaf_block_index(grid, block_index, shard_key)
         write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=local)
         if ragged:
             ragged_chunks.append((local, ragged))
+        if profile:
+            _write_elapsed += time.time() - _t0
 
     # Occupied-cell sink (issue #200): the worker already holds the shard's
     # populated cell words; collect them here to derive the stamp's coverage.
@@ -966,7 +978,10 @@ def process_and_write_hive(
     # the ``.zarr/`` prefix — same contract as the streaming path's first
     # ``_write_chunk``.
     if sharded and chunk_results and not metadata.get("error"):
+        _t0 = time.time() if profile else None
         write_leaf_to_zarr(chunk_results, _leaf(), grid=grid, shard_key=int(shard_key))
+        if profile:
+            _write_elapsed += time.time() - _t0
     # Stamp ONLY a fully-written leaf: an errored shard (or one that streamed
     # no chunks) stays unstamped — debris by definition (D4). The stamp is the
     # last write, so its presence certifies everything before it landed — the
@@ -976,6 +991,7 @@ def process_and_write_hive(
     # The leaf write order is pinned: dense (streamed, or one object each when
     # sharded) -> ragged (one object, issue #209) -> coverage sidecar -> stamp.
     if "store" in box and not metadata.get("error"):
+        _t0 = time.time() if profile else None
         if not sharded:
             write_ragged_leaf_to_zarr(ragged_chunks, box["store"], grid=grid)
         words = np.concatenate(occupied) if occupied else None
@@ -1004,6 +1020,16 @@ def process_and_write_hive(
             window=window["label"] if window else None,
             time_range=time_range,
         )
+        if profile:
+            _write_elapsed += time.time() - _t0
+    # Write-phase split (issue #249): read/index/aggregate come from
+    # ``process_shard``; ``write`` is the leaf write-out above (template +
+    # dense chunks + ragged + coverage sidecar + stamp). Same gate as the flat
+    # Lambda handler's issue #100 write bracket: only a clean, actually-written
+    # shard carries it, so a time-to-failure never lands as a write duration
+    # and a no-data shard (no leaf) stays write-less.
+    if profile and not metadata.get("error") and "phase_timings" in metadata and "store" in box:
+        metadata["phase_timings"]["write"] = _write_elapsed
     return metadata
 
 

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -24,6 +24,7 @@ import concurrent.futures
 import os
 import re
 import threading
+import time
 from urllib.parse import urlparse
 
 import numpy as np
@@ -154,6 +155,38 @@ def _build_store(key):
     return LocalStore(loc)
 
 
+def new_stage_stats() -> dict:
+    """Fresh per-invoke stage accumulator for the sample path (issue #249).
+
+    The floats are wall-clock seconds (``time.time()`` deltas, the issue #100
+    convention) of **stage work volume**: each asset-sample times its own
+    stages independently and the K x bands concurrent samples of an invoke
+    overlap on one event loop, so a stage total is the sum of per-sample
+    elapsed walls *including* time suspended while sibling samples ran. The
+    sums attribute where the samples' time went (which stage differs between
+    a fast and a slow invoke) — they are NOT a wall decomposition and can
+    exceed the invoke's wall clock. That is deliberate: the ``write_buffer >
+    1`` sample/write remainder on PR #232 already showed wall splits go
+    approximate under overlap.
+
+    Keys — seconds: ``open`` (store lookup + TIFF header round trips + geo/
+    dtype parse), ``geometry`` (pull-NN mapping; a ``geom_cache`` hit records
+    ~0), ``fetch`` (tile GETs), ``decode``, ``gather`` (numpy scatter/gather).
+    Counts: ``assets`` (asset-samples), ``tiles`` (tiles fetched),
+    ``geom_hits`` (mappings served from ``geom_cache``).
+    """
+    return {
+        "open": 0.0,
+        "geometry": 0.0,
+        "fetch": 0.0,
+        "decode": 0.0,
+        "gather": 0.0,
+        "assets": 0,
+        "tiles": 0,
+        "geom_hits": 0,
+    }
+
+
 async def sample_asset_async(
     grid,
     cells,
@@ -194,6 +227,7 @@ async def _sample_one(
     anonymous: bool = True,
     fill=0,
     geom_cache: dict | None = None,
+    stage_stats: dict | None = None,
 ):
     """:func:`sample_asset_async` body, also returning the raster's center
     ``(lon, lat)`` — the ownership rule's tile-center input (#218).
@@ -204,9 +238,20 @@ async def _sample_one(
     computes it once per distinct grid (~175 ms at o9) instead of once per
     asset-sample. ``None`` (the default, and the public ``sample_asset*``
     path) computes per call, unchanged.
+
+    ``stage_stats`` (issue #249) accumulates per-stage seconds + counts in
+    place — see :func:`new_stage_stats` for the keys and the work-volume (not
+    wall-decomposition) semantics. ``None`` (the default, and the public
+    ``sample_asset*`` path) makes no timing calls at all — the hot path is
+    unchanged. Accumulation is plain ``+=`` on the event loop with no await
+    between read and write, so it is atomic by the same argument as the
+    ``geom_cache`` store below — no locks; the ``write_buffer`` sink threads
+    never touch this dict.
     """
     from async_tiff import TIFF
 
+    prof = stage_stats is not None
+    _t0 = time.time() if prof else None
     store, path = _store_and_path(href, region=region, anonymous=anonymous)
     tiff = await TIFF.open(path, store=store)
     ifd = tiff.ifds[0]
@@ -223,8 +268,14 @@ async def _sample_one(
     epsg, transform = _geo_from_ifd(ifd)
     shape = (ifd.image_height, ifd.image_width)
     center = _raster_center_lonlat(epsg, transform, shape)
+    if prof:
+        stage_stats["open"] += time.time() - _t0
+        stage_stats["assets"] += 1
+        _t0 = time.time()
     geom_key = (epsg, transform, shape)
     geom = geom_cache.get(geom_key) if geom_cache is not None else None
+    if prof and geom is not None:
+        stage_stats["geom_hits"] += 1
     if geom is None:
         # INVARIANT (issue #244 thread): no ``await`` between this check and
         # the store below. asyncio interleaves only at await points, so the
@@ -243,6 +294,8 @@ async def _sample_one(
         if geom_cache is not None:
             geom_cache[geom_key] = geom
     rows, cols, valid = geom
+    if prof:
+        stage_stats["geometry"] += time.time() - _t0
 
     th, tw = ifd.tile_height, ifd.tile_width
     vr, vc = rows[valid], cols[valid]
@@ -252,8 +305,17 @@ async def _sample_one(
         return np.full(rows.shape, fill, dtype=dtype), valid, center
 
     pairs = np.unique(np.stack([tr, tc], axis=1), axis=0)
+    if prof:
+        _t0 = time.time()
     tiles = await asyncio.gather(*[tiff.fetch_tile(int(c), int(r), 0) for r, c in pairs])
+    if prof:
+        stage_stats["fetch"] += time.time() - _t0
+        stage_stats["tiles"] += len(pairs)
+        _t0 = time.time()
     decoded = await asyncio.gather(*[t.decode() for t in tiles])
+    if prof:
+        stage_stats["decode"] += time.time() - _t0
+        _t0 = time.time()
 
     gathered = np.full(vr.shape, fill, dtype=dtype)
     for (trow, tcol), dec in zip(pairs, decoded):
@@ -263,6 +325,8 @@ async def _sample_one(
 
     values = np.full(rows.shape, fill, dtype=dtype)
     values[valid] = gathered
+    if prof:
+        stage_stats["gather"] += time.time() - _t0
     return values, valid, center
 
 
@@ -323,6 +387,7 @@ async def sample_item_async(
     region: str | None = None,
     anonymous: bool = True,
     geom_cache: dict | None = None,
+    stage_stats: dict | None = None,
 ):
     """Sample every configured band of one STAC item, concurrently.
 
@@ -366,6 +431,7 @@ async def sample_item_async(
                 anonymous=anonymous,
                 fill=bands[f]["fill_value"],
                 geom_cache=geom_cache,
+                stage_stats=stage_stats,
             )
             for f in fields
         ]
@@ -496,6 +562,7 @@ def process_raster_shard(
     region: str | None = None,
     anonymous: bool = True,
     on_slab=None,
+    stage_stats: dict | None = None,
 ):
     """Process one shard of a raster pipeline: every acquisition group -> slab.
 
@@ -521,6 +588,14 @@ def process_raster_shard(
         double-buffer); the returned ``slabs`` is then empty. When ``None``
         (the default) every slab accumulates into ``slabs`` and is returned,
         as before, and ``write_buffer`` is ignored.
+    stage_stats : dict, optional
+        Per-invoke stage accumulator from :func:`new_stage_stats` (issue
+        #249): the sample path adds per-stage seconds (``open`` / ``geometry``
+        / ``fetch`` / ``decode`` / ``gather``) and counts (``assets`` /
+        ``tiles`` / ``geom_hits``) in place. Stage seconds are work volume,
+        not a wall decomposition — concurrent samples overlap, so their sum
+        can exceed this call's wall (see :func:`new_stage_stats`). ``None``
+        (the default) makes no timing calls — the sample path is unchanged.
 
     Returns
     -------
@@ -584,6 +659,7 @@ def process_raster_shard(
                             region=region,
                             anonymous=anonymous,
                             geom_cache=geom_cache,
+                            stage_stats=stage_stats,
                         )
                         for e in items
                     ]
@@ -792,6 +868,7 @@ def write_raster_coords(store, grid, shard_key: int):
 
 
 __all__ = [
+    "new_stage_stats",
     "sample_asset",
     "sample_asset_async",
     "sample_item_async",

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -171,7 +171,8 @@ def new_stage_stats() -> dict:
 
     Keys — seconds: ``open`` (store lookup + TIFF header round trips + geo/
     dtype parse), ``geometry`` (pull-NN mapping; a ``geom_cache`` hit records
-    ~0), ``fetch`` (tile GETs), ``decode``, ``gather`` (numpy scatter/gather).
+    ~0), ``fetch`` (tile GETs), ``decode``, ``gather`` (tile-index derivation
+    + numpy scatter/gather).
     Counts: ``assets`` (asset-samples), ``tiles`` (tiles fetched),
     ``geom_hits`` (mappings served from ``geom_cache``).
     """
@@ -296,16 +297,20 @@ async def _sample_one(
     rows, cols, valid = geom
     if prof:
         stage_stats["geometry"] += time.time() - _t0
+        _t0 = time.time()
 
     th, tw = ifd.tile_height, ifd.tile_width
     vr, vc = rows[valid], cols[valid]
     tr, tc = vr // th, vc // tw
 
     if vr.size == 0:
+        if prof:
+            stage_stats["gather"] += time.time() - _t0
         return np.full(rows.shape, fill, dtype=dtype), valid, center
 
     pairs = np.unique(np.stack([tr, tc], axis=1), axis=0)
     if prof:
+        stage_stats["gather"] += time.time() - _t0
         _t0 = time.time()
     tiles = await asyncio.gather(*[tiff.fetch_tile(int(c), int(r), 0) for r, c in pairs])
     if prof:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -608,6 +608,7 @@ class RasterStrategy:
     ):
         from zagg.processing.raster import (
             emit_raster_template,
+            new_stage_stats,
             process_raster_shard,
             raster_time_index,
             write_raster_coords,
@@ -686,6 +687,11 @@ class RasterStrategy:
         def _one(pair):
             shard_key, granules = pair
             wrote = False
+            # Per-stage sample profiling (issue #249), the local flavor of the
+            # lambda handler's opt-in ``profile`` key: allocated only when
+            # debug logging is on, so the default path passes None and the
+            # sample path times nothing.
+            stage_stats = new_stage_stats() if logger.isEnabledFor(logging.DEBUG) else None
 
             def _write_slab(t_idx, slab):
                 nonlocal wrote
@@ -701,10 +707,15 @@ class RasterStrategy:
                 config,
                 time_index,
                 on_slab=_write_slab,
+                stage_stats=stage_stats,
                 **src_kwargs,
             )
             if wrote:
                 write_raster_coords(zarr_store, grid, int(shard_key))
+            if stage_stats is not None:
+                logger.debug(
+                    f"raster shard {shard_label(grid, int(shard_key))} stages: {stage_stats}"
+                )
             return meta
 
         with ThreadPoolExecutor(max_workers=max_workers) as pool:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -161,7 +161,7 @@ def agg(
     profile : bool
         Opt-in per-phase timing (issue #100). When ``True`` (lambda backend),
         forwards ``profile`` into each cell event so the worker emits a
-        ``phase_timings`` (read/index/aggregate) sub-dict, and the run prints a
+        ``phase_timings`` (read/index/aggregate/write — issue #249) sub-dict, and the run prints a
         per-phase worker breakdown. Default ``False`` leaves the worker path and
         per-cell event payload byte-identical -- no probe tax.
     max_retries : int

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -866,6 +866,158 @@ class TestProcessAndWriteHiveSharded:
                 assert outs["on"][rel] == outs["off"][rel], rel
 
 
+class TestHiveProfileWritePhase:
+    """Issue #249 (PR #256): opt-in ``profile`` adds an additive ``write``
+    phase to the hive worker's ``phase_timings``, next to process_shard's
+    read/index/aggregate — the same split the flat Lambda handler has carried
+    since issue #100. Default off: zero timing calls and byte-identical
+    output."""
+
+    _grid = TestProcessAndWriteHive._grid
+    _carrier = TestProcessAndWriteHive._carrier
+    _meta = TestProcessAndWriteHive._meta
+
+    # The read/index/aggregate values the profiled process_shard fake seeds,
+    # so tests can pin that the write split leaves them untouched.
+    _SHARD_PHASES = {"read": 1.0, "index": 0.5, "aggregate": 0.25}
+
+    def _profiled_fake(self, grid, ragged=None, error=None):
+        """Streaming fake honoring the real profile contract: seeds
+        ``metadata['phase_timings']`` only when ``profile=True`` arrives."""
+
+        def fake(g, shard_key, urls, **kwargs):
+            meta = self._meta(shard_key, error=error)
+            if kwargs.get("profile"):
+                meta["phase_timings"] = dict(self._SHARD_PHASES)
+            if error is None:
+                carrier = self._carrier(grid, shard_key)
+                kwargs["write_chunk"](grid.block_index(int(shard_key)), carrier, ragged or {})
+            return pd.DataFrame(), meta
+
+        return fake
+
+    def _run(self, monkeypatch, cfg, tmp_path, fake, *, profile=False, name="store"):
+        import zagg.processing as processing
+
+        monkeypatch.setattr(processing, "process_shard", fake)
+        grid = self._grid(cfg)
+        shard = _shard_word()
+        root = str(tmp_path / name)
+        meta = hive.process_and_write_hive(
+            shard,
+            ["s3://bucket/granule1.h5"],
+            grid,
+            {},
+            root,
+            cfg,
+            store_kwargs={},
+            profile=profile,
+        )
+        return grid, shard, root, meta
+
+    def test_profile_adds_nonnegative_write_phase(self, monkeypatch, cfg, tmp_path):
+        fake = self._profiled_fake(self._grid(cfg), ragged={"h": ([np.array([1.0, 2.0])], [0])})
+        _grid, _shard, _root, meta = self._run(monkeypatch, cfg, tmp_path, fake, profile=True)
+        timings = meta["phase_timings"]
+        # Additive: the process_shard phases keep their names and values.
+        assert set(timings) == {"read", "index", "aggregate", "write"}
+        assert {k: timings[k] for k in self._SHARD_PHASES} == self._SHARD_PHASES
+        assert timings["write"] >= 0.0
+
+    def test_sharded_leaf_write_counted(self, monkeypatch, cfg, tmp_path):
+        # K>1 sharded: the single post-stream write_leaf_to_zarr pass lands in
+        # the same write bucket.
+        import zagg.processing as processing
+
+        sharded_helper = TestProcessAndWriteHiveSharded()
+        grid = sharded_helper._grid(cfg)
+
+        def meta_with_phases(shard_key, error=None):
+            meta = self._meta(shard_key, error=error)
+            meta["phase_timings"] = dict(self._SHARD_PHASES)
+            return meta
+
+        fake = _sharded_accumulate_fake(grid, sharded_helper._chunk_carrier, meta_with_phases)
+        monkeypatch.setattr(processing, "process_shard", fake)
+        shard = _shard_word()
+        meta = hive.process_and_write_hive(
+            shard,
+            ["s3://b/g1.h5"],
+            grid,
+            {},
+            str(tmp_path / "store"),
+            cfg,
+            store_kwargs={},
+            profile=True,
+        )
+        assert meta["phase_timings"]["write"] >= 0.0
+        assert set(meta["phase_timings"]) == {"read", "index", "aggregate", "write"}
+
+    def test_errored_shard_omits_write(self, monkeypatch, cfg, tmp_path):
+        # Same gate as the flat handler (issue #100): a shard that wrote no
+        # leaf carries no write phase — read/index/aggregate stay as reported.
+        fake = self._profiled_fake(self._grid(cfg), error="No granules found")
+        _grid, _shard, root, meta = self._run(monkeypatch, cfg, tmp_path, fake, profile=True)
+        assert meta["phase_timings"] == self._SHARD_PHASES
+        assert "write" not in meta["phase_timings"]
+
+    def test_default_path_makes_no_timing_calls(self, monkeypatch, cfg, tmp_path):
+        # The issue #249 zero-overhead gate, hive edition: without profile the
+        # write path must never call time.time(). Rebind hive.py's module-level
+        # ``time`` name to a booby trap — only this module's calls are caught.
+        class _Boom:
+            @staticmethod
+            def time():
+                raise AssertionError("time.time() called on the unprofiled hive write path")
+
+        monkeypatch.setattr(hive, "time", _Boom)
+        fake = self._profiled_fake(self._grid(cfg), ragged={"h": ([np.array([1.0, 2.0])], [0])})
+        _grid, shard, root, meta = self._run(monkeypatch, cfg, tmp_path, fake)
+        assert "phase_timings" not in meta
+        # The leaf still landed, fully stamped.
+        from zagg.store import open_store
+
+        leaf = hive.shard_leaf_path(root, shard)
+        assert hive.read_commit(open_store(leaf))["complete"] is True
+
+    def test_profiled_leaf_bytes_match_unprofiled(self, monkeypatch, cfg, tmp_path):
+        # Parity: profiling changes the returned metadata only — the leaf's
+        # file set and bytes are identical (stamp compared modulo timestamp),
+        # the same comparison the K==1 sharded no-op test pins.
+        grid_probe = self._grid(cfg)
+        ragged = {"h": ([np.array([1.0, 2.0])], [0])}
+        outs: dict = {}
+        leaves: dict = {}
+        for tag, profile in (("on", True), ("off", False)):
+            fake = self._profiled_fake(grid_probe, ragged=ragged)
+            _grid, shard, root, meta = self._run(
+                monkeypatch, cfg, tmp_path, fake, profile=profile, name=tag
+            )
+            leaf = hive.shard_leaf_path(root, shard)
+            leaves[tag] = meta
+            files = {}
+            for dirpath, _dirs, filenames in os.walk(leaf):
+                for f in filenames:
+                    p = os.path.join(dirpath, f)
+                    with open(p, "rb") as fh:
+                        files[os.path.relpath(p, leaf)] = fh.read()
+            outs[tag] = files
+        assert sorted(outs["on"]) == sorted(outs["off"])
+        for rel in outs["on"]:
+            if rel == "zarr.json":
+                on = json.loads(outs["on"][rel])
+                off = json.loads(outs["off"][rel])
+                on["attributes"][hive.COMMIT_ATTR].pop("written_at")
+                off["attributes"][hive.COMMIT_ATTR].pop("written_at")
+                assert on == off
+            else:
+                assert outs["on"][rel] == outs["off"][rel], rel
+        # And the metadata differs ONLY by the phase_timings sub-dict.
+        on_meta = {k: v for k, v in leaves["on"].items() if k != "phase_timings"}
+        assert on_meta == leaves["off"]
+        assert "phase_timings" not in leaves["off"]
+
+
 class TestLeafBlockIndex:
     def test_k1_maps_to_zero(self, cfg):
         g = HealpixGrid(6, 8, layout="fullsphere", config=cfg)

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -980,6 +980,34 @@ class TestHiveProfileWritePhase:
         leaf = hive.shard_leaf_path(root, shard)
         assert hive.read_commit(open_store(leaf))["complete"] is True
 
+    def test_sharded_default_path_makes_no_timing_calls(self, monkeypatch, cfg, tmp_path):
+        # Sharded edition of the trap (review finding): the post-stream
+        # write_leaf_to_zarr bracket must also make zero time.time() calls
+        # when profile is off — the streaming trap above never executes it.
+        import zagg.processing as processing
+
+        class _Boom:
+            @staticmethod
+            def time():
+                raise AssertionError("time.time() called on the unprofiled sharded write path")
+
+        monkeypatch.setattr(hive, "time", _Boom)
+        sharded_helper = TestProcessAndWriteHiveSharded()
+        grid = sharded_helper._grid(cfg)
+        fake = _sharded_accumulate_fake(grid, sharded_helper._chunk_carrier, self._meta)
+        monkeypatch.setattr(processing, "process_shard", fake)
+        shard = _shard_word()
+        root = str(tmp_path / "store")
+        meta = hive.process_and_write_hive(
+            shard, ["s3://b/g1.h5"], grid, {}, root, cfg, store_kwargs={}
+        )
+        assert "phase_timings" not in meta
+        # The sharded leaf still landed, fully stamped.
+        from zagg.store import open_store
+
+        leaf = hive.shard_leaf_path(root, shard)
+        assert hive.read_commit(open_store(leaf))["complete"] is True
+
     def test_profiled_leaf_bytes_match_unprofiled(self, monkeypatch, cfg, tmp_path):
         # Parity: profiling changes the returned metadata only — the leaf's
         # file set and bytes are identical (stamp compared modulo timestamp),

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -200,7 +200,7 @@ class TestRasterPhaseTimings:
         assert resp["statusCode"] == 200, resp
         body = json.loads(resp["body"])
         pt = body["phase_timings"]
-        assert set(pt) == {"sample", "write"}
+        assert set(pt) == {"sample", "write", "stages"}
         assert pt["write"] > 0.0
         assert pt["sample"] + pt["write"] == pytest.approx(body["duration_s"], rel=0.05)
 

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -208,3 +208,42 @@ class TestRasterPhaseTimings:
         event, _grid, _data = raster_event
         resp = handler_mod.lambda_handler(event, MagicMock())
         assert "phase_timings" not in json.loads(resp["body"])
+
+    def test_profile_emits_stage_split(self, handler_mod, raster_event):
+        # Issue #249: the sample bucket split per stage + counts, additive
+        # next to the unchanged sample/write keys.
+        event, _grid, _data = raster_event
+        event["profile"] = True
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200, resp
+        stages = json.loads(resp["body"])["phase_timings"]["stages"]
+        floats = ("open", "geometry", "fetch", "decode", "gather")
+        assert set(stages) == {*floats, "assets", "tiles", "geom_hits"}
+        assert stages["assets"] == 1  # 1 timestep x 1 band
+        assert stages["geom_hits"] == 0  # single asset, nothing to hit
+        assert stages["tiles"] >= 1
+        assert all(stages[k] >= 0.0 for k in floats)
+        assert sum(stages[k] for k in floats) > 0.0
+
+    def test_no_profile_passes_no_stage_stats(self, handler_mod, raster_event, monkeypatch):
+        # Zero-overhead gate: without ``profile`` the worker must receive
+        # stage_stats=None so the sample path makes no timing calls at all.
+        import zagg.processing.raster as raster_mod
+
+        event, _grid, _data = raster_event
+        seen = {}
+
+        def _fake(grid_, shard_key, granules, config, time_index, *, stage_stats=None, **kw):
+            seen["stage_stats"] = stage_stats
+            return {}, {
+                "shard_key": int(shard_key),
+                "granule_count": 1,
+                "skipped": 0,
+                "timesteps": 0,
+            }
+
+        monkeypatch.setattr(raster_mod, "process_raster_shard", _fake)
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200, resp
+        assert seen["stage_stats"] is None
+        assert "phase_timings" not in json.loads(resp["body"])

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -21,6 +21,7 @@ from zagg.processing.raster import (
     _shard_workers,
     _write_buffer,
     emit_raster_template,
+    new_stage_stats,
     process_raster_shard,
     raster_group_spec,
     raster_time_index,
@@ -652,3 +653,68 @@ class TestGeometryCache:
         for got in (cached1, cached2):
             np.testing.assert_array_equal(got[0]["red"], uncached[0]["red"])
             np.testing.assert_array_equal(got[1], uncached[1])
+
+
+class TestStageStats:
+    """Issue #249: opt-in per-stage sample profiling via ``stage_stats``."""
+
+    _STAGES = ("open", "geometry", "fetch", "decode", "gather")
+
+    def _run(self, tmp_path, n_timesteps=3, second_grid=True, stage_stats=None):
+        # Mirrors TestGeomCache._run_counting: n timesteps of a 96x96 10 m
+        # 'red' plus (optionally) a 48x48 20 m 'scl' — two distinct source
+        # grids exercising the geom_cache hit accounting.
+        vals = [11, 22, 33, 44][:n_timesteps]
+        granules = []
+        for i, v in enumerate(vals):
+            _write_tiff(tmp_path / f"s{i}.tif", np.full((96, 96), v, dtype=np.uint16))
+            assets = {"red": str(tmp_path / f"s{i}.tif")}
+            if second_grid:
+                _write_tiff(tmp_path / f"c{i}.tif", np.full((48, 48), 4, dtype=np.uint16), res=20.0)
+                assets["scl"] = str(tmp_path / f"c{i}.tif")
+            granules.append(
+                _entry(f"g{i}", assets, f"2026-07-{13 + i:02d}T16:02:20+00:00", time_key=f"dt-{i}")
+            )
+        bands = {"red": {"asset": "red", "dtype": "uint16"}}
+        if second_grid:
+            bands["scl"] = {"asset": "scl", "dtype": "uint16"}
+        grid = _rect_grid([ORIGIN[0], ORIGIN[1] - 960.0, ORIGIN[0] + 960.0, ORIGIN[1]], [96, 96])
+        cfg = _raster_config(bands=bands, nodata=None)
+        index, _ = raster_time_index([granules])
+        return process_raster_shard(grid, 0, granules, cfg, index, stage_stats=stage_stats)
+
+    def test_counts_and_stage_seconds(self, tmp_path):
+        stats = new_stage_stats()
+        _slabs, meta = self._run(tmp_path, n_timesteps=3, second_grid=True, stage_stats=stats)
+        assert meta["timesteps"] == 3
+        assert stats["assets"] == 6  # 3 timesteps x 2 bands
+        assert stats["geom_hits"] == 4  # assets - 2 distinct source grids
+        assert stats["tiles"] >= stats["assets"]  # every sample fetches >= 1 tile
+        assert all(stats[k] >= 0.0 for k in self._STAGES)
+        assert sum(stats[k] for k in self._STAGES) > 0.0
+
+    def test_profiled_output_matches_default(self, tmp_path):
+        golden, _m = self._run(tmp_path)
+        stats = new_stage_stats()
+        profiled, _m2 = self._run(tmp_path, stage_stats=stats)
+        assert stats["assets"] == 6
+        assert set(golden) == set(profiled)
+        for t in golden:
+            assert set(golden[t]) == set(profiled[t])
+            for f in golden[t]:
+                np.testing.assert_array_equal(golden[t][f], profiled[t][f])
+
+    def test_default_path_makes_no_timing_calls(self, tmp_path, monkeypatch):
+        # The issue #249 zero-overhead gate: with stage_stats=None the sample
+        # path must never call time.time(). Rebind raster.py's module-level
+        # ``time`` name to a booby trap — only this module's calls are caught.
+        import zagg.processing.raster as raster_mod
+
+        class _Boom:
+            @staticmethod
+            def time():
+                raise AssertionError("time.time() called on the unprofiled sample path")
+
+        monkeypatch.setattr(raster_mod, "time", _Boom)
+        _slabs, meta = self._run(tmp_path, n_timesteps=1, second_grid=False)
+        assert meta["timesteps"] == 1

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -6,6 +6,7 @@ and the shipped ``sentinel2_l2a`` template config.
 """
 
 import json
+import logging
 
 import numpy as np
 import pytest
@@ -120,6 +121,23 @@ class TestRasterAgg:
             store_path + f"/{grid.group_path}/time", zarr_format=3, consolidated=False
         )
         assert tarr.shape == (2,) and tarr[0] < tarr[1]
+
+    def test_debug_logging_emits_stage_stats(self, tmp_path, manifest, caplog):
+        # Issue #249, local flavor: stages are collected + logged per shard
+        # only when debug logging is on (espg-ratified on the issue).
+        cfg, sm_path, _shard, _data = manifest
+        with caplog.at_level(logging.DEBUG, logger="zagg.runner"):
+            agg(cfg, catalog=sm_path, backend="local", max_workers=2)
+        stage_msgs = [r.message for r in caplog.records if "stages:" in r.message]
+        assert len(stage_msgs) == 1  # one shard -> one debug line
+        assert "'assets': 2" in stage_msgs[0]  # 2 timesteps x 1 band
+        assert "'geom_hits': 1" in stage_msgs[0]  # one shared source grid
+
+    def test_no_debug_no_stage_logging(self, tmp_path, manifest, caplog):
+        cfg, sm_path, _shard, _data = manifest
+        with caplog.at_level(logging.INFO, logger="zagg.runner"):
+            agg(cfg, catalog=sm_path, backend="local", max_workers=2)
+        assert not [r for r in caplog.records if "stages:" in r.message]
 
     def test_multi_shard_disjoint_slabs(self, tmp_path):
         # Two rasters ~7 km apart feed two DISTINCT order-10 shards in one run;

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3145,6 +3145,19 @@ class TestProfilePlumbing:
         )
         assert summary["worker_phase_max"] == {"read": 5.0, "index": 1.0, "aggregate": 2.0}
 
+    def test_rollup_carries_write_phase(self, monkeypatch, atl06_config):
+        # Issue #249: the rollup iterates the body's phase keys generically, so
+        # the additive ``write`` phase (hive worker split, PR #256) flows into
+        # worker_phase_max with no special-casing.
+        summary = _run_lambda_with_durations(
+            monkeypatch,
+            atl06_config,
+            [1.0, 2.0, 3.0, 4.0],
+            profile=True,
+            phase_timings={"read": 5.0, "index": 1.0, "aggregate": 2.0, "write": 0.75},
+        )
+        assert summary["worker_phase_max"]["write"] == 0.75
+
     def test_profile_run_with_no_phase_timings_is_empty(self, monkeypatch, atl06_config):
         # profile=True but workers emitted no phase_timings (e.g. handler bridge
         # not yet wired): the key is present but empty, never raising.


### PR DESCRIPTION
Closes #249

## What

Splits the raster worker's `sample` profile bucket into per-stage accumulators, emitted under the existing opt-in `profile` key (the issue #100 convention) as `phase_timings["stages"]`: seconds for `open` (store lookup + TIFF header round trips), `geometry` (pull-NN mapping; a `geom_cache` hit records ~0 s), `fetch` (tile GETs), `decode`, and `gather` (tile-index derivation + numpy scatter/gather), plus counts `assets`, `tiles`, `geom_hits`. This is the telemetry issue #249 needs to make the issue #244 Phase-3 A/B attributive instead of correlational.

**Point-path `write` split (phase 3, approved scope addition):** the point pipeline's profiled phase set gains an additive `write` phase on the hive worker path. The flat Lambda handler has carried a `write` bracket since issue #100, but `process_and_write_hive` — the shared per-shard write path both backends' hive branches call, and the configuration the per-merge benchmark runs — recorded no write timing at all. It now accumulates the leaf write-out (lazy leaf template + dense chunk writes + ragged + coverage sidecar + stamp) into `phase_timings["write"]` next to `process_shard`'s `read`/`index`/`aggregate`, behind the same opt-in gate (zero timing calls when `profile` is off) and the same clean-write attach gate as the flat handler. Approved in [espg's comment](https://github.com/englacial/zagg/pull/256#issuecomment-5006361723), ratifying understanding (1) of the [example-rendering comment](https://github.com/englacial/zagg/pull/256#issuecomment-5005931022). The display-side `agg = index + aggregate` mapping is harness work and rides issue #250, **not** this PR.

## Approach

Follows the [implementation plan on the issue](https://github.com/englacial/zagg/issues/249#issuecomment-4989305160) and espg's [sign-off on both open questions](https://github.com/englacial/zagg/issues/249#issuecomment-4989732869) (local backend: yes; keep `sample`/`write` keys: yes, additive only).

- `new_stage_stats()` in `src/zagg/processing/raster.py` returns the fresh accumulator (single-sourced schema, exported). It is threaded `process_raster_shard(..., stage_stats=None)` → `sample_item_async` → `_sample_one`, exactly like the issue #244 `geom_cache` pattern.
- **Zero overhead when absent:** `stage_stats=None` (the default, and the public `sample_asset*` path) makes no timing calls at all — `_sample_one` gates every `time.time()` behind `prof = stage_stats is not None`, mirroring the `_t0 = time.time() if profile else None` convention in `worker.py` / the handler.
- **No locks:** accumulation is plain `+=` on the event loop with no `await` between read and write (atomic by the same argument as the geom_cache store; the `write_buffer` sink threads never touch the dict). Noted in the `_sample_one` docstring.
- `_handle_process_raster` allocates the accumulator when `profile` is set and emits it as `phase_timings["stages"]` next to the unchanged `sample`/`write` split.
- Local backend (`RasterStrategy`, per espg's sign-off): the accumulator is allocated only when debug logging is enabled and logged per shard at debug level; the default path passes `None`.

### Measurement semantics (important)

The stage floats are **work volume, not a wall decomposition**. Each asset-sample times its own stages, and the K×bands concurrent samples of an invoke overlap on one event loop — so a per-coroutine stage wall includes time suspended while sibling samples ran, and stage sums can exceed the invoke's wall clock. That is deliberate and documented in `new_stage_stats()`: the numbers attribute *which stage differs* between a fast and a slow invoke (the #244 question), and avoid the wall-decomposition trap the `write_buffer > 1` sample/write split hit on PR #232. Per the phase-1 self-review fold, the tile-index derivation is bucketed into `gather` (two accumulation windows) so `fetch` stays a clean network-only signal; the only untimed sliver left is the fill-array construction on the no-valid-cells early return.

## Phases

- [x] Phase 1 — per-stage accumulators + counts wired through the worker (`raster.py`), emitted by the Lambda handler under `phase_timings["stages"]`, debug-logged per shard on the local backend; minimal update to the existing handler profile test so the phase lands green
- [x] Phase 2 — tests: stage counts (`assets == timesteps × bands`, `geom_hits == assets − distinct grids`, `tiles >= assets`) and non-negative stage seconds on synthetic COGs; profiled output identical to unprofiled; zero-timing-calls trap (module `time` rebound to raise) proving the absent-`profile` gate; handler emits the full stages schema and passes `stage_stats=None` without `profile`; local-backend debug log emits stages per shard (and not at INFO)
- [x] Phase 3 — point-path `write` phase split ([approved scope addition](https://github.com/englacial/zagg/pull/256#issuecomment-5006361723)): `process_and_write_hive` accumulates the leaf write-out into an additive `phase_timings["write"]` behind the existing `profile` gate (zero timing calls when off, flat-handler attach gate); tests for the profiled write phase (streaming + sharded), the errored-shard omission, the zero-timing-calls trap, profiled/unprofiled leaf byte parity, and the runner rollup carrying `write` generically

## Testing

`uv run pytest -q`: full suite green after phase 1 (2151 passed, 30 skipped); raster-path files green after each subsequent commit and the full suite re-run on the final tree (2164 passed, 30 skipped after phase 3). `ruff format --check`: clean. `ruff check`: one **pre-existing** failure unrelated to this diff (see below).

## Questions for review

1. **Pre-existing lint failure:** `ruff check src tests` fails on main with `N818 Exception name UnknownCapability should be named with an Error suffix` (`src/zagg/registry.py:64`) — present on a clean checkout of `origin/main`, not touched here, flagged per the conventions rather than fixed.
2. **Stage boundary choices:** `open` includes the IFD geo/dtype parse and the raster-center pyproj transform (all header-derived, µs-scale); the tile-index derivation is bucketed into `gather` per the phase-1 review fold, keeping `fetch` network-only.
3. **Local-backend gate:** stages on the local path are gated on `logger.isEnabledFor(logging.DEBUG)` (there is no `profile` knob on `agg()`); that reads as the natural local flavor of "opt-in", but say the word if you'd prefer an explicit parameter.
4. **Repo scope note:** CLAUDE.md §8 lists `github.com/espg` as the source-control scope while this repo (and the routine's remote) is `github.com/englacial/zagg`; proceeded since the routine, remote, and issue author all point here — flagging so §8 can be updated if the repo moved orgs.
5. The phase-1 commit carries session-trailer lines from the harness default; noticed the repo's title-only convention after pushing, and amending would need a force-push (never done here). Subsequent commits are title-only.
6. **Hive `write` includes leaf templating:** unlike the flat handler (whose timer starts after the store open/template check, because the dispatcher owns the flat template), the hive `write` bucket counts the lazy leaf template emission — in hive the worker owns its leaf's template PUTs, so excluding them would hide real write-out cost. Documented in the `process_and_write_hive` docstring; say the word if you'd rather match the flat exclusion.