### PR TITLE
Pre-provisioned Lambda worker-size variants (issue #235)

### DIFF
--- a/deployment/aws/stand_up.sh
+++ b/deployment/aws/stand_up.sh
@@ -183,11 +183,13 @@ else
 fi
 
 echo "Deploying stack $STACK_NAME..."
+# CAPABILITY_AUTO_EXPAND acknowledges the AWS::LanguageExtensions macro expansion
+# (issue #235); harmless if the change-set path would have processed it anyway.
 run aws cloudformation deploy \
     --template-file "$SCRIPT_DIR/template.yaml" \
     --stack-name "$STACK_NAME" \
     --region "$REGION" \
-    --capabilities CAPABILITY_NAMED_IAM \
+    --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
     --parameter-overrides \
         Architecture="$ARCH" \
         FunctionName="$FUNCTION_NAME" \

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -1,4 +1,12 @@
 AWSTemplateFormatVersion: "2010-09-09"
+# The AWS::LanguageExtensions macro provides Fn::ForEach, which stamps the
+# issue #235 worker-size variants from one parameterized block per resource
+# family instead of ~24 hand-written near-identical resources. The macro runs
+# server-side at change-set creation (stand_up.sh deploys via change sets, so
+# no mechanical change there); the expansion is deterministic and visible in
+# the change set, or post-deploy via
+# `aws cloudformation get-template --template-stage Processed`.
+Transform: AWS::LanguageExtensions
 Description: >-
   zagg serverless backend — Lambda execution role, dependency layer, and the
   process-shard Lambda function. By default the stack creates its own execution
@@ -145,7 +153,30 @@ Parameters:
       creates /aws/lambda/<fn> log groups lazily on first invocation and
       AWS::Logs::MetricFilter requires the group to exist, so on a FRESH
       stack: create with "false", invoke each function once, then update
-      the stack with "true". Existing deployments keep the default.
+      the stack with "true". This covers all 8 log groups — the base
+      function, its -extract twin, and the 6 worker-size variants
+      (issue #235). Existing deployments keep the default.
+
+  WorkerMemorySizes:
+    Type: CommaDelimitedList
+    Default: "2048,4096,8192"
+    Description: >-
+      Memory sizes (MB) of the pre-provisioned worker-size variants
+      (issue #235). Each size S stamps two functions via Fn::ForEach:
+      <FunctionName>-S (default 512 MB /tmp) and <FunctionName>-S-disk
+      (/tmp from the WorkerDiskTmp mapping — keep that table in sync with
+      this list). The unsuffixed function and its -extract twin are
+      independent of this list and stay the no-config default.
+
+Mappings:
+  # /tmp for the -disk variants is memory + 2048 MB (issue #235 thread
+  # decision); 10240 for the 8192 variant is exactly Lambda's
+  # EphemeralStorage ceiling, so the rule holds with no clamping. Keys must
+  # cover every WorkerMemorySizes entry.
+  WorkerDiskTmp:
+    "2048": {SizeMb: 4096}
+    "4096": {SizeMb: 6144}
+    "8192": {SizeMb: 10240}
 
 Conditions:
   ShouldCreateBucket: !Equals [!Ref CreateOutputBucket, "true"]
@@ -366,6 +397,139 @@ Resources:
           MetricValue: "1"
           DefaultValue: 0
 
+  # Pre-provisioned worker-size variants (issue #235): same code zip, layer,
+  # role, timeout, and env as ProcessFn — selected at run time by function
+  # name (config `worker:` block / agg(function_name=...)), so per-run sizing
+  # needs no admin-role config mutation. Two Fn::ForEach loops over
+  # WorkerMemorySizes stamp, per size S: <FunctionName>-S (this loop, default
+  # 512 MB /tmp) and <FunctionName>-S-disk (next loop, /tmp from
+  # WorkerDiskTmp). Each variant carries the issue #151 EventInvokeConfig and
+  # the issue #175 self-recycle/worker-error metric-filter pair, mirroring
+  # the unsuffixed function's blocks above. The variant FunctionName strings
+  # are assembled ONLY in each loop's `FunctionName: !Sub` line.
+  'Fn::ForEach::WorkerSizeVariants':
+    - WorkerMemory
+    - !Ref WorkerMemorySizes
+    - 'WorkerFn${WorkerMemory}':
+        Type: AWS::Lambda::Function
+        Properties:
+          FunctionName: !Sub "${FunctionName}-${WorkerMemory}"
+          Handler: lambda_handler.lambda_handler
+          Runtime: python3.12
+          Architectures: [!Ref Architecture]
+          MemorySize: !Ref WorkerMemory
+          Timeout: !Ref Timeout
+          Role: !If [ShouldCreateRole, !GetAtt ExecutionRole.Arn, !Ref ExecutionRoleArn]
+          Layers: [!Ref DepsLayer]
+          Environment:
+            Variables:
+              MALLOC_ARENA_MAX: !Ref MallocArenaMax
+              MALLOC_TRIM_THRESHOLD_: !Ref MallocTrimThreshold
+              ZAGG_RECYCLE_RSS_MB: !Ref RecycleRssMb
+              ZAGG_RECYCLE_MAX_INVOCATIONS: !Ref RecycleMaxInvocations
+          Code:
+            S3Bucket: !Ref ArtifactBucket
+            S3Key: !Ref FunctionS3Key
+      'WorkerFn${WorkerMemory}AsyncConfig':
+        Type: AWS::Lambda::EventInvokeConfig
+        Properties:
+          FunctionName: !Ref 'WorkerFn${WorkerMemory}'
+          Qualifier: "$LATEST"
+          MaximumRetryAttempts: 0
+          MaximumEventAgeInSeconds: 60
+      'WorkerFn${WorkerMemory}SelfRecycleFilter':
+        Type: AWS::Logs::MetricFilter
+        Condition: ShouldCreateMetricFilters
+        DependsOn: 'WorkerFn${WorkerMemory}'
+        Properties:
+          LogGroupName: !Sub "/aws/lambda/${FunctionName}-${WorkerMemory}"
+          FilterPattern: '"ZAGG_SELF_RECYCLE"'
+          MetricTransformations:
+            - MetricNamespace: zagg/lambda
+              MetricName: 'Worker${WorkerMemory}SelfRecycleCount'
+              MetricValue: "1"
+              DefaultValue: 0
+      'WorkerFn${WorkerMemory}WorkerErrorFilter':
+        Type: AWS::Logs::MetricFilter
+        Condition: ShouldCreateMetricFilters
+        DependsOn: 'WorkerFn${WorkerMemory}'
+        Properties:
+          LogGroupName: !Sub "/aws/lambda/${FunctionName}-${WorkerMemory}"
+          FilterPattern: >-
+            ?"Task timed out" ?"Runtime.OutOfMemory"
+            ?"Runtime exited with error" ?"[ERROR]"
+            ?"Traceback (most recent call last)"
+          MetricTransformations:
+            - MetricNamespace: zagg/lambda
+              MetricName: 'Worker${WorkerMemory}WorkerErrorCount'
+              MetricValue: "1"
+              DefaultValue: 0
+
+  # The -disk trio (issue #235 / #217): identical to the loop above except
+  # for the -disk name suffix and an explicit EphemeralStorage from the
+  # WorkerDiskTmp mapping (memory + 2048 MB). EphemeralStorage appears ONLY
+  # here — the default-512 trio omits it (512 is free; extra /tmp bills per
+  # GB-s above 512, idle functions cost nothing either way).
+  'Fn::ForEach::WorkerDiskVariants':
+    - WorkerMemory
+    - !Ref WorkerMemorySizes
+    - 'WorkerFn${WorkerMemory}Disk':
+        Type: AWS::Lambda::Function
+        Properties:
+          FunctionName: !Sub "${FunctionName}-${WorkerMemory}-disk"
+          Handler: lambda_handler.lambda_handler
+          Runtime: python3.12
+          Architectures: [!Ref Architecture]
+          MemorySize: !Ref WorkerMemory
+          Timeout: !Ref Timeout
+          Role: !If [ShouldCreateRole, !GetAtt ExecutionRole.Arn, !Ref ExecutionRoleArn]
+          Layers: [!Ref DepsLayer]
+          EphemeralStorage:
+            Size: !FindInMap [WorkerDiskTmp, !Ref WorkerMemory, SizeMb]
+          Environment:
+            Variables:
+              MALLOC_ARENA_MAX: !Ref MallocArenaMax
+              MALLOC_TRIM_THRESHOLD_: !Ref MallocTrimThreshold
+              ZAGG_RECYCLE_RSS_MB: !Ref RecycleRssMb
+              ZAGG_RECYCLE_MAX_INVOCATIONS: !Ref RecycleMaxInvocations
+          Code:
+            S3Bucket: !Ref ArtifactBucket
+            S3Key: !Ref FunctionS3Key
+      'WorkerFn${WorkerMemory}DiskAsyncConfig':
+        Type: AWS::Lambda::EventInvokeConfig
+        Properties:
+          FunctionName: !Ref 'WorkerFn${WorkerMemory}Disk'
+          Qualifier: "$LATEST"
+          MaximumRetryAttempts: 0
+          MaximumEventAgeInSeconds: 60
+      'WorkerFn${WorkerMemory}DiskSelfRecycleFilter':
+        Type: AWS::Logs::MetricFilter
+        Condition: ShouldCreateMetricFilters
+        DependsOn: 'WorkerFn${WorkerMemory}Disk'
+        Properties:
+          LogGroupName: !Sub "/aws/lambda/${FunctionName}-${WorkerMemory}-disk"
+          FilterPattern: '"ZAGG_SELF_RECYCLE"'
+          MetricTransformations:
+            - MetricNamespace: zagg/lambda
+              MetricName: 'Worker${WorkerMemory}DiskSelfRecycleCount'
+              MetricValue: "1"
+              DefaultValue: 0
+      'WorkerFn${WorkerMemory}DiskWorkerErrorFilter':
+        Type: AWS::Logs::MetricFilter
+        Condition: ShouldCreateMetricFilters
+        DependsOn: 'WorkerFn${WorkerMemory}Disk'
+        Properties:
+          LogGroupName: !Sub "/aws/lambda/${FunctionName}-${WorkerMemory}-disk"
+          FilterPattern: >-
+            ?"Task timed out" ?"Runtime.OutOfMemory"
+            ?"Runtime exited with error" ?"[ERROR]"
+            ?"Traceback (most recent call last)"
+          MetricTransformations:
+            - MetricNamespace: zagg/lambda
+              MetricName: 'Worker${WorkerMemory}DiskWorkerErrorCount'
+              MetricValue: "1"
+              DefaultValue: 0
+
 Outputs:
   FunctionArn:
     Description: ARN of the deployed Lambda function.
@@ -385,3 +549,12 @@ Outputs:
   OutputBucket:
     Description: Bucket where results are written.
     Value: !Ref OutputBucketName
+  'Fn::ForEach::WorkerVariantArns':
+    - WorkerMemory
+    - !Ref WorkerMemorySizes
+    - 'WorkerFn${WorkerMemory}Arn':
+        Description: 'ARN of the ${WorkerMemory} MB worker-size variant (issue #235).'
+        Value: !GetAtt 'WorkerFn${WorkerMemory}.Arn'
+      'WorkerFn${WorkerMemory}DiskArn':
+        Description: 'ARN of the ${WorkerMemory} MB extra-disk worker variant (issue #235).'
+        Value: !GetAtt 'WorkerFn${WorkerMemory}Disk.Arn'

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -165,8 +165,11 @@ Parameters:
       (issue #235). Each size S stamps two functions via Fn::ForEach:
       <FunctionName>-S (default 512 MB /tmp) and <FunctionName>-S-disk
       (/tmp from the WorkerDiskTmp mapping — keep that table in sync with
-      this list). The unsuffixed function and its -extract twin are
-      independent of this list and stay the no-config default.
+      this list). This is not a free-form knob: any added size needs a
+      matching WorkerDiskTmp entry and must keep memory+2048 within Lambda's
+      10240 MB /tmp ceiling (so nothing above 8192). The unsuffixed function
+      and its -extract twin are independent of this list and stay the
+      no-config default.
 
 Mappings:
   # /tmp for the -disk variants is memory + 2048 MB (issue #235 thread

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -2,9 +2,9 @@ AWSTemplateFormatVersion: "2010-09-09"
 # The AWS::LanguageExtensions macro provides Fn::ForEach, which stamps the
 # issue #235 worker-size variants from one parameterized block per resource
 # family instead of ~24 hand-written near-identical resources. The macro runs
-# server-side at change-set creation (stand_up.sh deploys via change sets, so
-# no mechanical change there); the expansion is deterministic and visible in
-# the change set, or post-deploy via
+# server-side at change-set creation (stand_up.sh deploys via change sets and
+# passes CAPABILITY_AUTO_EXPAND to acknowledge the macro); the expansion is
+# deterministic and visible in the change set, or post-deploy via
 # `aws cloudformation get-template --template-stage Processed`.
 Transform: AWS::LanguageExtensions
 Description: >-

--- a/docs/deployment/lambda.md
+++ b/docs/deployment/lambda.md
@@ -177,6 +177,47 @@ execution role for you; the only exception is an account whose deploy identity
 [Execution Role](execution-role.md) for that IAM-constrained, legacy/unverified
 path.
 
+### Worker-size variants {#worker-size-variants}
+
+The stack pre-provisions six size variants of the worker (issue #235) --
+same code, layer, and role as `process-shard`, differing only in memory and
+`/tmp` -- so a run picks its size by *function name*, with no
+admin-role `UpdateFunctionConfiguration` swap and no serialization between
+concurrent runs of different workloads:
+
+| Function | Memory | `/tmp` |
+|----------|--------|--------|
+| `process-shard-2048` | 2048 MB | 512 MB |
+| `process-shard-4096` | 4096 MB | 512 MB |
+| `process-shard-8192` | 8192 MB | 512 MB |
+| `process-shard-2048-disk` | 2048 MB | 4096 MB |
+| `process-shard-4096-disk` | 4096 MB | 6144 MB |
+| `process-shard-8192-disk` | 8192 MB | 10240 MB |
+
+Select a variant from the aggregation YAML with the optional top-level
+`worker:` block (alongside `pipeline:`):
+
+```yaml
+worker:
+  memory: 2048       # one of 2048 | 4096 | 8192
+  extra_disk: false  # true -> the -disk twin (/tmp = memory + 2048 MB)
+```
+
+Resolution precedence (`_resolve_function_name` in `zagg/runner.py`): an
+explicit `agg(function_name=...)` / `--function-name` wins verbatim; else the
+base name from `ZAGG_LAMBDA_FUNCTION_NAME` (default `process-shard`, so test
+stacks compose -- e.g. `process-shard-test-2048`) gets the `worker:` suffix
+appended; no block invokes the unsuffixed default, exactly as before. Invalid
+`worker:` values fail at config load with the allowed set named.
+
+!!! note "Cost caveat: memory buys vCPU"
+    Lambda allocates vCPU proportional to memory, so halving memory halves
+    $/GB-s **and** halves compute. CPU-bound shards (e.g. dense ATL03
+    aggregation) stretch in duration and eat most of the savings; I/O-bound
+    work (raster sampling, temporal readers) keeps nearly the full 2x. Pick
+    the per-template default from the workload's bottleneck, not price alone
+    (see the issue #213 utilization analysis).
+
 ### Legacy / manual deploy {#legacy-manual-deploy}
 
 !!! warning "Not the recommended path"

--- a/docs/deployment/standup.md
+++ b/docs/deployment/standup.md
@@ -45,9 +45,10 @@ to hand-assemble zips or wire up the IAM role yourself.
    `STAGING_BUCKET` (a bucket you own in that region) and `stand_up.sh` copies
    the zips into it first.
 5. **Deploys `template.yaml`** with `aws cloudformation deploy
-   --capabilities CAPABILITY_NAMED_IAM`, passing the resolved architecture,
-   artifact bucket/keys, output bucket, and role settings as parameter
-   overrides.
+   --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND` (the latter
+   acknowledges the `AWS::LanguageExtensions` macro that expands the
+   worker-size variants), passing the resolved architecture, artifact
+   bucket/keys, output bucket, and role settings as parameter overrides.
 6. **Prints the stack outputs** (function ARN/name, layer ARN, role ARN, output
    bucket).
 
@@ -56,8 +57,29 @@ to hand-assemble zips or wire up the IAM role yourself.
 `template.yaml` provisions (see the file for the authoritative definition):
 
 - **`ProcessFn`** -- the `process-shard` Lambda (`python3.12`, handler
-  `lambda_handler.lambda_handler`, default 2048 MB / 900 s timeout), wired to the
-  layer and execution role.
+  `lambda_handler.lambda_handler`, default 4096 MB / 900 s timeout), wired to the
+  layer and execution role -- plus its `-extract` twin (own concurrency pool
+  for full-archive extraction runs).
+- **The worker-size variants** -- six additional functions sharing the same
+  code, layer, and role, pre-provisioned so a run can pick its memory//tmp
+  size by *name* with no admin-role config swap (selected via the config
+  `worker:` block or `agg(function_name=...)` -- see
+  [AWS Lambda](lambda.md#worker-size-variants)):
+
+  | Function | Memory | `/tmp` |
+  |----------|--------|--------|
+  | `process-shard-2048` | 2048 MB | 512 MB |
+  | `process-shard-4096` | 4096 MB | 512 MB |
+  | `process-shard-8192` | 8192 MB | 512 MB |
+  | `process-shard-2048-disk` | 2048 MB | 4096 MB |
+  | `process-shard-4096-disk` | 4096 MB | 6144 MB |
+  | `process-shard-8192-disk` | 8192 MB | 10240 MB |
+
+  `-disk` `/tmp` is memory + 2048 MB (10240 is Lambda's ceiling). The
+  unsuffixed `process-shard`/`-extract` pair stays the no-config default.
+  Each variant carries the same async-invoke hygiene (retries 0 / event age
+  60 s) and self-recycle/worker-error metric-filter pair as the base
+  function; idle variants cost nothing (Lambda bills invocations only).
 - **`DepsLayer`** -- the dependency layer version (`<FunctionName>-deps`).
 - **`ExecutionRole`** -- created only when `CreateExecutionRole=true` (the
   default). It trusts `lambda.amazonaws.com` and is scoped least-privilege to

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -150,6 +150,9 @@ output:
 # Optional top-level fields:
 catalog: catalog_ATL06_cycle22_order6.json
 store: ./output.zarr
+worker:            # lambda backend: pick a pre-provisioned worker size
+  memory: 2048     # 2048 | 4096 | 8192 (see docs/deployment/lambda.md)
+  extra_disk: false
 ```
 
 See `src/zagg/configs/atl06.yaml` for a complete example and the

--- a/src/zagg/__main__.py
+++ b/src/zagg/__main__.py
@@ -10,7 +10,6 @@ Usage:
 import argparse
 import json
 import logging
-import os
 
 from zagg.config import load_config
 from zagg.runner import agg, normalize_output_credentials
@@ -76,8 +75,11 @@ examples:
     )
     parser.add_argument(
         "--function-name",
-        default=os.environ.get("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard"),
-        help="Lambda function name (default: env ZAGG_LAMBDA_FUNCTION_NAME or 'process-shard')",
+        default=None,
+        help="Lambda function name; an explicit value wins verbatim. Default: "
+        "env ZAGG_LAMBDA_FUNCTION_NAME (or 'process-shard') plus the config "
+        "worker: block's variant suffix (issue #235). Resolved in the runner "
+        "so the config selection is not silently masked.",
     )
     args = parser.parse_args()
 

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -91,6 +91,12 @@ FILTER_OPS = _SCALAR_OPS | _SET_OPS
 
 _PIPELINE_TYPES = frozenset({"spatial", "temporal", "event"})
 
+# Memory sizes (MB) of the pre-provisioned Lambda worker-size variants
+# (issue #235). Must match template.yaml's WorkerMemorySizes parameter — the
+# runner resolves ``worker:`` to a ``<base>-<memory>[-disk]`` function name,
+# so an unlisted size would dispatch to a function that does not exist.
+WORKER_MEMORIES = frozenset({2048, 4096, 8192})
+
 
 @dataclass
 class PipelineConfig:
@@ -114,6 +120,14 @@ class PipelineConfig:
         ``"event"`` route to the event-streaming engines added in later
         phases. Absent ``pipeline`` key in YAML defaults to ``spatial`` for
         backward compatibility with every existing config.
+    worker : dict or None
+        Optional Lambda worker-size selector (issue #235):
+        ``{"memory": 2048|4096|8192, "extra_disk": bool}``. The runner
+        resolves it to a pre-provisioned function-name suffix
+        (``-<memory>``, plus ``-disk`` when ``extra_disk`` is true) on the
+        lambda backend; an explicit ``function_name`` kwarg wins over it.
+        Absent block -> the unsuffixed default function, byte-identical
+        prior behavior. Ignored by the local backend.
     """
 
     data_source: DataSourceDict = field(default_factory=dict)
@@ -122,6 +136,7 @@ class PipelineConfig:
     catalog: str | None = None
     bounds: dict | None = None
     pipeline: dict = field(default_factory=lambda: {"type": "spatial"})
+    worker: dict | None = None
 
 
 def get_pipeline_type(config: PipelineConfig) -> str:
@@ -175,6 +190,7 @@ def load_config_from_dict(d: dict) -> PipelineConfig:
         catalog=d.get("catalog"),
         bounds=d.get("bounds"),
         pipeline=d.get("pipeline", {"type": "spatial"}),
+        worker=d.get("worker"),
     )
 
 
@@ -230,6 +246,11 @@ def validate_config(config: PipelineConfig) -> None:
             "data_source.credentials_provider must be a credential-provider "
             f"registry name string, e.g. 'nsidc' or 'gesdisc' (got {provider!r})"
         )
+
+    # The optional top-level worker block (issue #235) selects a
+    # pre-provisioned Lambda size variant on any pipeline kind, so it is
+    # validated before the kind branch, like credentials_provider above.
+    _validate_worker(config)
 
     ptype = get_pipeline_type(config)
     if ptype != "spatial":
@@ -556,6 +577,38 @@ def validate_config(config: PipelineConfig) -> None:
 # ``process_event`` rather than a load-time guess about which plugins are
 # installed.
 _TEMPORAL_SPEC_KEYS = ("variable", "collection", "spatial_func", "temporal_reducer")
+
+
+def _validate_worker(config: PipelineConfig) -> None:
+    """Validate the optional top-level ``worker:`` block (issue #235).
+
+    ``{memory, extra_disk?}`` selects one of the pre-provisioned Lambda
+    worker-size variants: ``memory`` (required, one of
+    :data:`WORKER_MEMORIES`) picks the ``-<memory>`` function, and
+    ``extra_disk: true`` (optional, default false) the ``-disk`` twin with
+    ``/tmp`` sized memory + 2048 MB. Fails at load — a typo here would
+    otherwise surface as a per-shard ResourceNotFound after the fan-out
+    starts. Absent block is today's behavior (unsuffixed function).
+    """
+    worker = config.worker
+    if worker is None:
+        return
+    if not isinstance(worker, dict):
+        raise ValueError(f"worker must be a mapping {{memory, extra_disk?}} (got {worker!r})")
+    unknown = set(worker) - {"memory", "extra_disk"}
+    if unknown:
+        raise ValueError(
+            f"Unknown worker keys: {sorted(unknown)} (allowed: 'memory', 'extra_disk')"
+        )
+    memory = worker.get("memory")
+    if isinstance(memory, bool) or memory not in WORKER_MEMORIES:
+        raise ValueError(
+            f"worker.memory must be one of {sorted(WORKER_MEMORIES)} MB — the "
+            f"pre-provisioned variant sizes (issue #235) — (got {memory!r})"
+        )
+    extra_disk = worker.get("extra_disk")
+    if extra_disk is not None and not isinstance(extra_disk, bool):
+        raise ValueError(f"worker.extra_disk must be a boolean (got {extra_disk!r})")
 
 
 def _validate_temporal_config(config: PipelineConfig) -> None:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -81,6 +81,30 @@ def _maybe_warn_dense(layout: str) -> None:
         warnings.warn(_DENSE_DEPRECATION_MSG, DeprecationWarning, stacklevel=3)
 
 
+def _resolve_function_name(config, function_name):
+    """Resolve the Lambda function to invoke (issue #235).
+
+    Precedence: an explicit ``function_name`` (``agg`` kwarg /
+    ``--function-name``) wins verbatim; otherwise the base name comes from
+    ``ZAGG_LAMBDA_FUNCTION_NAME`` (default ``"process-shard"``) and the
+    config's optional top-level ``worker:`` block appends the
+    pre-provisioned variant suffix — ``-<memory>``, plus ``-disk`` when
+    ``extra_disk`` is true (validated against the provisioned set at config
+    load). No block -> the bare base name, byte-identical prior behavior.
+    Shared by the spatial, raster, and temporal Lambda paths.
+    """
+    if function_name is not None:
+        return function_name
+    base = os.environ.get("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard")
+    worker = config.worker
+    if not worker:
+        return base
+    suffix = f"-{worker['memory']}"
+    if worker.get("extra_disk"):
+        suffix += "-disk"
+    return base + suffix
+
+
 def agg(
     config: PipelineConfig,
     *,
@@ -132,8 +156,11 @@ def agg(
     dry_run : bool
         Preview what would be processed without running.
     function_name : str, optional
-        Lambda function name. Defaults to env ``ZAGG_LAMBDA_FUNCTION_NAME``
-        or ``"process-shard"``. Only used with ``backend="lambda"``.
+        Lambda function name; an explicit value wins verbatim. Default
+        resolves env ``ZAGG_LAMBDA_FUNCTION_NAME`` (or ``"process-shard"``)
+        plus the config ``worker:`` block's pre-provisioned variant suffix
+        (``-<memory>``/``-disk``, issue #235) via
+        :func:`_resolve_function_name`. Only used with ``backend="lambda"``.
     region : str
         AWS region for S3 and Lambda. Default ``"us-west-2"``.
     output_credentials : dict, optional
@@ -356,8 +383,7 @@ class SpatialStrategy:
                 raise ValueError(f"Lambda backend requires s3:// store path, got: {store_path}")
             if invocation not in ("async", "sync"):
                 raise ValueError(f"Unknown invocation: {invocation!r} (expected 'async' or 'sync')")
-            if function_name is None:
-                function_name = os.environ.get("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard")
+            function_name = _resolve_function_name(config, function_name)
             return _run_lambda(
                 config,
                 catalog_data,
@@ -775,8 +801,7 @@ class RasterStrategy:
         import boto3
         from botocore.config import Config
 
-        if function_name is None:
-            function_name = os.environ.get("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard")
+        function_name = _resolve_function_name(config, function_name)
         max_workers = min(max_workers or 64, len(cells)) or 1
         client = boto3.client(
             "lambda",
@@ -1000,8 +1025,7 @@ def _run_lambda_events(
         )
     if invocation not in ("async", "sync"):
         raise ValueError(f"Unknown invocation: {invocation!r} (expected 'async' or 'sync')")
-    if function_name is None:
-        function_name = os.environ.get("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard")
+    function_name = _resolve_function_name(config, function_name)
 
     # Orchestrator-side credential fetch (issue #213, Phase 4): a config-named
     # provider is resolved through the registry and called ONCE (DAAC creds

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -81,7 +81,7 @@ def _maybe_warn_dense(layout: str) -> None:
         warnings.warn(_DENSE_DEPRECATION_MSG, DeprecationWarning, stacklevel=3)
 
 
-def _resolve_function_name(config, function_name):
+def _resolve_function_name(config: PipelineConfig, function_name: str | None) -> str:
     """Resolve the Lambda function to invoke (issue #235).
 
     Precedence: an explicit ``function_name`` (``agg`` kwarg /

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2270,3 +2270,103 @@ class TestConsolidateMetadataFlag:
         cfg.output = {**cfg.output, "consolidate_metadata": "yes"}
         with pytest.raises(ValueError, match="output.consolidate_metadata must be a boolean"):
             validate_config(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Worker-size selection block (issue #235)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerBlock:
+    """Issue #235: the optional top-level ``worker:`` block selects one of the
+    pre-provisioned Lambda size variants (memory in {2048, 4096, 8192},
+    ``extra_disk`` for the ``-disk`` /tmp twin). Invalid values fail at config
+    load — a typo would otherwise surface as a per-shard ResourceNotFound
+    after the Lambda fan-out starts."""
+
+    def test_absent_block_is_none_and_valid(self, atl06_config):
+        # Back-compat: every existing config has no worker key.
+        assert atl06_config.worker is None
+        validate_config(atl06_config)
+
+    def test_all_provisioned_memories_accepted(self, atl06_config):
+        for memory in (2048, 4096, 8192):
+            for extra_disk in (True, False):
+                atl06_config.worker = {"memory": memory, "extra_disk": extra_disk}
+                validate_config(atl06_config)
+
+    def test_extra_disk_optional(self, atl06_config):
+        atl06_config.worker = {"memory": 2048}
+        validate_config(atl06_config)
+
+    def test_loads_from_yaml_top_level(self, atl06_yaml, tmp_path):
+        # The block is a top-level section alongside pipeline:, not nested
+        # under output: (thread decision).
+        text = open(atl06_yaml).read() + "\nworker:\n  memory: 2048\n  extra_disk: true\n"
+        p = tmp_path / "atl06_worker.yaml"
+        p.write_text(text)
+        cfg = load_config(str(p))
+        assert cfg.worker == {"memory": 2048, "extra_disk": True}
+
+    def test_dict_roundtrip_carries_worker(self, atl06_config):
+        atl06_config.worker = {"memory": 8192, "extra_disk": False}
+        restored = load_config_from_dict(asdict(atl06_config))
+        assert restored.worker == atl06_config.worker
+
+    def test_unprovisioned_memory_rejected_naming_allowed_set(self, atl06_config):
+        atl06_config.worker = {"memory": 1024}
+        with pytest.raises(ValueError, match=r"worker\.memory must be one of \[2048, 4096, 8192\]"):
+            validate_config(atl06_config)
+
+    def test_missing_memory_rejected(self, atl06_config):
+        atl06_config.worker = {"extra_disk": True}
+        with pytest.raises(ValueError, match=r"worker\.memory must be one of"):
+            validate_config(atl06_config)
+
+    def test_string_memory_rejected(self, atl06_config):
+        # "4096" (a string) is not the provisioned int — the suffix must be
+        # built from a validated int, not whatever str() yields.
+        atl06_config.worker = {"memory": "4096"}
+        with pytest.raises(ValueError, match=r"worker\.memory must be one of"):
+            validate_config(atl06_config)
+
+    def test_bool_memory_rejected(self, atl06_config):
+        atl06_config.worker = {"memory": True}
+        with pytest.raises(ValueError, match=r"worker\.memory must be one of"):
+            validate_config(atl06_config)
+
+    def test_non_mapping_block_rejected(self, atl06_config):
+        atl06_config.worker = 4096
+        with pytest.raises(ValueError, match="worker must be a mapping"):
+            validate_config(atl06_config)
+
+    def test_unknown_key_rejected(self, atl06_config):
+        # The plan's earlier extra_tmp spelling must not be silently ignored.
+        atl06_config.worker = {"memory": 4096, "extra_tmp": True}
+        with pytest.raises(ValueError, match=r"Unknown worker keys: \['extra_tmp'\]"):
+            validate_config(atl06_config)
+
+    def test_non_bool_extra_disk_rejected(self, atl06_config):
+        atl06_config.worker = {"memory": 4096, "extra_disk": "yes"}
+        with pytest.raises(ValueError, match=r"worker\.extra_disk must be a boolean"):
+            validate_config(atl06_config)
+
+    def test_validated_on_temporal_pipeline_too(self):
+        # The block is validated before the pipeline-kind branch, so a bad
+        # value fails on temporal configs as well (they fan out on Lambda).
+        cfg = PipelineConfig(
+            aggregation={
+                "variables": {
+                    "v": {
+                        "variable": "PRECT",
+                        "collection": "c",
+                        "spatial_func": "mean",
+                        "temporal_reducer": "sum",
+                    }
+                }
+            },
+            pipeline={"type": "temporal"},
+            worker={"memory": 512},
+        )
+        with pytest.raises(ValueError, match=r"worker\.memory must be one of"):
+            validate_config(cfg)

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -382,6 +382,172 @@ class TestTemplateEnvironment:
         assert props["MaximumEventAgeInSeconds"] < _ASYNC_POLL_MARGIN_S
 
 
+class TestWorkerSizeVariants:
+    """The Fn::ForEach worker-size variants must expand as ratified (issue #235).
+
+    The template declares the 6 pre-provisioned variants (memories 2048/4096/
+    8192, each with a default-512 and a -disk /tmp twin) via two
+    ``Fn::ForEach`` loops under the ``AWS::LanguageExtensions`` transform.
+    ``_expand_foreach`` renders those loops the way the transform does —
+    textual ``${Identifier}`` substitution plus ``!Ref Identifier``
+    replacement per collection value — so these tests pin the concrete
+    function set (names, memories, /tmp sizes) without a deploy.
+    """
+
+    _SIZES = ("2048", "4096", "8192")
+    _DISK_TMP = {"2048": 4096, "4096": 6144, "8192": 10240}
+    _LAMBDA_EPHEMERAL_CEILING_MB = 10240
+
+    @staticmethod
+    def _expand_foreach(tpl, section):
+        """Expand ``Fn::ForEach::*`` keys of ``section`` to concrete entries."""
+
+        def _subst(node, ident, value):
+            if isinstance(node, dict):
+                if node == {"Ref": ident}:
+                    return value
+                return {_subst(k, ident, value): _subst(v, ident, value) for k, v in node.items()}
+            if isinstance(node, list):
+                return [_subst(item, ident, value) for item in node]
+            if isinstance(node, str):
+                return node.replace("${" + ident + "}", value)
+            return node
+
+        out = {}
+        for key, node in section.items():
+            if not key.startswith("Fn::ForEach::"):
+                out[key] = node
+                continue
+            ident, collection, fragment = node
+            if isinstance(collection, dict) and "Ref" in collection:
+                collection = tpl["Parameters"][collection["Ref"]]["Default"].split(",")
+            for value in collection:
+                for frag_key, frag_val in fragment.items():
+                    expanded_key = _subst(frag_key, ident, value)
+                    assert expanded_key not in out, f"duplicate logical id {expanded_key}"
+                    out[expanded_key] = _subst(frag_val, ident, value)
+        return out
+
+    @classmethod
+    def _resolve_find_in_map(cls, tpl, node):
+        map_name, top_key, second_key = node["FindInMap"]
+        return tpl["Mappings"][map_name][top_key][second_key]
+
+    def _expanded_resources(self):
+        tpl = TestTemplateEnvironment._load_template()
+        return tpl, self._expand_foreach(tpl, tpl["Resources"])
+
+    def test_language_extensions_transform_declared(self):
+        # Fn::ForEach only exists under the macro; without the Transform the
+        # loops would deploy as (invalid) literal resources.
+        tpl = TestTemplateEnvironment._load_template()
+        assert tpl["Transform"] == "AWS::LanguageExtensions"
+
+    def test_size_list_and_disk_mapping_stay_in_sync(self):
+        # One source of truth for the sizes: the CommaDelimitedList default.
+        # The -disk /tmp mapping must cover exactly those sizes.
+        tpl = TestTemplateEnvironment._load_template()
+        sizes = tuple(tpl["Parameters"]["WorkerMemorySizes"]["Default"].split(","))
+        assert sizes == self._SIZES
+        assert set(tpl["Mappings"]["WorkerDiskTmp"]) == set(sizes)
+
+    def test_foreach_expands_to_six_variants(self):
+        # The ratified matrix: 3 memories x {default 512 /tmp, -disk /tmp =
+        # memory + 2048} -> 6 functions; the top -disk size sits exactly at
+        # Lambda's EphemeralStorage ceiling (no clamping).
+        tpl, resources = self._expanded_resources()
+        for size in self._SIZES:
+            std = resources[f"WorkerFn{size}"]["Properties"]
+            assert std["FunctionName"] == {"Sub": f"${{FunctionName}}-{size}"}
+            assert std["MemorySize"] == size
+            assert "EphemeralStorage" not in std  # default 512 MB /tmp
+            disk = resources[f"WorkerFn{size}Disk"]["Properties"]
+            assert disk["FunctionName"] == {"Sub": f"${{FunctionName}}-{size}-disk"}
+            assert disk["MemorySize"] == size
+            tmp_mb = self._resolve_find_in_map(tpl, disk["EphemeralStorage"]["Size"])
+            assert tmp_mb == self._DISK_TMP[size] == int(size) + 2048
+        assert self._DISK_TMP["8192"] == self._LAMBDA_EPHEMERAL_CEILING_MB
+
+    def test_variants_mirror_process_fn(self):
+        # Same lockstep contract as ExtractFn (test_extract_fn_mirrors_
+        # process_fn): variants share code/layer/role/timeout/env with
+        # ProcessFn, differing only in FunctionName, MemorySize, and (disk
+        # trio) EphemeralStorage.
+        _, resources = self._expanded_resources()
+        process = resources["ProcessFn"]["Properties"]
+        for size in self._SIZES:
+            for logical in (f"WorkerFn{size}", f"WorkerFn{size}Disk"):
+                variant = resources[logical]["Properties"]
+                for key in (
+                    "Handler",
+                    "Runtime",
+                    "Architectures",
+                    "Timeout",
+                    "Role",
+                    "Layers",
+                    "Environment",
+                    "Code",
+                ):
+                    assert variant[key] == process[key], f"{logical}.{key} diverges from ProcessFn"
+
+    def test_variant_async_configs_mirror_process_fn(self):
+        # issue #151 hygiene on every variant: retries 0, event age 60.
+        _, resources = self._expanded_resources()
+        process = dict(resources["ProcessFnAsyncConfig"]["Properties"])
+        process.pop("FunctionName")
+        for size in self._SIZES:
+            for logical in (f"WorkerFn{size}", f"WorkerFn{size}Disk"):
+                cfg = dict(resources[f"{logical}AsyncConfig"]["Properties"])
+                assert cfg.pop("FunctionName") == {"Ref": logical}
+                assert cfg == process  # Qualifier, retries, event age identical
+
+    def test_variant_metric_filters_mirror_process_fn(self):
+        # issue #175 split on every variant's log group, with per-function
+        # metric names (unique across the whole template) and patterns
+        # byte-identical to the unsuffixed function's.
+        _, resources = self._expanded_resources()
+        recycle = resources["ProcessSelfRecycleFilter"]["Properties"]["FilterPattern"]
+        errors = resources["ProcessWorkerErrorFilter"]["Properties"]["FilterPattern"]
+        for size in self._SIZES:
+            for logical, group_suffix, metric_stem in (
+                (f"WorkerFn{size}", f"-{size}", f"Worker{size}"),
+                (f"WorkerFn{size}Disk", f"-{size}-disk", f"Worker{size}Disk"),
+            ):
+                for kind, pattern, metric in (
+                    ("SelfRecycleFilter", recycle, f"{metric_stem}SelfRecycleCount"),
+                    ("WorkerErrorFilter", errors, f"{metric_stem}WorkerErrorCount"),
+                ):
+                    fltr = resources[f"{logical}{kind}"]
+                    assert fltr["Type"] == "AWS::Logs::MetricFilter"
+                    assert fltr["Condition"] == "ShouldCreateMetricFilters"
+                    assert fltr["DependsOn"] == logical
+                    props = fltr["Properties"]
+                    assert props["LogGroupName"] == {
+                        "Sub": f"/aws/lambda/${{FunctionName}}{group_suffix}"
+                    }
+                    assert props["FilterPattern"] == pattern
+                    (mt,) = props["MetricTransformations"]
+                    assert mt["MetricNamespace"] == "zagg/lambda"
+                    assert mt["MetricName"] == metric
+                    assert mt["MetricValue"] == "1"
+                    assert mt["DefaultValue"] == 0
+        names = [
+            fltr["Properties"]["MetricTransformations"][0]["MetricName"]
+            for fltr in resources.values()
+            if isinstance(fltr, dict) and fltr.get("Type") == "AWS::Logs::MetricFilter"
+        ]
+        assert len(names) == len(set(names)) == 16  # 8 functions x 2 filters
+
+    def test_outputs_expose_variant_arns(self):
+        tpl = TestTemplateEnvironment._load_template()
+        outputs = self._expand_foreach(tpl, tpl["Outputs"])
+        for size in self._SIZES:
+            assert outputs[f"WorkerFn{size}Arn"]["Value"] == {"GetAtt": f"WorkerFn{size}.Arn"}
+            assert outputs[f"WorkerFn{size}DiskArn"]["Value"] == {
+                "GetAtt": f"WorkerFn{size}Disk.Arn"
+            }
+
+
 class TestLayerExtraParity:
     """The ``lambda`` extra pins and build_layer.sh must actually stay in sync.
 

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -388,10 +388,11 @@ class TestWorkerSizeVariants:
     The template declares the 6 pre-provisioned variants (memories 2048/4096/
     8192, each with a default-512 and a -disk /tmp twin) via two
     ``Fn::ForEach`` loops under the ``AWS::LanguageExtensions`` transform.
-    ``_expand_foreach`` renders those loops the way the transform does —
-    textual ``${Identifier}`` substitution plus ``!Ref Identifier``
-    replacement per collection value — so these tests pin the concrete
-    function set (names, memories, /tmp sizes) without a deploy.
+    ``_expand_foreach`` models the transform for the constructs this template
+    uses — textual ``${Identifier}`` substitution plus ``!Ref Identifier``
+    replacement per collection value, with the collection taken from the
+    parameter's ``Default`` — so these tests pin the concrete function set
+    (names, memories, /tmp sizes) for the default size list without a deploy.
     """
 
     _SIZES = ("2048", "4096", "8192")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3632,6 +3632,72 @@ class TestLambdaDispatchFunctionSelection:
         assert self._dispatch(monkeypatch, atl06_config, catalog_file) == "process-shard-test-4096"
 
 
+class TestLambdaResolverSeamRasterEvents:
+    """Issue #235: the raster (``_run_lambda_shards``) and temporal-events
+    (``_run_lambda_events``) Lambda paths must route their function name
+    through ``_resolve_function_name`` exactly as the spatial path does. Stub
+    the resolver to record its ``(config, function_name)`` args and halt at the
+    seam with a sentinel error, then drive each path far enough to hit it --
+    guarding against a future edit dropping the resolver call on either path."""
+
+    def _seam_stub(self):
+        seen = {}
+
+        def _stub(config, function_name):
+            seen["config"] = config
+            seen["function_name"] = function_name
+            raise RuntimeError("seam reached")
+
+        return seen, _stub
+
+    def test_events_path_routes_through_resolver(self, monkeypatch):
+        from zagg import runner
+        from zagg.config import PipelineConfig
+
+        seen, stub = self._seam_stub()
+        monkeypatch.setattr(runner, "_resolve_function_name", stub)
+        # output.format must be tabular (not the "zarr" default) to clear the
+        # temporal guard preceding the resolver call.
+        config = PipelineConfig(output={"format": "parquet"})
+        with pytest.raises(RuntimeError, match="seam reached"):
+            runner._run_lambda_events(
+                config,
+                [{"event_key": "e", "event_mask_uri": "s3://b/m.npy"}],
+                "s3://b/out.parquet",
+                max_workers=1,
+                region="us-west-2",
+                function_name="pinned-events",
+            )
+        assert seen["config"] is config
+        assert seen["function_name"] == "pinned-events"
+
+    def test_raster_path_routes_through_resolver(self, monkeypatch):
+        from zagg import runner
+        from zagg.config import PipelineConfig
+
+        seen, stub = self._seam_stub()
+        monkeypatch.setattr(runner, "_resolve_function_name", stub)
+        config = PipelineConfig()
+        # The resolver call is the first statement after the boto3 imports and
+        # before ``boto3.client``, so tiny dummies never get used.
+        with pytest.raises(RuntimeError, match="seam reached"):
+            runner.RasterStrategy()._run_lambda_shards(
+                config,
+                {},
+                {},
+                None,
+                "s3://b/out.zarr",
+                max_workers=1,
+                region="us-west-2",
+                function_name="pinned-raster",
+                max_retries=1,
+                output_credentials=None,
+                output_endpoint_url=None,
+            )
+        assert seen["config"] is config
+        assert seen["function_name"] == "pinned-raster"
+
+
 class TestCliFunctionNameDefault:
     """Issue #235: ``--function-name`` must default to ``None`` (resolved in
     the runner), not env-or-``process-shard`` — the old eager default reached

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3512,3 +3512,176 @@ class TestResolveSourceCredentials:
         cfg = PipelineConfig(data_source={"credentials_provider": "not_a_provider"})
         with pytest.raises(KeyError, match="not_a_provider"):
             runner._resolve_source_credentials(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Worker-size variant selection (issue #235)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFunctionName:
+    """Issue #235: one resolver for all three Lambda paths. Explicit
+    ``function_name`` wins verbatim; else env base (default ``process-shard``)
+    plus the config ``worker:`` block's ``-<memory>[-disk]`` suffix; no block
+    keeps the bare base name (byte-identical prior behavior)."""
+
+    def test_no_block_no_env_default(self, monkeypatch):
+        from zagg.config import PipelineConfig
+        from zagg.runner import _resolve_function_name
+
+        monkeypatch.delenv("ZAGG_LAMBDA_FUNCTION_NAME", raising=False)
+        assert _resolve_function_name(PipelineConfig(), None) == "process-shard"
+
+    def test_no_block_env_base(self, monkeypatch):
+        from zagg.config import PipelineConfig
+        from zagg.runner import _resolve_function_name
+
+        monkeypatch.setenv("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard-test")
+        assert _resolve_function_name(PipelineConfig(), None) == "process-shard-test"
+
+    def test_block_appends_memory_suffix(self, monkeypatch):
+        from zagg.config import PipelineConfig
+        from zagg.runner import _resolve_function_name
+
+        monkeypatch.delenv("ZAGG_LAMBDA_FUNCTION_NAME", raising=False)
+        cfg = PipelineConfig(worker={"memory": 2048})
+        assert _resolve_function_name(cfg, None) == "process-shard-2048"
+
+    def test_block_extra_disk_appends_disk_suffix(self, monkeypatch):
+        from zagg.config import PipelineConfig
+        from zagg.runner import _resolve_function_name
+
+        monkeypatch.delenv("ZAGG_LAMBDA_FUNCTION_NAME", raising=False)
+        cfg = PipelineConfig(worker={"memory": 4096, "extra_disk": True})
+        assert _resolve_function_name(cfg, None) == "process-shard-4096-disk"
+
+    def test_block_extra_disk_false_no_disk_suffix(self, monkeypatch):
+        from zagg.config import PipelineConfig
+        from zagg.runner import _resolve_function_name
+
+        monkeypatch.delenv("ZAGG_LAMBDA_FUNCTION_NAME", raising=False)
+        cfg = PipelineConfig(worker={"memory": 8192, "extra_disk": False})
+        assert _resolve_function_name(cfg, None) == "process-shard-8192"
+
+    def test_block_composes_with_env_base(self, monkeypatch):
+        # A test stack (FUNCTION_NAME=process-shard-test at standup) gets the
+        # same size variants; the env base composes with the config suffix.
+        from zagg.config import PipelineConfig
+        from zagg.runner import _resolve_function_name
+
+        monkeypatch.setenv("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard-test")
+        cfg = PipelineConfig(worker={"memory": 8192, "extra_disk": True})
+        assert _resolve_function_name(cfg, None) == "process-shard-test-8192-disk"
+
+    def test_explicit_kwarg_wins_verbatim(self, monkeypatch):
+        # The orchestrator override: kwarg beats both the block and the env.
+        from zagg.config import PipelineConfig
+        from zagg.runner import _resolve_function_name
+
+        monkeypatch.setenv("ZAGG_LAMBDA_FUNCTION_NAME", "ignored")
+        cfg = PipelineConfig(worker={"memory": 2048, "extra_disk": True})
+        assert _resolve_function_name(cfg, "my-exact-fn") == "my-exact-fn"
+
+
+class TestLambdaDispatchFunctionSelection:
+    """The spatial lambda branch must hand the RESOLVED name to the transport
+    (whose ``client.invoke(FunctionName=...)`` plumbing is covered by the
+    TestInvokeLambdaCell* suites). Stub ``_run_lambda`` at the dispatch seam
+    and assert what each (config, kwarg, env) combination resolves to."""
+
+    def _dispatch(self, monkeypatch, config, catalog_file, **agg_kwargs):
+        from zagg import runner
+
+        seen = {}
+
+        def _stub(config, catalog_data, store_path, child_order, **kwargs):
+            seen.update(kwargs)
+            return {"stub": True}
+
+        monkeypatch.setattr(runner, "_run_lambda", _stub)
+        result = agg(
+            config,
+            catalog=catalog_file,
+            store="s3://bucket/out.zarr",
+            backend="lambda",
+            **agg_kwargs,
+        )
+        assert result == {"stub": True}
+        return seen["function_name"]
+
+    def test_no_block_regression(self, monkeypatch, atl06_config, catalog_file):
+        # Byte-identical prior behavior: no worker block, no kwarg, no env.
+        monkeypatch.delenv("ZAGG_LAMBDA_FUNCTION_NAME", raising=False)
+        assert self._dispatch(monkeypatch, atl06_config, catalog_file) == "process-shard"
+
+    def test_worker_block_selects_variant(self, monkeypatch, atl06_config, catalog_file):
+        monkeypatch.delenv("ZAGG_LAMBDA_FUNCTION_NAME", raising=False)
+        atl06_config.worker = {"memory": 2048, "extra_disk": True}
+        assert self._dispatch(monkeypatch, atl06_config, catalog_file) == "process-shard-2048-disk"
+
+    def test_kwarg_wins_over_block(self, monkeypatch, atl06_config, catalog_file):
+        atl06_config.worker = {"memory": 2048}
+        resolved = self._dispatch(
+            monkeypatch, atl06_config, catalog_file, function_name="pinned-fn"
+        )
+        assert resolved == "pinned-fn"
+
+    def test_env_base_composes_with_block(self, monkeypatch, atl06_config, catalog_file):
+        monkeypatch.setenv("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard-test")
+        atl06_config.worker = {"memory": 4096}
+        assert self._dispatch(monkeypatch, atl06_config, catalog_file) == "process-shard-test-4096"
+
+
+class TestCliFunctionNameDefault:
+    """Issue #235: ``--function-name`` must default to ``None`` (resolved in
+    the runner), not env-or-``process-shard`` — the old eager default reached
+    ``agg`` as an explicit kwarg and silently masked the config ``worker:``
+    selection."""
+
+    def test_default_is_none(self, monkeypatch):
+        import zagg.__main__ as cli
+
+        monkeypatch.setenv("ZAGG_LAMBDA_FUNCTION_NAME", "process-shard-test")
+        captured = {}
+
+        def _fake_agg(config, **kwargs):
+            captured.update(kwargs)
+            return {
+                "total_cells": 0,
+                "granules_per_cell_min": 0,
+                "granules_per_cell_max": 0,
+                "granules_per_cell_avg": 0.0,
+                "store_path": "x",
+            }
+
+        monkeypatch.setattr(cli, "agg", _fake_agg)
+        monkeypatch.setattr(cli, "load_config", lambda path: object())
+        monkeypatch.setattr("sys.argv", ["zagg", "--config", "c.yaml", "--dry-run"])
+        cli.main()
+        # None reaches agg: the resolver (not argparse) applies the env/config
+        # fallback, so the worker block is honored.
+        assert captured["function_name"] is None
+
+    def test_explicit_flag_passes_verbatim(self, monkeypatch):
+        import zagg.__main__ as cli
+
+        captured = {}
+
+        def _fake_agg(config, **kwargs):
+            captured.update(kwargs)
+            return {
+                "total_cells": 0,
+                "granules_per_cell_min": 0,
+                "granules_per_cell_max": 0,
+                "granules_per_cell_avg": 0.0,
+                "store_path": "x",
+            }
+
+        monkeypatch.setattr(cli, "agg", _fake_agg)
+        monkeypatch.setattr(cli, "load_config", lambda path: object())
+        monkeypatch.setattr(
+            "sys.argv",
+            ["zagg", "--config", "c.yaml", "--dry-run", "--function-name", "my-exact-fn"],
+        )
+        cli.main()
+        assert captured["function_name"] == "my-exact-fn"


### PR DESCRIPTION
Closes #235

## What / approach

Implements option (A) from the issue thread — pre-provisioned Lambda worker-size variants selectable at run time by function name, with zero AWS-side config mutation — per the [ratified plan](https://github.com/englacial/zagg/issues/235#issuecomment-4990684782) and the [answers to its open questions](https://github.com/englacial/zagg/issues/235#issuecomment-5005614732): suffix `-disk` (not `-tmp`), unsuffixed `process-shard`/`-extract` untouched at 4096/512 as the no-config default (8 functions total after standup), `worker:` as a new top-level YAML section, and `Fn::ForEach` instead of hand-enumerating ~24 resources (explanation posted [on the thread](https://github.com/englacial/zagg/issues/235#issuecomment-5005956364)).

The variant matrix (6 new functions):

| name | memory (MB) | /tmp (MB) |
|---|---|---|
| `process-shard-2048` | 2048 | 512 |
| `process-shard-4096` | 4096 | 512 |
| `process-shard-8192` | 8192 | 512 |
| `process-shard-2048-disk` | 2048 | 4096 |
| `process-shard-4096-disk` | 4096 | 6144 |
| `process-shard-8192-disk` | 8192 | 10240 |

`-disk` /tmp is memory + 2048 MB; 10240 is exactly Lambda's EphemeralStorage ceiling, so the rule holds with no clamping.

`template.yaml` gains `Transform: AWS::LanguageExtensions` and two `Fn::ForEach` loops over a `WorkerMemorySizes` CommaDelimitedList parameter (the single source of truth for the size list), with a `WorkerDiskTmp` Mappings table for the `-disk` /tmp sizes. Each loop stamps, per size: the function (sharing `DepsLayer`, the execution role, timeout, and env with `ProcessFn`), its issue-151 `EventInvokeConfig` (retries 0 / event age 60), and the issue-175 self-recycle/worker-error metric-filter pair. `EphemeralStorage` appears only in the `-disk` loop. Outputs gain the 6 variant ARNs. `stand_up.sh` now passes `CAPABILITY_AUTO_EXPAND` (review fold — acknowledges the macro; harmless if the change-set path would have processed it anyway).

Selection: a new optional top-level `worker:` block —

```yaml
worker:
  memory: 2048       # one of 2048 | 4096 | 8192
  extra_disk: false  # true -> the -disk variant
```

— resolved by one runner helper (`_resolve_function_name`): explicit `agg(function_name=...)` wins verbatim; otherwise base from `ZAGG_LAMBDA_FUNCTION_NAME` (default `process-shard`) + the config suffix; no block → byte-identical current behavior. The CLI's `--function-name` default moved from eager env-or-`process-shard` to `None` so an unset flag no longer reaches `agg` as an explicit kwarg and silently masks the config selection; an explicitly passed flag still wins verbatim.

## Phases

- [x] Phase 1 — `deployment/aws/template.yaml`: transform + ForEach variants, per-variant EventInvokeConfig + metric filters, `-disk` EphemeralStorage, extended `CreateLogMetricFilters` caveat (8 log groups), variant ARN outputs; expansion pinned by pure-Python render tests in `tests/test_lambda_build.py` (+ 3 review-fold commits incl. `CAPABILITY_AUTO_EXPAND` in `stand_up.sh`)
- [x] Phase 2 — `src/zagg/config.py`: validate the optional top-level `worker:` block (memory in {2048, 4096, 8192}, `extra_disk` bool), fail-at-load errors naming the allowed set; 13 tests in `tests/test_config.py`
- [x] Phase 3 — `src/zagg/runner.py` + `src/zagg/__main__.py`: `_resolve_function_name(config, function_name)` replacing the three inline env fallbacks (spatial/raster/temporal paths); CLI `--function-name` default becomes `None`; resolver unit tests + dispatch-seam tests + CLI tests in `tests/test_runner.py`
- [x] Phase 4 — docs: variant table + `worker:` selection section + cost caveat (halving memory halves vCPU) in `docs/deployment/lambda.md`, stack-contents table in `docs/deployment/standup.md`, `worker:` in `docs/quickstart.md`'s optional-fields example

## How tested

- `tests/test_lambda_build.py::TestWorkerSizeVariants` renders the `Fn::ForEach` expansion in pure Python (textual `${Identifier}` + `!Ref` substitution over the parameter-default size list) and asserts: the 6 concrete names/memories//tmp sizes, lockstep with `ProcessFn` (same code/layer/role/timeout/env — mirroring the existing `ExtractFn` lockstep test), per-variant async-config and metric-filter parity, metric-name uniqueness (16 filters across 8 functions), and the size-list/mapping sync.
- `tests/test_config.py::TestWorkerBlock`: accept/reject matrix for the `worker:` block incl. YAML top-level load, dict roundtrip, and temporal-pipeline validation.
- `tests/test_runner.py`: `TestResolveFunctionName` (env/config/kwarg combinations), `TestLambdaDispatchFunctionSelection` (stubbed `_run_lambda` at the dispatch seam asserting the resolved name handed to the transport, incl. the no-block byte-identical regression), `TestCliFunctionNameDefault` (argparse default `None`, explicit flag verbatim).
- Full suite + `ruff check` / `ruff format --check` green locally (phase status comments have the numbers). Pre-existing `N818` in `src/zagg/registry.py` fails plain `ruff check src tests` on `main` too — not touched here.
- No live-AWS validation by design — template is parse/render tested only; the first real standup (which settles the `CAPABILITY_AUTO_EXPAND` question live) is a human action.

## Questions for review

1. **Config key rename from the plan:** the plan proposed `extra_tmp`; since the ratified *function suffix* is `-disk`, the config key here is `extra_disk` so the YAML key and the function name it selects agree. Flagging the divergence from the plan text for sign-off.
2. **ForEach grep-ability tradeoff:** `grep process-shard-8192-disk` finds the loop, not a literal resource block. Mitigated by assembling the name strings only in each loop's `FunctionName: !Sub` line and pinning the concrete expansion in `TestWorkerSizeVariants`; if literal blocks are preferred after seeing the diff, say so and phase 1 can be redone hand-enumerated.
3. **Metric names:** variant metrics are `Worker<size>[Disk]{SelfRecycle,WorkerError}Count` in the existing `zagg/lambda` namespace — 12 new metric names. Any dashboard/alarm naming convention this should match instead?
4. **Stale doc default corrected in passing:** `docs/deployment/standup.md` said `ProcessFn` defaults to 2048 MB; the template default has been 4096 since issue #180 — fixed while adding the variants table (flagging since it predates this PR).