### PR TITLE
Arena state layout for streaming digest state (issue #217)

### DIFF
--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -241,17 +241,43 @@ class StreamingAggregator:
         buffer is an **anonymous** file mapping: the file is unlinked the
         moment the mapping exists, so the mapping itself is the only
         reference — space frees on GC and nothing can accumulate in ``/tmp``
-        across warm Lambda invokes. The payoff is failure mode: dirty pages
-        are file-backed page cache the kernel can write back and reclaim
+        across warm Lambda invokes. The reclaim payoff holds only where
+        ``/tmp`` is genuinely disk-backed (Lambda ephemeral storage): dirty
+        pages are file-backed page cache the kernel can write back and reclaim
         under cgroup pressure, so an oversized flush transient degrades into
-        paging instead of an OOM kill of anonymous heap.
+        paging instead of an OOM kill of anonymous heap. Where ``/tmp`` is
+        tmpfs (common on dev/CI boxes) those pages are RAM that counts against
+        the same cgroup and cannot be evicted — no benefit, strictly extra
+        overhead.
+
+        ``mode="w+"`` grows the file with a single sparse seek+write, so the
+        allocation succeeds even when the filesystem cannot hold the full
+        buffer; the shortfall only surfaces later as an **uncatchable SIGBUS**
+        on the page-fault writes that fill the mapping. To turn that deferred
+        crash into a clean loud error we check free space against the request
+        up front and refuse if it won't fit. ``arena_backing: tmp`` therefore
+        requires ephemeral storage sized above the arena flush transient — up
+        to three of these buffers (old + staging + bounded merge) can be live
+        at once during a fold, so size for their combined peak, not one buffer.
         """
         if self.arena_backing != "tmp" or n_rows == 0:
             return np.empty((n_rows, 2), dtype=np.float32)
         import os
         import tempfile
 
-        fd, path = tempfile.mkstemp(suffix=".arena")
+        tmp_dir = tempfile.gettempdir()
+        need_bytes = n_rows * 2 * np.dtype(np.float32).itemsize
+        st = os.statvfs(tmp_dir)
+        avail_bytes = st.f_bavail * st.f_frsize
+        if avail_bytes < need_bytes:
+            raise RuntimeError(
+                f"arena_backing: tmp needs {need_bytes} bytes for a centroid buffer but "
+                f"{tmp_dir!r} has only {avail_bytes} free; raise the function's ephemeral "
+                "storage / EphemeralStorage size (up to three such buffers — old + staging + "
+                "bounded merge — can be live concurrently during a fold, so size for their "
+                "combined peak). Overflow otherwise surfaces as an uncatchable SIGBUS on write."
+            )
+        fd, path = tempfile.mkstemp(suffix=".arena", dir=tmp_dir)
         try:
             mapped = np.memmap(path, dtype=np.float32, mode="w+", shape=(n_rows, 2))
         finally:

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -43,6 +43,16 @@ from zagg.stats.tdigest import _DEFAULT_DELTA, build_tdigest, merge_tdigests
 _TDIGEST_FUNCTION = "zagg.stats.tdigest.build_tdigest"
 
 
+#: Safe per-cell slot bound for staged tdigest builds/merges, as a multiple of
+#: the field's delta: the k-1 compression law lands at <= ~1.13*delta centroids
+#: (measured: 289 max at delta=256, 578 at delta=512), so 2*delta never
+#: truncates; asserted at every staged write.
+_K_SLOT_FACTOR = 2
+
+#: Shared zero-size arena so releasing a field's old buffer needs no allocation.
+_EMPTY_ARENA = np.empty((0, 2), dtype=np.float32)
+
+
 def _ranges_to_indices(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
     """Element indices for concatenated ``[start, start+length)`` ranges.
 
@@ -233,14 +243,17 @@ class StreamingAggregator:
         self._buffered_granules = 0
 
     def _fold_arena(self, col_arrays, cell_to_slice) -> None:
-        """Rebuild the CSR state with this flush's cells folded in.
+        """Rebuild the CSR state with this flush's cells folded in — staged.
 
-        Sizes are exact before allocation: fresh digests (and, for cells
-        already held, their merges) are built first, so the new arena is
-        allocated once at its final size and filled — untouched cells by a
-        vectorized element gather, touched cells by per-cell slice writes.
-        Transients are one buffer's digests plus the old arena, freed on
-        return; the steady state is pure ndarrays with no per-cell objects.
+        Every intermediate is a bulk array, never a per-cell object list:
+        fresh digests are built straight into a bounded staging arena (slot
+        bound ``min(n, 2*delta)`` — group sizes are known before any build),
+        old-only and fresh-only cells move by vectorized element gathers, and
+        only genuine merges loop. A final one-gather compaction squeezes the
+        merge-compression slack back out. Flush transient is therefore old +
+        staging + bounded-new (all payload-sized, freed in stages) — the naive
+        rebuild's list of ~1M small fresh-digest ndarrays measurably cost more
+        than the state itself (issue #217 A/B replay).
         """
         fresh_cells = np.fromiter(cell_to_slice, dtype=np.uint64, count=len(cell_to_slice))
         order = np.argsort(fresh_cells)
@@ -258,35 +271,70 @@ class StreamingAggregator:
         new_counts[pos_old] = self._cell_counts
         np.add.at(new_counts, pos_fresh, ends - starts)
 
+        keep = ~np.isin(self._cells, fresh_cells, assume_unique=True)
+        ovl_idx = np.nonzero(overlap)[0]
+        held_pos = np.searchsorted(self._cells, fresh_cells[overlap])
+
         for name, (source, delta) in self._digest_fields.items():
             offsets, arena = self._offsets[name], self._arenas[name]
             k_old = np.diff(offsets)
-            # Fresh (and merged, for held cells) digests first — the same
-            # build/merge calls the dict layout makes — so every cell's final
-            # length is known before the single allocation below.
-            held_pos = np.searchsorted(self._cells, fresh_cells[overlap])
-            digests = []
+            cap = _K_SLOT_FACTOR * delta
+
+            # Stage fresh digests straight into a bounded arena — group sizes
+            # are known before any build (k <= min(n, cap)), so no per-cell
+            # object list ever exists (a 1M-cell flush as a list of small
+            # ndarrays transiently costs more than the state itself).
+            bound_fresh = np.minimum(ends - starts, cap)
+            stage_off = np.concatenate(([0], np.cumsum(bound_fresh)))
+            stage = np.empty((int(stage_off[-1]), 2), dtype=np.float32)
+            k_fresh = np.empty(len(fresh_cells), dtype=np.int64)
             for j in range(len(fresh_cells)):
                 d = build_tdigest(col_arrays[source][starts[j] : ends[j]], delta=delta)
-                digests.append(d)
-            for j, i_old in zip(np.nonzero(overlap)[0], held_pos, strict=True):
-                held = arena[offsets[i_old] : offsets[i_old + 1]]
-                digests[j] = merge_tdigests(held, digests[j], delta=delta)
+                assert len(d) <= bound_fresh[j], (
+                    f"tdigest returned {len(d)} centroids > slot bound {bound_fresh[j]} "
+                    f"(delta={delta}) — the {_K_SLOT_FACTOR}*delta compression bound broke"
+                )
+                stage[stage_off[j] : stage_off[j] + len(d)] = d
+                k_fresh[j] = len(d)
 
-            k_new = np.zeros(len(union), dtype=np.int64)
-            k_new[pos_old] = k_old
-            k_new[pos_fresh] = [len(d) for d in digests]
-            new_offsets = np.concatenate(([0], np.cumsum(k_new)))
-            new_arena = np.empty((int(new_offsets[-1]), 2), dtype=np.float32)
+            # Bounded merged layout: exact slots for old-only / fresh-only
+            # cells, min(k_old + k_fresh, cap) for merges.
+            k_bound = np.zeros(len(union), dtype=np.int64)
+            k_bound[pos_old] = k_old
+            k_bound[pos_fresh] = k_fresh
+            k_bound[pos_fresh[ovl_idx]] = np.minimum(k_old[held_pos] + k_fresh[ovl_idx], cap)
+            bound_off = np.concatenate(([0], np.cumsum(k_bound)))
+            bound_arena = np.empty((int(bound_off[-1]), 2), dtype=np.float32)
+            k_exact = k_bound.copy()
 
-            keep = ~np.isin(self._cells, fresh_cells, assume_unique=True)
             src = _ranges_to_indices(offsets[:-1][keep], k_old[keep])
-            dst = _ranges_to_indices(new_offsets[:-1][pos_old[keep]], k_old[keep])
-            new_arena[dst] = arena[src]
-            for j, i_union in enumerate(pos_fresh):
-                d = digests[j]
-                new_arena[new_offsets[i_union] : new_offsets[i_union] + len(d)] = d
-            self._offsets[name], self._arenas[name] = new_offsets, new_arena
+            dst = _ranges_to_indices(bound_off[:-1][pos_old[keep]], k_old[keep])
+            bound_arena[dst] = arena[src]
+            solo = ~overlap
+            src = _ranges_to_indices(stage_off[:-1][solo], k_fresh[solo])
+            dst = _ranges_to_indices(bound_off[:-1][pos_fresh[solo]], k_fresh[solo])
+            bound_arena[dst] = stage[src]
+            for j, i_old in zip(ovl_idx, held_pos, strict=True):
+                held = arena[offsets[i_old] : offsets[i_old + 1]]
+                fresh = stage[stage_off[j] : stage_off[j] + k_fresh[j]]
+                d = merge_tdigests(held, fresh, delta=delta)
+                u = pos_fresh[j]
+                assert len(d) <= k_bound[u], (
+                    f"merged tdigest {len(d)} centroids > slot bound {k_bound[u]} "
+                    f"(delta={delta}) — the {_K_SLOT_FACTOR}*delta compression bound broke"
+                )
+                bound_arena[bound_off[u] : bound_off[u] + len(d)] = d
+                k_exact[u] = len(d)
+            # Release the old arena and staging before compaction so the
+            # compaction peak is bound + exact, not old + stage + bound + exact.
+            self._arenas[name] = _EMPTY_ARENA
+            del arena, stage
+
+            # Compact the bounded layout to exact CSR in one vectorized gather
+            # (merge compression leaves slack only inside merged slots).
+            new_offsets = np.concatenate(([0], np.cumsum(k_exact)))
+            src = _ranges_to_indices(bound_off[:-1], k_exact)
+            self._offsets[name], self._arenas[name] = new_offsets, bound_arena[src]
 
         self._cells, self._cell_counts = union, new_counts
 

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -206,6 +206,10 @@ class StreamingAggregator:
         self._arenas: dict[str, np.ndarray] = {
             n: np.empty((0, 2), dtype=np.float32) for n in self._digest_fields
         }
+        # Set to the field name while its arena is released for compaction and
+        # cleared once compaction lands; a lingering value means a compaction
+        # failed mid-rebuild and the running state is unusable (see update()).
+        self._poisoned: str | None = None
         self.n_obs_total = 0
         self.flushes = 0
         self._buffer: list = []
@@ -330,14 +334,20 @@ class StreamingAggregator:
                 k_exact[u] = len(d)
             # Release the old arena and staging before compaction so the
             # compaction peak is bound + exact, not old + stage + bound + exact.
+            # This leaves the field transiently inconsistent (arena emptied,
+            # offsets still describing the pre-merge layout); poison it so a
+            # failed gather below (e.g. OOM) can't be caught and then read as a
+            # silent no-digest result. Cleared once compaction lands atomically.
             self._arenas[name] = _EMPTY_ARENA
             del arena, stage
+            self._poisoned = name
 
             # Compact the bounded layout to exact CSR in one vectorized gather
             # (merge compression leaves slack only inside merged slots).
             new_offsets = np.concatenate(([0], np.cumsum(k_exact)))
             src = _ranges_to_indices(bound_off[:-1], k_exact)
             self._offsets[name], self._arenas[name] = new_offsets, bound_arena[src]
+            self._poisoned = None
 
         self._cells, self._cell_counts = union, new_counts
 
@@ -410,6 +420,11 @@ class StreamingAggregator:
         count, empty cells 0 (the pooled ``len`` over an empty slice), digests
         only where nonempty — via one ``searchsorted`` over the sorted cell ids.
         """
+        if self._poisoned is not None:
+            raise RuntimeError(
+                f"streaming digest state for {self._poisoned!r} was left inconsistent "
+                "by a failed compaction; the running state is unusable"
+            )
         cells = children.astype(np.uint64)
         pos = np.searchsorted(self._cells, cells)
         pos_c = np.minimum(pos, max(self._cells.size - 1, 0))

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -43,11 +43,28 @@ from zagg.stats.tdigest import _DEFAULT_DELTA, build_tdigest, merge_tdigests
 _TDIGEST_FUNCTION = "zagg.stats.tdigest.build_tdigest"
 
 
+def _ranges_to_indices(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
+    """Element indices for concatenated ``[start, start+length)`` ranges.
+
+    Vectorized (no per-range Python loop): for the arena rebuild it turns the
+    kept cells' old/new offset ranges into flat gather/scatter indices.
+    """
+    total = int(lengths.sum())
+    if total == 0:
+        return np.empty(0, dtype=np.int64)
+    shifts = np.concatenate(([0], np.cumsum(lengths)[:-1]))
+    return np.arange(total, dtype=np.int64) + np.repeat(starts - shifts, lengths)
+
+
 def get_streaming(config: PipelineConfig) -> dict | None:
     """Return the ``aggregation.streaming`` block, or ``None`` (pooled path).
 
-    The block is ``{"buffer_granules": int}``; ``buffer_granules`` must be a
-    positive int. Absent block -> ``None`` so existing configs are untouched.
+    The block is ``{"buffer_granules": int, "state_layout": "dict"|"arena"}``;
+    ``buffer_granules`` must be a positive int. ``state_layout`` (issue #217)
+    picks the running-state container: ``"dict"`` (default, per-cell ndarrays)
+    or ``"arena"`` (contiguous CSR buffers — same merge sequence, same bytes
+    out, ~24 B/cell overhead instead of ~290). Absent block -> ``None`` so
+    existing configs are untouched.
     """
     block = config.aggregation.get("streaming")
     if block is None:
@@ -60,7 +77,12 @@ def get_streaming(config: PipelineConfig) -> dict | None:
             f"aggregation.streaming.buffer_granules must be a positive int "
             f"(got {buffer_granules!r})"
         )
-    return {"buffer_granules": buffer_granules}
+    state_layout = block.get("state_layout", "dict")
+    if state_layout not in ("dict", "arena"):
+        raise ValueError(
+            f"aggregation.streaming.state_layout must be 'dict' or 'arena' (got {state_layout!r})"
+        )
+    return {"buffer_granules": buffer_granules, "state_layout": state_layout}
 
 
 def validate_streaming(config: PipelineConfig) -> None:
@@ -129,11 +151,19 @@ class StreamingAggregator:
     returns, so the worker's carrier/ragged construction is shared verbatim.
     """
 
-    def __init__(self, config: PipelineConfig, grid, handoff: str, buffer_granules: int):
+    def __init__(
+        self,
+        config: PipelineConfig,
+        grid,
+        handoff: str,
+        buffer_granules: int,
+        state_layout: str = "dict",
+    ):
         validate_streaming(config)
         self.grid = grid
         self.handoff = handoff
         self.buffer_granules = buffer_granules
+        self.state_layout = state_layout
         agg_fields = get_agg_fields(config)
         self._count_fields: list[str] = []
         self._digest_fields: dict[str, tuple[str, int]] = {}  # name -> (source, delta)
@@ -149,6 +179,20 @@ class StreamingAggregator:
                 self._count_fields.append(name)
         self.counts: dict[int, int] = {}
         self.digests: dict[str, dict[int, np.ndarray]] = {n: {} for n in self._digest_fields}
+        # Arena layout (issue #217): the same running state held as contiguous
+        # CSR buffers — sorted cell ids + parallel counts, and per digest field
+        # one packed centroid buffer addressed by offsets. Identical merge
+        # sequence to the dict layout (same build/merge calls in the same
+        # order), so the emitted bytes match; only the container differs
+        # (~24 B/cell instead of ~290 B of dict-slot + ndarray-header overhead).
+        self._cells = np.empty(0, dtype=np.uint64)
+        self._cell_counts = np.empty(0, dtype=np.int64)
+        self._offsets: dict[str, np.ndarray] = {
+            n: np.zeros(1, dtype=np.int64) for n in self._digest_fields
+        }
+        self._arenas: dict[str, np.ndarray] = {
+            n: np.empty((0, 2), dtype=np.float32) for n in self._digest_fields
+        }
         self.n_obs_total = 0
         self.flushes = 0
         self._buffer: list = []
@@ -173,21 +217,84 @@ class StreamingAggregator:
 
         col_arrays, cell_to_slice, n_obs = _concat_and_group(self._buffer, self.grid, self.handoff)
         self.n_obs_total += n_obs
-        for cell, (start, end) in cell_to_slice.items():
-            self.counts[cell] = self.counts.get(cell, 0) + (end - start)
-            for name, (source, delta) in self._digest_fields.items():
-                fresh = build_tdigest(col_arrays[source][start:end], delta=delta)
-                held = self.digests[name].get(cell)
-                self.digests[name][cell] = (
-                    fresh if held is None else merge_tdigests(held, fresh, delta=delta)
-                )
+        if self.state_layout == "arena":
+            self._fold_arena(col_arrays, cell_to_slice)
+        else:
+            for cell, (start, end) in cell_to_slice.items():
+                self.counts[cell] = self.counts.get(cell, 0) + (end - start)
+                for name, (source, delta) in self._digest_fields.items():
+                    fresh = build_tdigest(col_arrays[source][start:end], delta=delta)
+                    held = self.digests[name].get(cell)
+                    self.digests[name][cell] = (
+                        fresh if held is None else merge_tdigests(held, fresh, delta=delta)
+                    )
         self.flushes += 1
         self._buffer = []
         self._buffered_granules = 0
 
+    def _fold_arena(self, col_arrays, cell_to_slice) -> None:
+        """Rebuild the CSR state with this flush's cells folded in.
+
+        Sizes are exact before allocation: fresh digests (and, for cells
+        already held, their merges) are built first, so the new arena is
+        allocated once at its final size and filled — untouched cells by a
+        vectorized element gather, touched cells by per-cell slice writes.
+        Transients are one buffer's digests plus the old arena, freed on
+        return; the steady state is pure ndarrays with no per-cell objects.
+        """
+        fresh_cells = np.fromiter(cell_to_slice, dtype=np.uint64, count=len(cell_to_slice))
+        order = np.argsort(fresh_cells)
+        fresh_cells = fresh_cells[order]
+        slices = list(cell_to_slice.values())
+        starts = np.array([slices[i][0] for i in order], dtype=np.int64)
+        ends = np.array([slices[i][1] for i in order], dtype=np.int64)
+
+        union = np.union1d(self._cells, fresh_cells)
+        pos_old = np.searchsorted(union, self._cells)
+        pos_fresh = np.searchsorted(union, fresh_cells)
+        overlap = np.isin(fresh_cells, self._cells, assume_unique=True)
+
+        new_counts = np.zeros(len(union), dtype=np.int64)
+        new_counts[pos_old] = self._cell_counts
+        np.add.at(new_counts, pos_fresh, ends - starts)
+
+        for name, (source, delta) in self._digest_fields.items():
+            offsets, arena = self._offsets[name], self._arenas[name]
+            k_old = np.diff(offsets)
+            # Fresh (and merged, for held cells) digests first — the same
+            # build/merge calls the dict layout makes — so every cell's final
+            # length is known before the single allocation below.
+            held_pos = np.searchsorted(self._cells, fresh_cells[overlap])
+            digests = []
+            for j in range(len(fresh_cells)):
+                d = build_tdigest(col_arrays[source][starts[j] : ends[j]], delta=delta)
+                digests.append(d)
+            for j, i_old in zip(np.nonzero(overlap)[0], held_pos, strict=True):
+                held = arena[offsets[i_old] : offsets[i_old + 1]]
+                digests[j] = merge_tdigests(held, digests[j], delta=delta)
+
+            k_new = np.zeros(len(union), dtype=np.int64)
+            k_new[pos_old] = k_old
+            k_new[pos_fresh] = [len(d) for d in digests]
+            new_offsets = np.concatenate(([0], np.cumsum(k_new)))
+            new_arena = np.empty((int(new_offsets[-1]), 2), dtype=np.float32)
+
+            keep = ~np.isin(self._cells, fresh_cells, assume_unique=True)
+            src = _ranges_to_indices(offsets[:-1][keep], k_old[keep])
+            dst = _ranges_to_indices(new_offsets[:-1][pos_old[keep]], k_old[keep])
+            new_arena[dst] = arena[src]
+            for j, i_union in enumerate(pos_fresh):
+                d = digests[j]
+                new_arena[new_offsets[i_union] : new_offsets[i_union] + len(d)] = d
+            self._offsets[name], self._arenas[name] = new_offsets, new_arena
+
+        self._cells, self._cell_counts = union, new_counts
+
     @property
     def empty(self) -> bool:
         """True when no observation ever survived filtering (mirror of no reads)."""
+        if self.state_layout == "arena":
+            return self._cells.size == 0 and not self._buffer
         return not self.counts and not self._buffer
 
     def chunk_outputs(self, children, agg_fields: dict):
@@ -210,6 +317,10 @@ class StreamingAggregator:
         ragged_payloads: dict[str, list] = {n: [] for n in self._digest_fields}
         ragged_cell_indices: dict[str, list[int]] = {n: [] for n in self._digest_fields}
 
+        if self.state_layout == "arena":
+            return self._chunk_outputs_arena(
+                children, stats_arrays, ragged_payloads, ragged_cell_indices
+            )
         cells_with_data = 0
         for i, child in enumerate(children):
             cell = int(child)
@@ -229,3 +340,26 @@ class StreamingAggregator:
                     ragged_payloads[name].append(digest)
                     ragged_cell_indices[name].append(i)
         return stats_arrays, ragged_payloads, ragged_cell_indices, cells_with_data
+
+    def _chunk_outputs_arena(self, children, stats_arrays, ragged_payloads, ragged_cell_indices):
+        """Arena-layout ``chunk_outputs``: vectorized lookup instead of dict gets.
+
+        Same emitted values as the dict branch — occupied cells carry their
+        count, empty cells 0 (the pooled ``len`` over an empty slice), digests
+        only where nonempty — via one ``searchsorted`` over the sorted cell ids.
+        """
+        cells = children.astype(np.uint64)
+        pos = np.searchsorted(self._cells, cells)
+        pos_c = np.minimum(pos, max(self._cells.size - 1, 0))
+        occupied = (self._cells[pos_c] == cells) if self._cells.size else np.zeros(len(cells), bool)
+        counts = np.where(occupied, self._cell_counts[pos_c], 0)
+        for name in self._count_fields:
+            stats_arrays[name][:] = counts.astype(stats_arrays[name].dtype)
+        for name in self._digest_fields:
+            offsets, arena = self._offsets[name], self._arenas[name]
+            for i in np.nonzero(occupied)[0]:
+                lo, hi = offsets[pos[i]], offsets[pos[i] + 1]
+                if hi > lo:
+                    ragged_payloads[name].append(arena[lo:hi])
+                    ragged_cell_indices[name].append(int(i))
+        return stats_arrays, ragged_payloads, ragged_cell_indices, int(occupied.sum())

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -72,11 +72,14 @@ def _ranges_to_indices(starts: np.ndarray, lengths: np.ndarray) -> np.ndarray:
 def get_streaming(config: PipelineConfig) -> dict | None:
     """Return the ``aggregation.streaming`` block, or ``None`` (pooled path).
 
-    The block is ``{"buffer_granules": int, "state_layout": "dict"|"arena"}``;
-    ``buffer_granules`` must be a positive int. ``state_layout`` (issue #217)
-    picks the running-state container: ``"dict"`` (default, per-cell ndarrays)
-    or ``"arena"`` (contiguous CSR buffers — same merge sequence, same bytes
-    out, ~24 B/cell overhead instead of ~290). Absent block -> ``None`` so
+    The block is ``{"buffer_granules": int, "state_layout": "dict"|"arena",
+    "arena_backing": "memory"|"tmp"}``; ``buffer_granules`` must be a positive
+    int. ``state_layout`` (issue #217) picks the running-state container:
+    ``"dict"`` (default, per-cell ndarrays) or ``"arena"`` (contiguous CSR
+    buffers — same merge sequence, same bytes out, ~24 B/cell overhead instead
+    of ~290). ``arena_backing: tmp`` (arena only) puts the centroid buffers in
+    unlinked ``/tmp``-backed memmaps so flush transients page under memory
+    pressure instead of OOM-killing the worker. Absent block -> ``None`` so
     existing configs are untouched.
     """
     block = config.aggregation.get("streaming")
@@ -95,7 +98,21 @@ def get_streaming(config: PipelineConfig) -> dict | None:
         raise ValueError(
             f"aggregation.streaming.state_layout must be 'dict' or 'arena' (got {state_layout!r})"
         )
-    return {"buffer_granules": buffer_granules, "state_layout": state_layout}
+    arena_backing = block.get("arena_backing", "memory")
+    if arena_backing not in ("memory", "tmp"):
+        raise ValueError(
+            f"aggregation.streaming.arena_backing must be 'memory' or 'tmp' (got {arena_backing!r})"
+        )
+    if arena_backing == "tmp" and state_layout != "arena":
+        raise ValueError(
+            "aggregation.streaming.arena_backing: tmp requires state_layout: arena "
+            "(the dict layout has no contiguous buffers to back with a file)"
+        )
+    return {
+        "buffer_granules": buffer_granules,
+        "state_layout": state_layout,
+        "arena_backing": arena_backing,
+    }
 
 
 def validate_streaming(config: PipelineConfig) -> None:
@@ -171,12 +188,14 @@ class StreamingAggregator:
         handoff: str,
         buffer_granules: int,
         state_layout: str = "dict",
+        arena_backing: str = "memory",
     ):
         validate_streaming(config)
         self.grid = grid
         self.handoff = handoff
         self.buffer_granules = buffer_granules
         self.state_layout = state_layout
+        self.arena_backing = arena_backing
         agg_fields = get_agg_fields(config)
         self._count_fields: list[str] = []
         self._digest_fields: dict[str, tuple[str, int]] = {}  # name -> (source, delta)
@@ -214,6 +233,31 @@ class StreamingAggregator:
         self.flushes = 0
         self._buffer: list = []
         self._buffered_granules = 0
+
+    def _alloc_arena(self, n_rows: int) -> np.ndarray:
+        """Allocate one centroid buffer: RAM, or a ``/tmp``-backed memmap.
+
+        Under ``arena_backing: tmp`` (issue #217, the spill/arena hybrid) the
+        buffer is an **anonymous** file mapping: the file is unlinked the
+        moment the mapping exists, so the mapping itself is the only
+        reference — space frees on GC and nothing can accumulate in ``/tmp``
+        across warm Lambda invokes. The payoff is failure mode: dirty pages
+        are file-backed page cache the kernel can write back and reclaim
+        under cgroup pressure, so an oversized flush transient degrades into
+        paging instead of an OOM kill of anonymous heap.
+        """
+        if self.arena_backing != "tmp" or n_rows == 0:
+            return np.empty((n_rows, 2), dtype=np.float32)
+        import os
+        import tempfile
+
+        fd, path = tempfile.mkstemp(suffix=".arena")
+        try:
+            mapped = np.memmap(path, dtype=np.float32, mode="w+", shape=(n_rows, 2))
+        finally:
+            os.close(fd)
+            os.unlink(path)
+        return mapped
 
     def add_read(self, chunk) -> None:
         """Buffer one group read (the carrier ``_read_group`` returned)."""
@@ -293,7 +337,7 @@ class StreamingAggregator:
             # ndarrays transiently costs more than the state itself).
             bound_fresh = np.minimum(ends - starts, cap)
             stage_off = np.concatenate(([0], np.cumsum(bound_fresh)))
-            stage = np.empty((int(stage_off[-1]), 2), dtype=np.float32)
+            stage = self._alloc_arena(int(stage_off[-1]))
             k_fresh = np.empty(len(fresh_cells), dtype=np.int64)
             for j in range(len(fresh_cells)):
                 d = build_tdigest(col_arrays[source][starts[j] : ends[j]], delta=delta)
@@ -311,7 +355,7 @@ class StreamingAggregator:
             k_bound[pos_fresh] = k_fresh
             k_bound[pos_fresh[ovl_idx]] = np.minimum(k_old[held_pos] + k_fresh[ovl_idx], cap)
             bound_off = np.concatenate(([0], np.cumsum(k_bound)))
-            bound_arena = np.empty((int(bound_off[-1]), 2), dtype=np.float32)
+            bound_arena = self._alloc_arena(int(bound_off[-1]))
             k_exact = k_bound.copy()
 
             src = _ranges_to_indices(offsets[:-1][keep], k_old[keep])
@@ -343,10 +387,15 @@ class StreamingAggregator:
             self._poisoned = name
 
             # Compact the bounded layout to exact CSR in one vectorized gather
-            # (merge compression leaves slack only inside merged slots).
+            # (merge compression leaves slack only inside merged slots). The
+            # gather lands directly in a fresh factory buffer (``out=``) so
+            # the compacted state inherits the configured backing instead of
+            # fancy-indexing into an anonymous RAM copy.
             new_offsets = np.concatenate(([0], np.cumsum(k_exact)))
             src = _ranges_to_indices(bound_off[:-1], k_exact)
-            self._offsets[name], self._arenas[name] = new_offsets, bound_arena[src]
+            new_arena = self._alloc_arena(int(new_offsets[-1]))
+            np.take(bound_arena, src, axis=0, out=new_arena)
+            self._offsets[name], self._arenas[name] = new_offsets, new_arena
             self._poisoned = None
 
         self._cells, self._cell_counts = union, new_counts

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -44,9 +44,12 @@ _TDIGEST_FUNCTION = "zagg.stats.tdigest.build_tdigest"
 
 
 #: Safe per-cell slot bound for staged tdigest builds/merges, as a multiple of
-#: the field's delta: the k-1 compression law lands at <= ~1.13*delta centroids
-#: (measured: 289 max at delta=256, 578 at delta=512), so 2*delta never
-#: truncates; asserted at every staged write.
+#: the field's delta. On heavy-tailed adversarial inputs (Cauchy/Pareto) the
+#: k-1 compression law peaks near ~1.55*delta centroids (measured: 388 at
+#: delta=256, 776 at delta=512, 1544 at delta=1024) — well above the ~1.13*delta
+#: seen on well-behaved data — so keep the factor at 2: 2*delta clears that
+#: worst case and never truncates; asserted at every staged write. Do not
+#: tighten below the ~1.55*delta adversarial bound.
 _K_SLOT_FACTOR = 2
 
 #: Shared zero-size arena so releasing a field's old buffer needs no allocation.

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -297,6 +297,17 @@ class StreamingAggregator:
             return self._cells.size == 0 and not self._buffer
         return not self.counts and not self._buffer
 
+    def occupied_cells(self) -> np.ndarray:
+        """Populated cell words as a ``uint64`` array (issue #200 coverage sink).
+
+        Layout-agnostic: the dict layout keys ``self.counts``, the arena layout
+        holds the sorted ids in ``self._cells``. Read after the final flush, so
+        both mirror the merged running state.
+        """
+        if self.state_layout == "arena":
+            return self._cells
+        return np.fromiter(self.counts.keys(), dtype=np.uint64, count=len(self.counts))
+
     def chunk_outputs(self, children, agg_fields: dict):
         """Emit one chunk's aggregation outputs from the running state.
 

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -572,12 +572,17 @@ def process_shard(
         col = col_arrays[time_range_of]
         metadata["time_range"] = [float(col.min()), float(col.max())]
 
-    # Occupied-cell sink (issue #200): both paths already key per-cell state by
-    # the packed cell word — ``cell_to_slice`` pooled, ``buffered.counts``
-    # merged — so the occupied set is in hand with no extra observation pass.
+    # Occupied-cell sink (issue #200): both paths already hold the shard's
+    # populated cell words — ``cell_to_slice`` pooled, the streaming running
+    # state merged (dict counts or arena cell ids, via ``occupied_cells``) — so
+    # the occupied set is in hand with no extra observation pass.
     if occupied_out is not None:
-        cells = buffered.counts if buffered is not None else cell_to_slice
-        occupied_out.append(np.fromiter(cells.keys(), dtype=np.uint64, count=len(cells)))
+        if buffered is not None:
+            occupied_out.append(buffered.occupied_cells())
+        else:
+            occupied_out.append(
+                np.fromiter(cell_to_slice.keys(), dtype=np.uint64, count=len(cell_to_slice))
+            )
 
     if profile:
         phase_timings["index"] = time.time() - _index_t0

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -314,7 +314,13 @@ def process_shard(
 
     streaming_cfg = get_streaming(config)
     buffered = (
-        StreamingAggregator(config, grid, handoff, streaming_cfg["buffer_granules"])
+        StreamingAggregator(
+            config,
+            grid,
+            handoff,
+            streaming_cfg["buffer_granules"],
+            state_layout=streaming_cfg["state_layout"],
+        )
         if streaming_cfg is not None
         else None
     )

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -320,6 +320,7 @@ def process_shard(
             handoff,
             streaming_cfg["buffer_granules"],
             state_layout=streaming_cfg["state_layout"],
+            arena_backing=streaming_cfg["arena_backing"],
         )
         if streaming_cfg is not None
         else None

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -69,24 +69,40 @@ class TestStreamingConfig:
         assert get_streaming(_config(streaming={})) == {
             "buffer_granules": 50,
             "state_layout": "dict",
+            "arena_backing": "memory",
         }
 
     def test_explicit_buffer(self):
         assert get_streaming(_config(streaming={"buffer_granules": 7})) == {
             "buffer_granules": 7,
             "state_layout": "dict",
+            "arena_backing": "memory",
         }
 
     def test_arena_layout_accepted(self):
         assert get_streaming(_config(streaming={"state_layout": "arena"})) == {
             "buffer_granules": 50,
             "state_layout": "arena",
+            "arena_backing": "memory",
         }
+
+    def test_arena_tmp_backing_accepted(self):
+        block = {"state_layout": "arena", "arena_backing": "tmp"}
+        assert get_streaming(_config(streaming=block))["arena_backing"] == "tmp"
 
     @pytest.mark.parametrize("bad", ["csr", 1, None])
     def test_bad_state_layout_raises(self, bad):
         with pytest.raises(ValueError, match="state_layout"):
             get_streaming(_config(streaming={"state_layout": bad}))
+
+    @pytest.mark.parametrize("bad", ["disk", 1, None])
+    def test_bad_arena_backing_raises(self, bad):
+        with pytest.raises(ValueError, match="arena_backing"):
+            get_streaming(_config(streaming={"state_layout": "arena", "arena_backing": bad}))
+
+    def test_tmp_backing_requires_arena(self):
+        with pytest.raises(ValueError, match="requires state_layout: arena"):
+            get_streaming(_config(streaming={"arena_backing": "tmp"}))
 
     @pytest.mark.parametrize("bad", [0, -1, "50", 2.5])
     def test_bad_buffer_raises(self, bad):
@@ -464,6 +480,69 @@ class TestArenaLayout:
         out = _ranges_to_indices(np.array([5, 20, 3]), np.array([2, 0, 3]))
         np.testing.assert_array_equal(out, [5, 6, 3, 4, 5])
         assert _ranges_to_indices(np.array([], dtype=int), np.array([], dtype=int)).size == 0
+
+
+class TestArenaTmpBacking:
+    """arena_backing: tmp (issue #217) — unlinked /tmp memmaps, same bytes out."""
+
+    def test_matches_memory_backed_arena(self, monkeypatch):
+        # Identical allocation contents through the same fold sequence — only
+        # the buffer's backing differs, so output equality must be exact.
+        key = _shard_key()
+        results = []
+        for backing in ("memory", "tmp"):
+            cfg = _config(
+                streaming={
+                    "buffer_granules": 1,
+                    "state_layout": "arena",
+                    "arena_backing": backing,
+                },
+                delta=256,
+            )
+            cfg.data_source["shard_workers"] = 1
+            grid = _grid(cfg)
+            dfs = _granule_dfs_cells(grid, key, [[0, 4, 8], [2, 4, 10], [1, 8, 9]], seed=7)
+            results.append(_run(monkeypatch, cfg, grid, key, dfs))
+        (df_m, ragged_m, meta_m), (df_t, ragged_t, meta_t) = results
+        pd.testing.assert_frame_equal(df_m, df_t)
+        assert meta_m["cells_with_data"] == meta_t["cells_with_data"]
+        vals_m, idx_m = ragged_m["h_tdigest"]
+        vals_t, idx_t = ragged_t["h_tdigest"]
+        assert idx_m == idx_t
+        for x, y in zip(vals_m, vals_t, strict=True):
+            np.testing.assert_array_equal(x, y)
+
+    def test_state_lives_on_memmap_and_leaves_no_files(self, tmp_path, monkeypatch):
+        # The steady arena must actually be a memmap (the backing is doing
+        # something), and the anonymous-mapping trick must leave zero files
+        # behind — /tmp persists across warm Lambda invokes, so any leak
+        # accumulates until the function dies.
+        import tempfile
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        cfg = _config(
+            streaming={"buffer_granules": 2, "state_layout": "arena", "arena_backing": "tmp"}
+        )
+        agg = StreamingAggregator(
+            cfg, _grid(cfg), "pandas", 2, state_layout="arena", arena_backing="tmp"
+        )
+        key = _shard_key()
+        for df in _granule_dfs(_grid(cfg), key, n_granules=3):
+            agg.add_read(df)
+            agg.granule_done()
+        agg.flush()
+        assert isinstance(agg._arenas["h_tdigest"], np.memmap)
+        assert list(tmp_path.iterdir()) == []
+
+    def test_memory_backing_stays_plain_ndarray(self):
+        cfg = _config(streaming={"buffer_granules": 2, "state_layout": "arena"})
+        agg = StreamingAggregator(cfg, _grid(cfg), "pandas", 2, state_layout="arena")
+        key = _shard_key()
+        for df in _granule_dfs(_grid(cfg), key, n_granules=2):
+            agg.add_read(df)
+            agg.granule_done()
+        agg.flush()
+        assert not isinstance(agg._arenas["h_tdigest"], np.memmap)
 
 
 class TestStreamingReviewFolds:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -485,6 +485,32 @@ class TestStreamingReviewFolds:
         cfg.aggregation["variables"]["count"]["function"] = "count"
         validate_streaming(cfg)
 
+    def test_poisoned_arena_state_raises_loudly(self):
+        # A compaction that fails mid-rebuild releases the field's arena but
+        # leaves its offsets stale; a later chunk_outputs must raise, not
+        # silently emit no digests (issue #217 fold).
+        from zagg.config import get_agg_fields
+
+        cfg = _config(streaming={"buffer_granules": 1, "state_layout": "arena"})
+        grid = _grid(cfg)
+        key = _shard_key()
+        agg = StreamingAggregator(cfg, grid, "pandas", 1, state_layout="arena")
+        children = grid.children(key)
+        cells = np.array([int(children[0]), int(children[1])], dtype=np.uint64)
+        agg.add_read(
+            pd.DataFrame(
+                {
+                    "h_ph": np.arange(20, dtype=np.float32),
+                    "leaf_id": np.repeat(cells, 10),
+                }
+            )
+        )
+        agg.flush()
+        assert agg._cells.size == 2  # state populated, so a read would emit digests
+        agg._poisoned = "h_tdigest"
+        with pytest.raises(RuntimeError, match="failed compaction"):
+            agg.chunk_outputs(children, get_agg_fields(cfg))
+
     def test_profile_charges_merge_to_read_phase(self, monkeypatch):
         # All flush cost (intermediate AND tail) is deliberately charged to
         # the ``read`` phase; the stamp lands after the tail flush.

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -66,10 +66,27 @@ class TestStreamingConfig:
         assert get_streaming(_config()) is None
 
     def test_block_defaults_buffer(self):
-        assert get_streaming(_config(streaming={})) == {"buffer_granules": 50}
+        assert get_streaming(_config(streaming={})) == {
+            "buffer_granules": 50,
+            "state_layout": "dict",
+        }
 
     def test_explicit_buffer(self):
-        assert get_streaming(_config(streaming={"buffer_granules": 7})) == {"buffer_granules": 7}
+        assert get_streaming(_config(streaming={"buffer_granules": 7})) == {
+            "buffer_granules": 7,
+            "state_layout": "dict",
+        }
+
+    def test_arena_layout_accepted(self):
+        assert get_streaming(_config(streaming={"state_layout": "arena"})) == {
+            "buffer_granules": 50,
+            "state_layout": "arena",
+        }
+
+    @pytest.mark.parametrize("bad", ["csr", 1, None])
+    def test_bad_state_layout_raises(self, bad):
+        with pytest.raises(ValueError, match="state_layout"):
+            get_streaming(_config(streaming={"state_layout": bad}))
 
     @pytest.mark.parametrize("bad", [0, -1, "50", 2.5])
     def test_bad_buffer_raises(self, bad):
@@ -293,6 +310,124 @@ class TestStreamingWorker:
         monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
         with pytest.raises(ValueError, match="not streamable"):
             process_shard(grid, key, ["s3://b/g0.h5"], s3_credentials=_CREDS, config=cfg)
+
+
+def _granule_dfs_cells(grid, shard_key, cell_idx_lists, obs_per_cell=50, seed=0, nan_cells=()):
+    """One DataFrame per granule over caller-chosen child-cell indices.
+
+    Unlike ``_granule_dfs`` (fixed three cells), each granule can hit a
+    different cell subset — exercising the arena rebuild's insert / merge /
+    keep paths. Cells in ``nan_cells`` get all-NaN heights (an empty digest
+    but a nonzero count).
+    """
+    rng = np.random.default_rng(seed)
+    children = grid.children(shard_key)
+    dfs = []
+    for idxs in cell_idx_lists:
+        leaf, h = [], []
+        for ci in idxs:
+            leaf.extend([int(children[ci])] * obs_per_cell)
+            vals = rng.normal(0.0, 10.0, obs_per_cell)
+            h.extend([np.nan] * obs_per_cell if ci in nan_cells else vals)
+        dfs.append(
+            pd.DataFrame(
+                {
+                    "h_ph": np.array(h, dtype=np.float32),
+                    "leaf_id": np.array(leaf, dtype=np.uint64),
+                }
+            )
+        )
+    return dfs
+
+
+class TestArenaLayout:
+    """state_layout: arena (issue #217) — same bytes out, different container."""
+
+    def _ab(self, monkeypatch, dfs_fn, buffer_granules, delta=256):
+        key = _shard_key()
+        results = []
+        for layout in ("dict", "arena"):
+            cfg = _config(
+                streaming={"buffer_granules": buffer_granules, "state_layout": layout},
+                delta=delta,
+            )
+            grid = _grid(cfg)
+            results.append(_run(monkeypatch, cfg, grid, key, dfs_fn(grid, key)))
+        return results
+
+    def _assert_identical(self, a, b):
+        df_a, ragged_a, meta_a = a
+        df_b, ragged_b, meta_b = b
+        pd.testing.assert_frame_equal(df_a, df_b)
+        assert meta_a["total_obs"] == meta_b["total_obs"]
+        assert meta_a["cells_with_data"] == meta_b["cells_with_data"]
+        vals_a, idx_a = ragged_a["h_tdigest"]
+        vals_b, idx_b = ragged_b["h_tdigest"]
+        assert idx_a == idx_b
+        for x, y in zip(vals_a, vals_b, strict=True):
+            np.testing.assert_array_equal(x, y)
+
+    def test_matches_dict_multi_flush_overlapping_cells(self, monkeypatch):
+        # Same merge sequence => byte-identical output; 7 granules at buffer 2
+        # is 4 flushes over the same three cells (merge path every flush).
+        dict_out, arena_out = self._ab(
+            monkeypatch,
+            lambda g, k: _granule_dfs(g, k, n_granules=7, obs_per_cell=200, seed=3),
+            buffer_granules=2,
+        )
+        self._assert_identical(dict_out, arena_out)
+
+    def test_matches_dict_disjoint_and_inserted_cells(self, monkeypatch):
+        # Per-granule flushes where later flushes insert cells between held
+        # ones and partially overlap them: exercises the rebuild's insert,
+        # merge, and vectorized keep-gather paths together.
+        cell_lists = [[0, 4, 8], [2, 4, 10], [1, 8, 9], [0, 10, 15]]
+        dict_out, arena_out = self._ab(
+            monkeypatch,
+            lambda g, k: _granule_dfs_cells(g, k, cell_lists, seed=7),
+            buffer_granules=1,
+        )
+        self._assert_identical(dict_out, arena_out)
+
+    def test_matches_dict_with_all_nan_cell(self, monkeypatch):
+        # An all-NaN cell holds a zero-length digest (k=0) but a real count —
+        # the arena must keep the empty range through rebuilds and omit it
+        # from the ragged payloads exactly like the dict layout.
+        cell_lists = [[0, 3], [0, 3], [3, 5]]
+        dict_out, arena_out = self._ab(
+            monkeypatch,
+            lambda g, k: _granule_dfs_cells(g, k, cell_lists, seed=11, nan_cells={3}),
+            buffer_granules=1,
+        )
+        self._assert_identical(dict_out, arena_out)
+        df, ragged, _ = arena_out
+        # cell 3 counted but digest-less: counts exact, one fewer payload.
+        vals, idx = ragged["h_tdigest"]
+        assert len(vals) == df["count"].astype(bool).sum() - 1
+
+    def test_single_buffer_byte_identical_to_pooled(self, monkeypatch):
+        # One flush == one pooled build — exact, same as the dict layout.
+        key = _shard_key()
+        pooled_cfg = _config()
+        arena_cfg = _config(streaming={"buffer_granules": 10, "state_layout": "arena"})
+        dfs = _granule_dfs(_grid(pooled_cfg), key, n_granules=4)
+        pooled = _run(monkeypatch, pooled_cfg, _grid(pooled_cfg), key, list(dfs))
+        arena = _run(monkeypatch, arena_cfg, _grid(arena_cfg), key, list(dfs))
+        self._assert_identical(pooled, arena)
+
+    def test_empty_property(self):
+        cfg = _config(streaming={"buffer_granules": 2, "state_layout": "arena"})
+        agg = StreamingAggregator(cfg, _grid(cfg), "pandas", 2, state_layout="arena")
+        assert agg.empty
+        agg.add_read(pd.DataFrame({"h_ph": [1.0], "leaf_id": np.array([1], dtype="uint64")}))
+        assert not agg.empty
+
+    def test_ranges_to_indices(self):
+        from zagg.processing.streaming import _ranges_to_indices
+
+        out = _ranges_to_indices(np.array([5, 20, 3]), np.array([2, 0, 3]))
+        np.testing.assert_array_equal(out, [5, 6, 3, 4, 5])
+        assert _ranges_to_indices(np.array([], dtype=int), np.array([], dtype=int)).size == 0
 
 
 class TestStreamingReviewFolds:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -415,6 +415,36 @@ class TestArenaLayout:
         arena = _run(monkeypatch, arena_cfg, _grid(arena_cfg), key, list(dfs))
         self._assert_identical(pooled, arena)
 
+    def test_occupied_out_fed_under_arena(self, monkeypatch):
+        # Regression (issue #217): the occupied-cell sink (issue #200, feeds the
+        # coverage/MOC stamp) must be populated under arena layout, not just
+        # dict — the arena keeps state in _cells, never touching self.counts.
+        key = _shard_key()
+        cell_lists = [[0, 4, 8], [2, 4, 10], [1, 8, 9]]
+        occ = {}
+        for layout in ("dict", "arena"):
+            cfg = _config(
+                streaming={"buffer_granules": 1, "state_layout": layout},
+            )
+            grid = _grid(cfg)
+            dfs = _granule_dfs_cells(grid, key, cell_lists, seed=5)
+            reads = iter(dfs)
+            monkeypatch.setattr("zagg.processing._read_group", lambda *a, **k: next(reads))
+            monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
+            monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+            sink: list = []
+            process_shard(
+                grid,
+                key,
+                [f"s3://b/g{i}.h5" for i in range(len(dfs))],
+                s3_credentials=_CREDS,
+                config=cfg,
+                occupied_out=sink,
+            )
+            occ[layout] = np.concatenate(sink) if sink else np.empty(0, dtype=np.uint64)
+        assert occ["arena"].size > 0
+        np.testing.assert_array_equal(np.sort(occ["arena"]), np.sort(occ["dict"]))
+
     def test_empty_property(self):
         cfg = _config(streaming={"buffer_granules": 2, "state_layout": "arena"})
         agg = StreamingAggregator(cfg, _grid(cfg), "pandas", 2, state_layout="arena")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -155,6 +155,55 @@ class TestStreamingConfig:
             validate_streaming(cfg)
 
 
+# --- arena tmp allocation ----------------------------------------------------
+
+
+class TestArenaTmpAlloc:
+    def _agg(self, cfg):
+        return StreamingAggregator(
+            cfg,
+            _grid(cfg),
+            "pandas",
+            50,
+            state_layout="arena",
+            arena_backing="tmp",
+        )
+
+    def test_alloc_raises_when_tmp_too_small(self, monkeypatch):
+        import os as _os
+
+        cfg = _config(streaming={"state_layout": "arena", "arena_backing": "tmp"})
+        agg = self._agg(cfg)
+        real = _os.statvfs(".")
+
+        class _Tiny:
+            f_bavail = 1
+            f_frsize = real.f_frsize
+
+        monkeypatch.setattr(_os, "statvfs", lambda _p: _Tiny())
+        with pytest.raises(RuntimeError, match="ephemeral"):
+            agg._alloc_arena(100_000)
+
+    def test_alloc_happy_path_allocates(self):
+        cfg = _config(streaming={"state_layout": "arena", "arena_backing": "tmp"})
+        agg = self._agg(cfg)
+        buf = agg._alloc_arena(16)
+        assert buf.shape == (16, 2)
+        assert buf.dtype == np.float32
+
+    def test_alloc_zero_rows_skips_statvfs(self, monkeypatch):
+        import os as _os
+
+        cfg = _config(streaming={"state_layout": "arena", "arena_backing": "tmp"})
+        agg = self._agg(cfg)
+
+        def _boom(_p):
+            raise AssertionError("statvfs should not run for an empty buffer")
+
+        monkeypatch.setattr(_os, "statvfs", _boom)
+        assert agg._alloc_arena(0).shape == (0, 2)
+
+
 # --- worker integration ------------------------------------------------------
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -351,6 +351,12 @@ class TestArenaLayout:
                 streaming={"buffer_granules": buffer_granules, "state_layout": layout},
                 delta=delta,
             )
+            # Serial reads: the granule pool (default 4) drains the fake-read
+            # iterator from worker threads, so which granule gets which frame
+            # is scheduling-dependent — buffer composition then varies run to
+            # run, and cross-buffer merge_tdigests is not associative. Byte
+            # equality between two separate runs needs a pinned composition.
+            cfg.data_source["shard_workers"] = 1
             grid = _grid(cfg)
             results.append(_run(monkeypatch, cfg, grid, key, dfs_fn(grid, key)))
         return results


### PR DESCRIPTION
Refs #217 (chunk-scoped digest streaming — option (C), arena state layout).

## What

Adds an opt-in `aggregation.streaming.state_layout: arena` that holds the `StreamingAggregator` running state as contiguous CSR buffers — one sorted `cell_ids` array, a parallel counts array, and per digest field one packed `(k, 2)` float32 centroid buffer addressed by offsets — instead of the current dicts of per-cell ndarrays (`counts` + `digests`, [streaming.py:150-151 pre-change](https://github.com/englacial/zagg/blob/b3fe71e/src/zagg/processing/streaming.py#L150-L151)). Default `dict` is byte-untouched.

**Why**: the dict layout pays a measured ~290 B/cell fixed tax (dict slots + boxed keys + ndarray headers) on top of the centroid payload — 302 MB of the 861 MB digest state on the 120-granule CONUS o8 plateau shard ([measured decomposition](https://github.com/englacial/zagg/issues/217#issuecomment-5006544129)). The arena replaces that with ~24 B/cell.

**How the fold stays identical**: `_fold_arena` makes the *same* `build_tdigest`/`merge_tdigests` calls in the same per-cell order as the dict branch, then rebuilds the CSR state at its exact final size (sizes are known before allocation because the merged digests are built first). Untouched cells move via a vectorized element gather (`_ranges_to_indices`); touched cells are written per-cell. Output is therefore byte-identical to the dict layout — asserted by the A/B tests — and the transients (one buffer's fresh digests + the old arena) are freed on return.

`chunk_outputs` under the arena is a single `searchsorted` + vectorized dense fill (the dict branch loops all children per chunk).

## Phases

- [x] Arena layout: config knob + validation, `_fold_arena` rebuild, vectorized `chunk_outputs`, tests (A/B byte-equality vs dict across multi-flush merges, cell insertion, all-NaN cells; pooled equivalence at single buffer; helper unit tests)
- [x] A/B memory/runtime replay of the pinned-shard distributions through both layouts — [verdict posted on #217](https://github.com/englacial/zagg/issues/217#issuecomment-5007662673): steady state −28% (605 vs 836 MB, matching the analytic model), but the rebuild-per-flush transient peaks ~2× the dict layout (3,254 vs 1,722 MB traced) — a net loss on the OOM-relevant metric as-is. The open fork (fleet A/B for glibc fragmentation vs in-place-slot iteration vs park) is on the issue.
- [x] `arena_backing: tmp` (per espg direction on the session thread): the three `_fold_arena` centroid buffers (staging, bounded merge target, compacted state) allocate as **unlinked `/tmp`-backed memmaps** — the file is deleted the instant the mapping exists, so nothing can leak across warm invokes, and the flush transient becomes file-backed page cache the kernel can write back and evict under cgroup pressure instead of OOM-killing anonymous heap. Opt-in (`arena_backing: memory` default), arena-only (validated), byte-identical output (tested). Fleet plan per espg: merge as a **merge commit** (easy revert), then A/B on the fleet with tmp backing on/off across a regular shard and the 148/155 g difficult shards.

## Testing

`uv run pytest tests/test_streaming.py -v` — 34 passed (7 new arena tests). `ruff check` / `ruff format --check` clean on the touched files.

## Questions for review

- The knob is deliberately temporary A/B surface: if the replay confirms the arena and espg adopts it, `state_layout` should collapse (arena becomes the only layout) per the #238-style knob-collapse direction rather than shipping two containers indefinitely.
- A `/tmp`-memmap-backed arena (the (A)+(C) hybrid discussed on #217) would be a follow-up on top of this: the arena allocation site is the single place a `np.memmap` would slot in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


