### PR TITLE
add process-global ambient S3 store cache (issue #287)

### DIFF
--- a/src/zagg/store.py
+++ b/src/zagg/store.py
@@ -1,6 +1,7 @@
 """Store factory for opening Zarr stores from path strings."""
 
 import copy
+import threading
 from datetime import timedelta
 from pathlib import Path
 
@@ -98,6 +99,26 @@ def open_store(
     return LocalStore(Path(path).resolve(), read_only=read_only)
 
 
+# Ambient-credential object-store cache (issue #287): one obstore ``S3Store``
+# per ``s3://`` path per PROCESS, for the ambient (execution-role) hot path only.
+# The sidecar index backend (``h5coro_hidefix.zagg_backend.SidecarIndex``) calls
+# ``open_object_store(self.store)`` once per granule to fetch that granule's
+# manifest parquet; without this cache each call built a fresh
+# ``Boto3CredentialProvider`` whose ``__init__`` eagerly walks the botocore
+# credential chain (~300 ms of client/TLS + "Found credentials..." per granule),
+# on the read critical path — 675 rebuilds on one 784-granule o9 shard. Mirrors
+# the raster ``_STORE_CACHE`` (issue #244). Module lifetime == sandbox lifetime:
+# ``Boto3CredentialProvider`` refreshes per call (30-min ttl) and Lambda role
+# creds are static per sandbox, so a cached store cannot outlive its creds.
+# Scoped deliberately to the ``credentials is None and endpoint_url is None and
+# not kwargs`` case (the sidecar's exact call): explicit-credential output
+# writes, custom endpoints, and retry-config/anonymous callers fall through to a
+# fresh build, byte-identical to before — a statically-supplied token must NOT
+# be cached (it would freeze on a warm worker).
+_OBJECT_STORE_CACHE: dict = {}
+_OBJECT_STORE_LOCK = threading.Lock()
+
+
 def open_object_store(
     path: str,
     credentials: dict | None = None,
@@ -111,8 +132,20 @@ def open_object_store(
     objects -- e.g. the per-shard async result JSON a Lambda worker writes next
     to the output store for the orchestrator to poll. Path forms and credential
     handling match ``open_store``; a local directory is created if absent.
+
+    Ambient ``s3://`` stores (no explicit ``credentials``/``endpoint_url`` and no
+    extra ``kwargs``) are cached per process and reused across calls (issue #287)
+    -- this is the sidecar manifest-fetch hot path. Every other call builds a
+    fresh store, unchanged.
     """
     if path.startswith("s3://"):
+        if credentials is None and endpoint_url is None and not kwargs:
+            with _OBJECT_STORE_LOCK:
+                store = _OBJECT_STORE_CACHE.get(path)
+                if store is None:
+                    store = _s3_object_store(path)
+                    _OBJECT_STORE_CACHE[path] = store
+            return store
         return _s3_object_store(
             path,
             credentials=credentials,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -25,6 +25,17 @@ def mock_s3(monkeypatch):
     return s3_cls, prov_cls
 
 
+@pytest.fixture(autouse=True)
+def _clear_object_store_cache():
+    """Reset the process-global ambient store cache (issue #287) around every
+    test so one test's cached store can't leak into another's assertions."""
+    from zagg import store
+
+    store._OBJECT_STORE_CACHE.clear()
+    yield
+    store._OBJECT_STORE_CACHE.clear()
+
+
 class TestOpenStore:
     def test_local_absolute_path(self, tmp_path):
         store = open_store(str(tmp_path / "test.zarr"))
@@ -316,6 +327,61 @@ class TestOpenObjectStore:
         assert kwargs["endpoint"] == "https://minio.local"
         assert kwargs["virtual_hosted_style_request"] is False
         prov_cls.assert_not_called()
+
+
+class TestObjectStoreCache:
+    """Ambient ``s3://`` stores are memoized per process (issue #287): the
+    sidecar manifest fetch calls ``open_object_store(self.store)`` once per
+    granule, and each call previously rebuilt a ``Boto3CredentialProvider``
+    (~300 ms credential-chain walk) on the read hot path."""
+
+    def test_ambient_store_built_once_and_reused(self, mock_s3):
+        s3_cls, prov_cls = mock_s3
+        p = "s3://sliderule-public-cors/zagg-index/ATL03/007"
+        stores = [open_object_store(p) for _ in range(5)]
+        # One construction total; the credential chain is walked once, not 5x.
+        assert s3_cls.call_count == 1
+        assert prov_cls.call_count == 1
+        # Every caller gets the same shared store.
+        assert all(s is stores[0] for s in stores)
+
+    def test_distinct_paths_get_distinct_stores(self, mock_s3):
+        s3_cls, _ = mock_s3
+        open_object_store("s3://bucket/a")
+        open_object_store("s3://bucket/b")
+        assert s3_cls.call_count == 2
+
+    def test_explicit_credentials_bypass_cache(self, mock_s3):
+        s3_cls, _ = mock_s3
+        creds = {"accessKeyId": "AKIA", "secretAccessKey": "secret"}
+        open_object_store("s3://bucket/a", credentials=creds)
+        open_object_store("s3://bucket/a", credentials=creds)
+        # A statically-supplied token must never be cached (it would freeze on a
+        # warm worker) -- each call builds fresh.
+        assert s3_cls.call_count == 2
+
+    def test_endpoint_bypasses_cache(self, mock_s3):
+        s3_cls, _ = mock_s3
+        open_object_store("s3://bucket/a", endpoint_url="https://minio.local")
+        open_object_store("s3://bucket/a", endpoint_url="https://minio.local")
+        assert s3_cls.call_count == 2
+
+    def test_kwargs_bypass_cache(self, mock_s3):
+        """A caller passing any kwargs (e.g. the read-only retry config on the
+        temporal path) falls through to a fresh build -- the cache is scoped to
+        the sidecar's bare ``open_object_store(path)`` call only."""
+        s3_cls, _ = mock_s3
+        from zagg.store import _S3_READONLY_RETRY_CONFIG
+
+        open_object_store("s3://bucket/a", retry_config=_S3_READONLY_RETRY_CONFIG)
+        open_object_store("s3://bucket/a", retry_config=_S3_READONLY_RETRY_CONFIG)
+        assert s3_cls.call_count == 2
+
+    def test_local_paths_not_cached(self, tmp_path):
+        s1 = open_object_store(str(tmp_path / "s"))
+        s2 = open_object_store(str(tmp_path / "s"))
+        # Local stores are cheap and unaffected -- fresh each call, not cached.
+        assert s1 is not s2
 
 
 class TestParseS3Path:


### PR DESCRIPTION
Closes #287

## What this does

Memoizes the obstore `S3Store` per process on the **sidecar manifest-fetch hot path**, so the worker builds the S3 client + walks the botocore credential chain **once per sandbox** instead of **once per granule**.

`SidecarIndex._fetch_manifest` calls `open_object_store(self.store)` on every manifest fetch (once per granule). Without caching, each call constructed a fresh `Boto3CredentialProvider`, whose `__init__` eagerly builds `boto3.Session()` and walks the default credential chain (~300 ms of client/TLS + credential resolution, plus the `Found credentials in environment variables.` log line) — on the read critical path. On one 784-granule o9 shard that fired 675 rebuilds.

## Approach

Adds a process-global `_OBJECT_STORE_CACHE` (dict) guarded by `_OBJECT_STORE_LOCK` to `zagg/store.py`, mirroring the raster path's `_STORE_CACHE` (issue #244). In `open_object_store`, the cache is entered **only** for the ambient hot-path case:

```python
if credentials is None and endpoint_url is None and not kwargs:
    with _OBJECT_STORE_LOCK:
        store = _OBJECT_STORE_CACHE.get(path)
        if store is None:
            store = _s3_object_store(path)
            _OBJECT_STORE_CACHE[path] = store
    return store
```

Keyed on the path string. Single-flight build under the lock. This is exactly the sidecar's bare `open_object_store(self.store)` call. Every other caller — explicit `credentials` (output writes, `runner.py`), custom `endpoint_url`, or any `kwargs` (read-only retry config on the temporal path, coverage, hive) — falls through to a fresh `_s3_object_store(...)` build, byte-identical to today. The fix lives entirely in zagg; no `h5coro-hidefix` change is needed, since the backend keeps calling `open_object_store` per fetch but now gets the cached store back.

## Credential-lifetime safety

- The cached store carries a live `Boto3CredentialProvider` that **refreshes per call** (30-min ttl). On Lambda the execution-role credentials are static per sandbox and don't rotate mid-invoke, so a sandbox-lifetime store cannot outlive its credentials — the same reasoning ratified for #244.
- **Statically-supplied explicit tokens are deliberately not cached** (they would freeze on a warm worker): the excluded branch preserves today's fresh-build behavior for every explicit-credential caller.

## How tested

- New `TestObjectStoreCache` class in `tests/test_store.py`: ambient store built once and reused across N calls (asserts `_s3_object_store`/provider constructed once, all callers get the same instance); distinct paths → distinct stores; explicit-credentials / endpoint / kwargs each bypass the cache (fresh build per call); local paths not cached. An autouse `_clear_object_store_cache` fixture resets the process-global cache around every test so state can't leak between tests (the pre-existing ambient tests rely on this).
- `uv run pytest tests/test_store.py -v` → **32 passed** (6 new + all pre-existing, none regressed).
- `uv run pre-commit run --files src/zagg/store.py tests/test_store.py`: ruff check, ruff-format, codespell all pass. (mypy reports only pre-existing errors in unrelated modules — 85 on the baseline branch; zero in the two touched files. CI's lint job runs ruff only.)

## Questions for review

- **Impact is unverified until deploy.** The motivating hypothesis is that the ~675 client rebuilds on the 85–86°S pole shards collapse to 1/sandbox, dropping ~200 s of setup off the ~885 s wall and plausibly clearing the 900 s Lambda ceiling (issue #148). That needs a deploy + a re-run of the 85–86°S ring shards to confirm — the change here is the enabler, not the measurement.
