### PR TITLE
Vectorize t-digest build/merge + order-independent k-way fold (issue #279)

### DIFF
--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -55,7 +55,12 @@ from zagg.config import (
     get_data_vars,
     get_output_signature,
 )
-from zagg.stats.tdigest import _DEFAULT_DELTA, build_tdigest, merge_tdigests
+from zagg.stats.tdigest import (
+    _DEFAULT_DELTA,
+    build_tdigest,
+    merge_tdigests,
+    merge_tdigests_kway,
+)
 
 #: Floor for the spill-enable /tmp check: below this, even a degraded
 #: many-block run is pointless — fail at config time instead of thrashing.
@@ -433,12 +438,18 @@ class SpillAggregator:
         except ValueError:
             self._mergeable = False
         self._count_fields: list[str] = []
-        self._digest_fields: dict[str, tuple[str, int]] = {}  # name -> (source, delta)
+        # name -> (source, delta, pairwise). ``pairwise`` selects the cross-block
+        # fold law: False -> order-independent k-way (build_tdigest, the default),
+        # True -> pairwise left-fold (build_tdigest_pairwise). See issue #279.
+        self._digest_fields: dict[str, tuple[str, int, bool]] = {}
         if self._mergeable:
+            from zagg.processing.streaming import _TDIGEST_PAIRWISE_FUNCTION
+
             for name, meta in agg_fields.items():
                 if get_output_signature(meta)["kind"] == "ragged":
                     delta = int((meta.get("params") or {}).get("delta", _DEFAULT_DELTA))
-                    self._digest_fields[name] = (meta.get("source") or "h_li", delta)
+                    pairwise = meta.get("function") == _TDIGEST_PAIRWISE_FUNCTION
+                    self._digest_fields[name] = (meta.get("source") or "h_li", delta, pairwise)
                 else:
                     self._count_fields.append(name)
         if hasattr(grid, "chunk_order") and int(getattr(grid, "chunks_per_shard", 1)) > 1:
@@ -465,6 +476,13 @@ class SpillAggregator:
         # Cross-block mergeable running state (only ever fed on block close).
         self._counts: dict[int, int] = {}
         self._digests: dict[str, dict[int, np.ndarray]] = {n: {} for n in self._digest_fields}
+        # k-way fold accumulator: for order-independent fields, each block's
+        # per-cell digest is stashed here and collapsed once at finalize
+        # (merge_tdigests_kway), rather than pairwise-folded per block. Each part
+        # is a saturated per-block digest and blocks are few, so this stays small.
+        self._digest_parts: dict[str, dict[int, list[np.ndarray]]] = {
+            n: {} for n, (_, _, pairwise) in self._digest_fields.items() if not pairwise
+        }
         # Per-flush unique cell words; unioned lazily by occupied_cells().
         self._occupied: list[np.ndarray] = []
         # Single-block reduce cache: (part_key, col_arrays, cell_to_slice) for
@@ -598,10 +616,12 @@ class SpillAggregator:
     def _fold_block(self, block: SpillBlock) -> None:
         """Fold one block into the running mergeable state, per partition.
 
-        This is the StreamingAggregator merge sequence at block granularity:
-        counts by summation (exact), tdigests built fresh per cell and merged
-        under the field's delta — one merge round per block instead of per
-        buffer, which is the ~6x merge-CPU collapse the design targets.
+        Counts fold by summation (exact). tdigests are built fresh per cell and
+        then, per the field's fold law: **k-way** fields stash the block digest
+        for one order-independent collapse at finalize (:meth:`_finalize_kway`);
+        **pairwise** fields merge it into the running digest here. Either way it
+        is one build round per block instead of per buffer — the ~6x merge-CPU
+        collapse the design targets (issue #279).
         """
         from zagg.processing.aggregate import _group_columns
 
@@ -613,12 +633,30 @@ class SpillAggregator:
             del cells, cols
             for cell, (start, end) in cell_to_slice.items():
                 self._counts[cell] = self._counts.get(cell, 0) + (end - start)
-                for name, (source, delta) in self._digest_fields.items():
+                for name, (source, delta, pairwise) in self._digest_fields.items():
                     fresh = build_tdigest(col_arrays[source][start:end], delta=delta)
-                    held = self._digests[name].get(cell)
-                    self._digests[name][cell] = (
-                        fresh if held is None else merge_tdigests(held, fresh, delta=delta)
-                    )
+                    if pairwise:
+                        held = self._digests[name].get(cell)
+                        self._digests[name][cell] = (
+                            fresh if held is None else merge_tdigests(held, fresh, delta=delta)
+                        )
+                    else:
+                        self._digest_parts[name].setdefault(cell, []).append(fresh)
+
+    def _finalize_kway(self) -> None:
+        """Collapse each k-way field's per-block parts into one digest per cell.
+
+        Runs once, after the final block is folded and before the first emission.
+        The single-pass k-way merge is order-independent (t-digest merge is not
+        associative), so the result does not depend on block reduce order — the
+        property #280 relies on to parallelize the reducer.
+        """
+        for name, cell_parts in self._digest_parts.items():
+            delta = self._digest_fields[name][1]
+            dest = self._digests[name]
+            for cell, parts in cell_parts.items():
+                dest[cell] = merge_tdigests_kway(parts, delta=delta)
+            cell_parts.clear()
 
     # -- post-read emission ----------------------------------------------------
 
@@ -640,6 +678,7 @@ class SpillAggregator:
         key = int(partition_ids(self.grid, children[:1])[0]) if len(children) else 0
         if self._loaded is None or self._loaded[0] != key:
             self._load_partition(key)
+        assert self._loaded is not None  # _load_partition always sets it before returning
         _, col_arrays, cell_to_slice = self._loaded
         chunk_pooled = _pool_chunk_columns(col_arrays, cell_to_slice, children)
         chunk_scalars = _eval_chunk_precompute(self.config, chunk_pooled)
@@ -688,12 +727,14 @@ class SpillAggregator:
         if not self._finalized:
             # Join the in-flight overlap reduce (its failure re-raises here),
             # then fold the final (still-open, never threshold-closed) block
-            # into the running state once, before the first emission.
+            # into the running state once, before the first emission. The k-way
+            # collapse runs after every block is folded so it sees all parts.
             self._join_reducer()
             try:
                 self._fold_block(self._block)
             finally:
                 self._block.close()
+            self._finalize_kway()
             self._finalized = True
         children = np.asarray(children)
         n_cells = len(children)

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -478,8 +478,16 @@ class SpillAggregator:
         self._digests: dict[str, dict[int, np.ndarray]] = {n: {} for n in self._digest_fields}
         # k-way fold accumulator: for order-independent fields, each block's
         # per-cell digest is stashed here and collapsed once at finalize
-        # (merge_tdigests_kway), rather than pairwise-folded per block. Each part
-        # is a saturated per-block digest and blocks are few, so this stays small.
+        # (merge_tdigests_kway), rather than pairwise-folded per block. Holding
+        # all parts to finalize is by design: order-independence forbids
+        # incremental collapse (folding subsets then combining is a tree
+        # reduction of a non-associative op, which reintroduces the very
+        # order-dependence k-way exists to remove). Cost is bounded: each part is
+        # a saturated ≤δ-centroid digest (~4 KB at δ=512, δ·8 bytes), so peak is
+        # ~B×C×(δ·8) over B closed blocks and C occupied cells — small relative
+        # to the multi-GB per-partition build peak the block threshold already
+        # reserves. Tighter memory-budget accounting against that reservation is
+        # owned by the #280 parallel-reduce work.
         self._digest_parts: dict[str, dict[int, list[np.ndarray]]] = {
             n: {} for n, (_, _, pairwise) in self._digest_fields.items() if not pairwise
         }

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -39,8 +39,13 @@ from zagg.config import (
 )
 from zagg.stats.tdigest import _DEFAULT_DELTA, build_tdigest, merge_tdigests
 
-#: The one ragged reducer with a merge law wired up.
+#: Ragged reducers with a cross-block merge law wired up. ``build_tdigest`` folds
+#: k-way (order-independent) on the spill path; ``build_tdigest_pairwise`` folds
+#: pairwise (order-dependent). Both share the same build and both merge pairwise
+#: on the merge-mode path (issue #279).
 _TDIGEST_FUNCTION = "zagg.stats.tdigest.build_tdigest"
+_TDIGEST_PAIRWISE_FUNCTION = "zagg.stats.tdigest.build_tdigest_pairwise"
+_TDIGEST_FUNCTIONS = (_TDIGEST_FUNCTION, _TDIGEST_PAIRWISE_FUNCTION)
 
 
 def get_streaming(config: PipelineConfig) -> dict | None:
@@ -110,10 +115,10 @@ def validate_streaming(config: PipelineConfig) -> None:
                     f"field '{name}': located ragged fields (location: "
                     f"{sig['location']!r}) cannot stream yet"
                 )
-            elif meta.get("function") != _TDIGEST_FUNCTION:
+            elif meta.get("function") not in _TDIGEST_FUNCTIONS:
                 problems.append(
                     f"field '{name}': ragged function {meta.get('function')!r} has no "
-                    f"merge law (only {_TDIGEST_FUNCTION})"
+                    f"merge law (only {' or '.join(_TDIGEST_FUNCTIONS)})"
                 )
             elif tuple(sig["inner_shape"]) != (2,):
                 # The pooled path validates payload shape per cell via

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -85,22 +85,14 @@ __all__ = [
 _DEFAULT_DELTA = 512
 
 
-def _k1_scale(q: float, delta: float) -> float:
-    """Dunning's k1 scale function: k(q) = delta * (arcsin(2q - 1)/pi + 1/2).
+def _k1_scale_array(q: np.ndarray, delta: float) -> np.ndarray:
+    """Dunning's k1 scale ``k(q) = delta * (arcsin(2q - 1)/pi + 1/2)``, vectorized.
 
-    Maps the cumulative rank fraction q ∈ [0, 1] onto [0, delta].  Its
+    Maps each cumulative rank fraction ``q ∈ [0, 1]`` onto ``[0, delta]``.  The
     derivative is largest at the tails (q → 0 or 1) and smallest at the median,
     so bounding each centroid to span ≤ 1 unit of k yields narrow, high-
     resolution centroids in the tails and wide centroids in the middle — the
-    defining t-digest property.  A digest holds ~delta centroids regardless of
-    the observation count, and is loss-free while the count stays ≤ delta.
-    """
-    qc = min(1.0, max(0.0, q))
-    return delta * (float(np.arcsin(2.0 * qc - 1.0)) / np.pi + 0.5)
-
-
-def _k1_scale_array(q: np.ndarray, delta: float) -> np.ndarray:
-    """Vectorized :func:`_k1_scale` over an array of rank fractions.
+    defining t-digest property.
 
     Evaluating the ``arcsin`` for every rank in **one** ufunc call is the whole
     point: the scalar per-observation ``float(np.arcsin(...))`` in the old
@@ -348,50 +340,15 @@ def merge_tdigests(
         else None
     )
 
-    delta_f = float(delta)
-    n_total = float(combined[:, 1].sum())
+    # Re-compress the concatenated sub-centroids under the same k1 budget as
+    # the build path — the weighted variant of the greedy rule (issue #279).
+    out_means, out_weights, starts = _compress(combined[:, 0], combined[:, 1], float(delta))
 
-    means: list[float] = []
-    weights: list[float] = []
-    starts: list[int] = []
-
-    cur_mean = float(combined[0, 0])
-    cur_weight = float(combined[0, 1])
-    cur_start = 0
-    # Cumulative weight before the current centroid's first sub-centroid, and
-    # the k1 scale value at that left edge. A sub-centroid merges in while the
-    # combined centroid still spans ≤ 1 unit of the k1 scale.
-    cum_left = 0.0
-    k_left = _k1_scale(0.0, delta_f)
-
-    for i in range(1, len(combined)):
-        v_mean = float(combined[i, 0])
-        v_weight = float(combined[i, 1])
-        k_right = _k1_scale((cum_left + cur_weight + v_weight) / n_total, delta_f)
-        if k_right - k_left <= 1.0:
-            # Weighted mean update.
-            total = cur_weight + v_weight
-            cur_mean = (cur_mean * cur_weight + v_mean * v_weight) / total
-            cur_weight = total
-        else:
-            means.append(cur_mean)
-            weights.append(cur_weight)
-            starts.append(cur_start)
-            cum_left += cur_weight
-            k_left = _k1_scale(cum_left / n_total, delta_f)
-            cur_mean = v_mean
-            cur_weight = v_weight
-            cur_start = i
-
-    means.append(cur_mean)
-    weights.append(cur_weight)
-    starts.append(cur_start)
-
-    out = np.empty((len(means), 2), dtype=np.float32)
-    out[:, 0] = means
-    out[:, 1] = weights
+    out = np.empty((len(out_means), 2), dtype=np.float32)
+    out[:, 0] = out_means
+    out[:, 1] = out_weights
     if combined_locs is not None:
-        return out, _centroid_ancestors(combined_locs, starts, len(combined))
+        return out, _centroid_ancestors(combined_locs, starts.tolist(), len(combined))
     return out
 
 

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -99,6 +99,69 @@ def _k1_scale(q: float, delta: float) -> float:
     return delta * (float(np.arcsin(2.0 * qc - 1.0)) / np.pi + 0.5)
 
 
+def _k1_scale_array(q: np.ndarray, delta: float) -> np.ndarray:
+    """Vectorized :func:`_k1_scale` over an array of rank fractions.
+
+    Evaluating the ``arcsin`` for every rank in **one** ufunc call is the whole
+    point: the scalar per-observation ``float(np.arcsin(...))`` in the old
+    compression loop was numpy-dispatch-bound, so hoisting it here is what turns
+    the ``O(n)`` Python loop into an ``O(delta)`` one (issue #279).
+    """
+    qc = np.clip(q, 0.0, 1.0)
+    return delta * (np.arcsin(2.0 * qc - 1.0) / np.pi + 0.5)
+
+
+def _compress(
+    means: np.ndarray, weights: np.ndarray, delta: float
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """k1-bounded greedy compression of sorted weighted sub-centroids.
+
+    Shared core for both :func:`build_tdigest` (unit weights over sorted values)
+    and the merge paths (weighted sub-centroids). ``means`` must be ascending
+    and ``weights`` strictly positive, both 1-D float64.
+
+    Returns ``(out_means, out_weights, starts)``: the compressed centroid means
+    (weighted averages), their weights, and ``starts`` — each output centroid's
+    first sub-centroid index, which the located channel reduces over.
+
+    The centroid **boundaries and weights are bit-identical** to the old scalar
+    loop (same k1 values at the same rank fractions, same ``span ≤ 1`` rule);
+    only the means differ, at the float-ULP level, because they are formed as a
+    single weighted ``sum / weight`` rather than an incremental Welford update.
+    Instead of testing every sub-centroid, this jumps straight to each
+    centroid's right edge with one ``searchsorted`` per centroid — so the loop
+    runs ~delta times regardless of ``n`` (issue #279).
+    """
+    n = len(means)
+    cumw = np.cumsum(weights)
+    total = float(cumw[-1])
+    # k1 at each sub-centroid's right edge (cumulative rank fraction cumw[i]/total).
+    # Monotonic in i (weights > 0), so searchsorted can locate boundaries.
+    k_right = _k1_scale_array(cumw / total, delta)
+    k_left0 = float(_k1_scale_array(np.zeros(1), delta)[0])
+
+    starts_list: list[int] = []
+    s = 0
+    while s < n:
+        starts_list.append(s)
+        # Left edge of the centroid starting at s: k1(cumw[s-1]/total), which is
+        # exactly k_right[s-1] (0-edge for s == 0). A sub-centroid i joins while
+        # k_right[i] - k_left <= 1; the first i that breaks it opens the next
+        # centroid. searchsorted(side="right") is that first breaking index.
+        k_left = k_left0 if s == 0 else float(k_right[s - 1])
+        e = int(np.searchsorted(k_right, k_left + 1.0, side="right"))
+        if e <= s:
+            # The very next sub-centroid already overflows the k-span (steep tail):
+            # the centroid holds only its start. Guarantees forward progress.
+            e = s + 1
+        s = e
+
+    starts = np.asarray(starts_list, dtype=np.int64)
+    out_weights = np.add.reduceat(weights, starts)
+    out_means = np.add.reduceat(means * weights, starts) / out_weights
+    return out_means, out_weights, starts
+
+
 def _centroid_ancestors(locations: np.ndarray, starts: list[int], n: int) -> np.ndarray:
     """Reduce per-member morton locations to one enclosing cell per centroid.
 
@@ -189,52 +252,20 @@ def build_tdigest(
         locations = locations[order]
     else:
         sorted_vals = np.sort(values)
-    n_total = float(n)
-    delta_f = float(delta)
 
-    # Centroids accumulated as parallel lists (faster than growing a 2-D array).
-    # ``starts`` records each centroid's first member index in the sorted order,
-    # so the location channel can reduce member words per centroid afterwards.
-    means: list[float] = []
-    weights: list[float] = []
-    starts: list[int] = []
+    # Unit-weight sub-centroids (one per observation); ``_compress`` greedily
+    # merges adjacent ones under the k1 budget. ``starts`` records each output
+    # centroid's first member index in the sorted order, so the location channel
+    # can reduce member words per centroid afterwards.
+    out_means, out_weights, starts = _compress(
+        sorted_vals, np.ones(n, dtype=np.float64), float(delta)
+    )
 
-    cur_mean = sorted_vals[0]
-    cur_weight = 1.0
-    cur_start = 0
-    # k1 scale value at the current centroid's left edge — the cumulative rank
-    # fraction *before* its first observation. Observation i extends the
-    # centroid's right edge to rank (i + 1); it joins the centroid while the
-    # centroid still spans ≤ 1 unit of the k1 scale, otherwise it opens a fresh
-    # centroid. This keeps the digest to ~delta centroids and loss-free until
-    # the count exceeds delta.
-    k_left = _k1_scale(0.0, delta_f)
-
-    for i in range(1, n):
-        v = sorted_vals[i]
-        k_right = _k1_scale((i + 1) / n_total, delta_f)
-        if k_right - k_left <= 1.0:
-            # Merge: update running mean via Welford one-pass update.
-            cur_mean += (v - cur_mean) / (cur_weight + 1.0)
-            cur_weight += 1.0
-        else:
-            means.append(cur_mean)
-            weights.append(cur_weight)
-            starts.append(cur_start)
-            cur_mean = v
-            cur_weight = 1.0
-            cur_start = i
-            k_left = _k1_scale(i / n_total, delta_f)
-
-    means.append(cur_mean)
-    weights.append(cur_weight)
-    starts.append(cur_start)
-
-    out = np.empty((len(means), 2), dtype=np.float32)
-    out[:, 0] = means
-    out[:, 1] = weights
+    out = np.empty((len(out_means), 2), dtype=np.float32)
+    out[:, 0] = out_means
+    out[:, 1] = out_weights
     if locations is not None:
-        return out, _centroid_ancestors(locations, starts, n)
+        return out, _centroid_ancestors(locations, starts.tolist(), n)
     return out
 
 

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -73,12 +73,16 @@ array. See ``zagg/configs/atl03_tdigest_located_healpix.yaml``.
 
 from __future__ import annotations
 
+from typing import overload
+
 import numpy as np
 
 __all__ = [
     "build_tdigest",
+    "build_tdigest_pairwise",
     "cdf_from_tdigest",
     "merge_tdigests",
+    "merge_tdigests_kway",
     "quantile_from_tdigest",
 ]
 
@@ -174,6 +178,12 @@ def _centroid_ancestors(locations: np.ndarray, starts: list[int], n: int) -> np.
     return out
 
 
+@overload
+def build_tdigest(values: np.ndarray, delta: int = ..., locations: None = ...) -> np.ndarray: ...
+@overload
+def build_tdigest(
+    values: np.ndarray, delta: int = ..., *, locations: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]: ...
 def build_tdigest(
     values: np.ndarray,
     delta: int = _DEFAULT_DELTA,
@@ -261,6 +271,19 @@ def build_tdigest(
     return out
 
 
+@overload
+def merge_tdigests(
+    d1: np.ndarray, d2: np.ndarray, delta: int = ..., locations1: None = ..., locations2: None = ...
+) -> np.ndarray: ...
+@overload
+def merge_tdigests(
+    d1: np.ndarray,
+    d2: np.ndarray,
+    delta: int = ...,
+    *,
+    locations1: np.ndarray,
+    locations2: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]: ...
 def merge_tdigests(
     d1: np.ndarray,
     d2: np.ndarray,
@@ -350,6 +373,109 @@ def merge_tdigests(
     if combined_locs is not None:
         return out, _centroid_ancestors(combined_locs, starts.tolist(), len(combined))
     return out
+
+
+@overload
+def merge_tdigests_kway(
+    digests: list[np.ndarray], delta: int = ..., locations: None = ...
+) -> np.ndarray: ...
+@overload
+def merge_tdigests_kway(
+    digests: list[np.ndarray], delta: int = ..., *, locations: list[np.ndarray]
+) -> tuple[np.ndarray, np.ndarray]: ...
+def merge_tdigests_kway(
+    digests: list[np.ndarray],
+    delta: int = _DEFAULT_DELTA,
+    locations: list[np.ndarray] | None = None,
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+    """Merge many t-digests in one pass — **order-independent**.
+
+    Concatenates every centroid array, sorts by mean once, and re-compresses
+    under the k1 budget. Unlike a left-fold of pairwise :func:`merge_tdigests`,
+    the result does **not** depend on the order the digests are combined (t-digest
+    merge is not associative), and it holds the centroid count at the δ budget
+    instead of drifting above it (issue #279). This is the fold law for the
+    standard ``build_tdigest`` reducer on the spill path, where each input is a
+    saturated per-block digest and the block count is small.
+
+    Parameters
+    ----------
+    digests : list of ndarray
+        Centroid arrays ``(k, 2)`` as returned by :func:`build_tdigest`. Empty
+        digests are skipped.
+    delta : int, optional
+        Compression parameter (same default as :func:`build_tdigest`).
+    locations : list of ndarray, optional
+        Per-digest ``uint64`` morton location vectors (issue #87), aligned with
+        ``digests`` (one array per digest, each aligned with that digest's
+        centroids). Pass for the located channel or omit entirely. All folded
+        locations must share a HEALPix base cell (mortie raises otherwise).
+
+    Returns
+    -------
+    ndarray, shape (k_merged, 2), dtype float32
+        Merged, re-compressed centroid array. With ``locations``, returns a
+        ``(digest, locs)`` tuple.
+    """
+    located = locations is not None
+    if locations is not None and len(locations) != len(digests):
+        raise ValueError(f"locations has {len(locations)} arrays but digests has {len(digests)}")
+    arrs: list[np.ndarray] = []
+    locs: list[np.ndarray] = []
+    for i, d in enumerate(digests):
+        d = np.asarray(d, dtype=np.float64)
+        if d.size == 0:
+            continue
+        arrs.append(d)
+        if locations is not None:
+            li = np.asarray(locations[i])
+            if li.dtype != np.uint64:
+                raise ValueError(
+                    f"locations[{i}] dtype {li.dtype} is not uint64; pass packed morton words"
+                )
+            if li.shape != (len(d),):
+                raise ValueError(
+                    f"locations[{i}] shape {li.shape} does not match {len(d)} centroids"
+                )
+            locs.append(li)
+
+    if not arrs:
+        empty = np.empty((0, 2), dtype=np.float32)
+        return (empty, np.empty(0, dtype=np.uint64)) if located else empty
+    if len(arrs) == 1:
+        # A single contributor is already a valid digest; no re-compression, and
+        # copy the location channel so the return never aliases the caller.
+        out = arrs[0].astype(np.float32)
+        return (out, locs[0].copy()) if located else out
+
+    combined = np.concatenate(arrs, axis=0)
+    order = np.argsort(combined[:, 0], kind="stable")
+    combined = combined[order]
+    out_means, out_weights, starts = _compress(combined[:, 0], combined[:, 1], float(delta))
+    out = np.empty((len(out_means), 2), dtype=np.float32)
+    out[:, 0] = out_means
+    out[:, 1] = out_weights
+    if located:
+        combined_locs = np.concatenate(locs)[order]
+        return out, _centroid_ancestors(combined_locs, starts.tolist(), len(combined))
+    return out
+
+
+def build_tdigest_pairwise(
+    values: np.ndarray,
+    delta: int = _DEFAULT_DELTA,
+    locations: np.ndarray | None = None,
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+    """t-digest build whose cross-block fold uses the **pairwise** merge law.
+
+    Output is identical to :func:`build_tdigest` — the difference is downstream,
+    in the spill reducer: ``build_tdigest_pairwise`` fields fold with a pairwise
+    left-fold of :func:`merge_tdigests` (order-dependent, drifts above the δ
+    budget, marginally finer far tail), whereas ``build_tdigest`` folds with the
+    order-independent :func:`merge_tdigests_kway`. This reducer preserves the
+    pre-#279 end-to-end fold semantics for anyone who wants them.
+    """
+    return build_tdigest(values, delta=delta, locations=locations)
 
 
 def quantile_from_tdigest(digest: np.ndarray, q: float) -> float:

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -449,7 +449,14 @@ def merge_tdigests_kway(
         return (out, locs[0].copy()) if located else out
 
     combined = np.concatenate(arrs, axis=0)
-    order = np.argsort(combined[:, 0], kind="stable")
+    # lexsort on (mean, weight) — primary key means, secondary weights — so the
+    # centroid order is intrinsic to (mean, weight) and independent of the input
+    # digest order. A stable argsort on mean alone breaks ties by concatenation
+    # position (i.e. input order), which makes the k-way fold permutation-
+    # dependent when means tie across digests (discrete/quantized sources).
+    # Sub-centroids with identical (mean, weight) are interchangeable, so their
+    # residual order does not affect the result (issue #279).
+    order = np.lexsort((combined[:, 1], combined[:, 0]))
     combined = combined[order]
     out_means, out_weights, starts = _compress(combined[:, 0], combined[:, 1], float(delta))
     out = np.empty((len(out_means), 2), dtype=np.float32)

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -120,10 +120,15 @@ def _compress(
     (weighted averages), their weights, and ``starts`` — each output centroid's
     first sub-centroid index, which the located channel reduces over.
 
-    The centroid **boundaries and weights are bit-identical** to the old scalar
-    loop (same k1 values at the same rank fractions, same ``span ≤ 1`` rule);
-    only the means differ, at the float-ULP level, because they are formed as a
-    single weighted ``sum / weight`` rather than an incremental Welford update.
+    This reproduces the old scalar loop's greedy rule (same k1 values at the same
+    rank fractions, same ``span ≤ 1`` join test) and was verified bit-identical
+    to it across randomized trials. Exact equality is not guaranteed *by
+    construction*, though: the join comparison is re-associated (``searchsorted``
+    on ``k_left + 1.0`` vs the loop's ``k_right - k_left <= 1.0``) and the rank
+    denominator uses ``cumw[-1]`` vs a pairwise ``.sum()``, so a boundary sitting
+    within an ULP of a 1.0 k-span could in principle flip. Means additionally
+    differ at the float-ULP level, being formed as a single weighted
+    ``sum / weight`` rather than an incremental Welford update.
     Instead of testing every sub-centroid, this jumps straight to each
     centroid's right edge with one ``searchsorted`` per centroid — so the loop
     runs ~delta times regardless of ``n`` (issue #279).

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -296,6 +296,13 @@ def _base_variables(delta=256):
     }
 
 
+def _pairwise_variables(delta=256):
+    """Like :func:`_base_variables` but the pairwise-fold reducer (issue #279)."""
+    variables = _base_variables(delta=delta)
+    variables["h_tdigest"]["function"] = "zagg.stats.tdigest.build_tdigest_pairwise"
+    return variables
+
+
 def _config(streaming=None, variables=None, chunk_precompute=None):
     agg = {"variables": variables or _base_variables()}
     if streaming is not None:
@@ -704,10 +711,11 @@ class TestSpillWorkerMultiBlock:
         # Every flush crosses the threshold -> one closed block per flush.
         monkeypatch.setattr("zagg.processing.spill._default_block_bytes", lambda k, tmp_dir=None: 1)
 
-    def test_mergeable_multi_block_byte_identical_to_merge_mode(self, monkeypatch):
-        # One block per flush == one merge round per flush: exactly merge
-        # mode's per-cell build+merge sequence, so the bytes must match it
-        # (and counts stay exact by summation).
+    def test_pairwise_multi_block_byte_identical_to_merge_mode(self, monkeypatch):
+        # The pairwise reducer folds identically per block on both paths, so
+        # spill multi-block must match merge mode byte-for-byte — even when the
+        # fold actually compresses (δ=16 with ~150 obs on the busiest cells, so
+        # this is not the loss-free regime where every law coincides). See #279.
         self._force_tiny_blocks(monkeypatch)
         key = _shard_key()
         results = []
@@ -715,7 +723,7 @@ class TestSpillWorkerMultiBlock:
             {"buffer_granules": 2, "mode": "merge"},
             {"buffer_granules": 2, "mode": "spill"},
         ):
-            cfg = _config(streaming=streaming)
+            cfg = _config(streaming=streaming, variables=_pairwise_variables(delta=16))
             grid = _grid(cfg)
             dfs = _granule_dfs(grid, key, _CELL_LISTS, seed=9)
             results.append(_run(monkeypatch, cfg, grid, key, dfs))
@@ -726,8 +734,54 @@ class TestSpillWorkerMultiBlock:
         vals_m, idx_m = ragged_m["h_tdigest"]
         vals_s, idx_s = ragged_s["h_tdigest"]
         assert idx_m == idx_s
+        # At least one cell spans 3 blocks and compresses, so this is a real test.
+        assert any(float(a[:, 1].sum()) > 16 * 1.27 for a in vals_s)
         for a, b in zip(vals_m, vals_s, strict=True):
             np.testing.assert_array_equal(a, b)
+
+    def test_standard_kway_diverges_from_pairwise_multi_block(self, monkeypatch):
+        # Intended #279 behavior: the standard (k-way) reducer folds a cell's
+        # 3+ blocks in one pass, the pairwise reducer folds them left-to-right,
+        # so the ragged bytes differ on the busiest cells — while counts (exact
+        # by summation) stay identical between the two.
+        self._force_tiny_blocks(monkeypatch)
+        key = _shard_key()
+        out = {}
+        for tag, variables in (("std", _base_variables(delta=16)), ("pw", _pairwise_variables(16))):
+            cfg = _config(streaming={"buffer_granules": 2, "mode": "spill"}, variables=variables)
+            grid = _grid(cfg)
+            dfs = _granule_dfs(grid, key, _CELL_LISTS, seed=9)
+            out[tag] = _run(monkeypatch, cfg, grid, key, dfs)
+        (df_std, ragged_std, _), (df_pw, ragged_pw, _) = out["std"], out["pw"]
+        pd.testing.assert_series_equal(df_std["count"], df_pw["count"])  # counts unchanged
+        vals_std, idx_std = ragged_std["h_tdigest"]
+        vals_pw, idx_pw = ragged_pw["h_tdigest"]
+        assert idx_std == idx_pw
+        assert any(not np.array_equal(a, b) for a, b in zip(vals_std, vals_pw, strict=True)), (
+            "k-way and pairwise should diverge on the multi-block cells"
+        )
+
+    def test_standard_kway_multi_block_tracks_pooled_quantiles(self, monkeypatch):
+        # Correctness: the standard k-way fold over many blocks estimates the
+        # same quantiles (within t-digest tolerance) as a one-shot pooled build.
+        from zagg.stats.tdigest import quantile_from_tdigest
+
+        self._force_tiny_blocks(monkeypatch)
+        key = _shard_key()
+        pooled_cfg = _config()  # no streaming -> one-shot pooled build per cell
+        spill_cfg = _config(streaming={"buffer_granules": 2, "mode": "spill"})
+        grid_p, grid_s = _grid(pooled_cfg), _grid(spill_cfg)
+        dfs = _granule_dfs(grid_p, key, _CELL_LISTS, obs_per_cell=200, seed=4)
+        _, ragged_p, _ = _run(monkeypatch, pooled_cfg, grid_p, key, list(dfs))
+        _, ragged_s, _ = _run(monkeypatch, spill_cfg, grid_s, key, list(dfs))
+        vals_p, idx_p = ragged_p["h_tdigest"]
+        vals_s, idx_s = ragged_s["h_tdigest"]
+        assert idx_p == idx_s
+        by_cell_p = dict(zip(idx_p, vals_p, strict=True))
+        for cell_i, ds in zip(idx_s, vals_s, strict=True):
+            dp = by_cell_p[cell_i]
+            for q in (0.1, 0.5, 0.9):
+                assert abs(quantile_from_tdigest(ds, q) - quantile_from_tdigest(dp, q)) < 1.0
 
     def test_multi_block_actually_engaged_and_counts_exact(self, monkeypatch):
         self._force_tiny_blocks(monkeypatch)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -119,6 +119,16 @@ class TestStreamingConfig:
         with pytest.raises(ValueError, match="merge law"):
             validate_streaming(cfg)
 
+    def test_pairwise_tdigest_reducer_is_streamable(self):
+        # build_tdigest_pairwise carries the pairwise merge law (issue #279),
+        # so it must validate as a mergeable ragged reducer just like the
+        # standard build_tdigest.
+        cfg = _config()
+        cfg.aggregation["variables"]["h_tdigest"]["function"] = (
+            "zagg.stats.tdigest.build_tdigest_pairwise"
+        )
+        validate_streaming(cfg)
+
     def test_located_ragged_rejected(self):
         # The located channel (issue #87) is not threaded through the
         # streaming state yet; reject rather than silently drop it.

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -578,6 +578,25 @@ class TestMergeTDigestsKway:
         for perm in ([2, 0, 4, 1, 5, 3], [5, 4, 3, 2, 1, 0], [1, 3, 5, 0, 2, 4]):
             assert np.array_equal(ref, merge_tdigests_kway([ds[i] for i in perm], delta=256))
 
+    def test_order_independent_with_tied_means(self):
+        """Discrete/quantized sources tie means across digests; the k-way fold
+        must still be permutation-invariant (lexsort tie-break, issue #279).
+
+        A stable argsort on mean alone would break these ties by concatenation
+        order, so a permuted digest list could emit different bytes.
+        """
+        rng = np.random.default_rng(279)
+        # Integers in a tiny range → every digest shares the same handful of
+        # distinct means, so cross-digest ties are guaranteed.
+        ds = [
+            build_tdigest(rng.integers(0, 5, size=4000).astype(np.float64), delta=256)
+            for _ in range(6)
+        ]
+        ref = merge_tdigests_kway(ds, delta=256)
+        assert np.array_equal(ref, merge_tdigests_kway(list(reversed(ds)), delta=256))
+        for perm in ([2, 0, 4, 1, 5, 3], [5, 4, 3, 2, 1, 0], [1, 3, 5, 0, 2, 4]):
+            assert np.array_equal(ref, merge_tdigests_kway([ds[i] for i in perm], delta=256))
+
     def test_pairwise_fold_is_order_dependent(self):
         """Contrast: the pairwise left-fold is NOT associative (issue #279)."""
         ds = self._digests(2, 6)

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -6,8 +6,10 @@ from conftest import point_words as _point_words
 
 from zagg.stats.tdigest import (
     build_tdigest,
+    build_tdigest_pairwise,
     cdf_from_tdigest,
     merge_tdigests,
+    merge_tdigests_kway,
     quantile_from_tdigest,
 )
 
@@ -557,3 +559,121 @@ class TestCdfFromTDigest:
             x = quantile_from_tdigest(digest, q)
             frac = cdf_from_tdigest(digest, x) / total
             assert abs(frac - q) < 0.03, f"q={q}: round-trip frac={frac:.4f}"
+
+
+class TestMergeTDigestsKway:
+    """The order-independent k-way fold (issue #279)."""
+
+    @staticmethod
+    def _digests(seed, k, delta=256):
+        rng = np.random.default_rng(seed)
+        # Enough obs per digest (well past δ) that the k-way vs pairwise fold
+        # actually compresses — the loss-free regime makes them coincide.
+        return [build_tdigest(rng.standard_normal(4000), delta=delta) for _ in range(k)]
+
+    def test_order_independent(self):
+        ds = self._digests(1, 6)
+        ref = merge_tdigests_kway(ds, delta=256)
+        assert np.array_equal(ref, merge_tdigests_kway(list(reversed(ds)), delta=256))
+        for perm in ([2, 0, 4, 1, 5, 3], [5, 4, 3, 2, 1, 0], [1, 3, 5, 0, 2, 4]):
+            assert np.array_equal(ref, merge_tdigests_kway([ds[i] for i in perm], delta=256))
+
+    def test_pairwise_fold_is_order_dependent(self):
+        """Contrast: the pairwise left-fold is NOT associative (issue #279)."""
+        ds = self._digests(2, 6)
+
+        def fold(seq):
+            held = None
+            for d in seq:
+                held = d if held is None else merge_tdigests(held, d, delta=256)
+            return held
+
+        fwd, rev = fold(ds), fold(list(reversed(ds)))
+        assert not np.array_equal(fwd, rev)  # order matters for pairwise
+
+    def test_kway_differs_from_pairwise_past_two(self):
+        """3+ compressing digests: k-way (single pass) ≠ pairwise left-fold."""
+        ds = self._digests(3, 3)
+        kway = merge_tdigests_kway(ds, delta=256)
+        pair = merge_tdigests(merge_tdigests(ds[0], ds[1], delta=256), ds[2], delta=256)
+        assert not np.array_equal(kway, pair)
+
+    def test_weights_sum_to_total(self):
+        ds = self._digests(4, 5)
+        merged = merge_tdigests_kway(ds, delta=256)
+        expected = sum(float(d[:, 1].sum()) for d in ds)
+        np.testing.assert_almost_equal(float(merged[:, 1].sum()), expected, decimal=2)
+
+    def test_centroid_count_bounded(self):
+        ds = self._digests(5, 8, delta=128)
+        merged = merge_tdigests_kway(ds, delta=128)
+        assert len(merged) <= 4 * 128
+
+    def test_means_sorted(self):
+        merged = merge_tdigests_kway(self._digests(6, 4), delta=256)
+        assert np.all(merged[1:, 0] >= merged[:-1, 0])
+
+    def test_empty_list(self):
+        out = merge_tdigests_kway([])
+        assert out.shape == (0, 2) and out.dtype == np.dtype("float32")
+
+    def test_all_empty(self):
+        empty = np.empty((0, 2), dtype=np.float32)
+        out = merge_tdigests_kway([empty, empty])
+        assert out.shape == (0, 2)
+
+    def test_single_nonempty_returned_as_is(self):
+        d = build_tdigest(np.arange(10.0))
+        out = merge_tdigests_kway([d])
+        np.testing.assert_array_equal(out, d.astype(np.float32))
+
+    def test_skips_empty_digests(self):
+        d1 = build_tdigest(np.arange(100.0), delta=64)
+        d2 = build_tdigest(np.arange(100.0, 200.0), delta=64)
+        empty = np.empty((0, 2), dtype=np.float32)
+        with_gaps = merge_tdigests_kway([empty, d1, empty, d2, empty], delta=64)
+        clean = merge_tdigests_kway([d1, d2], delta=64)
+        np.testing.assert_array_equal(with_gaps, clean)
+
+    def test_matches_one_shot_quantiles_within_tolerance(self):
+        rng = np.random.default_rng(11)
+        parts_raw = [rng.standard_normal(4000) for _ in range(5)]
+        pooled = np.concatenate(parts_raw)
+        merged = merge_tdigests_kway([build_tdigest(p, delta=512) for p in parts_raw], delta=512)
+        for q in (0.1, 0.5, 0.9):
+            assert abs(quantile_from_tdigest(merged, q) - float(np.quantile(pooled, q))) < 0.05
+
+    def test_located_channel_contains_contributors(self):
+        (d1, l1), (d2, l2) = (
+            build_tdigest(np.linspace(0, 1, 40), delta=4, locations=_point_words(40, seed=1)),
+            build_tdigest(np.linspace(0, 1, 40), delta=4, locations=_point_words(40, seed=2)),
+        )
+        merged, locs = merge_tdigests_kway([d1, d2], delta=4, locations=[l1, l2])
+        assert locs.dtype == np.uint64 and len(locs) == len(merged)
+        for member in np.concatenate([l1, l2]):
+            assert any(_contains(enclosing, member) for enclosing in locs)
+
+    def test_located_length_mismatch_raises(self):
+        d = build_tdigest(np.arange(10.0))
+        with pytest.raises(ValueError, match="does not match|arrays but digests"):
+            merge_tdigests_kway([d, d], locations=[np.empty(len(d), dtype=np.uint64)])
+
+
+class TestBuildTDigestPairwise:
+    """The pairwise-fold reducer variant (issue #279) — identical build output."""
+
+    def test_output_identical_to_standard(self):
+        rng = np.random.default_rng(21)
+        vals = rng.standard_normal(3000)
+        for delta in (8, 128, 512):
+            np.testing.assert_array_equal(
+                build_tdigest_pairwise(vals, delta=delta), build_tdigest(vals, delta=delta)
+            )
+
+    def test_located_output_identical_to_standard(self):
+        vals = np.linspace(0.0, 1.0, 200)
+        locs = _point_words(200, seed=3)
+        d_p, l_p = build_tdigest_pairwise(vals, delta=32, locations=locs)
+        d_s, l_s = build_tdigest(vals, delta=32, locations=locs)
+        np.testing.assert_array_equal(d_p, d_s)
+        np.testing.assert_array_equal(l_p, l_s)


### PR DESCRIPTION
Closes #279.

## What & why

After #270/#273 moved wall-clock off the read path, the t-digest **aggregation** compute became the tall pole on heavy shards — the hot path in `src/zagg/stats/tdigest.py` was essentially unvectorized (a scalar Python loop with a `float(np.arcsin(...))` per observation). This PR vectorizes it in **pure numpy** (no new deps, Lambda-clean) for ~15× on build and ~6× on the spill fold, and adds an order-independent k-way fold.

Approach:
- **One shared compression core** `_compress(means, weights, delta)` replaces the per-element scalar loop with a precomputed-k1 array + one `searchsorted` per centroid, so the loop runs ~δ times regardless of n. It reproduces the old greedy rule's **centroid boundaries and weights bit-for-bit** (verified across 200 randomized build trials and 150 merge trials); only the per-centroid means shift at the float-ULP level (single `sum/weight` vs. incremental Welford), which vanishes under the float32 cast. Both `build_tdigest` and `merge_tdigests` route through it.
- **`merge_tdigests_kway(digests, ...)`** — concatenate-sort-compress once, so the result is **order-independent** (t-digest merge is not associative) and holds the centroid count at the δ budget instead of drifting above it.
- **`build_tdigest_pairwise`** — a new reducer with identical build output but the pre-#279 **pairwise** fold law, for anyone who wants the old order-dependent semantics.
- **Fold wiring**: on the spill path, the standard `build_tdigest` folds k-way (parts accumulated per block, collapsed once at finalize); `build_tdigest_pairwise` keeps the running pairwise fold. Merge-mode keeps the pairwise fold for both variants (see caveat below).

## Where each fold law runs

| Path | `build_tdigest` (standard) | `build_tdigest_pairwise` |
|---|---|---|
| Pooled (no `streaming`) | one-shot build, no fold | one-shot build, no fold |
| Merge-mode streaming | pairwise | pairwise |
| Spill, single-block | one-shot build, no fold | one-shot build, no fold |
| Spill, multi-block | **k-way** | pairwise |

k-way runs in exactly one place: the standard reducer on the spill multi-block path — the path #280 will parallelize.

## Why merge-mode isn't k-way

k-way holds each block's per-cell digest as a "part" and compresses once at the end. On spill each part is a saturated ~δ-centroid digest over a large slab and blocks are few, so parts-per-cell is tiny. On the **merge-mode** path flushes are fine-grained: each per-flush per-cell digest is often loss-free (< δ obs → one centroid per obs), so accumulating parts ≈ retaining all raw observations, which would break streaming's memory bound. So merge-mode must stay pairwise — it's forced by memory characteristics, not a preference.

## Phases

- [x] Phase 1 — vectorize `build_tdigest` core (~15×; 765→51 ms at 1M obs). Byte-identical output.
- [x] Phase 2 — vectorize `merge_tdigests` (pairwise) via the shared core (~2× per merge). Byte-identical.
- [x] Phase 3 — `merge_tdigests_kway` + `build_tdigest_pairwise` + fold-law wiring in spill/streaming.

## Benchmarks (local, δ=512, normal data)

| n obs | build before | build after |
|---:|---:|---:|
| 100k | 74 ms | 4.7 ms |
| 1M | 765 ms | 51 ms |

Pairwise fold (50 blocks × 5k): 62 → 31 ms; the k-way single-pass over the same is ~10 ms.

## How tested

- Full suite green: **2390 passed, 34 skipped** (`uv run pytest`). ruff check + format clean; mypy clean on every file this PR touches.
- New unit tests (`tests/test_tdigest.py`): k-way order-independence (reversed + 3 permutations → byte-identical), the contrasting pairwise order-*dependence*, k-way ≠ pairwise past two contributors, weights/bounds/sorted, empties/single/skip-empty, one-shot quantile tolerance, located channel, `build_tdigest_pairwise` identical-to-standard.
- New integration tests (`tests/test_spill.py`): pairwise multi-block byte-identical to merge-mode under real compression; standard k-way diverges from pairwise on multi-block cells while counts stay exact; standard k-way tracks pooled quantiles within tolerance.
- Parity harnesses confirming boundaries/weights bit-identical to the pre-#279 scalar loop (build + merge).

## Questions for review

1. **Mode-dependent output for standard `build_tdigest`.** Because k-way ≠ pairwise, the *same config* under `mode: merge` vs `mode: spill` (multi-block, ≥3 compressing blocks) now yields different digest bytes — both valid within t-digest tolerance, diverging only when compression actually happens. `build_tdigest_pairwise` restores byte-identity with merge-mode (the old #270 contract). Is the mode-dependence acceptable as the default, or should the default reducer stay pairwise with k-way opt-in?
2. **δ unchanged** (still 512) — raising it for far-tail accuracy is out of scope here (deferred per #279); flagging only.
3. **Pre-existing, not addressed here:** `tests/test_lambda_build.py::test_function_build_succeeds` fails locally because `deployment/aws/build_function.sh` resolves against a Python <3.11 interpreter (can't satisfy `zarr>=3.1.5`). Unrelated to this change and a deploy script (§1) — flagging, not touching. The mypy baseline outside these files (`worker.py`, `catalog/*`) also remains dirty and is left alone.

Follow-up #280 (parallelize the spill reducer) is blocked on this landing.
