### PR TITLE
STAND_UP_ANON enables only on truthy values (issue #267 follow-up)

### DIFF
--- a/deployment/aws/stand_up.sh
+++ b/deployment/aws/stand_up.sh
@@ -82,10 +82,12 @@ DIST_REGION="${DIST_REGION:-us-west-2}"
 # dist bucket no longer allows anonymous reads (issue #267), so an unsigned
 # request 403s even for callers whose credentials could read it. Set
 # STAND_UP_ANON=1 to restore unsigned reads against a genuinely public mirror
-# (e.g. a self-hosted DIST_BUCKET copy). Expanded unquoted (single flag, no
-# spaces) so the empty default vanishes — macOS bash 3.2 + `set -u` rejects
-# the empty-array idiom.
-DIST_SIGN="${STAND_UP_ANON:+--no-sign-request}"
+# (e.g. a self-hosted DIST_BUCKET copy); only truthy values enable it, so
+# STAND_UP_ANON=0/false means signed as intended. Expanded unquoted (single
+# flag, no spaces) so the empty default vanishes — macOS bash 3.2 + `set -u`
+# rejects the empty-array idiom.
+DIST_SIGN=""
+case "${STAND_UP_ANON:-}" in 1|true|yes) DIST_SIGN="--no-sign-request" ;; esac
 
 dist_key()   { local p="$DIST_PREFIX"; [ -n "$p" ] && p="$p/"; echo "${p}${1}/${2}"; }  # minor, zip
 dist_root()  { local p="$DIST_PREFIX"; [ -n "$p" ] && p="$p/"; echo "${p}${1}"; }       # versions.json path


### PR DESCRIPTION
Refs #267 (follow-up; the main fixes merged in PR #268 before this review fold landed — my fold push arrived ~30 s after the merge and briefly recreated the auto-deleted branch, since removed).

One-line hardening from the PR #268 review (inline finding r3607181193): `DIST_SIGN` previously used `${STAND_UP_ANON:+--no-sign-request}`, which treats ANY non-empty value as on — so `STAND_UP_ANON=0` or `=false`, plainly intended to force signed reads, would instead enable anonymous mode and resurface the exact 403 the auth fix removed. Now a case statement enables it only for `1|true|yes`.

Tested: `bash -n` clean; behavior change is shell-level only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)