### PR TITLE
Spill reduce/read profiling split — #280 step 0 (measurement enablement)

### DIFF
--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -507,6 +507,11 @@ class SpillAggregator:
         self.spill_bytes = 0
         self.spill_write_s = 0.0
         self.spill_read_s = 0.0
+        # Wall spent in the block fold's *compute* (group + build + merge),
+        # separate from spill_read_s (the read-back I/O), so a profile run can
+        # split reduce-CPU vs read-I/O — the measurement that decides whether the
+        # #280 reducer parallelization should target compute or I/O.
+        self.spill_reduce_s = 0.0
         self._buffer: list = []
         self._buffered_granules = 0
 
@@ -637,6 +642,7 @@ class SpillAggregator:
             t0 = time.perf_counter()
             cells, cols = block.read_partition(key, close=True)
             self.spill_read_s += time.perf_counter() - t0
+            t1 = time.perf_counter()
             col_arrays, cell_to_slice = _group_columns(cols, cells)
             del cells, cols
             for cell, (start, end) in cell_to_slice.items():
@@ -650,6 +656,7 @@ class SpillAggregator:
                         )
                     else:
                         self._digest_parts[name].setdefault(cell, []).append(fresh)
+            self.spill_reduce_s += time.perf_counter() - t1
 
     def _finalize_kway(self) -> None:
         """Collapse each k-way field's per-block parts into one digest per cell.

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -714,6 +714,9 @@ def process_shard(
             # closes mid-read) or the aggregate phase (single-block reduce).
             phase_timings["spill_write_s"] = buffered.spill_write_s
             phase_timings["spill_read_s"] = buffered.spill_read_s
+            # Block-fold compute (group+build+merge), split from read-back I/O so
+            # a profile run shows reduce-CPU vs read-I/O — the #280 measurement.
+            phase_timings["spill_reduce_s"] = buffered.spill_reduce_s
             phase_timings["spill_bytes"] = buffered.spill_bytes
         metadata["phase_timings"] = phase_timings
 

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -697,11 +697,13 @@ class TestSpillWorkerSingleBlock:
             "aggregate",
             "spill_write_s",
             "spill_read_s",
+            "spill_reduce_s",
             "spill_bytes",
         }
         assert timings["spill_bytes"] > 0
         assert timings["spill_write_s"] >= 0
         assert timings["spill_read_s"] >= 0
+        assert timings["spill_reduce_s"] >= 0
 
 
 class TestSpillWorkerMultiBlock:
@@ -782,6 +784,18 @@ class TestSpillWorkerMultiBlock:
             dp = by_cell_p[cell_i]
             for q in (0.1, 0.5, 0.9):
                 assert abs(quantile_from_tdigest(ds, q) - quantile_from_tdigest(dp, q)) < 1.0
+
+    def test_multi_block_reduce_time_is_captured(self, monkeypatch):
+        # The block fold runs only in the multi-block regime, so spill_reduce_s
+        # (the #280 reduce-CPU-vs-read-I/O split) is populated here, not on the
+        # single-block exact path.
+        self._force_tiny_blocks(monkeypatch)
+        key = _shard_key()
+        cfg = _config(streaming={"buffer_granules": 2, "mode": "spill"})
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=200, seed=3)
+        _, _, meta = _run(monkeypatch, cfg, grid, key, dfs, profile=True)
+        assert meta["phase_timings"]["spill_reduce_s"] > 0
 
     def test_multi_block_actually_engaged_and_counts_exact(self, monkeypatch):
         self._force_tiny_blocks(monkeypatch)

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -703,7 +703,9 @@ class TestSpillWorkerSingleBlock:
         assert timings["spill_bytes"] > 0
         assert timings["spill_write_s"] >= 0
         assert timings["spill_read_s"] >= 0
-        assert timings["spill_reduce_s"] >= 0
+        # Single-block regime never enters _fold_block, so the reduce-CPU split
+        # is deterministically zero here (the multi-block case asserts > 0).
+        assert timings["spill_reduce_s"] == 0.0
 
 
 class TestSpillWorkerMultiBlock:


### PR DESCRIPTION
Refs #280. Step 0: before choosing how to parallelize the spill reducer, the profile has to show whether the fold is **reduce-CPU-bound or read-I/O-bound** (post-#279 the reduce is vectorized numpy, so this may have flipped).

## What
Adds `spill_reduce_s` to the spill profile — wall spent in the block fold's compute (`_group_columns` + `build_tdigest` + merge), split from the existing `spill_read_s` (read-back I/O). Populated in the multi-block regime (`_fold_block`); the single-block exact path has no fold.

## Why this gates #280
The A/B/pipelining decision hinges on the split (measured on the **158-granule CONUS slab**, not 88S):
- If `spill_reduce_s` ≪ `spill_read_s` → compute parallelism is pointless; the lever is I/O (output-preserving prefetch pipelining).
- If `spill_reduce_s` is significant → coupled parallel reduce (`reduce_workers=P` ⇄ `block_bytes/P`, since one partition reduce already peaks at ~60% mem) earns its keep.

Also relevant: one partition's reduce peak is ~0.6×mem (`_BUILD_MULT=3`, `partition_bytes=0.2×mem`), so partition-parallelism is **not** free/scheduling-only — it requires shrinking blocks, which changes (in-tolerance) digest bytes. That's why we measure before building.

## Tested
- `test_multi_block_reduce_time_is_captured` (reduce_s > 0 on a forced-multi-block run) + updated `test_profile_carries_spill_instrumentation` key set. `pytest tests/test_spill.py` → 50 passed; ruff clean.

## Next (pending the measurement)
Run the 158g CONUS slab with this and read the reduce/read split → pick coupled-parallel vs pipelining → implement Flavor A. Not byte-affecting; safe to land as the measurement prerequisite.