### PR TITLE
Raster template behind the sync setup invoke (issue #264)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -679,8 +679,19 @@ def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
         if (config.data_source or {}).get("reader") == "raster":
             import numpy as np
 
+            from zagg.config import get_layout
             from zagg.processing.raster import emit_raster_template
 
+            if get_layout(config) == "dense":
+                # Symmetry with the worker (_handle_process_raster): dense keys
+                # blocks by populated-shard position, unreconstructable from an
+                # invoke-only setup event, so from_config below would raise an
+                # opaque RuntimeError -> 500. Reject it with the worker's clean
+                # 400 instead. RasterStrategy.run rejects dense pre-dispatch too
+                # (runner.py), so this is defense-in-depth (issue #264).
+                error_msg = "raster lambda workers require output.grid.layout: fullsphere"
+                logger.error(error_msg)
+                return {"statusCode": 400, "body": json.dumps({"error": error_msg})}
             store = open_store(event["store_path"], **_output_store_kwargs(event))
             grid = from_config(config)
             times_us = np.asarray(event["times_us"], dtype=np.int64)

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -45,7 +45,9 @@ hive-layout config -- output.store_layout: hive, issue #199 -- it writes the
 morton_hive.json manifest instead, and each process-mode worker emits its own
 leaf template. Current dispatchers send hive setup as a fire-and-forget Event
 invoke right after the ping -- the primary manifest write, issue #252 hybrid
--- and older synchronous dispatchers keep working against this function):
+-- and older synchronous dispatchers keep working against this function. For
+a raster-pipeline config -- data_source.reader: raster, issue #264 -- it
+writes the raster (time, cells) template instead, from a synchronous invoke):
 {
     "mode": "setup",
     "store_path": str,
@@ -57,6 +59,10 @@ invoke right after the ping -- the primary manifest write, issue #252 hybrid
     "dataset": dict (optional, hive only) -- {"short_name", "version"} identity
         block for the manifest, sourced from the ShardMap metadata by the
         orchestrator (matching the local dispatcher). Absent on flat runs.
+    "times_us": [int, ...] (raster only, issue #264) -- the catalog-derived
+        time coordinate, int64 microseconds since the epoch; the orchestrator
+        owns the global timestep index and threads it here so the template
+        write needs no S3 access from the dispatcher.
     "output_credentials": dict (optional, same shape as process mode),
 }
 
@@ -639,6 +645,16 @@ def _handle_extract(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
     """Create the zarr template at ``event['store_path']``.
 
+    For a raster-pipeline config (``data_source.reader: raster``, issue #264)
+    this writes the ``(time, cells)`` raster template + its ``time``
+    coordinate via ``emit_raster_template`` — the orchestrator dispatches it
+    as a synchronous setup invoke before fan-out (the template is
+    load-bearing: workers write slabs into its arrays), so an invoke-only
+    dispatcher (the CI OIDC role) never needs S3 write access. ``times_us``
+    (the catalog-derived int64 time coordinate) rides in the event; the
+    success body echoes ``"pipeline": "raster"`` so the dispatcher can refuse
+    a stale deployment that fell through to the point-path template below.
+
     For a hive-layout config (issue #199 phase 3) template time writes ONLY
     the ``morton_hive.json`` manifest — no global zarr template exists (zero
     metadata above the leaves, D5); each worker emits its own leaf template.
@@ -660,6 +676,28 @@ def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
     logger.info(f"Setup mode: creating template at {event.get('store_path')}")
     try:
         config = load_config_from_dict(event["config"])
+        if (config.data_source or {}).get("reader") == "raster":
+            import numpy as np
+
+            from zagg.processing.raster import emit_raster_template
+
+            store = open_store(event["store_path"], **_output_store_kwargs(event))
+            grid = from_config(config)
+            times_us = np.asarray(event["times_us"], dtype=np.int64)
+            emit_raster_template(
+                store, grid, config, times_us, overwrite=event.get("overwrite", False)
+            )
+            return {
+                "statusCode": 200,
+                "body": json.dumps(
+                    {
+                        "ok": True,
+                        "mode": "setup",
+                        "pipeline": "raster",
+                        "timesteps": int(times_us.size),
+                    }
+                ),
+            }
         if get_store_layout(config) == "hive":
             from zagg.config import get_windowing
             from zagg.hive import build_manifest, ensure_manifest

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -684,6 +684,14 @@ def _handle_setup(event: Dict[str, Any]) -> Dict[str, Any]:
             store = open_store(event["store_path"], **_output_store_kwargs(event))
             grid = from_config(config)
             times_us = np.asarray(event["times_us"], dtype=np.int64)
+            if times_us.size == 0:
+                # A zero-timestep template is degenerate: the arrays get a
+                # 0-length time axis no worker can slab-write into.
+                # RasterStrategy.run refuses an empty catalog before it would
+                # dispatch (runner.py); guard the load-bearing invoke-only
+                # writer too, so a hand-rolled or drifted event can't write an
+                # unusable success-shaped store (issue #264).
+                raise ValueError("raster setup received empty times_us (no timesteps to template)")
             emit_raster_template(
                 store, grid, config, times_us, overwrite=event.get("overwrite", False)
             )

--- a/docs/deployment/benchmark.md
+++ b/docs/deployment/benchmark.md
@@ -33,7 +33,14 @@ Two release legs (`lambda-benchmark-fullaoi.yml`, tag-triggered):
   (`run_raster_benchmark.py`) dispatches through `agg(profile=True)` — the
   runner's raster path threads the profile key to the workers and rolls their
   stage timings, billed durations and peak RSS into the summary — and retains
-  its own `raster_series.parquet`. Two deviations from the target end-state,
+  its own `raster_series.parquet`. The dispatch is invoke-only end to end
+  (issue #264): after the issue #252 preflight ping, the `(time, cells)`
+  template is written by a synchronous `mode="setup"` Lambda invoke before
+  fan-out — recorded as `template_s`, the raster analogue of the point path's
+  `setup_s` — so the leg runs cleanly under the `zagg-benchmark` OIDC role's
+  no-S3 grant (the "template write happens inside the Lambda" invariant in
+  [Lambda benchmark CI/CD setup](benchmark-cicd.md) now holds for both legs).
+  Two deviations from the target end-state,
   pending upstream: **hive is gated, not absent** — the manifest carries a
   `pending_targets` hive variant the harness can already dispatch (a
   `store_layout` override + re-validate), promoted to live the moment issue

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -818,12 +818,29 @@ def emit_raster_template(store, grid, config, times_us: np.ndarray, *, overwrite
     """Write the raster template and its ``time`` coordinate values."""
     from zarr import config as zarr_config
     from zarr import open_array
+    from zarr.errors import ArrayNotFoundError, ContainsGroupError
 
+    times_us = np.asarray(times_us, dtype=np.int64)
     spec = raster_group_spec(grid, config, int(len(times_us)))
+    time_path = f"{grid.group_path}/time"
     with zarr_config.set({"async.concurrency": 128}):
+        if not overwrite:
+            # ``to_zarr(overwrite=False)`` only refuses a template whose SPEC
+            # differs (a changed timestep COUNT -> different ``time`` shape ->
+            # ContainsGroupError). A store already holding a same-length but
+            # different-valued time axis slips past it, and the unconditional
+            # ``arr[:]`` below would silently rewrite the coordinate the
+            # workers slab-write against. Refuse that too, so overwrite=False
+            # uniformly won't clobber a differing template (issue #264).
+            try:
+                existing = open_array(store, path=time_path, zarr_format=3, consolidated=False)
+            except ArrayNotFoundError:
+                existing = None
+            if existing is not None and not np.array_equal(existing[:], times_us):
+                raise ContainsGroupError(store, grid.group_path)
         spec.to_zarr(store, grid.group_path, overwrite=overwrite)
-        arr = open_array(store, path=f"{grid.group_path}/time", zarr_format=3, consolidated=False)
-        arr[:] = np.asarray(times_us, dtype=np.int64)
+        arr = open_array(store, path=time_path, zarr_format=3, consolidated=False)
+        arr[:] = times_us
     return store
 
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3278,7 +3278,17 @@ def _invoke_lambda_raster_setup(
         raise RuntimeError(f"Lambda raster setup failed: {payload}")
     result = json.loads(payload)
     if result.get("statusCode") != 200:
-        raise RuntimeError(f"Lambda raster setup error: {result.get('body')}")
+        # A pre-#264 function reaches the flat branch and calls
+        # grid.emit_template on the raster config, which can raise (a raster
+        # template has no point-path shape) → 500. A 500 is indistinguishable
+        # from a genuine failure here, so surface the redeploy hint alongside
+        # the body rather than swallowing the stale-deployment case.
+        raise RuntimeError(
+            f"Lambda raster setup error: {result.get('body')} — if this is a "
+            f"pre-#264 deployment, its flat point-path branch may have raised "
+            f"on the raster config; redeploy the function, then rerun with "
+            f"overwrite to replace anything it wrote"
+        )
     try:
         body = json.loads(result.get("body") or "{}")
     except (TypeError, ValueError):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3264,6 +3264,11 @@ def _invoke_lambda_raster_setup(
         "store_path": store_path,
         "overwrite": overwrite,
         "config": config_dict,
+        # times_us rides inline in this sync RequestResponse payload (6 MB
+        # cap, not the 256 KB async/Event cap); int64 μs stamps serialize at
+        # ~17 B each → ~350K-timestep headroom, orders above any real catalog
+        # (the pinned NEON benchmark catalog is 85 items). No chunking
+        # fallback — a pathological series would surface as a boto ClientError.
         "times_us": [int(t) for t in times_us],
     }
     if output_creds_event is not None:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -633,8 +633,11 @@ class RasterStrategy:
     simple transport: synchronous invokes with transient-only retries; the
     issue-151 async result-object channel and the preflight concurrency probe
     are follow-ups (raster shards are seconds of COG windows, well inside NAT
-    idle limits). Either way the runner owns the template + global time index
-    before fan-out (the single-writer append design).
+    idle limits). Either way the runner owns the global time index before
+    fan-out (the single-writer append design); the template write is
+    orchestrator-side on the local backend but rides the sync setup invoke on
+    lambda (issue #264 — the dispatcher may hold an invoke-only role with no
+    S3 write access, e.g. the CI OIDC benchmark role).
 
     Summary schema note: ``total_obs`` is shared with the spatial/temporal
     strategies so a caller sees one summary shape across pipeline kinds. On the
@@ -716,26 +719,19 @@ class RasterStrategy:
             raise ValueError("catalog carries no raster granule entries (no assets/datetime)")
 
         resolved_endpoint = output_endpoint_url or get_output_endpoint_url(config)
-        zarr_store = open_store(
-            store_path,
-            region=region,
-            credentials=output_credentials,
-            endpoint_url=resolved_endpoint,
-        )
-        # Template emission is orchestrator-owned; time it (always-on, the
-        # issue #180 bracket convention) so the benchmark harness can split
-        # setup-ish wall from the fan-out (issue #250).
-        template_t0 = time.time()
-        emit_raster_template(zarr_store, grid, config, times_us, overwrite=overwrite)
-        template_s = time.time() - template_t0
-
         if backend == "lambda":
+            # No orchestrator-side store write on the lambda path (issue
+            # #264): the template rides the sync setup invoke inside
+            # _run_lambda_shards, so the dispatcher needs only
+            # lambda:InvokeFunction (the CI OIDC invoke-only role).
             return self._run_lambda_shards(
                 config,
                 cells,
                 time_index,
                 grid,
                 store_path,
+                times_us=times_us,
+                overwrite=overwrite,
                 max_workers=max_workers,
                 region=region,
                 function_name=_ignored.get("function_name"),
@@ -743,8 +739,21 @@ class RasterStrategy:
                 output_credentials=output_credentials,
                 output_endpoint_url=resolved_endpoint,
                 profile=profile,
-                template_s=template_s,
             )
+
+        zarr_store = open_store(
+            store_path,
+            region=region,
+            credentials=output_credentials,
+            endpoint_url=resolved_endpoint,
+        )
+        # Local backend: template emission stays orchestrator-owned (the
+        # process writes the store directly); time it (always-on, the issue
+        # #180 bracket convention) so the benchmark harness can split
+        # setup-ish wall from the fan-out (issue #250).
+        template_t0 = time.time()
+        emit_raster_template(zarr_store, grid, config, times_us, overwrite=overwrite)
+        template_s = time.time() - template_t0
 
         source = config.data_source or {}
         src_kwargs = {
@@ -858,6 +867,8 @@ class RasterStrategy:
         grid,
         store_path,
         *,
+        times_us,
+        overwrite,
         max_workers,
         region,
         function_name,
@@ -865,15 +876,19 @@ class RasterStrategy:
         output_credentials,
         output_endpoint_url,
         profile=False,
-        template_s=None,
     ):
         """Fan shards out, one synchronous ``mode="process_raster"`` invoke each.
 
-        The worker gets the shard's ShardMap entries plus only its own slice of
-        the global time index (the template — runner-emitted before this — is
-        the shared truth for the full axis). Transient invoke faults retry with
-        backoff; a Lambda ``FunctionError`` or non-200 envelope is a shard
-        error (per-shard isolation, all-error raise as on the local backend).
+        Before fan-out the lifecycle is ping → sync setup (issue #264): the
+        lightweight ``mode="ping"`` fails fast on a pre-#252 deployment with
+        zero writes, then ``_invoke_lambda_raster_setup`` writes the template
+        WORKER-SIDE — the orchestrator never PUTs to the store, so an
+        invoke-only role (the CI OIDC benchmark role) dispatches cleanly. The
+        worker gets the shard's ShardMap entries plus only its own slice of
+        the global time index (the setup-emitted template is the shared truth
+        for the full axis). Transient invoke faults retry with backoff; a
+        Lambda ``FunctionError`` or non-200 envelope is a shard error
+        (per-shard isolation, all-error raise as on the local backend).
         """
         import boto3
         from botocore.config import Config
@@ -901,6 +916,30 @@ class RasterStrategy:
         output_creds_event = _build_output_creds_event(
             output_credentials, output_endpoint_url, region
         )
+        # Ping → sync setup, bracketed as template_s (the setup-ish wall the
+        # benchmark splits from fan-out, issue #250). The template is
+        # load-bearing before fan-out — workers write slabs into its arrays —
+        # so the setup invoke is synchronous (the flat point-path lifecycle,
+        # NOT the #252 async hybrid, whose artifact is not load-bearing).
+        template_t0 = time.time()
+        _invoke_lambda_ping(
+            client,
+            function_name,
+            store_path,
+            config_dict=config_dict,
+            overwrite=overwrite,
+            output_creds_event=output_creds_event,
+        )
+        _invoke_lambda_raster_setup(
+            client,
+            function_name,
+            store_path,
+            config_dict=config_dict,
+            times_us=times_us,
+            overwrite=overwrite,
+            output_creds_event=output_creds_event,
+        )
+        template_s = time.time() - template_t0
 
         def _event(shard_key, granules):
             keys = {e.get("time_key") or e.get("datetime") for e in granules if e.get("assets")}
@@ -3191,6 +3230,68 @@ def _invoke_lambda_setup_async(
     )
 
 
+def _invoke_lambda_raster_setup(
+    lambda_client,
+    function_name,
+    store_path,
+    *,
+    config_dict,
+    times_us,
+    overwrite=False,
+    output_creds_event=None,
+):
+    """Synchronous raster template write via the setup mode (issue #264).
+
+    One RequestResponse invoke of ``mode="setup"``: the handler detects the
+    raster pipeline from the event's config (``data_source.reader: raster``)
+    and runs ``emit_raster_template`` worker-side, so the orchestrator needs
+    only ``lambda:InvokeFunction`` — the CI OIDC benchmark role is
+    deliberately invoke-only and must never PUT to the store. Synchronous
+    because the template is load-bearing before fan-out (workers write slabs
+    into its arrays) — the flat point-path lifecycle, not the #252 async
+    hybrid. ``times_us`` is the catalog-derived global time coordinate
+    (int64 μs since the epoch), JSON-safe as a plain int list.
+
+    A deployed function that predates the raster setup branch would fall
+    through to the point-path ``grid.emit_template`` — wrong template, right
+    status code — so the success body must echo ``"pipeline": "raster"``
+    (the PR #205 layout-echo precedent); anything else raises a redeploy
+    error before any worker is dispatched. The ping preceding this call
+    already gated out pre-#252 functions with zero writes.
+    """
+    event = {
+        "mode": "setup",
+        "store_path": store_path,
+        "overwrite": overwrite,
+        "config": config_dict,
+        "times_us": [int(t) for t in times_us],
+    }
+    if output_creds_event is not None:
+        event["output_credentials"] = output_creds_event
+    response = lambda_client.invoke(
+        FunctionName=function_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(event),
+    )
+    payload = response["Payload"].read().decode("utf-8")
+    if response.get("FunctionError"):
+        raise RuntimeError(f"Lambda raster setup failed: {payload}")
+    result = json.loads(payload)
+    if result.get("statusCode") != 200:
+        raise RuntimeError(f"Lambda raster setup error: {result.get('body')}")
+    try:
+        body = json.loads(result.get("body") or "{}")
+    except (TypeError, ValueError):
+        body = {}
+    if body.get("pipeline") != "raster":
+        raise RuntimeError(
+            f"Lambda raster setup fell through to the point-path template "
+            f"(response body {result.get('body')!r}): the deployed function "
+            f"predates the issue #264 raster setup branch — redeploy the "
+            f"function, then rerun with overwrite to replace anything it wrote"
+        )
+
+
 def _invoke_lambda_ping(
     lambda_client,
     function_name,
@@ -3226,6 +3327,12 @@ def _invoke_lambda_ping(
       setup invoke) the loser's collision window shrinks from run-length to
       seconds. Same last-writer caveat the manifest write itself has always
       had.
+
+    The raster lambda path reuses this ping (issue #264) ahead of its sync
+    template-writing setup invoke: a raster config carries no hive layout, so
+    only the stale-deployment half applies (the handler's manifest precheck
+    is a no-op), and the setup response's ``pipeline`` echo covers the
+    hive-capable-but-pre-#264 window this ping cannot see.
 
     Kept while flat exists (issue #251): once flat is removed, a stale
     function just errors and the ping can be dropped.

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3285,11 +3285,20 @@ def _invoke_lambda_raster_setup(
     if result.get("statusCode") != 200:
         # A pre-#264 function reaches the flat branch and calls
         # grid.emit_template on the raster config, which can raise (a raster
-        # template has no point-path shape) → 500. A 500 is indistinguishable
-        # from a genuine failure here, so surface the redeploy hint alongside
-        # the body rather than swallowing the stale-deployment case.
+        # template has no point-path shape) → 500 — indistinguishable from a
+        # genuine failure, so it carries the redeploy hint. But the only non-200
+        # a correctly-deployed function returns on the normal runner path is the
+        # legitimate ContainsGroupError overwrite-refusal (a store already
+        # holding a different-valued group), for which "redeploy" is noise. Gate
+        # the hedge off that case with a conservative, best-effort match on
+        # zarr's "A group exists in store" text (messaging only, not control
+        # flow): always surface the handler body; append the redeploy hedge only
+        # when the body does NOT look like the overwrite refusal.
+        body_repr = result.get("body")
+        if "a group exists in store" in str(body_repr).lower():
+            raise RuntimeError(f"Lambda raster setup error: {body_repr}")
         raise RuntimeError(
-            f"Lambda raster setup error: {result.get('body')} — if this is a "
+            f"Lambda raster setup error: {body_repr} — if this is a "
             f"pre-#264 deployment, its flat point-path branch may have raised "
             f"on the raster config; redeploy the function, then rerun with "
             f"overwrite to replace anything it wrote"

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3373,14 +3373,14 @@ def _invoke_lambda_ping(
             )
         raise RuntimeError(
             f"Lambda ping failed (response body {result.get('body')!r}): the "
-            f"deployed function predates the issue #252 hive dispatch "
-            f"lifecycle — redeploy the function before dispatching hive runs"
+            f"deployed function predates the issue #252 dispatch lifecycle — "
+            f"redeploy the function before dispatching this run"
         )
     try:
         version = json.loads(result.get("body") or "{}").get("zagg_version")
     except (TypeError, ValueError):
         version = None
-    logger.info(f"Hive preflight OK (function zagg version {version})")
+    logger.info(f"Preflight OK (function zagg version {version})")
 
 
 def _invoke_lambda_finalize(

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -1444,12 +1444,14 @@ class TestInvokeLambdaSetupEvent:
         return json.loads(client.invoke.call_args.kwargs["Payload"])
 
     def test_flat_event_matches_baseline(self, cfg):
-        # The byte-identity claim, pinned on the wire: no "dataset" key, and
-        # the event is exactly the pre-phase-3 flat setup event.
+        # The byte-identity claim, pinned on the wire: no "dataset" key, no
+        # raster "times_us" key (issue #264 uses a separate helper), and the
+        # event is exactly the pre-phase-3 flat setup event.
         config_dict = asdict(cfg)
         client = _wire_client({"ok": True, "mode": "setup", "layout": "flat"})
         event = self._invoke(client, config_dict)
         assert "dataset" not in event
+        assert "times_us" not in event
         assert event == {
             "mode": "setup",
             "store_path": "s3://out/product",

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1275,6 +1275,13 @@ class TestSetupHive:
         assert handler_mod._handle_setup(self._event(tmp_path, cfg))["statusCode"] == 200
         assert handler_mod._handle_setup(self._event(tmp_path, cfg))["statusCode"] == 200
 
+    def test_hive_setup_body_pinned_no_raster_echo(self, handler_mod, tmp_path):
+        # Hive setup must keep its exact pre-#264 body: the raster branch
+        # (data_source.reader == "raster") never fires on a hive point config.
+        resp = handler_mod._handle_setup(self._event(tmp_path, TestProcessHive._hive_config_dict()))
+        assert resp["statusCode"] == 200, resp["body"]
+        assert json.loads(resp["body"]) == {"ok": True, "mode": "setup", "layout": "hive"}
+
 
 class TestFinalizeHive:
     """Issue #252 (hybrid): for a hive config, finalize mode re-ensures the
@@ -1476,6 +1483,15 @@ class TestSetupTemplate:
         n_chunks = self._template_chunk_count(store, worker_grid)
         assert (n_chunks,) == worker_grid.chunk_grid_shape
         assert n_chunks == HEALPIX_BASE_CELLS * 4**6
+
+    def test_flat_setup_body_pinned_no_raster_echo(self, handler_mod, monkeypatch):
+        # The raster setup branch (issue #264) keys on data_source.reader ==
+        # "raster": a point-path config must keep the flat branch and its
+        # exact pre-#264 body -- no "pipeline" echo, no "times_us" read.
+        cfg = default_config("atl06")
+        resp, _store = self._setup(handler_mod, monkeypatch, asdict(cfg), parent_order=6)
+        assert resp["statusCode"] == 200, resp["body"]
+        assert json.loads(resp["body"]) == {"ok": True, "mode": "setup", "layout": "flat"}
 
     def test_setup_dense_layout_threads_populated_shards(self, handler_mod, monkeypatch):
         # n_parent_cells signals the (deprecated) dense layout; the count must thread

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -328,6 +328,29 @@ class TestRasterSetupMode:
         )
         np.testing.assert_array_equal(tarr[:], np.asarray(changed, dtype=np.int64))
 
+    def test_setup_rerun_same_count_different_values_500(self, handler_mod, tmp_path):
+        # A rerun over a different catalog with the SAME timestep count but
+        # shifted values must refuse (500) without overwrite, not silently
+        # rewrite the persisted time coord out from under the workers' time
+        # index (issue #264). The original coordinate is left intact.
+        store_path = tmp_path / "samect.zarr"
+        first = handler_mod._handle_setup(self._setup_event(store_path, self.TIMES))
+        assert first["statusCode"] == 200, first["body"]
+        shifted = [self.TIMES[0], self.TIMES[1] + 86_400_000_000]
+        refuse = handler_mod._handle_setup(self._setup_event(store_path, shifted))
+        assert refuse["statusCode"] == 500
+        grid = from_config(load_config_from_dict(_config_dict(store_path)))
+        tarr = open_array(
+            str(store_path) + f"/{grid.group_path}/time", zarr_format=3, consolidated=False
+        )
+        np.testing.assert_array_equal(tarr[:], np.asarray(self.TIMES, dtype=np.int64))
+        redo = handler_mod._handle_setup(self._setup_event(store_path, shifted, overwrite=True))
+        assert redo["statusCode"] == 200, redo["body"]
+        tarr = open_array(
+            str(store_path) + f"/{grid.group_path}/time", zarr_format=3, consolidated=False
+        )
+        np.testing.assert_array_equal(tarr[:], np.asarray(shifted, dtype=np.int64))
+
 
 class TestRasterPhaseTimings:
     def test_profile_emits_sample_write_split(self, handler_mod, raster_event):

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -297,6 +297,17 @@ class TestRasterSetupMode:
         assert resp["statusCode"] == 500
         assert "times_us" in json.loads(resp["body"])["error"]
 
+    def test_setup_dense_layout_400(self, handler_mod, tmp_path):
+        # Symmetry with the worker (test_dense_layout_400): a dense-layout
+        # raster config gets the worker's clean 400 instead of an opaque
+        # from_config 500 (issue #264).
+        store_path = tmp_path / "dense.zarr"
+        event = self._setup_event(store_path, self.TIMES)
+        event["config"] = _config_dict(store_path, layout="dense")
+        resp = handler_mod._handle_setup(event)
+        assert resp["statusCode"] == 400
+        assert "fullsphere" in json.loads(resp["body"])["error"]
+
     def test_setup_rerun_overwrite_semantics(self, handler_mod, tmp_path):
         # Local-path parity (test_overwrite_and_rerun): an identical rerun is
         # idempotent; a CHANGED time index refuses without overwrite=True and

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -198,6 +198,117 @@ class TestProcessRasterMode:
         assert "asset" in json.loads(resp["body"])["error"]
 
 
+class TestRasterSetupMode:
+    """Issue #264: ``mode="setup"`` with a raster config writes the
+    ``(time, cells)`` template + ``time`` coordinate handler-side, so the
+    dispatcher needs only ``lambda:InvokeFunction`` (the CI OIDC invoke-only
+    role gets no S3 write access). The success body echoes
+    ``"pipeline": "raster"`` — the dispatcher's stale-deployment guard."""
+
+    TIMES = [1752422540000000, 1752854540000000]
+
+    def _setup_event(self, store_path, times_us, **extra):
+        return {
+            "mode": "setup",
+            "store_path": str(store_path),
+            "overwrite": False,
+            "config": _config_dict(store_path),
+            "times_us": [int(t) for t in times_us],
+            **extra,
+        }
+
+    def test_setup_writes_template_and_time_coord(self, handler_mod, tmp_path):
+        store_path = tmp_path / "raster-setup.zarr"
+        resp = handler_mod._handle_setup(self._setup_event(store_path, self.TIMES))
+        assert resp["statusCode"] == 200, resp["body"]
+        assert json.loads(resp["body"]) == {
+            "ok": True,
+            "mode": "setup",
+            "pipeline": "raster",
+            "timesteps": 2,
+        }
+        grid = from_config(load_config_from_dict(_config_dict(store_path)))
+        tarr = open_array(
+            str(store_path) + f"/{grid.group_path}/time", zarr_format=3, consolidated=False
+        )
+        np.testing.assert_array_equal(tarr[:], np.asarray(self.TIMES, dtype=np.int64))
+        red = open_array(
+            str(store_path) + f"/{grid.group_path}/red", zarr_format=3, consolidated=False
+        )
+        assert red.shape[0] == 2
+
+    def test_setup_template_matches_worker_writes(self, handler_mod, tmp_path):
+        # The handler-emitted template must be the SAME template the worker
+        # slab-writes into: setup then process_raster, end to end.
+        data = _index_raster()
+        _write_tiff(tmp_path / "t0.tif", data)
+        store_path = str(tmp_path / "e2e.zarr")
+        cfg_dict = _config_dict(store_path)
+        entry = {
+            "id": "g0",
+            "s3": None,
+            "https": None,
+            "assets": {"red": str(tmp_path / "t0.tif")},
+            "datetime": T0,
+            "time_key": "dt-1",
+        }
+        time_index, times = raster_time_index([[entry]])
+        resp = handler_mod._handle_setup(
+            {
+                "mode": "setup",
+                "store_path": store_path,
+                "overwrite": False,
+                "config": cfg_dict,
+                "times_us": [int(t) for t in times],
+            }
+        )
+        assert resp["statusCode"] == 200, resp["body"]
+        event = {
+            "mode": "process_raster",
+            "shard_key": _shard_for_raster(),
+            "granules": [entry],
+            "config": cfg_dict,
+            "store_path": store_path,
+            "time_index": time_index,
+        }
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200, resp["body"]
+        grid = from_config(load_config_from_dict(cfg_dict))
+        start = int(grid.block_index(event["shard_key"])[0]) * grid.cells_per_shard
+        red = open_array(store_path + f"/{grid.group_path}/red", zarr_format=3, consolidated=False)
+        got = red[0, start : start + grid.cells_per_shard]
+        cells = grid.children(event["shard_key"])
+        rows, cols, valid = grid.sample(cells, UTM18, TRANSFORM, (96, 96))
+        np.testing.assert_array_equal(got[valid], data[rows[valid], cols[valid]])
+
+    def test_setup_missing_times_us_500(self, handler_mod, tmp_path):
+        event = self._setup_event(tmp_path / "x.zarr", self.TIMES)
+        del event["times_us"]
+        resp = handler_mod._handle_setup(event)
+        assert resp["statusCode"] == 500
+        assert "times_us" in json.loads(resp["body"])["error"]
+
+    def test_setup_rerun_overwrite_semantics(self, handler_mod, tmp_path):
+        # Local-path parity (test_overwrite_and_rerun): an identical rerun is
+        # idempotent; a CHANGED time index refuses without overwrite=True and
+        # rewrites cleanly with it.
+        store_path = tmp_path / "rerun.zarr"
+        first = handler_mod._handle_setup(self._setup_event(store_path, self.TIMES))
+        assert first["statusCode"] == 200, first["body"]
+        again = handler_mod._handle_setup(self._setup_event(store_path, self.TIMES))
+        assert again["statusCode"] == 200, again["body"]
+        changed = self.TIMES[:1]
+        refuse = handler_mod._handle_setup(self._setup_event(store_path, changed))
+        assert refuse["statusCode"] == 500
+        redo = handler_mod._handle_setup(self._setup_event(store_path, changed, overwrite=True))
+        assert redo["statusCode"] == 200, redo["body"]
+        grid = from_config(load_config_from_dict(_config_dict(store_path)))
+        tarr = open_array(
+            str(store_path) + f"/{grid.group_path}/time", zarr_format=3, consolidated=False
+        )
+        np.testing.assert_array_equal(tarr[:], np.asarray(changed, dtype=np.int64))
+
+
 class TestRasterPhaseTimings:
     def test_profile_emits_sample_write_split(self, handler_mod, raster_event):
         event, _grid, _data = raster_event

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -288,6 +288,15 @@ class TestRasterSetupMode:
         assert resp["statusCode"] == 500
         assert "times_us" in json.loads(resp["body"])["error"]
 
+    def test_setup_empty_times_us_500(self, handler_mod, tmp_path):
+        # An empty times_us would write a degenerate zero-timestep template
+        # (0-length time axis, unusable). The runner refuses an empty catalog
+        # pre-dispatch; the invoke-only writer must too (issue #264).
+        event = self._setup_event(tmp_path / "empty.zarr", [])
+        resp = handler_mod._handle_setup(event)
+        assert resp["statusCode"] == 500
+        assert "times_us" in json.loads(resp["body"])["error"]
+
     def test_setup_rerun_overwrite_semantics(self, handler_mod, tmp_path):
         # Local-path parity (test_overwrite_and_rerun): an identical rerun is
         # idempotent; a CHANGED time index refuses without overwrite=True and

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -11,6 +11,7 @@ import pytest
 from pyproj import CRS, Transformer
 from test_raster import ORIGIN, RES, TRANSFORM, UTM18, _index_raster, _write_tiff
 from zarr import open_array
+from zarr.errors import ContainsGroupError
 from zarr.storage import MemoryStore
 
 from zagg.config import get_raster_bands, load_config_from_dict, validate_config
@@ -562,6 +563,27 @@ class TestTemplateAndSlabs:
         emit_raster_template(store, grid, cfg, np.array([], dtype=np.int64))
         red = open_array(store, path=f"{grid.group_path}/red", zarr_format=3, consolidated=False)
         assert red.shape == (0, 4096)
+
+    def test_overwrite_false_refuses_same_count_different_values(self, tmp_path):
+        # overwrite=False must refuse a rerun whose timestep COUNT is unchanged
+        # but whose time values differ: to_zarr's shape guard doesn't catch it,
+        # so without an explicit check the unconditional time write would
+        # silently clobber the coordinate workers slab-write against (issue
+        # #264). An identical rerun stays idempotent; overwrite=True rewrites.
+        cfg, grid, _shard = _healpix_setup(tmp_path)
+        store = MemoryStore()
+        emit_raster_template(store, grid, cfg, np.array([100, 200], dtype=np.int64))
+        # Idempotent: same values, overwrite=False, no raise.
+        emit_raster_template(store, grid, cfg, np.array([100, 200], dtype=np.int64))
+        # Same count, shifted values: refused, and the store is left untouched.
+        with pytest.raises(ContainsGroupError):
+            emit_raster_template(store, grid, cfg, np.array([100, 999], dtype=np.int64))
+        tarr = open_array(store, path=f"{grid.group_path}/time", zarr_format=3, consolidated=False)
+        np.testing.assert_array_equal(tarr[:], np.array([100, 200], dtype=np.int64))
+        # overwrite=True rewrites the shifted coordinate cleanly.
+        emit_raster_template(store, grid, cfg, np.array([100, 999], dtype=np.int64), overwrite=True)
+        tarr = open_array(store, path=f"{grid.group_path}/time", zarr_format=3, consolidated=False)
+        np.testing.assert_array_equal(tarr[:], np.array([100, 999], dtype=np.int64))
 
     def test_time_attrs_round_trip(self, tmp_path):
         cfg, grid, _shard = _healpix_setup(tmp_path)

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -289,11 +289,41 @@ class _FakeLambdaClient:
         return out
 
 
+def _lifecycle(responder):
+    """Wrap a per-shard responder with canned ping/setup answers (issue #264).
+
+    The lambda lifecycle is ping → sync raster setup → fan-out; tests that
+    exercise the fan-out answer the two lifecycle invokes canonically and
+    route only ``mode="process_raster"`` events to ``responder``.
+    """
+
+    def _respond(event):
+        if event["mode"] == "ping":
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"ok": True, "mode": "ping", "zagg_version": "test"}),
+            }
+        if event["mode"] == "setup":
+            body = {
+                "ok": True,
+                "mode": "setup",
+                "pipeline": "raster",
+                "timesteps": len(event["times_us"]),
+            }
+            return {"statusCode": 200, "body": json.dumps(body)}
+        return responder(event)
+
+    return _respond
+
+
 class TestRasterLambdaBackend:
+    # Issue #264: the lambda path never opens or writes the store from the
+    # orchestrator (the template rides the sync setup invoke), so these tests
+    # no longer intercept open_store for the s3 URL — a regression to an
+    # orchestrator-side write would surface as a real-S3 attempt.
+
     def test_events_and_summary(self, manifest, monkeypatch, tmp_path):
         import boto3
-
-        import zagg.runner as runner_mod
 
         cfg, sm_path, shard, _data = manifest
 
@@ -305,18 +335,8 @@ class TestRasterLambdaBackend:
             body = {"timesteps": len(event["time_index"]), "cells_with_data": 4096}
             return {"statusCode": 200, "body": json.dumps(body)}
 
-        fake = _FakeLambdaClient(responder)
+        fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        # Template emission targets the store path; keep it local by
-        # intercepting open_store for the s3 URL.
-        real_open = runner_mod.open_store
-
-        def fake_open(path, **kw):
-            if path.startswith("s3://"):
-                return str(tmp_path / "lambda_out.zarr")
-            return real_open(path, **kw)
-
-        monkeypatch.setattr(runner_mod, "open_store", fake_open)
         summary = agg(
             cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2
         )
@@ -324,22 +344,112 @@ class TestRasterLambdaBackend:
         assert summary["total_cells"] == 1 and summary["cells_with_data"] == 1
         assert summary["cells_error"] == 0
         assert summary["total_obs"] == 2
-        assert len(fake.events) == 1
+        assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
         # No profile -> the payload stays byte-identical (no key) and the
         # profile rollups stay out of the summary (issue #250).
-        assert "profile" not in fake.events[0]
+        assert "profile" not in fake.events[-1]
         assert "worker_stage_max" not in summary
         # Always-on telemetry rollups are null-safe on a body without them.
         assert summary["lambda_time_s"] is None and summary["max_memory_mb"] is None
         assert summary["template_s"] >= 0.0
+
+    def test_lifecycle_order_and_setup_event_pinned(self, manifest, monkeypatch):
+        # The wire-level pin of the raster lifecycle (issue #264): ping →
+        # sync setup → fan-out, with the EXACT setup event on the wire —
+        # config + times_us (plain ints, the catalog-derived coordinate) +
+        # overwrite — and no orchestrator store write anywhere.
+        import boto3
+
+        import zagg.runner as runner_mod
+        from zagg.processing.raster import raster_time_index
+
+        cfg, sm_path, shard, _data = manifest
+        _idx, times_us = raster_time_index(runner_mod._load_catalog(sm_path)["granules"])
+
+        def responder(event):
+            body = {"timesteps": len(event["time_index"]), "cells_with_data": 4096}
+            return {"statusCode": 200, "body": json.dumps(body)}
+
+        fake = _FakeLambdaClient(_lifecycle(responder))
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
+        real_open = runner_mod.open_store
+
+        def guard_open(path, **kw):
+            assert not path.startswith("s3://"), "orchestrator opened the s3 store"
+            return real_open(path, **kw)
+
+        monkeypatch.setattr(runner_mod, "open_store", guard_open)
+        agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+        assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
+        ping, setup = fake.events[0], fake.events[1]
+        expected_config = {
+            "data_source": cfg.data_source,
+            "output": cfg.output,
+            "pipeline": cfg.pipeline,
+        }
+        assert ping["store_path"] == "s3://bucket/out.zarr"
+        assert ping["config"] == expected_config
+        assert setup == {
+            "mode": "setup",
+            "store_path": "s3://bucket/out.zarr",
+            "overwrite": False,
+            "config": expected_config,
+            "times_us": [int(t) for t in times_us],
+        }
+        assert all(isinstance(t, int) for t in setup["times_us"])  # JSON-safe int64
+
+    def test_stale_ping_fails_fast_no_setup(self, manifest, monkeypatch):
+        # A pre-#252 function doesn't know mode="ping" (400 fall-through with
+        # zero writes): the raster dispatch must raise the redeploy message
+        # before the setup invoke or any worker.
+        import boto3
+
+        cfg, sm_path, _shard, _data = manifest
+
+        def responder(event):
+            if event["mode"] == "ping":
+                return {"statusCode": 400, "body": json.dumps({"error": "shard_key required"})}
+            raise AssertionError(f"unexpected invoke after failed ping: {event['mode']}")
+
+        fake = _FakeLambdaClient(responder)
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
+        with pytest.raises(RuntimeError, match="redeploy"):
+            agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+        assert [e["mode"] for e in fake.events] == ["ping"]
+
+    def test_stale_setup_echo_fails_fast_no_fanout(self, manifest, monkeypatch):
+        # A function that knows ping (#252) but predates the raster setup
+        # branch (#264) falls through to the point-path template and echoes
+        # "layout" instead of "pipeline": the dispatcher must refuse with the
+        # redeploy message before any worker writes into the wrong template.
+        import boto3
+
+        cfg, sm_path, _shard, _data = manifest
+
+        def responder(event):
+            if event["mode"] == "ping":
+                return {
+                    "statusCode": 200,
+                    "body": json.dumps({"ok": True, "mode": "ping", "zagg_version": "old"}),
+                }
+            if event["mode"] == "setup":
+                return {
+                    "statusCode": 200,
+                    "body": json.dumps({"ok": True, "mode": "setup", "layout": "flat"}),
+                }
+            raise AssertionError(f"unexpected invoke after stale setup: {event['mode']}")
+
+        fake = _FakeLambdaClient(responder)
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
+        with pytest.raises(RuntimeError, match="issue #264 raster setup branch"):
+            agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+        assert [e["mode"] for e in fake.events] == ["ping", "setup"]
 
     def test_lambda_profile_threads_key_and_rolls_up(self, manifest, monkeypatch, tmp_path):
         # Issue #250: profile=True rides the event; the summary rolls the
         # workers' phase_timings (stages straggler-maxed + write bucket,
         # counts summed) and the billed-duration / peak-RSS telemetry.
         import boto3
-
-        import zagg.runner as runner_mod
 
         cfg, sm_path, _shard, _data = manifest
 
@@ -367,16 +477,8 @@ class TestRasterLambdaBackend:
             }
             return {"statusCode": 200, "body": json.dumps(body)}
 
-        fake = _FakeLambdaClient(responder)
+        fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        real_open = runner_mod.open_store
-
-        def fake_open(path, **kw):
-            if path.startswith("s3://"):
-                return str(tmp_path / "lambda_out.zarr")
-            return real_open(path, **kw)
-
-        monkeypatch.setattr(runner_mod, "open_store", fake_open)
         summary = agg(
             cfg,
             catalog=sm_path,
@@ -404,9 +506,10 @@ class TestRasterLambdaBackend:
         # snake_case creds + a custom output endpoint must reach the worker event
         # as the handler-required camelCase block (accessKeyId/secretAccessKey)
         # with endpointUrl threaded in — parity with the spatial/temporal paths.
+        # The ping + setup lifecycle invokes (issue #264) carry the same block:
+        # the setup invoke is the template WRITE, so a dropped key there would
+        # 403 the handler against an external (R2/MinIO) target.
         import boto3
-
-        import zagg.runner as runner_mod
 
         cfg, sm_path, _shard, _data = manifest
 
@@ -414,16 +517,8 @@ class TestRasterLambdaBackend:
             body = {"timesteps": len(event["time_index"]), "cells_with_data": 4096}
             return {"statusCode": 200, "body": json.dumps(body)}
 
-        fake = _FakeLambdaClient(responder)
+        fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        real_open = runner_mod.open_store
-        monkeypatch.setattr(
-            runner_mod,
-            "open_store",
-            lambda path, **kw: (
-                str(tmp_path / "creds.zarr") if path.startswith("s3://") else real_open(path, **kw)
-            ),
-        )
         agg(
             cfg,
             catalog=sm_path,
@@ -435,32 +530,23 @@ class TestRasterLambdaBackend:
             },
             output_endpoint_url="https://custom.r2.example.com",
         )
-        assert len(fake.events) == 1
-        block = fake.events[0]["output_credentials"]
-        assert block["accessKeyId"] == "AKIA_SNAKE"
-        assert block["secretAccessKey"] == "SECRET_SNAKE"
-        assert block["endpointUrl"] == "https://custom.r2.example.com"
+        assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
+        for event in fake.events:
+            block = event["output_credentials"]
+            assert block["accessKeyId"] == "AKIA_SNAKE"
+            assert block["secretAccessKey"] == "SECRET_SNAKE"
+            assert block["endpointUrl"] == "https://custom.r2.example.com"
 
     def test_all_lambda_shards_error_raises(self, manifest, monkeypatch, tmp_path):
         import boto3
-
-        import zagg.runner as runner_mod
 
         cfg, sm_path, _shard, _data = manifest
 
         def responder(event):
             return {"statusCode": 500, "body": json.dumps({"error": "boom"})}
 
-        fake = _FakeLambdaClient(responder)
+        fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        real_open = runner_mod.open_store
-        monkeypatch.setattr(
-            runner_mod,
-            "open_store",
-            lambda path, **kw: (
-                str(tmp_path / "x.zarr") if path.startswith("s3://") else real_open(path, **kw)
-            ),
-        )
         with pytest.raises(RuntimeError, match="boom"):
             agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
 
@@ -469,26 +555,17 @@ class TestRasterLambdaBackend:
         # error — recorded, never retried. Single shard -> all-error RuntimeError.
         import boto3
 
-        import zagg.runner as runner_mod
-
         cfg, sm_path, _shard, _data = manifest
 
         def responder(event):
             return {"__function_error__": True, "errorMessage": "boom in worker"}
 
-        fake = _FakeLambdaClient(responder)
+        fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        real_open = runner_mod.open_store
-        monkeypatch.setattr(
-            runner_mod,
-            "open_store",
-            lambda path, **kw: (
-                str(tmp_path / "fe.zarr") if path.startswith("s3://") else real_open(path, **kw)
-            ),
-        )
         with pytest.raises(RuntimeError, match="Lambda error"):
             agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
-        assert len(fake.events) == 1  # deterministic FunctionError -> no retry
+        # deterministic FunctionError -> no retry
+        assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
 
     def test_lambda_transient_retry_then_success(self, manifest, monkeypatch, tmp_path):
         # A transient invoke fault (Connection reset) on the first attempt retries
@@ -507,42 +584,30 @@ class TestRasterLambdaBackend:
             body = {"timesteps": len(event["time_index"]), "cells_with_data": 4096}
             return {"statusCode": 200, "body": json.dumps(body)}
 
-        fake = _FakeLambdaClient(responder)
+        fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         monkeypatch.setattr(runner_mod.time, "sleep", lambda *a: None)
-        real_open = runner_mod.open_store
-        monkeypatch.setattr(
-            runner_mod,
-            "open_store",
-            lambda path, **kw: (
-                str(tmp_path / "tr.zarr") if path.startswith("s3://") else real_open(path, **kw)
-            ),
-        )
         summary = agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
         assert summary["cells_error"] == 0
         assert summary["cells_with_data"] == 1
-        assert len(fake.events) == 2  # first invoke raised (transient), retried once
+        # first shard invoke raised (transient), retried once
+        assert [e["mode"] for e in fake.events] == [
+            "ping",
+            "setup",
+            "process_raster",
+            "process_raster",
+        ]
 
     def test_lambda_dense_layout_fails_fast(self, manifest, monkeypatch, tmp_path):
         # A dense-layout config on the lambda backend must be refused up front,
         # before any invoke — the fake client records zero events.
         import boto3
 
-        import zagg.runner as runner_mod
-
         cfg, sm_path, _shard, _data = manifest
         cfg.output["grid"]["layout"] = "dense"
 
         fake = _FakeLambdaClient(lambda event: {"statusCode": 200, "body": "{}"})
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        real_open = runner_mod.open_store
-        monkeypatch.setattr(
-            runner_mod,
-            "open_store",
-            lambda path, **kw: (
-                str(tmp_path / "dense.zarr") if path.startswith("s3://") else real_open(path, **kw)
-            ),
-        )
         with pytest.raises(ValueError, match="fullsphere"):
             agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
         assert fake.events == []
@@ -551,8 +616,6 @@ class TestRasterLambdaBackend:
         # Granules without a time_key fall back to the datetime string as the
         # group key; the worker event's time_index must be keyed by that string.
         import boto3
-
-        import zagg.runner as runner_mod
 
         cfg = _cfg(tmp_path)
         data = _index_raster()
@@ -579,18 +642,79 @@ class TestRasterLambdaBackend:
             body = {"timesteps": 1, "cells_with_data": 4096}
             return {"statusCode": 200, "body": json.dumps(body)}
 
-        fake = _FakeLambdaClient(responder)
+        fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        real_open = runner_mod.open_store
-        monkeypatch.setattr(
-            runner_mod,
-            "open_store",
-            lambda path, **kw: (
-                str(tmp_path / "dt.zarr") if path.startswith("s3://") else real_open(path, **kw)
-            ),
-        )
         agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
         assert set(seen["time_index"]) == {T0}
+
+
+class TestInvokeLambdaRasterSetupEvent:
+    """Pin the ACTUAL raster setup event on the wire (issue #264) and the
+    stale-deployment echo guard: the sync RequestResponse invoke carries
+    config + times_us (plain ints) + overwrite, and any success body that
+    does not echo ``"pipeline": "raster"`` — a deployed function without the
+    raster setup branch fell through to the point-path template — raises the
+    redeploy message. Mirrors ``TestInvokeLambdaSetupEvent`` (test_hive)."""
+
+    @staticmethod
+    def _invoke(client, config_dict, **kw):
+        from zagg.runner import _invoke_lambda_raster_setup
+
+        _invoke_lambda_raster_setup(
+            client,
+            "process-shard",
+            "s3://out/product",
+            config_dict=config_dict,
+            times_us=np.array([1752422540000000, 1752854540000000], dtype=np.int64),
+            **kw,
+        )
+        return json.loads(client.invoke.call_args.kwargs["Payload"])
+
+    def test_event_matches_baseline(self, tmp_path):
+        from test_hive import _wire_client
+
+        cfg = _cfg(tmp_path)
+        config_dict = {"data_source": cfg.data_source, "output": cfg.output}
+        client = _wire_client({"ok": True, "mode": "setup", "pipeline": "raster", "timesteps": 2})
+        event = self._invoke(client, config_dict)
+        assert client.invoke.call_args.kwargs["InvocationType"] == "RequestResponse"
+        assert event == {
+            "mode": "setup",
+            "store_path": "s3://out/product",
+            "overwrite": False,
+            "config": config_dict,
+            "times_us": [1752422540000000, 1752854540000000],
+        }
+
+    def test_creds_and_overwrite_threaded(self, tmp_path):
+        from test_hive import _wire_client
+
+        creds = {"accessKeyId": "AK", "secretAccessKey": "SK"}
+        client = _wire_client({"ok": True, "mode": "setup", "pipeline": "raster", "timesteps": 2})
+        event = self._invoke(client, {"data_source": {}}, overwrite=True, output_creds_event=creds)
+        assert event["overwrite"] is True
+        assert event["output_credentials"] == creds
+
+    def test_non_200_raises(self, tmp_path):
+        from test_hive import _wire_client
+
+        with pytest.raises(RuntimeError, match="Lambda raster setup error"):
+            self._invoke(
+                _wire_client({"error": "boom", "mode": "setup"}, status_code=500),
+                {"data_source": {}},
+            )
+
+    def test_missing_pipeline_echo_raises_redeploy(self, tmp_path):
+        # A stale function's flat branch answers 200 with the layout echo but
+        # no "pipeline" key: the dispatcher must refuse with the redeploy
+        # remedy rather than fan workers into a point-path template.
+        from test_hive import _wire_client
+
+        with pytest.raises(RuntimeError, match="redeploy"):
+            self._invoke(
+                _wire_client({"ok": True, "mode": "setup", "layout": "flat"}),
+                {"data_source": {}},
+            )
 
 
 class TestShippedTemplate:

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -413,8 +413,11 @@ class TestRasterLambdaBackend:
 
         fake = _FakeLambdaClient(responder)
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        with pytest.raises(RuntimeError, match="redeploy"):
+        with pytest.raises(RuntimeError, match="redeploy") as excinfo:
             agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+        # The shared ping is pipeline-neutral (issue #264): a raster operator
+        # must not get hive-worded guidance for a raster run.
+        assert "hive" not in str(excinfo.value).lower()
         assert [e["mode"] for e in fake.events] == ["ping"]
 
     def test_stale_setup_echo_fails_fast_no_fanout(self, manifest, monkeypatch):

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -701,11 +701,14 @@ class TestInvokeLambdaRasterSetupEvent:
     def test_non_200_raises(self, tmp_path):
         from test_hive import _wire_client
 
-        with pytest.raises(RuntimeError, match="Lambda raster setup error"):
+        with pytest.raises(RuntimeError, match="Lambda raster setup error") as excinfo:
             self._invoke(
                 _wire_client({"error": "boom", "mode": "setup"}, status_code=500),
                 {"data_source": {}},
             )
+        # A raising pre-#264 flat branch also 500s; the message must carry the
+        # redeploy hint since a 500 can't be told apart from a genuine failure.
+        assert "redeploy" in str(excinfo.value)
 
     def test_missing_pipeline_echo_raises_redeploy(self, tmp_path):
         # A stale function's flat branch answers 200 with the layout echo but

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -701,14 +701,27 @@ class TestInvokeLambdaRasterSetupEvent:
     def test_non_200_raises(self, tmp_path):
         from test_hive import _wire_client
 
+        # A generic 500 can't be told apart from a raising pre-#264 flat branch,
+        # so the message must carry the redeploy hint.
         with pytest.raises(RuntimeError, match="Lambda raster setup error") as excinfo:
             self._invoke(
                 _wire_client({"error": "boom", "mode": "setup"}, status_code=500),
                 {"data_source": {}},
             )
-        # A raising pre-#264 flat branch also 500s; the message must carry the
-        # redeploy hint since a 500 can't be told apart from a genuine failure.
         assert "redeploy" in str(excinfo.value)
+
+        # The legitimate ContainsGroupError overwrite-refusal is the only non-200
+        # a correctly-deployed function returns on the normal path; it must
+        # surface the store message WITHOUT the inapplicable redeploy hedge.
+        err = "A group exists in store 's3://out/product' at path ''"
+        with pytest.raises(RuntimeError, match="Lambda raster setup error") as excinfo:
+            self._invoke(
+                _wire_client({"error": err, "mode": "setup"}, status_code=500),
+                {"data_source": {}},
+            )
+        msg = str(excinfo.value)
+        assert "redeploy" not in msg
+        assert "A group exists in store" in msg
 
     def test_missing_pipeline_echo_raises_redeploy(self, tmp_path):
         # A stale function's flat branch answers 200 with the layout echo but

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3700,6 +3700,8 @@ class TestLambdaResolverSeamRasterEvents:
                 {},
                 None,
                 "s3://b/out.zarr",
+                times_us=[0],
+                overwrite=False,
                 max_workers=1,
                 region="us-west-2",
                 function_name="pinned-raster",


### PR DESCRIPTION
Closes #264

Moves the raster (time, cells) template write off the orchestrator and behind the synchronous `mode="setup"` Lambda invoke, mirroring the flat point-path setup lifecycle from [issue #252](https://github.com/englacial/zagg/issues/252). The 0.32.0 raster benchmark leg (#250 / PR #261) exposed the gap: the CI OIDC `zagg-benchmark` role is deliberately lambda-invoke-only, so `RasterStrategy.run`'s direct `emit_raster_template` PUT died with `AccessDenied` before any worker ran ([failing job](https://github.com/englacial/zagg/actions/runs/29620830771/job/88015539402)). The raster template is load-bearing before fan-out (workers write slabs into its arrays), so the fix is the **sync** setup invoke — not the #255 async hybrid, which applies only to non-load-bearing artifacts like the hive manifest (see the [PR #255 lifecycle rationale](https://github.com/englacial/zagg/pull/255)).

## What / approach

**Handler (`deployment/aws/lambda_handler.py` — explicitly in scope per issue #264):** `_handle_setup` gains a raster branch keyed on `data_source.reader == "raster"` (checked before the hive branch): it rebuilds the grid via `from_config(config)` — exactly as the `mode="process_raster"` worker does, so template chunking cannot drift from worker writes (the issue #99 lesson) — and calls `emit_raster_template(store, grid, config, times_us, overwrite)`. `times_us` is catalog-derived and unavailable in the handler, so it rides in the event as an int64 list. The success body echoes `"pipeline": "raster"`, giving the dispatcher a stale-deployment guard (the PR #205 layout-echo precedent): a deployed function without this branch would fall through to the point-path `grid.emit_template` and write the wrong template — the echo check turns that into a loud pre-fan-out redeploy error. Flat and hive setup handling is byte-identical (bodies pinned in new tests, wire events pinned in the existing `TestInvokeLambdaSetupEvent`).

**Runner (`src/zagg/runner.py`):** on the lambda backend, `RasterStrategy.run` no longer opens the store or emits the template orchestrator-side. `_run_lambda_shards` now runs `_invoke_lambda_ping` (the issue #252 stale-deploy guard — a pre-#252 function 400s the ping with zero writes; the hive manifest precheck is a no-op for a raster config) followed by the new synchronous `_invoke_lambda_raster_setup` before fan-out; `template_s` brackets the ping + setup invokes, keeping the summary schema and the `raster_series.parquet` column semantics ("setup-ish wall before fan-out") intact. The local backend is byte-identical to today (direct `emit_raster_template` at init, correct where the operator's credentials can write S3).

**Stale-deployment posture** (the "degrade loudly" acceptance): two nested guards. A pre-#252 function falls through the ping to a 400 with zero writes → redeploy error before any invoke that writes. A #252-capable but pre-#264 function passes the ping but its flat setup branch answers without the `pipeline: "raster"` echo → redeploy error before any worker is dispatched (the error text also says to rerun with overwrite, since the stale function's flat branch may have written point-path template objects at the root before responding).

## Phases

- [x] Phase 1 — handler raster-setup branch + handler tests + flat/hive body pins (d14226f)
- [x] Phase 2 — runner: ping → sync setup invoke on the lambda backend, wire-level event pin + lifecycle-order test, local path byte-identical (413c505)
- [x] Phase 3 — audit the entire raster lambda path for orchestrator-side store writes (report below; no code change needed beyond phases 1–2)
- [x] Phase 4 — docs: raster benchmark-leg lifecycle text in `docs/deployment/benchmark.md` (93717b7)

Review round 1 (phase 1) folded: reject empty `times_us` (5066b20), clean 400 on dense layout in the setup branch (b8aa7da), refuse `overwrite=False` time-coordinate clobber at unchanged length (813edb8). Review round 2 (phase 2) folded: de-hive the shared ping wording (3ce2b41), redeploy hint on setup non-200 (6aa3d82), `times_us` sync-payload-cap note (7f56513); one finding left standing by design — the setup echo guard is post-write on a stale pre-#264 function (see "Stale-deployment posture" above and the inline thread; the window closes permanently once the fleet redeploys).

## Orchestrator-write audit (phase 3)

Swept `agg` → `RasterStrategy.run` → `_run_lambda_shards` and every helper on the raster lambda path for orchestrator-side store writes. **Result: none remain.** The template was the only one; specifically:

- **Template** — was the direct `emit_raster_template` at `runner.py:729`; now behind the sync setup invoke (phases 1–2). The lambda branch returns before `open_store` is ever called; the lifecycle test guards this (`test_lifecycle_order_and_setup_event_pinned` monkeypatches `open_store` to assert no `s3://` open).
- **Status markers (`*.zarr.status/`)** — not used on the raster path: shard fan-out is synchronous `RequestResponse` with no `result_url` key in the event (`_event` in `_run_lambda_shards`), so the issue #151 result-object channel (worker-written anyway, not orchestrator-written) never engages. The `.status/` prefixes in `runner.py` (`_run_lambda`, `_run_lambda_events`) belong to the spatial/temporal async paths.
- **Finalize / consolidation** — the raster path has no finalize leg at all: `_run_lambda_shards` returns the summary straight after fan-out; `consolidate_metadata` sites in `runner.py` are on the Spatial strategy only, and `validate_config` rejects `consolidate_metadata` on raster configs (issue #239).
- **Coverage artifacts (`coverage.moc`)** — hive-only dispatch (`_invoke_lambda_coverage` under the hive finalize block of the spatial path), and raster rejects `store_layout` entirely (issue #239); also already worker-side by design (issue #200).
- **Everything else on the path is read-only or in-memory:** `_load_catalog` (local file), `_select_cells`, `_check_signature`, `raster_time_index`, `from_config`, `_resolve_function_name`, `_build_output_creds_event`, `_dry_run_summary`, `raise_for_fd_exhaustion`.

The `docs/deployment/benchmark-cicd.md` claim "**No S3** — the Zarr template write happens inside the Lambda, so the orchestrator never touches the bucket" was previously true only for the point leg; it now holds for the raster leg too (noted in the phase-4 doc edit).

## Testing

- Full `uv run pytest -q`: **2275 passed, 32 skipped** (post-phase-2; fold commits re-ran the touched suites green: 224 passed across the raster/handler/hive files). One deselected failure, **pre-existing and environmental**: `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` shells out to `build_function.sh`, whose pip resolved against a Python 3.10 interpreter on this machine (cp310 wheels → `zarr>=3.1.5` unresolvable). Untouched by this PR — flagged, not fixed.
- `uv run ruff check src tests` / `ruff format --check` green on all touched files (known pre-existing N818 on `src/zagg/registry.py:64` left alone, as flagged on PR #255).
- Coverage highlights: exact wire pin of the raster setup event + `RequestResponse` invocation type; lifecycle order `ping → setup → process_raster` at the strategy level; stale-ping and stale-setup-echo fail-fast with zero subsequent invokes; creds/endpoint threading on all three lifecycle events; flat/hive setup events and bodies pinned byte-identical; handler setup→worker end-to-end proving workers slab-write into the setup-emitted template; local-path behavior unchanged (existing local tests untouched and green).

## Questions for review

- `template_s` on lambda rows now measures ping + sync setup invoke wall (previously the orchestrator-local template write). Same "setup-ish wall before fan-out" semantics the column documents, so `raster_series.parquet` history stays comparable — flagging in case a stricter split (ping vs setup) is wanted in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
