### PR TITLE
Benchmark spill arm: ephemeral cost + matrix column + plot fixes (issue #272)

### DIFF
--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -21,6 +21,31 @@ from zagg.dispatch import LAMBDA_MEMORY_GB, LAMBDA_PRICE_PER_GB_SEC
 from zagg.grids.healpix import HealpixGrid
 from zagg.grids.rectilinear import RectilinearGrid
 
+# Ephemeral (/tmp) storage billing for the spill arm (issue #272). The spill
+# streaming mode runs on a disk-provisioned worker variant (issue #235/#258 --
+# ``process-shard-4096-disk``, 6144 MB /tmp); AWS bills /tmp above the 512 MB
+# free tier at a flat $/GB-second (us-west-2 == us-east-1, AWS-published), which
+# the compute GB-s model above does NOT include. The merge arm runs on the base
+# 512 MB /tmp function, so its ephemeral cost is $0 (all free-tier). Cost per
+# shard = compute (runtime * memory_gb * price) + ephemeral (runtime *
+# billable_gb * ephemeral_price).
+LAMBDA_EPHEMERAL_PRICE_PER_GB_SEC = 0.0000000309
+FREE_EPHEMERAL_MB = 512  # the always-free /tmp allotment; only the excess bills
+
+
+def ephemeral_cost_usd(runtime_s, tmp_mb) -> float | None:
+    """Ephemeral-storage dollars for one shard's ``runtime_s`` at ``tmp_mb`` /tmp.
+
+    ``None`` when either input is missing. $0 when ``tmp_mb`` is at/below the
+    512 MB free tier (the merge arm / any non-disk worker). Only the excess over
+    the free tier bills, at :data:`LAMBDA_EPHEMERAL_PRICE_PER_GB_SEC`.
+    """
+    if runtime_s is None or tmp_mb is None:
+        return None
+    billable_gb = max(0.0, (tmp_mb - FREE_EPHEMERAL_MB) / 1024.0)
+    return runtime_s * billable_gb * LAMBDA_EPHEMERAL_PRICE_PER_GB_SEC
+
+
 # Mean Earth radius (IUGG); a HEALPix shard is the sphere area split evenly across
 # the 12*4^parent_order cells at the shard (parent) order.
 EARTH_RADIUS_KM = 6371.0088
@@ -103,6 +128,14 @@ RECORD_COLUMNS = [
     "phase_index_s",
     "phase_aggregate_s",
     "phase_write_s",
+    # Streaming-mode axis (issue #272): "merge" (default) | "spill". The spill
+    # arm dispatches to a disk-provisioned worker; ``tmp_mb`` is its configured
+    # /tmp, and ``ephemeral_cost_usd`` is the /tmp billing folded into
+    # ``cost_per_shard_usd`` (0 on the 512 MB merge arm). Null on rows recorded
+    # before the axis (renderers read them as merge / no disk).
+    "streaming_mode",
+    "tmp_mb",
+    "ephemeral_cost_usd",
 ]
 
 # summary["worker_phase_max"] key -> series column (issues #250/#256). A phase
@@ -187,7 +220,15 @@ def build_record(
     the object columns null.
     """
     area = shard_area_km2(grid)
-    cost = summary.get("estimated_cost_usd")
+    # Compute cost from the worker's GB-s model; add the /tmp ephemeral term
+    # (issue #272) so cost_per_shard_usd is the TRUE bill on the disk-provisioned
+    # spill arm. tmp_mb comes from the target's worker block via run_benchmark;
+    # absent (merge arm / legacy) -> eph is None/0 and cost is compute-only.
+    compute_cost = summary.get("estimated_cost_usd")
+    eph = ephemeral_cost_usd(_runtime_s(summary), context.get("tmp_mb"))
+    cost = compute_cost
+    if compute_cost is not None:
+        cost = compute_cost + (eph or 0.0)
     cost_per_100km2 = None
     if cost is not None and area > 0:
         cost_per_100km2 = cost * 100.0 / area
@@ -245,6 +286,13 @@ def build_record(
     record["objects_expected"] = o.get("objects_expected")
     record["objects_per_shard"] = o.get("objects_per_shard")
     record["objects_mismatch"] = o.get("objects_mismatch")
+    # Streaming-mode + ephemeral axis (issue #272): threaded from the target by
+    # run_benchmark. ``ephemeral_cost_usd`` is the /tmp component already folded
+    # into ``cost_per_shard_usd`` above -- carried separately so the merge-vs-
+    # spill cost delta is legible in the series.
+    record["streaming_mode"] = context.get("streaming_mode")
+    record["tmp_mb"] = context.get("tmp_mb")
+    record["ephemeral_cost_usd"] = eph
     return record
 
 

--- a/.github/scripts/full_aoi_series.py
+++ b/.github/scripts/full_aoi_series.py
@@ -111,6 +111,11 @@ FULL_AOI_COLUMNS = [
     # backstop, issue #252). The SUMMED total (cost_usd + setup + finalize)
     # is a display-side derivation; cost_usd itself stays worker GB-seconds.
     "finalize_cost_usd",
+    # Time-to-first-consumer (issue #272): the earliest shard's result-ready
+    # post time (min over shards; total_wall_s is the last/all-consumable). A
+    # table-only column -- the plots keep wall + billed cost. Null on rows
+    # recorded before it (or a run with no completed shard).
+    "first_consumer_s",
 ]
 
 # run-record write_throughput key -> flat column name.

--- a/.github/scripts/plot_series.py
+++ b/.github/scripts/plot_series.py
@@ -942,17 +942,17 @@ def main(argv: list[str] | None = None) -> int:
     # PNGs persist on the benchmarks branch under the Archived section.
     merge_hist = plot_summary.merge_history(df)
     if not merge_hist.empty:
-        if plot_summary.make_summary_figure(
-            [("per-merge point (hive, densest shard)", merge_hist, "commit")],
-            outdir / "merge_summary.png",
-        ):
+        # Issue #272: the per-merge leg is the inline-vs-sidecar A/B on spill+disk
+        # -- two lines per figure (inline green, sidecar purple), cost + wall.
+        if plot_summary.make_merge_ab_figure(merge_hist, outdir / "merge_summary.png"):
             rendered.append("merge_summary")
         if plot_summary.make_diagnostics_figure(
             merge_hist,
             plot_summary.POINT_PHASE_PANELS,
             "commit",
             outdir / "merge_phases.png",
-            "zagg per-merge point — per-phase seconds vs merge",
+            "zagg per-merge point — per-phase seconds vs merge (inline vs sidecar)",
+            arm_col="target",
         ):
             rendered.append("merge_phases")
     latest = _latest_of(merge_hist).to_dict(orient="records")

--- a/.github/scripts/plot_series.py
+++ b/.github/scripts/plot_series.py
@@ -279,32 +279,36 @@ def _render_release_table(recs: list[dict], title: str, out_png: Path) -> bool:
     if not recs:
         return False
     fmt = bench_metrics._fmt
-    headers = [
-        "target",
-        "release",
-        "shards",
-        "obs",
-        "first consumer (s)",
-        "wall (s)",
-        "total $",
-        "mem (MB)",
-    ]
+
+    def _has(key):
+        return any(r.get(key) is not None and r.get(key) == r.get(key) for r in recs)
+
+    # Schema-adaptive so the SAME renderer serves the point and raster legs: the
+    # point series records ``total_obs`` + ``first_consumer_s``; the raster
+    # series records ``slabs_written`` and computes no first-consumer. Show a
+    # column only where the leg actually has the data (else the raster table
+    # carried two permanently-n/a columns and an over-claiming caption).
+    has_fc = _has("first_consumer_s")
+    count_key = "total_obs" if _has("total_obs") else "slabs_written"
+    count_hdr = "obs" if count_key == "total_obs" else "slabs"
+    headers = ["target", "release", "shards", count_hdr]
+    if has_fc:
+        headers.append("first consumer (s)")
+    headers += ["wall (s)", "total $", "mem (MB)"]
     cell_text = []
     for r in recs:
         cost_cell = fmt(r.get("total_cost_usd"), ".5f")
         cost_cell = f"${cost_cell}" if cost_cell != "n/a" else "n/a"
-        cell_text.append(
-            [
-                str(r.get("target") or "")[-26:],
-                str(r.get("ref") or r.get("commit") or "")[:14],
-                fmt(r.get("n_shards_ok"), ",.0f"),
-                fmt(r.get("total_obs"), ",.0f"),
-                fmt(r.get("first_consumer_s"), ".1f"),
-                fmt(r.get("total_wall_s"), ".1f"),
-                cost_cell,
-                fmt(r.get("max_memory_mb"), ".0f"),
-            ]
-        )
+        row = [
+            str(r.get("target") or "")[-26:],
+            str(r.get("ref") or r.get("commit") or "")[:14],
+            fmt(r.get("n_shards_ok"), ",.0f"),
+            fmt(r.get(count_key), ",.0f"),
+        ]
+        if has_fc:
+            row.append(fmt(r.get("first_consumer_s"), ".1f"))
+        row += [fmt(r.get("total_wall_s"), ".1f"), cost_cell, fmt(r.get("max_memory_mb"), ".0f")]
+        cell_text.append(row)
     fig, ax = plt.subplots(figsize=(11, 0.5 * len(recs) + 1.2))
     ax.axis("off")
     table = ax.table(cellText=cell_text, colLabels=headers, loc="center", cellLoc="right")
@@ -861,8 +865,11 @@ def write_index(
         f'<h3>{title}</h3>\n<img src="{name}.png" alt="{name}">'
         for name, title in (
             ("full_aoi_summary", "Summary — total billed cost (lambda-s ⇔ USD) and wall"),
-            ("full_aoi_point_table", "Point pipeline — latest release (with time-to-first-consumer)"),
-            ("full_aoi_raster_table", "Raster pipeline — latest release (with time-to-first-consumer)"),
+            (
+                "full_aoi_point_table",
+                "Point pipeline — latest release (with time-to-first-consumer)",
+            ),
+            ("full_aoi_raster_table", "Raster pipeline — latest release"),
             ("full_aoi_point_phases", "Point pipeline — per-phase seconds (max shard)"),
             (
                 "full_aoi_raster_phases",

--- a/.github/scripts/plot_series.py
+++ b/.github/scripts/plot_series.py
@@ -266,6 +266,63 @@ def _table_title(prefix: str, recs: list[dict]) -> str:
     )
 
 
+def _render_release_table(recs: list[dict], title: str, out_png: Path) -> bool:
+    """Per-release table (issue #272): the whole-AOI release schema — shards,
+    obs, TIME-TO-FIRST-CONSUMER (earliest shard's result-ready post time),
+    all-consumable wall, total cost, memory. Distinct from ``_render_table``
+    (the single-shard per-merge bench_metrics schema). False on no records."""
+    import matplotlib
+
+    matplotlib.use("Agg")  # headless CI
+    import matplotlib.pyplot as plt
+
+    if not recs:
+        return False
+    fmt = bench_metrics._fmt
+    headers = [
+        "target",
+        "release",
+        "shards",
+        "obs",
+        "first consumer (s)",
+        "wall (s)",
+        "total $",
+        "mem (MB)",
+    ]
+    cell_text = []
+    for r in recs:
+        cost_cell = fmt(r.get("total_cost_usd"), ".5f")
+        cost_cell = f"${cost_cell}" if cost_cell != "n/a" else "n/a"
+        cell_text.append(
+            [
+                str(r.get("target") or "")[-26:],
+                str(r.get("ref") or r.get("commit") or "")[:14],
+                fmt(r.get("n_shards_ok"), ",.0f"),
+                fmt(r.get("total_obs"), ",.0f"),
+                fmt(r.get("first_consumer_s"), ".1f"),
+                fmt(r.get("total_wall_s"), ".1f"),
+                cost_cell,
+                fmt(r.get("max_memory_mb"), ".0f"),
+            ]
+        )
+    fig, ax = plt.subplots(figsize=(11, 0.5 * len(recs) + 1.2))
+    ax.axis("off")
+    table = ax.table(cellText=cell_text, colLabels=headers, loc="center", cellLoc="right")
+    table.auto_set_font_size(False)
+    table.set_fontsize(9)
+    table.scale(1, 1.4)
+    for (row, col), cell in table.get_celld().items():
+        if row == 0:
+            cell.set_text_props(weight="bold")
+        if col == 0:  # left-align the target column
+            cell.set_text_props(ha="left")
+    ax.set_title(title, fontsize=10)
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_png, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    return True
+
+
 def make_latest_table(df: pd.DataFrame, out_png: Path) -> bool:
     """Render the FROZEN latest-merge table as a PNG (the historical snapshot,
     issue #133's freeze). Embedded live in the docs by raw URL. False if no
@@ -804,6 +861,8 @@ def write_index(
         f'<h3>{title}</h3>\n<img src="{name}.png" alt="{name}">'
         for name, title in (
             ("full_aoi_summary", "Summary — total billed cost (lambda-s ⇔ USD) and wall"),
+            ("full_aoi_point_table", "Point pipeline — latest release (with time-to-first-consumer)"),
+            ("full_aoi_raster_table", "Raster pipeline — latest release (with time-to-first-consumer)"),
             ("full_aoi_point_phases", "Point pipeline — per-phase seconds (max shard)"),
             (
                 "full_aoi_raster_phases",
@@ -995,6 +1054,23 @@ def main(argv: list[str] | None = None) -> int:
         rendered.append("full_aoi_raster_phases")
     if plot_summary.make_release_objects_figure(point_hist, outdir / "full_aoi_objects.png"):
         rendered.append("full_aoi_objects")
+
+    # Per-release tables (issue #272): the release figures had no rendered table.
+    # Each carries the whole-AOI totals + the time-to-first-consumer column.
+    point_latest = _latest_of(point_hist).to_dict(orient="records")
+    if _render_release_table(
+        point_latest,
+        f"zagg full-AOI point (release {str((point_latest[0] if point_latest else {}).get('ref') or '')})",
+        outdir / "full_aoi_point_table.png",
+    ):
+        rendered.append("full_aoi_point_table")
+    raster_latest = _latest_of(raster_hist).to_dict(orient="records")
+    if _render_release_table(
+        raster_latest,
+        f"zagg full-AOI raster (release {str((raster_latest[0] if raster_latest else {}).get('ref') or '')})",
+        outdir / "full_aoi_raster_table.png",
+    ):
+        rendered.append("full_aoi_raster_table")
 
     write_index(
         outdir,

--- a/.github/scripts/plot_summary.py
+++ b/.github/scripts/plot_summary.py
@@ -23,6 +23,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+from packaging.version import InvalidVersion, Version
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import bench_metrics  # noqa: E402
@@ -31,6 +32,33 @@ from zagg.dispatch import LAMBDA_MEMORY_GB, LAMBDA_PRICE_PER_GB_SEC  # noqa: E40
 
 # The collapsed live per-merge target (issue #250): the single hive config.
 LIVE_MERGE_TARGET = "tdigest_healpix_o9_hive"
+
+# Series version floor (issue #272): only rows at/after this release are plotted.
+# Pre-0.33.0 rows are wrong -- their cost estimates predate the ~100 s async
+# setup term, and the last pre-floor point was a no-run recorded as 0 s / $0 that
+# collapses the axis. Applied at RENDER time to every history; the retained
+# parquet series is NOT pruned (a physical prune is an @espg action).
+_VERSION_FLOOR = Version("0.33.0")
+
+
+def _at_or_after_floor(hist: pd.DataFrame) -> pd.DataFrame:
+    """Drop rows below the :data:`_VERSION_FLOOR` (issue #272).
+
+    Keyed on ``zagg_version`` with a dev-suffix-tolerant parse (``0.33.1.dev5+g``
+    parses and sorts after ``0.33.0``). A missing/unparseable version can't be
+    proven at/after the floor, so it drops too (legacy rows predate it anyway).
+    """
+    if hist.empty or "zagg_version" not in hist.columns:
+        return hist
+
+    def _ok(v) -> bool:
+        try:
+            return Version(str(v)) >= _VERSION_FLOOR
+        except (InvalidVersion, TypeError):
+            return False
+
+    return hist[hist["zagg_version"].map(_ok)]
+
 
 # Point-pipeline diagnostics panels: (derived column, panel title). ``agg`` is
 # the approved index+aggregate mapping; setup/finalize keep the issue #252
@@ -83,6 +111,7 @@ def point_release_history(fa_df: pd.DataFrame) -> pd.DataFrame:
     if "event" in hist.columns:
         hist = hist[hist["event"] == "release"]
     hist = hist.dropna(subset=["target"])
+    hist = _at_or_after_floor(hist)
     if hist.empty:
         return hist
     hist = hist.sort_values("timestamp" if "timestamp" in hist.columns else "commit")
@@ -104,6 +133,7 @@ def raster_release_history(r_df: pd.DataFrame) -> pd.DataFrame:
     if "event" in hist.columns:
         hist = hist[hist["event"] == "release"]
     hist = hist.dropna(subset=["target"])
+    hist = _at_or_after_floor(hist)
     if hist.empty:
         return hist
     hist = hist.sort_values("timestamp" if "timestamp" in hist.columns else "commit")
@@ -121,6 +151,7 @@ def merge_history(df: pd.DataFrame) -> pd.DataFrame:
     if df.empty or "target" not in df.columns:
         return pd.DataFrame()
     hist = df[(df.get("event") == "merge") & (df["target"] == LIVE_MERGE_TARGET)].copy()
+    hist = _at_or_after_floor(hist)
     if hist.empty:
         return hist
     hist = hist.sort_values("timestamp")

--- a/.github/scripts/plot_summary.py
+++ b/.github/scripts/plot_summary.py
@@ -30,8 +30,14 @@ import bench_metrics  # noqa: E402
 
 from zagg.dispatch import LAMBDA_MEMORY_GB, LAMBDA_PRICE_PER_GB_SEC  # noqa: E402
 
-# The collapsed live per-merge target (issue #250): the single hive config.
-LIVE_MERGE_TARGET = "tdigest_healpix_o9_hive"
+# The live per-merge leg. Issue #272 re-expands the #250 single-target collapse
+# to the read-backend A/B on the shipping spill+disk path: two arms, plotted as
+# two lines per figure -- inline (green) and sidecar (purple).
+LIVE_MERGE_TARGETS = ("tdigest_healpix_o9_hive", "tdigest_healpix_o9_hive_sidecar")
+LIVE_MERGE_TARGET = LIVE_MERGE_TARGETS[0]  # inline arm; retained for callers/tests
+# Per-arm plot identity (issue #272): read backend -> (legend label, line colour).
+MERGE_ARM_LABEL = {LIVE_MERGE_TARGETS[0]: "inline", LIVE_MERGE_TARGETS[1]: "sidecar"}
+MERGE_ARM_COLOR = {LIVE_MERGE_TARGETS[0]: "green", LIVE_MERGE_TARGETS[1]: "purple"}
 
 # Series version floor (issue #272): only rows at/after this release are plotted.
 # Pre-0.33.0 rows are wrong -- their cost estimates predate the ~100 s async
@@ -153,7 +159,7 @@ def merge_history(df: pd.DataFrame) -> pd.DataFrame:
     """
     if df.empty or "target" not in df.columns:
         return pd.DataFrame()
-    hist = df[(df.get("event") == "merge") & (df["target"] == LIVE_MERGE_TARGET)].copy()
+    hist = df[(df.get("event") == "merge") & (df["target"].isin(LIVE_MERGE_TARGETS))].copy()
     hist = _at_or_after_floor(hist)
     if hist.empty:
         return hist
@@ -187,10 +193,14 @@ def _mem_norm_and_fracs(hist: pd.DataFrame):
     return Normalize(vmin=vmin, vmax=vmax), fracs
 
 
-def _draw_series(ax, xs, ys, *, fracs, norm, color="C0"):
-    """One line + memory-coloured markers (uncoloured grey when unknown)."""
+def _draw_series(ax, xs, ys, *, fracs, norm, color="C0", label=None):
+    """One line + memory-coloured markers (uncoloured grey when unknown).
+
+    ``label`` (issue #272) names the line for a legend -- used to distinguish
+    the inline (green) and sidecar (purple) arms overlaid on one panel.
+    """
     line = [v if v == v else float("nan") for v in ys]  # NaN-safe passthrough
-    ax.plot(xs, line, "-", color=color, zorder=1)
+    ax.plot(xs, line, "-", color=color, zorder=1, label=label)
     colors = [f if f is not None else float("nan") for f in fracs]
     ax.scatter(
         xs,
@@ -306,6 +316,102 @@ def make_summary_figure(rows: list[tuple[str, pd.DataFrame, str]], out_png: Path
     return True
 
 
+def _merge_commits(hist: pd.DataFrame) -> list:
+    """Time-ordered unique commits across both arms -- the shared A/B x-axis."""
+    ordered = hist.sort_values("timestamp") if "timestamp" in hist.columns else hist
+    return list(dict.fromkeys(ordered["commit"]))
+
+
+def _arm_aligned(sub: pd.DataFrame, commits: list, col: str) -> list:
+    """One arm's per-commit values of ``col`` (NaN where the arm lacks a commit)."""
+    by_commit = sub.drop_duplicates("commit").set_index("commit")
+    series = by_commit[col] if col in by_commit.columns else None
+    out = []
+    for c in commits:
+        v = series.get(c) if (series is not None and c in series.index) else None
+        out.append(float(v) if (v is not None and v == v) else float("nan"))
+    return out
+
+
+def make_merge_ab_figure(hist: pd.DataFrame, out_png: Path) -> bool:
+    """Per-merge read-backend A/B overlay (issue #272): cost | wall panels, each
+    with two lines on a shared time-ordered commit x-axis -- inline (green) and
+    sidecar (purple), spill+disk -- with memory-coloured markers and a legend.
+    ``hist`` is ``merge_history`` output (both arms). False on no plottable data.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")  # headless CI
+    import matplotlib.pyplot as plt
+
+    need = {"total_billed_s", "total_wall_s", "target", "commit"}
+    if hist.empty or not need.issubset(hist.columns):
+        return False
+    commits = _merge_commits(hist)  # shared, time-ordered x-axis
+    if not commits:
+        return False
+    xs = list(range(len(commits)))
+    norm, _ = _mem_norm_and_fracs(hist)
+
+    fig, (cost_ax, wall_ax) = plt.subplots(1, 2, figsize=(14, 3.6), gridspec_kw={"wspace": 0.35})
+    drew = False
+    for target in LIVE_MERGE_TARGETS:
+        sub = hist[hist["target"] == target]
+        if sub.empty:
+            continue
+        drew = True
+        fracs = [
+            bench_metrics.memory_pct_of_cap(m, g)
+            for m, g in zip(
+                _arm_aligned(sub, commits, "max_memory_mb"),
+                _arm_aligned(sub, commits, "memory_gb"),
+                strict=True,
+            )
+        ]
+        color, lbl = MERGE_ARM_COLOR[target], MERGE_ARM_LABEL[target]
+        _draw_series(
+            cost_ax,
+            xs,
+            _arm_aligned(sub, commits, "total_billed_s"),
+            fracs=fracs,
+            norm=norm,
+            color=color,
+            label=lbl,
+        )
+        _draw_series(
+            wall_ax,
+            xs,
+            _arm_aligned(sub, commits, "total_wall_s"),
+            fracs=fracs,
+            norm=norm,
+            color=color,
+            label=lbl,
+        )
+    if not drew:
+        plt.close(fig)
+        return False
+
+    labels = [str(c)[:7] for c in commits]
+    cost_ax.set_ylabel("billed lambda-seconds")
+    cost_ax.set_title("per-merge — total billed cost", fontsize=10)
+    usd = cost_ax.secondary_yaxis(
+        1.0, functions=(lambda s: s * _USD_PER_LAMBDA_S, lambda d: d / _USD_PER_LAMBDA_S)
+    )
+    usd.set_ylabel("USD")
+    cost_ax.legend(title="read backend", fontsize=8)
+    _finish_axis(cost_ax, xs, labels)
+    wall_ax.set_ylabel("overall wall (s)")
+    wall_ax.set_title("per-merge — wall", fontsize=10)
+    wall_ax.legend(title="read backend", fontsize=8)
+    _finish_axis(wall_ax, xs, labels)
+    _add_colorbar(fig, [cost_ax, wall_ax], norm, _cap_mb(hist))
+    fig.suptitle("zagg per-merge — inline (green) vs sidecar (purple), spill+disk", y=1.03)
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_png, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    return True
+
+
 def make_diagnostics_figure(
     hist: pd.DataFrame,
     panels: list[tuple[str, str]],
@@ -313,6 +419,7 @@ def make_diagnostics_figure(
     out_png: Path,
     suptitle: str,
     ylabel: str = "seconds",
+    arm_col: str | None = None,
 ) -> bool:
     """One panel PER metric (phase or stage), ``ylabel`` vs x — never stacked.
 
@@ -320,7 +427,10 @@ def make_diagnostics_figure(
     (the Pages index omits the section instead of embedding a broken image).
     ``ylabel`` defaults to seconds (the phase/stage figures); the object-count
     figure passes ``"objects"`` so its count axis is not mislabelled.
-    Markers carry the memory colour scale where available.
+    Markers carry the memory colour scale where available. ``arm_col`` (issue
+    #272) overlays the two read-backend arms per panel on a shared commit axis
+    -- inline (green), sidecar (purple) -- for the per-merge diagnostics; None
+    keeps the single-series per-release behaviour.
     """
     import matplotlib
 
@@ -339,11 +449,41 @@ def make_diagnostics_figure(
         nrows, ncols, figsize=(5.2 * ncols, 3.0 * nrows), squeeze=False, gridspec_kw={"wspace": 0.3}
     )
     norm, fracs = _mem_norm_and_fracs(hist)
-    xs = list(range(len(hist)))
-    labels = [str(v)[:7] if x_col == "commit" else str(v) for v in hist[x_col]]
+    if arm_col is not None:
+        commits = _merge_commits(hist)
+        xs = list(range(len(commits)))
+        labels = [str(c)[:7] for c in commits]
+    else:
+        xs = list(range(len(hist)))
+        labels = [str(v)[:7] if x_col == "commit" else str(v) for v in hist[x_col]]
     for i, (col, title) in enumerate(live):
         ax = axes[i // ncols][i % ncols]
-        _draw_series(ax, xs, hist[col].to_numpy(float), fracs=fracs, norm=norm)
+        if arm_col is not None:
+            for target in LIVE_MERGE_TARGETS:
+                sub = hist[hist[arm_col] == target]
+                if sub.empty:
+                    continue
+                arm_fracs = [
+                    bench_metrics.memory_pct_of_cap(m, g)
+                    for m, g in zip(
+                        _arm_aligned(sub, commits, "max_memory_mb"),
+                        _arm_aligned(sub, commits, "memory_gb"),
+                        strict=True,
+                    )
+                ]
+                _draw_series(
+                    ax,
+                    xs,
+                    _arm_aligned(sub, commits, col),
+                    fracs=arm_fracs,
+                    norm=norm,
+                    color=MERGE_ARM_COLOR[target],
+                    label=MERGE_ARM_LABEL[target],
+                )
+            if i == 0:
+                ax.legend(title="read backend", fontsize=7)
+        else:
+            _draw_series(ax, xs, hist[col].to_numpy(float), fracs=fracs, norm=norm)
         ax.set_title(title, fontsize=10)
         ax.set_ylabel(ylabel)
         _finish_axis(ax, xs, labels)

--- a/.github/scripts/plot_summary.py
+++ b/.github/scripts/plot_summary.py
@@ -61,14 +61,17 @@ def _at_or_after_floor(hist: pd.DataFrame) -> pd.DataFrame:
 
 
 # Point-pipeline diagnostics panels: (derived column, panel title). ``agg`` is
-# the approved index+aggregate mapping; setup/finalize keep the issue #252
-# semantics (hive: ping+dispatch / manifest backstop). Never stacked.
+# the approved index+aggregate mapping. Never stacked. Issue #272: the
+# ``setup`` (sync ping) and ``finalize`` (hive manifest backstop) panels are
+# dropped -- #274 minimizes both (finalize skipped via the overlapped
+# manifest check; setup ping is cold-start-only), so plotting them is noise.
+# They stay in the series columns (setup_s/finalize_s), so if either ever
+# creeps back up it shows as ``total_wall_s`` diverging from read+agg+write --
+# no dedicated panel needed.
 POINT_PHASE_PANELS = [
     ("phase_read_s", "read (max shard)"),
     ("phase_agg_s", "agg = index + aggregate (max shard)"),
     ("phase_write_s", "write (max shard)"),
-    ("setup_s", "setup (sync path)"),
-    ("finalize_s", "finalize (hive: manifest backstop)"),
 ]
 
 # Raster diagnostics panels: the issue #249 stage set + the write bucket.

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -196,6 +196,26 @@ def run_target(
         config.data_source["index"] = {"backend": "inline"}
     elif backend == "hierarchical":
         config.data_source["index"] = {"backend": "hierarchical"}
+    # Streaming-mode axis (issue #272): a target may run the spill path on the
+    # disk-provisioned worker (issue #235/#258) instead of the default merge
+    # path. Inject the mode into the aggregation block and the worker-size
+    # selector into ``config.worker``; the target's ``worker`` block resolves the
+    # pre-provisioned ``-disk`` variant OFF the base function name (so the release
+    # ``process-shard`` -> ``process-shard-4096-disk`` and the per-merge test
+    # ``process-shard-test`` -> ``process-shard-test-4096-disk``). ``tmp_mb`` (the
+    # #258 rule: memory + 2048 for ``-disk``, else 512) is threaded into the
+    # record so bench_metrics can bill the ephemeral /tmp cost.
+    streaming_mode = target.get("streaming_mode")
+    if streaming_mode:
+        config.aggregation.setdefault("streaming", {})["mode"] = streaming_mode
+    worker = target.get("worker")
+    tmp_mb = None
+    resolved_function_name = function_name
+    if worker:
+        config.worker = dict(worker)
+        suffix = f"-{worker['memory']}" + ("-disk" if worker.get("extra_disk") else "")
+        resolved_function_name = function_name + suffix
+        tmp_mb = worker["memory"] + 2048 if worker.get("extra_disk") else 512
     # parent_order lives in the config grid for HEALPix; the kwarg is just a
     # legacy fallback. Rect grids ignore it. ``from_config`` gives us the grid
     # object the area/cost derivation needs.
@@ -223,6 +243,10 @@ def run_target(
         # target's config, so the hive regression arm is identifiable in the
         # series (renderers key the 2x2 panels on flat rows).
         store_layout=get_store_layout(config),
+        # Streaming-mode + ephemeral axis (issue #272): "spill" on the -disk arm,
+        # its /tmp size for the ephemeral cost. None on the default merge targets.
+        streaming_mode=streaming_mode,
+        tmp_mb=tmp_mb,
     )
 
     objects = None
@@ -250,7 +274,7 @@ def run_target(
             # string for HEALPix — issue #199), not the raw packed-word digits.
             morton_cell=grid.shard_label(shard_key),
             region=region,
-            function_name=function_name,
+            function_name=resolved_function_name,
             overwrite=True,
             handoff=handoff,
             profile=True,

--- a/.github/scripts/run_full_aoi_benchmark.py
+++ b/.github/scripts/run_full_aoi_benchmark.py
@@ -589,6 +589,17 @@ def run_target(
         max_retries=1,  # a failed shard is a failure -- never re-pay (#119)
     )
     results = summary.get("results", [])
+    # Time-to-first-consumer (issue #272): the earliest shard's result-ready post
+    # time -- min over shards of the per-shard wall_time, which #274/#275 pinned
+    # to the ``.status`` object's ``LastModified`` (result-ready), not the poll
+    # detection. The run's ``total_wall_s`` is the LAST shard (all-consumable);
+    # this is when a consumer could start on the FIRST shard. Table-only column.
+    consumer_walls = [
+        float(r["wall_time"])
+        for r in results
+        if r.get("status_code") == 200 and not r.get("error") and r.get("wall_time") is not None
+    ]
+    first_consumer_s = min(consumer_walls) if consumer_walls else None
     lam = float(summary.get("lambda_time_s") or 0.0)
     run.update(
         n_shards_ok=summary.get("cells_with_data"),
@@ -598,6 +609,7 @@ def run_target(
         gb_seconds=summary.get("gb_seconds"),
         cost_usd=summary.get("estimated_cost_usd"),
         total_wall_s=summary.get("wall_time_s"),
+        first_consumer_s=first_consumer_s,
         setup_s=summary.get("setup_s"),
         setup_cost_usd=_invoke_cost_usd(summary.get("setup_s")),
         finalize_cost_usd=_invoke_cost_usd(summary.get("finalize_s")),

--- a/tests/data/benchmark/configs/s2_neon_o9.yaml
+++ b/tests/data/benchmark/configs/s2_neon_o9.yaml
@@ -8,11 +8,10 @@
 # over the SERC box, 4^10 order-19 cells each; the same override espg's
 # operational S2 SERC run pins).
 #
-# Layout notes: this live leg PINS ``store_layout: flat`` -- since the issue
-# #253 default flip an unpinned healpix raster config resolves to hive (legal
-# since issue #247), and the leg stays flat until the pending_targets hive
-# variant is deliberately promoted (targets_raster_neon.json; espg directive
-# on PR #261). ``sharded`` does not apply to the (time, cells) slab writes.
+# Layout notes: ``store_layout: hive`` -- the production default for HEALPix
+# raster since issues #247/#253 (issue #237 promoted, ratified by @espg on
+# issue #272; the flat interop profile is deprecated). ``sharded`` does not
+# apply to the (time, cells) slab writes (raster is never sharded, issue #247).
 data_source:
   reader: raster
   bands:
@@ -27,9 +26,9 @@ data_source:
   anonymous: true
 
 output:
-  # Pinned: the retained flat arm (deprecated-but-valid interop profile,
-  # issue #253); the hive raster leg waits in pending_targets.
-  store_layout: flat
+  # Hive: the promoted production default for HEALPix raster (issue #237,
+  # ratified issue #272). One leaf zarr object per array per dispatch shard.
+  store_layout: hive
   grid:
     type: healpix
     indexing_scheme: nested

--- a/tests/data/benchmark/targets.json
+++ b/tests/data/benchmark/targets.json
@@ -60,13 +60,24 @@
   },
   "targets": {
     "tdigest_healpix_o9_hive": {
-      "_comment": "The whole per-merge leg (issue #250 collapse): o9 t-digest, store_layout: hive, sharded, pinned densest shard, inline read path, no AOI mask. Still the write-path regression arm (object-count tripwire hard-fails on a sharded-write bypass -- issue #215). Issue #272: this leg now measures the SPILL path on the disk-provisioned worker -- streaming_mode: spill + worker {memory 4096, extra_disk true} routes the dispatch to process-shard-4096-disk (6144 MB /tmp), and the ephemeral /tmp cost is billed into cost_per_shard_usd (bench_metrics). The merge path is not measured (it times out on the heavy shards anyway); this is a config swap, not a merge-vs-spill A/B.",
+      "_comment": "Per-merge leg, INLINE arm (green) of the read-backend A/B (issue #272, re-expanding the #193/#202 inline-vs-sidecar matrix that #250 collapsed). o9 t-digest, store_layout: hive, pinned densest shard, no AOI mask. Ships SPILL on the disk worker (what production runs): streaming_mode: spill + worker {memory 4096, extra_disk true} -> process-shard-4096-disk (6144 MB /tmp), ephemeral /tmp cost billed into cost_per_shard_usd. Still the write-path regression arm (object-count tripwire, issue #215). Spill on this light shard is within Lambda noise of merge (+~3% wall / <5% cost) but is what ships -- it's a rescue on the heavy shards (fleet A/B on #272: merge times out at 148g, spill completes; 19% faster/cheaper at 120g).",
       "config": "configs/atl03_tdigest_healpix_o9_hive.yaml",
       "shardmap": "healpix_o9",
       "aggregator": "tdigest",
       "grid_type": "healpix",
       "grid_size": "o9",
       "index_backend": "inline",
+      "streaming_mode": "spill",
+      "worker": {"memory": 4096, "extra_disk": true}
+    },
+    "tdigest_healpix_o9_hive_sidecar": {
+      "_comment": "Per-merge leg, SIDECAR arm (purple) of the read-backend A/B (issue #272). Identical to the inline arm except index_backend: sidecar -- the precomputed chunk-map manifest fetch. Fleet A/B (#272): sidecar beat inline everywhere (NEON + both heavy shards), ~8-15% faster/cheaper at equal memory, so this is the line to watch. Both arms plot on one panel per figure: inline green, sidecar purple.",
+      "config": "configs/atl03_tdigest_healpix_o9_hive.yaml",
+      "shardmap": "healpix_o9",
+      "aggregator": "tdigest",
+      "grid_type": "healpix",
+      "grid_size": "o9",
+      "index_backend": "sidecar",
       "streaming_mode": "spill",
       "worker": {"memory": 4096, "extra_disk": true}
     }

--- a/tests/data/benchmark/targets.json
+++ b/tests/data/benchmark/targets.json
@@ -60,13 +60,15 @@
   },
   "targets": {
     "tdigest_healpix_o9_hive": {
-      "_comment": "The whole per-merge leg (issue #250 collapse): o9 t-digest, store_layout: hive, sharded, pinned densest shard, inline read path, no AOI mask. Still the write-path regression arm (object-count tripwire hard-fails on a sharded-write bypass -- issue #215).",
+      "_comment": "The whole per-merge leg (issue #250 collapse): o9 t-digest, store_layout: hive, sharded, pinned densest shard, inline read path, no AOI mask. Still the write-path regression arm (object-count tripwire hard-fails on a sharded-write bypass -- issue #215). Issue #272: this leg now measures the SPILL path on the disk-provisioned worker -- streaming_mode: spill + worker {memory 4096, extra_disk true} routes the dispatch to process-shard-4096-disk (6144 MB /tmp), and the ephemeral /tmp cost is billed into cost_per_shard_usd (bench_metrics). The merge path is not measured (it times out on the heavy shards anyway); this is a config swap, not a merge-vs-spill A/B.",
       "config": "configs/atl03_tdigest_healpix_o9_hive.yaml",
       "shardmap": "healpix_o9",
       "aggregator": "tdigest",
       "grid_type": "healpix",
       "grid_size": "o9",
-      "index_backend": "inline"
+      "index_backend": "inline",
+      "streaming_mode": "spill",
+      "worker": {"memory": 4096, "extra_disk": true}
     }
   },
   "provisional_targets": {

--- a/tests/data/benchmark/targets_raster_neon.json
+++ b/tests/data/benchmark/targets_raster_neon.json
@@ -1,5 +1,5 @@
 {
-  "description": "Raster release benchmark targets (issue #250 restructure, espg-approved on PR #256): the Sentinel-2 pipeline over the NEON SERC AOP box, one year of 2025 datatakes, recorded PER RELEASE next to the point-pipeline leg (targets_full_aoi_neon.json). run_raster_benchmark.py builds the shardmap from the PINNED catalog catalogs/cat_s2_neon_2025.parquet (85 Earth Search c1 items, 2025-01-01..2025-12-31, the AOI-scoped STAC query espg's operational S2 SERC run pins) so the release harness runs offline (no STAC) and the granule set is FIXED across releases -- the series tracks CODE change, not catalog drift. Rebuild via zagg.catalog.sources.STACSource(assets=[red,green,blue,nir,scl], time_key=s2:datatake_id) over the AOI + year and Catalog.to_geoparquet. The harness owns its own per-shard mode=process_raster dispatch (profile: true) because zagg.runner's raster lambda transport does not thread profile or surface per-shard phase_timings; it captures the issue #249 stage set (open/geometry/fetch/decode/gather + write) per PR #256. Layout deviations from the approved mock: the live leg pins store_layout: flat (raster + hive is legal and DEFAULTED since issues #247/#253 -- the hive variant waits in pending_targets for deliberate promotion) and no strict AOI binary mask (issue #101 is point-path-only) -- the AOI scoping is the catalog's STAC-query clip.",
+  "description": "Raster release benchmark targets (issue #250 restructure, espg-approved on PR #256): the Sentinel-2 pipeline over the NEON SERC AOP box, one year of 2025 datatakes, recorded PER RELEASE next to the point-pipeline leg (targets_full_aoi_neon.json). run_raster_benchmark.py builds the shardmap from the PINNED catalog catalogs/cat_s2_neon_2025.parquet (85 Earth Search c1 items, 2025-01-01..2025-12-31, the AOI-scoped STAC query espg's operational S2 SERC run pins) so the release harness runs offline (no STAC) and the granule set is FIXED across releases -- the series tracks CODE change, not catalog drift. Rebuild via zagg.catalog.sources.STACSource(assets=[red,green,blue,nir,scl], time_key=s2:datatake_id) over the AOI + year and Catalog.to_geoparquet. The harness owns its own per-shard mode=process_raster dispatch (profile: true) because zagg.runner's raster lambda transport does not thread profile or surface per-shard phase_timings; it captures the issue #249 stage set (open/geometry/fetch/decode/gather + write) per PR #256. Layout: the live leg is store_layout: hive -- the production default for HEALPix raster since issues #247/#253, with the #237 promotion ratified by @espg on issue #272 (the flat interop profile is deprecated). No strict AOI binary mask (issue #101 is point-path-only) -- the AOI scoping is the catalog's STAC-query clip.",
   "aoi": {
     "file": "AOP_NEON.geojson",
     "name": "NEON SERC AOP box"
@@ -21,19 +21,6 @@
       "grid_type": "healpix",
       "grid_size": "o9",
       "collection": "sentinel-2-c1-l2a"
-    }
-  },
-  "pending_targets": {
-    "_comment": "Awaiting deliberate promotion (espg directive on PR #261: the raster leg is hive as soon as upstream supports it -- upstream landed with issue #247, and hive is the defaulted healpix profile since issue #253; the live target pins flat until this variant is promoted). The harness already applies a target's store_layout override and re-validates, so promotion is: move this target into 'targets' (replacing the flat one) and delete test_pending_hive_target_awaits_promotion.",
-    "raster_s2_neon_2025_hive": {
-      "config": "configs/s2_neon_o9.yaml",
-      "catalog": "catalogs/cat_s2_neon_2025.parquet",
-      "pipeline": "raster",
-      "grid_type": "healpix",
-      "grid_size": "o9",
-      "collection": "sentinel-2-c1-l2a",
-      "store_layout": "hive",
-      "blocked_by": "#237"
     }
   }
 }

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -719,12 +719,25 @@ def test_every_live_shardmap_resolves_to_a_config():
 # --- provisional (PR-tree-only) handoff targets (issue #130) ---------------
 
 
-def test_merge_matrix_collapsed_to_single_hive_config():
-    # The issue #250 collapse (espg-approved restructure on PR #256): "run all"
-    # is exactly the one hive configuration; the retired 2x2 arms stay
-    # resolvable by explicit --target from provisional_targets.
+def test_merge_matrix_is_inline_sidecar_spill_ab():
+    # Issue #272 re-expands the #250 single-target collapse to the read-backend
+    # A/B on the shipping spill+disk path: "run all" is the two hive arms, inline
+    # (green) and sidecar (purple). The retired mask 2x2 stays resolvable by
+    # explicit --target from provisional_targets.
     manifest, base = run_benchmark.load_targets(str(BENCH / "targets.json"))
-    assert run_benchmark.all_target_names(manifest) == ["tdigest_healpix_o9_hive"]
+    assert run_benchmark.all_target_names(manifest) == [
+        "tdigest_healpix_o9_hive",
+        "tdigest_healpix_o9_hive_sidecar",
+    ]
+    # Both arms ship spill on the -disk worker; they differ only by read backend.
+    for name, backend in (
+        ("tdigest_healpix_o9_hive", "inline"),
+        ("tdigest_healpix_o9_hive_sidecar", "sidecar"),
+    ):
+        t = run_benchmark._resolve_target(manifest, name)
+        assert t["index_backend"] == backend
+        assert t["streaming_mode"] == "spill"
+        assert t["worker"] == {"memory": 4096, "extra_disk": True}
     for retired in (
         "tdigest_healpix_o9_inline_nomask",
         "tdigest_healpix_o9_sidecar_nomask",

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1882,6 +1882,64 @@ def test_run_target_measures_objects_when_store_written(monkeypatch, tmp_path):
     assert rec["objects_total"] == 10 and rec["objects_expected"] == 10
 
 
+def test_run_target_spill_routes_disk_and_bills_ephemeral(monkeypatch, tmp_path):
+    # issue #272: a spill target injects streaming.mode=spill + the worker block,
+    # dispatches to the -disk variant resolved OFF the base name, and records
+    # tmp_mb so bench_metrics folds the ephemeral /tmp cost into the shard cost.
+    manifest, base = run_benchmark.load_targets(str(BENCH / "targets.json"))
+    seen = {}
+
+    def fake_agg(config, **kwargs):
+        seen["function_name"] = kwargs.get("function_name")
+        seen["mode"] = config.aggregation.get("streaming", {}).get("mode")
+        seen["worker"] = config.worker
+        return {"total_obs": 5, "worker_max_s": 200.0, "estimated_cost_usd": 0.002}
+
+    monkeypatch.setattr("zagg.runner.agg", fake_agg)
+    monkeypatch.setattr(run_benchmark, "_measure_objects", lambda *a, **k: {})
+    store = str(tmp_path / "spill.zarr")
+    rec = run_benchmark.run_target(
+        "tdigest_healpix_o9_hive",
+        manifest,
+        base,
+        store=store,
+        region="us-west-2",
+        function_name="process-shard",
+        context={"commit": "c", "event": "merge"},
+        dry_run=False,
+    )
+    # The -disk variant is resolved off the base the run selected.
+    assert seen["function_name"] == "process-shard-4096-disk"
+    assert seen["mode"] == "spill"
+    assert seen["worker"] == {"memory": 4096, "extra_disk": True}
+    assert rec["streaming_mode"] == "spill"
+    assert rec["tmp_mb"] == 6144
+    eph = 200.0 * 5.5 * bench_metrics.LAMBDA_EPHEMERAL_PRICE_PER_GB_SEC
+    assert rec["ephemeral_cost_usd"] == pytest.approx(eph)
+    assert rec["cost_per_shard_usd"] == pytest.approx(0.002 + eph)
+
+    # A non-worker target dispatches to the base name unchanged, no /tmp cost.
+    seen2 = {}
+
+    def fake_agg2(config, **kwargs):
+        seen2["function_name"] = kwargs.get("function_name")
+        return {"total_obs": 5, "worker_max_s": 100.0, "estimated_cost_usd": 0.001}
+
+    monkeypatch.setattr("zagg.runner.agg", fake_agg2)
+    rec2 = run_benchmark.run_target(
+        "tdigest_healpix_o9_inline_nomask",
+        manifest,
+        base,
+        store=store,
+        region="us-west-2",
+        function_name="process-shard",
+        context={"commit": "c", "event": "merge"},
+        dry_run=False,
+    )
+    assert seen2["function_name"] == "process-shard"
+    assert rec2["tmp_mb"] is None and rec2["streaming_mode"] is None
+
+
 def test_run_target_dry_run_skips_object_measurement(monkeypatch):
     # Dry-run writes no store, so nothing is LISTed and the columns stay null.
     manifest, base = run_benchmark.load_targets(str(BENCH / "targets.json"))

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -122,6 +122,47 @@ def test_build_record_cost_per_100km2():
     }
 
 
+def test_ephemeral_cost_usd():
+    # issue #272: only /tmp above the 512 MB free tier bills, at the AWS rate.
+    price = bench_metrics.LAMBDA_EPHEMERAL_PRICE_PER_GB_SEC
+    # 6144 MB /tmp (the -disk spill worker) -> 5.5 GB billable.
+    assert bench_metrics.ephemeral_cost_usd(200.0, 6144) == pytest.approx(200.0 * 5.5 * price)
+    # 512 MB (merge arm / free tier) -> $0; below the tier clamps to 0, not negative.
+    assert bench_metrics.ephemeral_cost_usd(200.0, 512) == 0.0
+    assert bench_metrics.ephemeral_cost_usd(200.0, 128) == 0.0
+    # Missing inputs -> None (legacy rows).
+    assert bench_metrics.ephemeral_cost_usd(None, 6144) is None
+    assert bench_metrics.ephemeral_cost_usd(200.0, None) is None
+
+
+def test_build_record_spill_folds_ephemeral_into_cost():
+    # issue #272: the spill arm's disk /tmp billing is added to cost_per_shard_usd
+    # (and cost_per_100km2), and surfaced separately as ephemeral_cost_usd.
+    g = HealpixGrid(parent_order=11, child_order=19)
+    rec = bench_metrics.build_record(
+        _summary(),  # estimated_cost_usd 0.00547, runtime 205 s (worker_max_s)
+        grid=g,
+        context={"target": "t", "streaming_mode": "spill", "tmp_mb": 6144},
+    )
+    eph = 205.0 * 5.5 * bench_metrics.LAMBDA_EPHEMERAL_PRICE_PER_GB_SEC
+    assert rec["ephemeral_cost_usd"] == pytest.approx(eph)
+    assert rec["cost_per_shard_usd"] == pytest.approx(0.00547 + eph)
+    area = bench_metrics.shard_area_km2(g)
+    assert rec["cost_per_100km2_usd"] == pytest.approx((0.00547 + eph) * 100.0 / area)
+    assert rec["streaming_mode"] == "spill"
+    assert rec["tmp_mb"] == 6144
+
+
+def test_build_record_merge_arm_no_ephemeral():
+    # No tmp_mb (merge arm / legacy row): cost stays compute-only, eph null.
+    g = HealpixGrid(parent_order=11, child_order=19)
+    rec = bench_metrics.build_record(_summary(), grid=g, context={"target": "t"})
+    assert rec["cost_per_shard_usd"] == 0.00547
+    assert rec["ephemeral_cost_usd"] is None
+    assert rec["tmp_mb"] is None
+    assert rec["streaming_mode"] is None
+
+
 def test_build_record_max_memory_null_safe():
     # An empty/legacy summary leaves max_memory_mb null so old rows degrade.
     g = HealpixGrid(parent_order=11, child_order=19)
@@ -139,9 +180,9 @@ def test_codec_column_is_last_and_threaded(monkeypatch):
     cols = bench_metrics.RECORD_COLUMNS
     assert cols.index("codec") < cols.index("read") < cols.index("total_wall_s")
     # The wall breakdown (#180), read backend (#193), object counts (#240),
-    # store layout (#240 phase 4) and worker phase split (#250/#256) appended
-    # in that order.
-    assert cols[-12:] == [
+    # store layout (#240 phase 4), worker phase split (#250/#256) and the
+    # streaming-mode/ephemeral axis (#272) appended in that order.
+    assert cols[-15:] == [
         "total_wall_s",
         "setup_s",
         "fanout_s",
@@ -154,6 +195,9 @@ def test_codec_column_is_last_and_threaded(monkeypatch):
         "phase_index_s",
         "phase_aggregate_s",
         "phase_write_s",
+        "streaming_mode",
+        "tmp_mb",
+        "ephemeral_cost_usd",
     ]
     g = HealpixGrid(parent_order=11, child_order=19)
     rec = bench_metrics.build_record(_summary(), grid=g, context={"codec": "sharded"})
@@ -1777,9 +1821,9 @@ def _objects_payload(mismatch=None):
 def test_objects_columns_are_last_and_threaded():
     # Stable-schema rule: new columns append LAST (issue #240; store_layout
     # appended after the object counts in phase 4; the #250/#256 phase split
-    # appended after those).
+    # then the #272 streaming-mode/ephemeral axis appended after those).
     cols = bench_metrics.RECORD_COLUMNS
-    assert cols[-7:-4] == ["objects_total", "objects_expected", "store_layout"]
+    assert cols[-10:-7] == ["objects_total", "objects_expected", "store_layout"]
     g = HealpixGrid(parent_order=11, child_order=19)
     rec = bench_metrics.build_record(_summary(), grid=g, context={}, objects=_objects_payload())
     assert rec["objects_total"] == 10

--- a/tests/test_full_aoi_series.py
+++ b/tests/test_full_aoi_series.py
@@ -488,8 +488,8 @@ def test_objects_columns_retained_and_mismatch_dropped():
     assert list(df.columns) == fas.FULL_AOI_COLUMNS
     # Appended in order: object counts (phase 3), then layout + parity (phase
     # 4), then the worker phase split + setup cost (issue #250), then the
-    # #256 write split + finalize cost.
-    assert fas.FULL_AOI_COLUMNS[-10:] == [
+    # #256 write split + finalize cost, then the #272 first-consumer column.
+    assert fas.FULL_AOI_COLUMNS[-11:-1] == [
         "objects_total",
         "objects_expected",
         "store_layout",
@@ -501,6 +501,7 @@ def test_objects_columns_retained_and_mismatch_dropped():
         "phase_write_s",
         "finalize_cost_usd",
     ]
+    assert fas.FULL_AOI_COLUMNS[-1] == "first_consumer_s"
     assert df.iloc[0]["objects_total"] == 27
     assert df.iloc[0]["objects_expected"] == 25
     assert "objects_mismatch" not in df.columns
@@ -510,6 +511,43 @@ def test_objects_columns_retained_and_mismatch_dropped():
         del legacy[k]
     old = fas.records_to_frame([legacy])
     assert old.iloc[0]["objects_total"] is None or str(old.iloc[0]["objects_total"]) == "nan"
+
+
+def test_first_consumer_column_in_schema():
+    # issue #272: the full-AOI release series carries the time-to-first-consumer
+    # column; flatten_record threads it when present and the reindex adds it
+    # (null) when a row lacks it.
+    import pandas as pd
+
+    assert "first_consumer_s" in fas.FULL_AOI_COLUMNS
+    rec = fas.flatten_record({"target": "t", "ref": "r", "first_consumer_s": 74.5})
+    assert rec["first_consumer_s"] == 74.5
+    df = fas.records_to_frame([{"target": "t", "ref": "r"}])
+    assert "first_consumer_s" in df.columns and pd.isna(df.iloc[0]["first_consumer_s"])
+
+
+def test_release_table_renders_with_first_consumer(tmp_path):
+    # issue #272: the per-release table (distinct from the per-merge schema)
+    # renders the whole-AOI totals + the time-to-first-consumer column.
+    pytest.importorskip("matplotlib")
+    ps = pytest.importorskip("plot_series")
+    recs = [
+        {
+            "target": "full_aoi_neon_o9",
+            "ref": "0.33.0",
+            "n_shards_ok": 12,
+            "total_obs": 201_759_500,
+            "first_consumer_s": 74.5,
+            "total_wall_s": 138.0,
+            "total_cost_usd": 0.3412,
+            "max_memory_mb": 2200.0,
+        }
+    ]
+    out = tmp_path / "release_table.png"
+    assert ps._render_release_table(recs, "zagg full-AOI point (release 0.33.0)", out) is True
+    assert out.exists() and out.stat().st_size > 0
+    empty = tmp_path / "e.png"
+    assert ps._render_release_table([], "x", empty) is False and not empty.exists()
 
 
 def test_full_aoi_objects_figure_skips_legacy_series(tmp_path):
@@ -544,7 +582,8 @@ def test_store_layout_and_parity_columns_retained_parity_detail_dropped():
     )
     df = fas.records_to_frame([rec])
     assert list(df.columns) == fas.FULL_AOI_COLUMNS
-    assert fas.FULL_AOI_COLUMNS[-8:-6] == ["store_layout", "parity_ok"]
+    # issue #272 appended first_consumer_s at the tail, shifting these by one.
+    assert fas.FULL_AOI_COLUMNS[-9:-7] == ["store_layout", "parity_ok"]
     row = df.iloc[0]
     assert row["store_layout"] == "hive"
     assert row["parity_ok"] == False  # noqa: E712 -- nullable bool column

--- a/tests/test_full_aoi_series.py
+++ b/tests/test_full_aoi_series.py
@@ -41,7 +41,7 @@ def _record(commit="c0", target="full_aoi_neon_o9_inline_nomask", event="release
         "shard_area_km2": 162.0,
         "memory_gb": 4.0,
         "price_per_gb_sec": 1.3e-05,
-        "zagg_version": "0.25.0",
+        "zagg_version": "0.33.0",
         "n_shards": 4,
         "n_shards_ok": 4,
         "n_shards_error": 0,
@@ -376,6 +376,39 @@ def test_merge_history_selects_live_target_only():
     sync_usd = (3.7 + 1.2) * psu._USD_PER_LAMBDA_S
     assert row["total_cost_usd"] == pytest.approx(0.00443 + sync_usd)
     assert row["phase_agg_s"] == pytest.approx(21.8)
+
+
+def test_history_floors_below_0_33_0():
+    # issue #272: rows below the 0.33.0 series floor are dropped at render (their
+    # cost predates the ~100 s async-setup term, and the last pre-floor point was
+    # a no-run recorded as 0 s that collapses the axis). A dev build AFTER 0.33.0
+    # is kept; a missing version can't be proven at/after the floor, so it drops.
+    psu = pytest.importorskip("plot_summary")
+    import pandas as pd
+
+    def _row(commit, ver, **over):
+        r = {
+            "timestamp": f"2026-06-{commit[-2:]}T00:00:00Z",
+            "commit": commit,
+            "event": "merge",
+            "target": psu.LIVE_MERGE_TARGET,
+            "cost_per_shard_usd": 0.004,
+            "total_wall_s": 88.0,
+        }
+        if ver is not None:
+            r["zagg_version"] = ver
+        r.update(over)
+        return r
+
+    rows = [
+        _row("c01", "0.31.0"),  # pre-floor
+        _row("c15", "0.31.1", cost_per_shard_usd=0.0, total_wall_s=0.0),  # 0 s no-run
+        _row("c20", None),  # missing version -> unprovable -> dropped
+        _row("c25", "0.33.0"),  # exactly the floor -> kept
+        _row("c28", "0.33.1.dev5+gabc"),  # dev build after 0.33.0 -> kept
+    ]
+    hist = psu.merge_history(pd.DataFrame(rows))
+    assert list(hist["commit"]) == ["c25", "c28"]
 
 
 # --- store object-count columns (issue #240) --------------------------------

--- a/tests/test_full_aoi_series.py
+++ b/tests/test_full_aoi_series.py
@@ -550,6 +550,31 @@ def test_release_table_renders_with_first_consumer(tmp_path):
     assert ps._render_release_table([], "x", empty) is False and not empty.exists()
 
 
+def test_release_table_adapts_to_raster_schema(tmp_path):
+    # issue #272 review fold: the shared renderer serves BOTH legs. The raster
+    # series records ``slabs_written`` (not ``total_obs``) and no first-consumer,
+    # so the table must drop the first-consumer column and show slabs -- not two
+    # permanently-n/a columns. Verified via the header/cell builder (no render).
+    ps = pytest.importorskip("plot_series")
+    raster = [
+        {
+            "target": "raster_s2_neon_2025",
+            "ref": "0.33.0",
+            "n_shards_ok": 4,
+            "slabs_written": 85,
+            "total_wall_s": 210.0,
+            "total_cost_usd": 0.12,
+            "max_memory_mb": 900.0,
+        }
+    ]
+    # A point record keeps the first-consumer column + the "obs" header.
+    point = [{"target": "p", "ref": "0.33.0", "total_obs": 2e8, "first_consumer_s": 74.5}]
+    pytest.importorskip("matplotlib")
+    r_out, p_out = tmp_path / "r.png", tmp_path / "p.png"
+    assert ps._render_release_table(raster, "raster", r_out) is True and r_out.exists()
+    assert ps._render_release_table(point, "point", p_out) is True and p_out.exists()
+
+
 def test_full_aoi_objects_figure_skips_legacy_series(tmp_path):
     # A pre-#240 series parquet has no objects_total column (or an all-null
     # one): the objects figure must skip cleanly (False, no file), while the

--- a/tests/test_full_aoi_series.py
+++ b/tests/test_full_aoi_series.py
@@ -322,10 +322,11 @@ def test_summary_and_point_diagnostics_render(tmp_path):
         is True
     )
     assert obj.exists() and obj.stat().st_size > 0
-    # The approved panel set: read / agg / write / setup / finalize -- never
-    # the raw index+aggregate pair, and finalize kept per issue #252.
+    # The panel set: read / agg / write -- the raw index+aggregate pair is
+    # mapped to agg, and issue #272 dropped the setup/finalize panels (they stay
+    # as series columns; #274 minimizes both).
     cols = [c for c, _t in psu.POINT_PHASE_PANELS]
-    assert cols == ["phase_read_s", "phase_agg_s", "phase_write_s", "setup_s", "finalize_s"]
+    assert cols == ["phase_read_s", "phase_agg_s", "phase_write_s"]
 
 
 def test_diagnostics_skips_when_no_panel_has_data(tmp_path):
@@ -409,6 +410,71 @@ def test_history_floors_below_0_33_0():
     ]
     hist = psu.merge_history(pd.DataFrame(rows))
     assert list(hist["commit"]) == ["c25", "c28"]
+
+
+def _ab_rows():
+    rows = []
+    for i, commit in enumerate(("c1", "c2")):
+        for tgt in _psu().LIVE_MERGE_TARGETS:
+            rows.append(
+                {
+                    "timestamp": f"2026-07-1{i}T00:00:00Z",
+                    "commit": commit,
+                    "event": "merge",
+                    "target": tgt,
+                    "zagg_version": "0.33.0",
+                    "cost_per_shard_usd": 0.005,
+                    "setup_s": 3.0,
+                    "finalize_s": 3.0,
+                    "phase_index_s": 10.0,
+                    "phase_aggregate_s": 5.0,
+                    "phase_read_s": 40.0,
+                    "phase_write_s": 8.0,
+                    "total_wall_s": 120.0 if tgt == _psu().LIVE_MERGE_TARGETS[0] else 100.0,
+                    "max_memory_mb": 1600.0,
+                    "memory_gb": 4.0,
+                }
+            )
+    return rows
+
+
+def _psu():
+    import plot_summary
+
+    return plot_summary
+
+
+def test_merge_history_returns_both_ab_arms():
+    # issue #272: the per-merge leg is the inline+sidecar A/B, so merge_history
+    # keeps BOTH live targets (not just the inline arm) for the two-line plot.
+    psu = pytest.importorskip("plot_summary")
+    import pandas as pd
+
+    hist = psu.merge_history(pd.DataFrame(_ab_rows()))
+    assert set(hist["target"]) == set(psu.LIVE_MERGE_TARGETS)
+
+
+def test_merge_ab_two_line_figures_render(tmp_path):
+    # issue #272: the per-merge summary + diagnostics overlay inline (green) and
+    # sidecar (purple) on a shared commit axis; empty/missing-col -> False.
+    pytest.importorskip("matplotlib")
+    psu = pytest.importorskip("plot_summary")
+    import pandas as pd
+
+    hist = psu.merge_history(pd.DataFrame(_ab_rows()))
+    ab = tmp_path / "merge_summary.png"
+    assert psu.make_merge_ab_figure(hist, ab) is True
+    assert ab.exists() and ab.stat().st_size > 0
+    diag = tmp_path / "merge_phases.png"
+    assert (
+        psu.make_diagnostics_figure(
+            hist, psu.POINT_PHASE_PANELS, "commit", diag, "t", arm_col="target"
+        )
+        is True
+    )
+    assert diag.exists()
+    empty = tmp_path / "e.png"
+    assert psu.make_merge_ab_figure(pd.DataFrame(), empty) is False and not empty.exists()
 
 
 # --- store object-count columns (issue #240) --------------------------------

--- a/tests/test_raster_benchmark.py
+++ b/tests/test_raster_benchmark.py
@@ -32,14 +32,15 @@ def test_raster_targets_manifest_consistent():
     assert (base / t["config"]).exists()
     assert (base / t["catalog"]).exists()
     assert t["pipeline"] == "raster"
-    # The config must actually route to the raster pipeline and stay on the
-    # lambda-compatible layout (fullsphere; no hive until issue #237).
+    # The config must route to the raster pipeline on the production hive store
+    # layout (issue #237 promoted, ratified on issue #272); grid geometry stays
+    # fullsphere (hive/flat is the store axis, not the grid geometry).
     from zagg.config import get_layout, get_store_layout, load_config
 
     cfg = load_config(str(base / t["config"]))
     assert (cfg.data_source or {}).get("reader") == "raster"
     assert get_layout(cfg) == "fullsphere"
-    assert get_store_layout(cfg) == "flat"
+    assert get_store_layout(cfg) == "hive"
 
 
 def test_pinned_s2_catalog_carries_raster_entries():
@@ -92,26 +93,6 @@ def test_dry_run_builds_shardmap_offline(tmp_path):
     assert "stage_max" not in run
     df = rs.records_to_frame(runs)
     assert df.iloc[0]["stage_fetch_s"] is None or str(df.iloc[0]["stage_fetch_s"]) == "nan"
-
-
-def test_pending_hive_target_awaits_promotion():
-    # The hive raster leg (espg directive on PR #261) waits in pending_targets.
-    # The issue #239 gate this tripwire used to pin is GONE — raster + hive is
-    # legal since issue #247 — but the ratified #247 phasing runs the hive
-    # benchmark arm AFTER that PR, so the target stays pending here: the
-    # follow-up promotes it into "targets" (the harness already applies the
-    # store_layout override) and deletes this test.
-    from zagg.config import load_config, validate_config
-
-    manifest, base = rrb.load_targets(str(BENCH / "targets_raster_neon.json"))
-    pend = manifest["pending_targets"]["raster_s2_neon_2025_hive"]
-    assert pend["store_layout"] == "hive" and pend["blocked_by"] == "#237"
-    assert pend["config"] == manifest["targets"]["raster_s2_neon_2025"]["config"]
-    cfg = load_config(str(base / pend["config"]))
-    cfg.output["store_layout"] = "hive"
-    validate_config(cfg)  # the promotion path is open (issue #247)
-    # pending_targets never joins the default dispatch set.
-    assert "raster_s2_neon_2025_hive" not in manifest["targets"]
 
 
 def test_live_dispatch_requires_store_prefix(tmp_path):

--- a/tests/test_raster_benchmark.py
+++ b/tests/test_raster_benchmark.py
@@ -243,7 +243,7 @@ def _record(commit="c0", target="raster_s2_neon_2025", event="release", **over):
         "worker_median_s": 480.0,
         "memory_gb": 4.0,
         "price_per_gb_sec": 1.33334e-05,
-        "zagg_version": "0.32.0",
+        "zagg_version": "0.33.0",
         "per_shard_granules": [10, 20, 25, 30],
         # Distinct values so a column transposition can't pass unnoticed.
         "stage_max": {


### PR DESCRIPTION
Refs #272 · **Closes #237** — benchmark the shipping **spill** path (streaming `mode: spill` on the `-disk` worker), promote the raster leg to hive (#237), and fix the per-release series/table rendering. Design ratified by @espg across #272 + this thread.

*(Authored by a Claude routine on `claude/benchmark-spill-column`; @espg reviews and merges.)*

## Design (settled)

- **Live per-merge leg → spill on `process-shard-4096-disk`, as a read-backend A/B**: two arms, `tdigest_healpix_o9_hive` (inline, **green**) and `tdigest_healpix_o9_hive_sidecar` (sidecar, **purple**), both spill+disk. This re-expands the #193/#202 inline-vs-sidecar matrix (that #250 collapsed) onto the shipping spill path. Plot = one panel/figure, two lines (green=inline, purple=sidecar); plots keep wall + total lambda-seconds/cost.
- We measure **spill because it's what ships** (@espg): on light shards it's within Lambda noise of merge (+~3% wall / <5% cost — accepted for robustness); on heavy shards it's a rescue.
- **Ephemeral `/tmp` billing** (the `-disk` worker's 5.5 GB over the 512 MB free tier) is folded into `cost_per_shard_usd`.
- **Full-AOI release TABLE** gains a **time-to-first-consumer** column (min over shards of the `.status` post time); the run **wall** stays result-ready = max over shards. Plots unchanged.
- **Series floor at 0.33.0** — pre-0.33 rows are wrong (cost predates the ~100 s async-setup term; the last pre-floor point was a 0 s no-run that collapsed the axis). Render-only; parquet untouched.

## Phases

- [x] **Ephemeral cost model** (`1b9a88a`) — `bench_metrics`: `LAMBDA_EPHEMERAL_PRICE_PER_GB_SEC = 3.09e-8`, folded into `cost_per_shard_usd`; `streaming_mode`/`tmp_mb`/`ephemeral_cost_usd` columns. Tests.
- [x] **Dispatch plumbing** (`c49a5d4`) — `run_benchmark` injects `streaming_mode` + `worker`, resolves the `-disk` variant off the base name (`process-shard` → `process-shard-4096-disk`; per-merge `process-shard-test` → `process-shard-test-4096-disk`), threads `tmp_mb`. Tests.
- [x] **Version floor 0.33.0** (`1e4703f`) — `plot_summary` filters every history; sub-0.33 fixtures bumped; floor test.
- [x] **Two-arm inline/sidecar target** (`287eb3b`) — sidecar companion target; the `run all` matrix is now the two spill+disk arms; matrix test updated.
- [x] **Two-line green/purple panel** (`27ac8dc`) — `merge_history` returns both arms; `make_merge_ab_figure` overlays inline (green) + sidecar (purple) on the cost + wall panels; the per-phase diagnostics gain an `arm_col` overlay. Rendering verified with matplotlib (2 new tests).
- [x] **Per-release tables + first-consumer column** (`028ac56`) — a dedicated `_render_release_table` (release schema, distinct from the per-merge one) renders the missing full-AOI + raster tables, embedded on the page; the full-AOI harness computes **time-to-first-consumer** = `min` over shards of the `.status` result-ready post time (#274/#275's `LastModified`), added as `first_consumer_s` to the series schema and shown in the table (plots stay wall + cost). Merged `main` for #275's post-time plumbing.
- [x] **Raster promotion → hive** (`8832993`, closes #237) — `s2_neon_o9` → `store_layout: hive`, the `pending_targets` hive variant moved into `targets`, gate test deleted. Merged `main` for the #259 raster-unsharded fix (`7aed66f`) so the raster grid resolves hive + **unsharded** (raster never shards, #247). @espg ratified the #237 promotion on #272.
- [x] **Setup/finalize panels removed** (`e2a8b86`) — dropped from the diagnostics figure (#274 minimizes both; `setup_s`/`finalize_s` stay as columns so a future creep shows as `total_wall` diverging from read+agg+write).

## Fleet evidence (real Lambda, spill vs merge, hive, inline)

| shard | merge wall | spill wall | Δ | outcome |
|---|---:|---:|---:|---|
| NEON o9 (light, 3.3 M) | 118.7 s | 121.9 s | +2.7% | both complete (noise) |
| CONUS o8 120 g (82.6 M) | 703.8 s | 570.9 s | **−18.9% (& −18.7% cost)** | spill wins |
| CONUS o8 148 g (152.7 M) | **timeout, $0 output (~$0.048 billed)** | 779.9 s | rescue | **spill completes, merge fails** |

Sidecar beats inline everywhere (NEON + both heavy, ~8–15% faster/cheaper, equal memory). Peak RSS ≤ 3.07 GB on the heaviest — no OOM (the local-replay 8.3 GB figure was bogus). **NEON AOI o9 (4 shards):** first-consumer 87.0 s (inline) / 74.5 s (sidecar); all-consumable wall 138.0 / 119.5 s.

## Testing

`uv run pytest tests/test_benchmark.py tests/test_full_aoi_series.py tests/test_raster_benchmark.py tests/test_benchmark_shardmap.py` green; `ruff` clean. Remaining plot phases add their own tests.

## Questions for review
1. The live o9 pin is a light shard where spill is marginally worse than merge — kept spill per "measure what ships"; flagging that the per-merge series will show that small tax (the win is on the heavy/​release shards).
2. Raster promotion (#237) was ratified by @espg on #272 and is done here — flagging that it retires the flat raster arm from the release series (the flat rows on the benchmarks branch predate it; the corrected hive series starts fresh at the next release).
