### PR TITLE
Shrink async-dispatch wall overhead: result-ready LastModified wall + overlapped manifest check

### DIFF
--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -16,6 +16,7 @@ import logging
 import os
 import random
 import statistics
+import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -2493,11 +2494,28 @@ def _run_lambda(
     # manifest inputs (config + dataset identity from the ShardMap metadata,
     # the same source as the local path) ride the finalize event; flat
     # finalize events stay byte-identical.
+    # Hive manifest checker handles (issue #274 Fix 2): the background thread is
+    # started after the async setup invoke (below) and joined at fan-out end;
+    # _finalize_fn reads ``manifest_found`` to decide whether the backstop invoke
+    # is still needed. None on the flat path (no checker runs there).
+    manifest_found = None
+    manifest_stop = None
+    manifest_thread = None
+
     if get_store_layout(config) == "hive":
         md = catalog_data.get("metadata") or {}
         dataset = {"short_name": md.get("short_name"), "version": md.get("version")}
 
         def _finalize_fn():
+            # issue #274 Fix 2: the checker overlapped the fan-out. Manifest
+            # present -> the async init write (#252) landed; SKIP the backstop
+            # invoke (happy path, ~0 wall). Absent -> rare lost retries-0 Event
+            # write; invoke the finalize backstop to self-heal (unchanged path).
+            if manifest_found is not None and manifest_found.is_set():
+                logger.info(
+                    "morton_hive.json present (overlapped check) -- skipping finalize backstop"
+                )
+                return None
             return _invoke_lambda_finalize(
                 state["lambda_client"],
                 function_name,
@@ -2574,6 +2592,16 @@ def _run_lambda(
             overwrite=overwrite,
             output_creds_event=output_creds_event,
         )
+        # Overlap the fan-out with the client-side morton_hive.json check
+        # (issue #274 Fix 2): the async setup write above typically lands
+        # within seconds, so by finalize the flag is set and the blocking
+        # backstop invoke is skipped. Reads via the poller's output-store path.
+        from zagg.hive import read_manifest
+
+        manifest_kwargs = _output_store_kwargs(output_creds_event, region)
+        manifest_found, manifest_stop, manifest_thread = _start_manifest_checker(
+            lambda: read_manifest(store_path, **manifest_kwargs) is not None
+        )
     else:
         _invoke_lambda_setup(
             state["lambda_client"],
@@ -2622,6 +2650,13 @@ def _run_lambda(
         )
     finally:
         executor.shutdown()
+        # Stop the overlapped manifest checker and read its verdict (#274 Fix 2).
+        # It ran the whole fan-out; stopping now wakes it from its interval wait
+        # and joins cleanly (a final check already ran), leaving manifest_found
+        # settled before _finalize_fn consults it.
+        if manifest_stop is not None:
+            manifest_stop.set()
+            manifest_thread.join(timeout=_MANIFEST_CHECK_JOIN_TIMEOUT_S)
     fanout_s = time.time() - start_time
 
     # Consolidate metadata via Lambda (same rationale as setup -- avoids
@@ -2897,6 +2932,14 @@ _DEFAULT_FUNCTION_TIMEOUT_S = 900
 _ASYNC_POLL_MARGIN_S = 90.0
 _ASYNC_POLL_INTERVAL_S = 5.0
 
+# Hive manifest checker (issue #274 Fix 2). The morton_hive.json backstop is
+# confirmed CLIENT-side, overlapped with the fan-out, instead of a blocking
+# finalize invoke: a background thread GETs the manifest every INTERVAL until
+# it's present (async init write, #252), then the finalize backstop is skipped.
+# JOIN_TIMEOUT bounds the wait when stopping the checker at fan-out end.
+_MANIFEST_CHECK_INTERVAL_S = 10.0
+_MANIFEST_CHECK_JOIN_TIMEOUT_S = 30.0
+
 # Async (Event) invoke requests cap at 256 KB (vs 6 MB synchronous). Budget a
 # little under it so the dispatch pre-flight fails with a remedy before
 # Lambda's raw RequestEntityTooLargeException does; the realistic trigger is a
@@ -2975,6 +3018,39 @@ def _fetch_result(result_store, key):
     except (FileNotFoundError, NotFoundError):
         return None
     return json.loads(bytes(data)), last_modified
+
+
+def _start_manifest_checker(check_present, *, interval_s=_MANIFEST_CHECK_INTERVAL_S):
+    """Overlap the hive fan-out with a background morton_hive.json check (#274 Fix 2).
+
+    ``check_present`` is a zero-arg predicate returning True once the manifest is
+    readable. The moment it is, ``found`` is set and the thread stops; otherwise
+    it re-checks every ``interval_s`` until ``stop`` is set (the caller sets it and
+    joins at fan-out end). The dispatcher NEVER blocks on this -- it overlaps the
+    (hundreds-of-seconds) fan-out, so the async init-time manifest write (#252) has
+    landed by the first check in practice and the finalize backstop is skipped. A
+    transient GET fault is swallowed and retried next tick, never fatal. At least
+    one check always runs (even if ``stop`` is already set), so joining right after
+    an instant fan-out still yields a definitive present/absent verdict. Returns
+    ``(found, stop, thread)``; the thread is a daemon.
+    """
+    found = threading.Event()
+    stop = threading.Event()
+
+    def _run():
+        while True:
+            try:
+                if check_present():
+                    found.set()
+            except Exception:
+                pass  # transient GET fault -- re-check next tick, never fatal
+            if found.is_set() or stop.is_set():
+                return
+            stop.wait(interval_s)
+
+    thread = threading.Thread(target=_run, name="hive-manifest-check", daemon=True)
+    thread.start()
+    return found, stop, thread
 
 
 def _invoke_lambda_event(

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2919,27 +2919,37 @@ _POLL_RETRY_CONFIG = {
 }
 
 
+def _output_store_kwargs(output_creds_event, region):
+    """obstore kwargs for the output store, shared by the async result poller
+    and the hive manifest checker (issues #151, #274).
+
+    Mirrors the worker's ``_output_store_kwargs``: the explicit
+    output-credentials block when supplied, else the ambient chain. Carries the
+    short per-request :data:`_POLL_RETRY_CONFIG` (issue #186) so a single 5xx
+    can't block for minutes and silently overrun a poll/check deadline.
+    """
+    kwargs = {"region": region, "retry_config": _POLL_RETRY_CONFIG}
+    if output_creds_event:
+        kwargs["region"] = output_creds_event.get("region", region)
+        kwargs["credentials"] = output_creds_event
+        if output_creds_event.get("endpointUrl"):
+            kwargs["endpoint_url"] = output_creds_event["endpointUrl"]
+    return kwargs
+
+
 def _result_fetcher(box, prefix, output_creds_event, region, key):
     """Zero-arg fetch closure for one shard's async result object (#151).
 
     The obstore store is built lazily on the first poll and shared across all
     cells via ``box`` (a plain dict; a benign first-poll race just builds it
     twice), so runs whose dispatch is fully mocked (tests) never touch
-    obstore/S3. Credential resolution mirrors the worker's
-    ``_output_store_kwargs``: the explicit output-credentials block when
-    supplied, else the ambient chain.
+    obstore/S3.
     """
 
     def fetch():
         store = box.get("store")
         if store is None:
-            kwargs = {"region": region, "retry_config": _POLL_RETRY_CONFIG}
-            if output_creds_event:
-                kwargs["region"] = output_creds_event.get("region", region)
-                kwargs["credentials"] = output_creds_event
-                if output_creds_event.get("endpointUrl"):
-                    kwargs["endpoint_url"] = output_creds_event["endpointUrl"]
-            store = open_object_store(prefix, **kwargs)
+            store = open_object_store(prefix, **_output_store_kwargs(output_creds_event, region))
             box["store"] = store
         return _fetch_result(store, key)
 
@@ -2947,15 +2957,24 @@ def _result_fetcher(box, prefix, output_creds_event, region, key):
 
 
 def _fetch_result(result_store, key):
-    """Read one worker-written result envelope; None while it hasn't landed."""
+    """Read one worker-written result envelope + its S3 post time (#151, #274).
+
+    Returns ``(envelope, last_modified)`` -- the parsed JSON envelope and the
+    result object's ``LastModified`` (obstore ``GetResult.meta["last_modified"]``,
+    an ``ObjectMeta`` TypedDict), which IS the moment the worker POSTed its
+    ``.status`` result. ``None`` while the object hasn't landed. The post time
+    is the true result-ready wall, independent of poll cadence (issue #274 Fix 1).
+    """
     import obstore
     from obstore.exceptions import NotFoundError
 
     try:
-        data = obstore.get(result_store, key).bytes()
+        response = obstore.get(result_store, key)
+        last_modified = response.meta["last_modified"]
+        data = response.bytes()
     except (FileNotFoundError, NotFoundError):
         return None
-    return json.loads(bytes(data))
+    return json.loads(bytes(data)), last_modified
 
 
 def _invoke_lambda_event(
@@ -3124,21 +3143,32 @@ def _poll_lambda_result(
         # *persistent* fault (e.g. missing s3:GetObject) surfaces in the
         # deadline error below instead of masquerading as a worker crash.
         try:
-            result = result_fetch()
+            fetched = result_fetch()
             fetch_error = None
         except Exception as e:
             fetch_error = e
-            result = None
-        if result is not None:
+            fetched = None
+        if fetched is not None:
+            result, post_time = fetched
             try:
                 body = json.loads(result.get("body", "{}"))
             except (json.JSONDecodeError, TypeError):
                 body = {}
+            # Result-ready wall (issue #274 Fix 1): measure to when the worker
+            # POSTed its .status result (the object's S3 LastModified), not to
+            # when this poll happened to catch it -- so the reported wall is the
+            # same true value at any poll cadence. Fall back to the real clock
+            # only if the store reported no timestamp (defensive; S3 always has
+            # one). ~+-1s LastModified granularity is accepted (issue decision).
+            if post_time is not None:
+                wall_time = post_time.timestamp() - wall_start
+            else:
+                wall_time = time.time() - wall_start
             return {
                 "shard_key": shard_key,
                 "status_code": result.get("statusCode"),
                 "body": body,
-                "wall_time": time.time() - wall_start,
+                "wall_time": wall_time,
                 "lambda_duration": body.get("duration_s", 0),
                 "error": body.get("error"),
                 "retries": retries,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3569,6 +3569,158 @@ class TestConsolidationGate:
         assert self._lambda_finalize_calls(monkeypatch, atl06_config, enabled=True) == 1
 
 
+class TestManifestChecker:
+    """Overlapped morton_hive.json check replacing the blocking finalize
+    backstop on the hive path (issue #274 Fix 2)."""
+
+    def test_checker_sets_found_on_first_hit_and_joins(self):
+        from zagg.runner import _start_manifest_checker
+
+        found, _stop, thread = _start_manifest_checker(lambda: True, interval_s=0.01)
+        thread.join(timeout=2)
+        assert not thread.is_alive()  # stops the moment the manifest is present
+        assert found.is_set()
+
+    def test_checker_stays_unset_while_absent_then_stops(self):
+        import itertools
+
+        from zagg.runner import _start_manifest_checker
+
+        calls = itertools.count()
+
+        def absent():
+            next(calls)
+            return False
+
+        found, stop, thread = _start_manifest_checker(absent, interval_s=0.01)
+        import time as _time
+
+        _time.sleep(0.05)  # let it re-check across a few ticks
+        assert not found.is_set()
+        stop.set()
+        thread.join(timeout=2)
+        assert not thread.is_alive()  # joins cleanly once stopped
+        assert not found.is_set()
+        assert next(calls) > 1  # re-checked, never gave up on its own
+
+    def test_transient_predicate_fault_is_swallowed(self):
+        from zagg.runner import _start_manifest_checker
+
+        state = {"n": 0}
+
+        def flaky():
+            state["n"] += 1
+            if state["n"] == 1:
+                raise RuntimeError("S3 blip")  # a GET fault must not kill it
+            return True
+
+        found, _stop, thread = _start_manifest_checker(flaky, interval_s=0.01)
+        thread.join(timeout=2)
+        assert found.is_set()
+
+    def _hive_finalize_calls(self, monkeypatch, atl06_config, *, manifest_present):
+        import threading
+        from unittest.mock import MagicMock
+
+        import boto3
+
+        import zagg.grids as grids_mod
+        from zagg import runner
+        from zagg.concurrency import ConcurrencyReport
+
+        monkeypatch.setattr(
+            runner,
+            "get_nsidc_s3_credentials",
+            lambda: {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
+        )
+        monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
+        atl06_config.output["store_layout"] = "hive"
+        atl06_config.output["coverage_moc"] = False  # skip the root-coverage dispatch
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        monkeypatch.setattr(runner, "_invoke_lambda_ping", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_invoke_lambda_setup_async", lambda *a, **k: None)
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(
+            runner,
+            "compute_available_workers",
+            lambda requested, *a, **k: (
+                1,
+                ConcurrencyReport(
+                    account_limit=1000,
+                    current_concurrent=0,
+                    padding=100,
+                    available=900,
+                    function_reserved=None,
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            runner,
+            "_invoke_lambda_cell",
+            lambda client, chunk_idx, shard_key, *a, **k: {
+                "shard_key": shard_key,
+                "status_code": 200,
+                "body": {"total_obs": 1},
+                "error": None,
+                "timeout": False,
+            },
+        )
+        # Control the overlapped checker's verdict deterministically -- no real
+        # thread or obstore GET: return a settled Event and capture the predicate.
+        captured = {}
+
+        def fake_checker(check_present, **k):
+            captured["predicate"] = check_present
+            found = threading.Event()
+            if manifest_present:
+                found.set()
+            thread = MagicMock()
+            captured["thread"] = thread
+            return found, threading.Event(), thread
+
+        monkeypatch.setattr(runner, "_start_manifest_checker", fake_checker)
+        calls = []
+        monkeypatch.setattr(runner, "_invoke_lambda_finalize", lambda *a, **k: calls.append(1))
+        runner._run_lambda(
+            atl06_config,
+            _run_catalog(),
+            "s3://out/x.zarr",
+            12,
+            max_cells=None,
+            morton_cell=None,
+            max_workers=1,
+            overwrite=False,
+            dry_run=False,
+            region="us-west-2",
+            function_name="fn",
+        )
+        return len(calls), captured
+
+    def test_hive_skips_finalize_when_manifest_present(self, monkeypatch, atl06_config):
+        n, captured = self._hive_finalize_calls(monkeypatch, atl06_config, manifest_present=True)
+        assert n == 0  # backstop invoke skipped -- happy path, ~0 wall
+        captured["thread"].join.assert_called()  # checker joined, run didn't hang
+
+    def test_hive_invokes_finalize_when_manifest_absent(self, monkeypatch, atl06_config):
+        n, _ = self._hive_finalize_calls(monkeypatch, atl06_config, manifest_present=False)
+        assert n == 1  # rare lost async write -> self-heal via the backstop
+
+    def test_checker_predicate_reads_manifest_at_store_root(self, monkeypatch, atl06_config):
+        import zagg.hive as hive
+
+        seen = {}
+        monkeypatch.setattr(
+            hive,
+            "read_manifest",
+            lambda root, **k: seen.setdefault("root", root) or {"ok": 1},
+        )
+        _n, captured = self._hive_finalize_calls(monkeypatch, atl06_config, manifest_present=True)
+        # The predicate handed to the checker reads morton_hive.json at the store
+        # root via the poller's output-store path (issue #274 Fix 2).
+        assert captured["predicate"]() is True
+        assert seen["root"] == "s3://out/x.zarr"
+
+
 class TestResolveSourceCredentials:
     """Provider-selected source credentials, both pipelines (issue #213 Phase 6)."""
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,7 @@
 """Tests for the runner module (Python API)."""
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 
@@ -745,8 +746,12 @@ class TestInvokeLambdaCellAsync:
         )
 
     @staticmethod
-    def _envelope(body):
-        return {"statusCode": 200, "body": json.dumps(body)}
+    def _envelope(body, *, last_modified=None):
+        # result_fetch now yields (envelope, LastModified) -- the result
+        # object's S3 post time (issue #274 Fix 1). Default to "now" for the
+        # shape-only tests that don't assert the reported wall.
+        env = {"statusCode": 200, "body": json.dumps(body)}
+        return env, last_modified or datetime.now(timezone.utc)
 
     def test_event_invoke_carries_result_url(self):
         from unittest.mock import MagicMock
@@ -793,6 +798,38 @@ class TestInvokeLambdaCellAsync:
         assert len(sleeps) == 2  # slept between the misses
         assert result["status_code"] == 200
 
+    def test_wall_is_result_post_time_not_detection(self, monkeypatch):
+        """Fix 1 (issue #274): the reported wall is measured to the worker's
+        ``.status`` POST time (the result object's S3 ``LastModified``), NOT to
+        when the poll loop happened to catch it -- so widening the poll interval
+        leaves the reported wall unchanged."""
+        from unittest.mock import MagicMock
+
+        import zagg.runner as runner
+
+        # Sleeps are no-ops, so detection (time.time()) lands ~immediately after
+        # wall_start; a detection-based wall would be ~0s. The worker posted its
+        # result 3s after the invoke fired -- the true result-ready wall is 3s.
+        monkeypatch.setattr(runner.time, "sleep", lambda s: None)
+        wall_start = runner.time.time()
+        post_time = datetime.fromtimestamp(wall_start + 3.0, tz=timezone.utc)
+        envelope = {"statusCode": 200, "body": json.dumps({"total_obs": 1, "duration_s": 1.0})}
+
+        def poll_with_interval(poll_interval_s):
+            # Two misses (interval-driven sleeps) before the result lands.
+            fetch = MagicMock(side_effect=[None, None, (envelope, post_time)])
+            return runner._poll_lambda_result(
+                fetch, 12345, 0, wall_start, 0, 60.0, poll_interval_s=poll_interval_s
+            )
+
+        fast = poll_with_interval(5.0)
+        slow = poll_with_interval(30.0)
+        # Post-time wall (3s), not detection (~0s) -- and identical at either
+        # cadence, so tightening/loosening the interval never moves the wall.
+        assert fast["wall_time"] == pytest.approx(3.0, abs=0.5)
+        assert slow["wall_time"] == pytest.approx(3.0, abs=0.5)
+        assert fast["status_code"] == 200
+
     def test_missing_result_at_deadline_records_error_without_retry(self):
         from unittest.mock import MagicMock
 
@@ -817,7 +854,10 @@ class TestInvokeLambdaCellAsync:
         client.invoke.return_value = {"StatusCode": 202}
         result = self._invoke(
             client,
-            lambda: {"statusCode": 500, "body": json.dumps({"error": "Failed to write zarr"})},
+            lambda: (
+                {"statusCode": 500, "body": json.dumps({"error": "Failed to write zarr"})},
+                datetime.now(timezone.utc),
+            ),
         )
         assert result["status_code"] == 500
         assert result["error"] == "Failed to write zarr"
@@ -940,7 +980,11 @@ class TestResultFetcher:
         assert fetch() is None  # nothing written yet
         writer = open_object_store(prefix)
         obstore.put(writer, "12345.json", json.dumps({"statusCode": 200, "body": "{}"}).encode())
-        assert fetch() == {"statusCode": 200, "body": "{}"}
+        # fetch now yields (envelope, LastModified) -- the object's S3 post
+        # time drives the result-ready wall (issue #274 Fix 1).
+        envelope, last_modified = fetch()
+        assert envelope == {"statusCode": 200, "body": "{}"}
+        assert last_modified is not None
         assert "store" in box  # built lazily, cached for subsequent cells
 
     def test_poller_store_uses_short_retry_config(self, monkeypatch):
@@ -2134,12 +2178,15 @@ class TestInvokeLambdaEvent:
         from zagg import runner
 
         client = self._client()
-        fetched = {
-            "statusCode": 200,
-            "body": json.dumps(
-                {"results": {"max_t2m": 5.0}, "timesteps_processed": 2, "duration_s": 2.0}
-            ),
-        }
+        fetched = (
+            {
+                "statusCode": 200,
+                "body": json.dumps(
+                    {"results": {"max_t2m": 5.0}, "timesteps_processed": 2, "duration_s": 2.0}
+                ),
+            },
+            datetime.now(timezone.utc),
+        )
         result = runner._invoke_lambda_event(
             client,
             dict(self._EV),


### PR DESCRIPTION
Closes #274

## What

Shrinks the async-dispatch wall overhead measured on light shards (~19 s gap between end-to-end wall and worker compute), per the espg-ratified design on #274. Two separable, worker-independent fixes; both scoped to `src/zagg/runner.py`. The finalize event shape is unchanged.

### Fix 1 — result-ready wall via S3 `LastModified`

The poll-detection lag was a measurement artifact: the worker POSTs its `.status` result at time T, but the dispatcher recorded the wall at T + (however long until its next 5 s poll caught it).

- `_fetch_result` now returns `(envelope, last_modified)` — the result object's obstore `GetResult.meta["last_modified"]` (an `ObjectMeta` TypedDict) IS the worker's POST time.
- `_poll_lambda_result` sets `wall_time = post_time.timestamp() - wall_start` (falling back to the real clock only if the store reports no timestamp).
- The poll interval (`_ASYNC_POLL_INTERVAL_S = 5.0`) is **unchanged**; deadline/timeout logic stays on `time.time()`. Only the *reported* per-shard wall uses the post time. `±1 s` `LastModified` granularity is accepted (issue decision).
- Run-level result-ready = max over shards of the post time; that aggregation already lives in the benchmark consumer reading `results[*]["wall_time"]` — no new summary key invented.

### Fix 2 — overlapped manifest check replaces the blocking finalize backstop (HIVE only)

`_invoke_lambda_finalize` was a synchronous `RequestResponse` invoke (~3.2 s) the dispatcher blocked on as the idempotent `morton_hive.json` backstop, pure overhead on the happy path (the async init write of #252 virtually always succeeds).

- During the hive fan-out a lightweight background checker (`_start_manifest_checker`) GETs `morton_hive.json` every ~10 s, sets a `threading.Event` the moment it's present, then stops. It overlaps the (hundreds-of-seconds) fan-out and is joined at finalize — the dispatcher never blocks on it.
- At finalize: flag **set** → skip the backstop invoke entirely (happy path, ~0 wall); flag **unset** (rare lost retries-0 Event write) → invoke the finalize backstop to self-heal (unchanged path).
- Flat-layout finalize (metadata consolidation, `mode="finalize"`, #191) is a different path and untouched. Store credentials/obstore kwargs are shared with the result poller via a new `_output_store_kwargs` helper.

## Phases

- [x] Phase 1 — Fix 1 (result-ready `LastModified` wall) + tests
- [x] Phase 2 — Fix 2 (overlapped manifest check) + tests

## How tested

- `uv run pytest tests/test_runner.py tests/test_dispatch.py tests/test_runner_concurrency.py -m "not slow"` green.
- Fix 1: new `test_wall_is_result_post_time_not_detection` — mocked fetch whose `LastModified` is 3 s past `wall_start` with no-op sleeps → asserts `wall_time == 3 s` (not the ~0 s detection time), identical at poll intervals 5 s and 30 s. Existing async/temporal/`_result_fetcher` tests updated to the `(envelope, LastModified)` fetch contract.
- Fix 2: `TestManifestChecker` — `_start_manifest_checker` unit tests (hit sets the flag + thread joins; absent re-checks across ticks then stops; a transient predicate fault is swallowed), plus hive `_run_lambda` integration: manifest present -> `_invoke_lambda_finalize` NOT called + checker joined (no hang); absent -> it IS called (self-heal); a wiring test asserts the predicate reads `morton_hive.json` at the store root.
- `ruff check` / `ruff format --check` clean.

## Questions for review

- (none yet)

