### PR TITLE
Async result-object channel for the raster Lambda transport (issue #286)

### DIFF
--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -615,16 +615,20 @@ class RasterStrategy:
     the template emission (and, later, the single-writer resize on append).
 
     Backends: ``"local"`` (thread pool, in-process workers) and ``"lambda"``
-    (one synchronous ``mode="process_raster"`` invoke per shard —
-    espg-confirmed scope on issue #218). The lambda cut is deliberately the
-    simple transport: synchronous invokes with transient-only retries; the
-    issue-151 async result-object channel and the preflight concurrency probe
-    are follow-ups (raster shards are seconds of COG windows, well inside NAT
-    idle limits). Either way the runner owns the global time index before
-    fan-out (the single-writer append design); the template write is
-    orchestrator-side on the local backend but rides the sync setup invoke on
-    lambda (issue #264 — the dispatcher may hold an invoke-only role with no
-    S3 write access, e.g. the CI OIDC benchmark role).
+    (one ``mode="process_raster"`` invoke per shard — espg-confirmed scope on
+    issue #218). The lambda shard fan-out defaults to the issue-151 async
+    result-object channel (``invocation="async"``, issue #286): each shard is
+    a fire-and-forget ``InvocationType="Event"`` invoke and the dispatcher
+    polls a per-shard result object the worker mirrors, so a shard running
+    longer than a GitHub runner's ~4 min synchronous-HTTP (NAT idle) tolerance
+    no longer severs the dispatcher. ``invocation="sync"`` keeps the legacy
+    synchronous ``RequestResponse`` transport (byte-identical events, no
+    result object). The preflight concurrency probe stays a follow-up. Either
+    way the runner owns the global time index before fan-out (the
+    single-writer append design); the template write is orchestrator-side on
+    the local backend but rides the SYNC setup invoke on lambda even under
+    async shard dispatch (issue #264 — the dispatcher may hold an invoke-only
+    role with no S3 write access, e.g. the CI OIDC benchmark role).
 
     Summary schema note: ``total_obs`` is shared with the spatial/temporal
     strategies so a caller sees one summary shape across pipeline kinds. On the
@@ -661,6 +665,7 @@ class RasterStrategy:
         output_credentials,
         output_endpoint_url,
         profile=False,
+        invocation="async",
         **_ignored,
     ):
         from zagg.processing.raster import (
@@ -738,6 +743,7 @@ class RasterStrategy:
                 store_layout=store_layout,
                 dataset={"short_name": md.get("short_name"), "version": md.get("version")},
                 profile=profile,
+                invocation=invocation,
             )
 
         # Local backend: template emission stays orchestrator-owned (the
@@ -940,8 +946,23 @@ class RasterStrategy:
         store_layout="flat",
         dataset=None,
         profile=False,
+        invocation="async",
     ):
-        """Fan shards out, one synchronous ``mode="process_raster"`` invoke each.
+        """Fan shards out, one ``mode="process_raster"`` invoke each.
+
+        The shard fan-out defaults to the issue-151 async result-object
+        channel (``invocation="async"``, issue #286): each shard is a
+        fire-and-forget ``InvocationType="Event"`` invoke and the dispatcher
+        polls ``<store>.status/<run>/<shard_label>.json`` (per-window suffix on
+        hive) for the worker's mirrored envelope, with the poll deadline keyed
+        to the function timeout + margin. No synchronous connection sits open
+        while a shard runs, so a shard longer than a GitHub runner's ~4 min NAT
+        idle tolerance survives (the #286 failure mode). ``invocation="sync"``
+        keeps the legacy synchronous ``RequestResponse`` invoke, byte-identical
+        to the pre-#286 transport (no ``result_url`` on the event). The
+        ping/setup lifecycle stays SYNCHRONOUS under either mode (only the
+        shard fan-out goes async) so the load-bearing template write still
+        lands before fan-out (issue #264, below).
 
         Before fan-out the lifecycle is ping → setup. Flat (issue #264): the
         lightweight ``mode="ping"`` fails fast on a pre-#252 deployment with
@@ -965,6 +986,8 @@ class RasterStrategy:
         import boto3
         from botocore.config import Config
 
+        if invocation not in ("async", "sync"):
+            raise ValueError(f"Unknown invocation: {invocation!r} (expected 'async' or 'sync')")
         function_name = _resolve_function_name(config, function_name)
         max_workers = min(max_workers or 64, len(cells)) or 1
         client = boto3.client(
@@ -988,6 +1011,23 @@ class RasterStrategy:
         output_creds_event = _build_output_creds_event(
             output_credentials, output_endpoint_url, region
         )
+        # Async result channel (issue #286, mirroring the spatial #151 path): a
+        # per-run unique ``.status`` prefix next to the output store. Each shard
+        # worker mirrors its response envelope to <prefix>/<shard_label>.json
+        # (per-window suffix on hive, issue #247) and the dispatch threads poll
+        # for it instead of holding a synchronous invoke open — GitHub-hosted
+        # runners sit behind a ~4 min NAT idle timeout that severs longer
+        # synchronous shards. The poll deadline is keyed to the function
+        # Timeout, read once here. ``invocation="sync"`` skips the channel
+        # (legacy RequestResponse). Only the SHARD fan-out goes async; the
+        # ping/setup lifecycle below stays synchronous (issue #264).
+        result_prefix = None
+        result_box: dict = {}
+        function_timeout_s = _DEFAULT_FUNCTION_TIMEOUT_S
+        if invocation == "async":
+            result_prefix = f"{store_path.rstrip('/')}.status/{uuid.uuid4().hex}"
+            function_timeout_s = _get_function_timeout_s(client, function_name)
+            logger.info(f"Async raster results at {result_prefix}")
         # Ping → setup, bracketed as template_s (the setup-ish wall the
         # benchmark splits from fan-out, issue #250). Flat: the template is
         # load-bearing before fan-out — workers write slabs into its arrays —
@@ -1066,51 +1106,36 @@ class RasterStrategy:
                 ev["output_credentials"] = output_creds_event
             return ev
 
-        # Substring markers for a transient invoke fault, matched
-        # case-insensitively (parity intent with _invoke_lambda_cell's policy,
-        # #119): throttles, service faults, connection resets, and read timeouts
-        # retry with jittered backoff; everything else is a deterministic error.
-        transient_markers = (
-            "toomanyrequests",
-            "throttling",
-            "serviceexception",
-            "connection",
-            "timeout",
-        )
-
         def _one(pair):
-            payload = json.dumps(_event(*pair))
-            last = None
-            for attempt in range(max_retries):
-                try:
-                    resp = client.invoke(
-                        FunctionName=function_name,
-                        InvocationType="RequestResponse",
-                        Payload=payload,
-                    )
-                    raw_text = resp["Payload"].read().decode("utf-8")
-                    if resp.get("FunctionError"):
-                        # Deterministic for a given shard (timeout/OOM/unhandled):
-                        # never retried, mirroring _invoke_lambda_cell (#119).
-                        return {"error": f"Lambda error: {raw_text[:150]}", "body": {}}
-                    raw = json.loads(raw_text)
-                    body = json.loads(raw.get("body", "{}"))
-                    if raw.get("statusCode") != 200:
-                        return {
-                            "error": body.get("error", f"status {raw.get('statusCode')}"),
-                            "body": body,
-                        }
-                    return {"error": None, "body": body}
-                except Exception as e:
-                    raise_for_fd_exhaustion(e, max_workers)
-                    last = str(e)
-                    low = last.lower()
-                    if not any(t in low for t in transient_markers) or attempt == max_retries - 1:
-                        return {"error": last, "body": {}}
-                    # Jitter the backoff so a wide synchronous fan-out does not
-                    # retry in a synchronized wave (mirrors _invoke_lambda_cell).
-                    time.sleep(min(2**attempt, 8) * (0.5 + random.random() / 2))
-            return {"error": last, "body": {}}
+            # (shard, records) pairs, or (shard, records, window) triples when a
+            # window schedule fanned the dispatch (issue #247).
+            shard_key = pair[0]
+            window = pair[2] if len(pair) > 2 else None
+            event = _event(*pair)
+            extra = {}
+            # Async dispatch (issue #286): tell the worker where to mirror its
+            # envelope, how to poll for it, and how long to wait (function
+            # timeout + margin). Status objects are named by the shard label —
+            # the decimal morton string for HEALPix (issue #199) — with the
+            # window label suffixed on hive so two windows of one shard cannot
+            # clobber each other's object (mirroring the leaf naming, #246).
+            # Sync runs pass none of these, keeping the event byte-identical.
+            if result_prefix is not None:
+                label = shard_label(grid, int(shard_key))
+                key = f"{label}.json" if window is None else f"{label}_{window['label']}.json"
+                extra["result_url"] = f"{result_prefix}/{key}"
+                extra["result_fetch"] = _result_fetcher(
+                    result_box, result_prefix, output_creds_event, region, key
+                )
+                extra["poll_timeout_s"] = function_timeout_s + _ASYNC_POLL_MARGIN_S
+            return _invoke_lambda_raster(
+                client,
+                event,
+                function_name=function_name,
+                max_retries=max_retries,
+                max_workers=max_workers,
+                **extra,
+            )
 
         t0 = time.time()
         shards_with_data = 0
@@ -3274,6 +3299,116 @@ def _poll_lambda_result(
             }
         # Sub-second jitter de-synchronizes the fan-out's poll bursts.
         time.sleep(poll_interval_s + (time.time() % 1))
+
+
+def _invoke_lambda_raster(
+    lambda_client,
+    event,
+    *,
+    function_name,
+    max_retries=3,
+    max_workers=None,
+    result_url=None,
+    result_fetch=None,
+    poll_timeout_s=None,
+):
+    """Invoke Lambda ``mode="process_raster"`` for one shard (issue #218/#286).
+
+    Returns ``{"error": str | None, "body": dict}`` -- the shape
+    :meth:`RasterStrategy._run_lambda_shards` folds into its summary. Sync
+    (``result_url`` absent) reads the worker's envelope off the
+    ``RequestResponse`` payload, byte-identical to the pre-#286 transport.
+    Async (``result_url`` present, issue #286) flips the invoke to
+    fire-and-forget ``InvocationType="Event"`` and polls ``result_fetch`` (a
+    zero-arg callable returning the parsed envelope + post time, or None while
+    absent) for the worker's mirrored envelope until ``poll_timeout_s`` -- no
+    synchronous connection sits open while the shard runs, so a shard longer
+    than a GitHub runner's ~4 min NAT idle tolerance survives (the #286
+    failure mode). The raster twin of :func:`_invoke_lambda_cell`: a
+    ``FunctionError`` / non-200 envelope is a deterministic shard error, never
+    retried (#119); only transient client-side invoke faults back off and retry.
+    """
+    # Transient invoke-fault markers, matched case-insensitively (parity with
+    # _invoke_lambda_cell's policy, #119): throttles, service faults,
+    # connection resets, and read timeouts retry with jittered backoff;
+    # everything else is a deterministic shard error.
+    transient_markers = (
+        "toomanyrequests",
+        "throttling",
+        "serviceexception",
+        "connection",
+        "timeout",
+    )
+    invocation_type = "RequestResponse"
+    if result_url is not None:
+        # Rebuild so the event dict the caller holds stays free of result_url
+        # (the sync-path invariant) — only this Event copy carries it.
+        event = {**event, "result_url": result_url}
+        invocation_type = "Event"
+
+    # json.dumps is ASCII by default, so len() is the request byte size. Gate
+    # async payloads against the 256 KB Event cap with a remedy up front,
+    # mirroring _invoke_lambda_cell, rather than letting Lambda reject each
+    # attempt with a raw RequestEntityTooLargeException.
+    payload = json.dumps(event)
+    if invocation_type == "Event" and len(payload) > _ASYNC_PAYLOAD_CAP_BYTES:
+        raise ValueError(
+            f"raster shard {event.get('shard_key')} event payload is {len(payload):,} "
+            f"bytes, over the {_ASYNC_PAYLOAD_CAP_BYTES:,}-byte async dispatch budget "
+            '(Lambda caps Event invokes at 256 KB): pass invocation="sync" for this '
+            "run, or dispatch fewer granules per shard"
+        )
+
+    wall_start = time.time()
+    last = None
+    for attempt in range(max_retries):
+        try:
+            resp = lambda_client.invoke(
+                FunctionName=function_name,
+                InvocationType=invocation_type,
+                Payload=payload,
+            )
+            if result_url is not None:
+                # 202 accepted -- an Event invoke returns no payload; the worker
+                # mirrors its envelope to result_url. Poll with the shared
+                # spatial machinery and map to the raster {error, body} shape.
+                polled = _poll_lambda_result(
+                    result_fetch,
+                    int(event["shard_key"]),
+                    0,
+                    wall_start,
+                    attempt,
+                    poll_timeout_s,
+                )
+                body = polled.get("body") or {}
+                error = polled.get("error")
+                status = polled.get("status_code")
+                if not error and status is not None and status != 200:
+                    error = body.get("error", f"status {status}")
+                return {"error": error, "body": body}
+            raw_text = resp["Payload"].read().decode("utf-8")
+            if resp.get("FunctionError"):
+                # Deterministic for a given shard (timeout/OOM/unhandled):
+                # never retried, mirroring _invoke_lambda_cell (#119).
+                return {"error": f"Lambda error: {raw_text[:150]}", "body": {}}
+            raw = json.loads(raw_text)
+            body = json.loads(raw.get("body", "{}"))
+            if raw.get("statusCode") != 200:
+                return {
+                    "error": body.get("error", f"status {raw.get('statusCode')}"),
+                    "body": body,
+                }
+            return {"error": None, "body": body}
+        except Exception as e:
+            raise_for_fd_exhaustion(e, max_workers)
+            last = str(e)
+            low = last.lower()
+            if not any(t in low for t in transient_markers) or attempt == max_retries - 1:
+                return {"error": last, "body": {}}
+            # Jitter the backoff so a wide fan-out does not retry in a
+            # synchronized wave (mirrors _invoke_lambda_cell).
+            time.sleep(min(2**attempt, 8) * (0.5 + random.random() / 2))
+    return {"error": last, "body": {}}
 
 
 def _force_cold_containers(lambda_client, function_name, *, wait_s=120, poll_interval_s=2.0):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3383,7 +3383,12 @@ def _invoke_lambda_raster(
                 body = polled.get("body") or {}
                 error = polled.get("error")
                 status = polled.get("status_code")
-                if not error and status is not None and status != 200:
+                # Surface a non-200 landed envelope as a shard error, exactly as
+                # the sync branch's ``raw.get("statusCode") != 200`` does. A
+                # deadline miss already set ``error`` (short-circuiting here), and
+                # a status-less landed envelope maps to ``"status None"`` — parity
+                # with sync (the deployed worker always emits ``statusCode``).
+                if not error and status != 200:
                     error = body.get("error", f"status {status}")
                 return {"error": error, "body": body}
             raw_text = resp["Payload"].read().decode("utf-8")

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -204,6 +204,50 @@ class TestProcessRasterMode:
         assert "asset" in json.loads(resp["body"])["error"]
 
 
+class TestProcessRasterResultMirror:
+    """``result_url`` async channel for ``mode="process_raster"`` (issue #286).
+
+    The handler-level mirror (issue #151) is mode-agnostic: any per-unit
+    handler that falls through ``lambda_handler`` -- spatial ``process``,
+    temporal ``process_event``, and raster ``process_raster`` -- has its
+    response envelope written to ``result_url`` on an async (Event) invoke.
+    These tests pin that the raster branch reaches the mirror when the event
+    carries ``result_url`` and stays byte-identical (no write) when it does
+    not, so the dispatcher's async poll (issue #286) has an object to read.
+    """
+
+    def test_mirrors_envelope_to_result_url(self, handler_mod, raster_event, monkeypatch):
+        event, _grid, _data = raster_event
+        event["result_url"] = "s3://bucket/out.zarr.status/run1/12345.json"
+        captured = {}
+        monkeypatch.setattr(
+            handler_mod,
+            "_write_result",
+            lambda url, resp, ev: captured.update(url=url, resp=resp) or True,
+        )
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        # The response is returned AND mirrored to result_url with the exact
+        # same envelope the poller will read back.
+        assert resp["statusCode"] == 200
+        assert captured["url"] == event["result_url"]
+        assert captured["resp"] is resp
+        assert json.loads(resp["body"])["timesteps"] == 1
+
+    def test_no_result_url_is_byte_identical(self, handler_mod, raster_event, monkeypatch):
+        # Absent result_url (sync invoke): the mirror is never touched and the
+        # response is exactly the pre-#286 envelope -- the local/sync path is
+        # unaffected.
+        event, _grid, _data = raster_event
+        called = []
+        monkeypatch.setattr(
+            handler_mod, "_write_result", lambda *a: called.append(a) or True
+        )
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert called == []
+        assert resp["statusCode"] == 200
+        assert json.loads(resp["body"])["timesteps"] == 1
+
+
 class TestRasterSetupMode:
     """Issue #264: ``mode="setup"`` with a raster config writes the
     ``(time, cells)`` template + ``time`` coordinate handler-side, so the

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -1266,3 +1266,363 @@ class TestRasterHiveIdempotency:
         names = {p.name for p in store.rglob("*")}
         assert "morton_hive.json" not in names
         assert "coverage.moc" not in names
+
+
+class TestInvokeLambdaRaster:
+    """Sync/async transport of ``_invoke_lambda_raster`` (issue #218/#286).
+
+    The raster twin of ``TestInvokeLambdaCell``: the sync path reads the worker
+    envelope off the ``RequestResponse`` payload (byte-identical to the pre-#286
+    transport); the async path (``result_url``) flips to a fire-and-forget
+    ``Event`` invoke and polls the worker-mirrored result object. A
+    ``FunctionError`` / non-200 is a deterministic shard error, never retried;
+    only transient client-side invoke faults back off.
+    """
+
+    _EVENT = {
+        "mode": "process_raster",
+        "shard_key": 12345,
+        "granules": [{"assets": {"red": "s3://b/t0.tif"}, "time_key": "dt-1"}],
+        "config": {"data_source": {"reader": "raster"}},
+        "store_path": "s3://out/x.zarr",
+    }
+
+    def _client(self, body=None, status=200, function_error=False):
+        import io
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        if function_error:
+            payload = MagicMock()
+            payload.read.return_value = b"Task timed out after 900.00 seconds"
+            client.invoke.return_value = {"FunctionError": "Unhandled", "Payload": payload}
+        else:
+            body = body if body is not None else {"timesteps": 2, "duration_s": 1.5}
+            env = {"statusCode": status, "body": json.dumps(body)}
+            client.invoke.return_value = {"Payload": io.BytesIO(json.dumps(env).encode())}
+        return client
+
+    def test_sync_reads_response_and_omits_result_url(self):
+        from zagg import runner
+
+        client = self._client(body={"timesteps": 2, "duration_s": 1.5})
+        result = runner._invoke_lambda_raster(
+            client, dict(self._EVENT), function_name="process-shard"
+        )
+        event = json.loads(client.invoke.call_args.kwargs["Payload"])
+        assert client.invoke.call_args.kwargs["InvocationType"] == "RequestResponse"
+        assert "result_url" not in event  # byte-identical to the pre-#286 event
+        assert result == {"error": None, "body": {"timesteps": 2, "duration_s": 1.5}}
+
+    def test_sync_function_error_is_shard_error_not_retried(self):
+        from zagg import runner
+
+        client = self._client(function_error=True)
+        result = runner._invoke_lambda_raster(
+            client, dict(self._EVENT), function_name="process-shard", max_retries=3
+        )
+        assert client.invoke.call_count == 1  # deterministic, never retried (#119)
+        assert result["body"] == {}
+        assert "Lambda error" in result["error"]
+
+    def test_sync_non_200_surfaces_body_error(self):
+        from zagg import runner
+
+        client = self._client(body={"error": "boom"}, status=500)
+        result = runner._invoke_lambda_raster(
+            client, dict(self._EVENT), function_name="process-shard"
+        )
+        assert result["error"] == "boom"
+        assert result["body"] == {"error": "boom"}
+
+    def test_async_event_invoke_carries_result_url_and_polls(self):
+        from zagg import runner
+
+        client = self._client()  # sync payload is ignored on the async path
+        fetched = (
+            {"statusCode": 200, "body": json.dumps({"timesteps": 2, "duration_s": 2.0})},
+            None,
+        )
+        result = runner._invoke_lambda_raster(
+            client,
+            dict(self._EVENT),
+            function_name="process-shard",
+            result_url="s3://out/x.zarr.status/run1/12345.json",
+            result_fetch=lambda: fetched,
+            poll_timeout_s=10,
+        )
+        event = json.loads(client.invoke.call_args.kwargs["Payload"])
+        assert client.invoke.call_args.kwargs["InvocationType"] == "Event"
+        assert event["result_url"] == "s3://out/x.zarr.status/run1/12345.json"
+        assert result == {"error": None, "body": {"timesteps": 2, "duration_s": 2.0}}
+
+    def test_async_tolerates_result_landing_after_a_delay(self, monkeypatch):
+        from zagg import runner
+
+        monkeypatch.setattr(runner.time, "sleep", lambda *a: None)
+        landed = {"statusCode": 200, "body": json.dumps({"timesteps": 2})}
+        seen = {"n": 0}
+
+        def fetch():
+            seen["n"] += 1
+            return (landed, None) if seen["n"] >= 3 else None  # two misses, then lands
+
+        client = self._client()
+        result = runner._invoke_lambda_raster(
+            client,
+            dict(self._EVENT),
+            function_name="process-shard",
+            result_url="s3://out/x.zarr.status/run1/12345.json",
+            result_fetch=fetch,
+            poll_timeout_s=30,
+        )
+        assert client.invoke.call_count == 1  # ONE Event invoke, then polled
+        assert seen["n"] >= 3
+        assert result["body"] == {"timesteps": 2}
+
+    def test_async_missing_result_at_deadline_is_error_without_reinvoke(self):
+        from zagg import runner
+
+        client = self._client()
+        result = runner._invoke_lambda_raster(
+            client,
+            dict(self._EVENT),
+            function_name="process-shard",
+            result_url="s3://out/x.zarr.status/run1/12345.json",
+            result_fetch=lambda: None,  # never lands
+            poll_timeout_s=0.0,  # first miss is already past the deadline
+        )
+        assert client.invoke.call_count == 1  # a still-running shard is NOT re-dispatched
+        assert result["body"] == {}
+        assert "no worker result" in result["error"]
+
+    def test_async_oversized_payload_raises_before_dispatch(self):
+        from zagg import runner
+
+        fat = dict(
+            self._EVENT,
+            granules=[{"blob": "x" * (runner._ASYNC_PAYLOAD_CAP_BYTES + 1)}],
+        )
+        client = self._client()
+        with pytest.raises(ValueError, match="async dispatch budget"):
+            runner._invoke_lambda_raster(
+                client,
+                fat,
+                function_name="process-shard",
+                result_url="s3://out/x.zarr.status/run1/12345.json",
+                result_fetch=lambda: None,
+                poll_timeout_s=10,
+            )
+        client.invoke.assert_not_called()
+
+    def test_async_transient_invoke_fault_retries_then_polls(self, monkeypatch):
+        from zagg import runner
+
+        monkeypatch.setattr(runner.time, "sleep", lambda *a: None)
+        client = self._client()
+        client.invoke.side_effect = [
+            Exception("Connection reset by peer"),  # transient -> retry
+            {"StatusCode": 202},  # Event accepted
+        ]
+        fetched = ({"statusCode": 200, "body": json.dumps({"timesteps": 1})}, None)
+        result = runner._invoke_lambda_raster(
+            client,
+            dict(self._EVENT),
+            function_name="process-shard",
+            max_retries=3,
+            result_url="s3://out/x.zarr.status/run1/12345.json",
+            result_fetch=lambda: fetched,
+            poll_timeout_s=10,
+        )
+        assert client.invoke.call_count == 2
+        assert result == {"error": None, "body": {"timesteps": 1}}
+
+
+class TestRasterLambdaAsyncBackend:
+    """Async shard fan-out (issue #286): the DEFAULT lambda raster transport.
+
+    Each shard fires ``InvocationType="Event"`` and the dispatcher polls a
+    per-shard result object the worker mirrors, so a shard longer than a GitHub
+    runner's ~4 min NAT idle tolerance no longer severs the dispatcher. The
+    ping/setup lifecycle stays synchronous so the load-bearing template write
+    lands before fan-out (issue #264). A real run's poll reads S3; here an
+    in-memory result box (a patched ``_result_fetcher``) stands in -- no AWS,
+    no obstore.
+    """
+
+    def _wire(self, monkeypatch, proc_body, *, delay=0, timeout=720):
+        import io
+
+        import boto3
+
+        import zagg.runner as runner_mod
+
+        results: dict = {}
+        calls: list = []  # (mode, InvocationType)
+        events: list = []
+
+        def _envelope(body):
+            raw = json.dumps({"statusCode": 200, "body": json.dumps(body)}).encode()
+            return {"Payload": io.BytesIO(raw)}
+
+        class _AsyncFake:
+            def invoke(self, **kwargs):
+                event = json.loads(kwargs["Payload"])
+                mode = event.get("mode")
+                calls.append((mode, kwargs["InvocationType"]))
+                events.append(event)
+                if mode == "ping":
+                    return _envelope({"ok": True, "mode": "ping", "zagg_version": "test"})
+                if mode == "setup":
+                    return _envelope(
+                        {
+                            "ok": True,
+                            "mode": "setup",
+                            "pipeline": "raster",
+                            "timesteps": len(event.get("times_us", [])),
+                        }
+                    )
+                if mode == "finalize":
+                    return _envelope({"ok": True, "mode": "finalize", "layout": "hive"})
+                if mode == "coverage":
+                    return {"StatusCode": 202, "Payload": io.BytesIO(b"")}
+                # #286: the shard fan-out is fire-and-forget Event + result_url.
+                assert mode == "process_raster"
+                assert kwargs["InvocationType"] == "Event"
+                assert event.get("result_url")
+                results[event["result_url"]] = proc_body(event)
+                return {"StatusCode": 202, "Payload": io.BytesIO(b"")}
+
+            def get_function_configuration(self, **kwargs):
+                return {"Timeout": timeout}
+
+        fake = _AsyncFake()
+        fake.results, fake.calls, fake.events = results, calls, events  # type: ignore[attr-defined]
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
+
+        miss: dict = {}
+
+        def fake_fetcher(box, prefix, creds, region, key):
+            url = f"{prefix}/{key}"
+
+            def fetch():
+                if miss.get(url, 0) < delay:
+                    miss[url] = miss.get(url, 0) + 1
+                    return None
+                resp = results.get(url)
+                return (resp, None) if resp is not None else None
+
+            return fetch
+
+        monkeypatch.setattr(runner_mod, "_result_fetcher", fake_fetcher)
+        monkeypatch.setattr(runner_mod.time, "sleep", lambda *a: None)
+        return fake
+
+    def _flat_body(self, event):
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                {"timesteps": len(event["time_index"]), "cells_with_data": 4096, "duration_s": 3.0}
+            ),
+        }
+
+    def test_default_async_threads_result_channel(self, manifest, monkeypatch):
+        cfg, sm_path, _shard, _data = manifest
+        fake = self._wire(monkeypatch, self._flat_body)
+        summary = agg(
+            cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2
+        )
+        # Lifecycle stays synchronous; ONLY the shard fan-out is Event (#264/#286).
+        assert fake.calls == [
+            ("ping", "RequestResponse"),
+            ("setup", "RequestResponse"),
+            ("process_raster", "Event"),
+        ]
+        proc = fake.events[-1]
+        assert proc["result_url"].startswith("s3://bucket/out.zarr.status/")
+        assert proc["result_url"].endswith(".json")
+        # Summary reads back from the polled result object, same shape as sync.
+        assert summary["backend"] == "lambda"
+        assert summary["cells_with_data"] == 1 and summary["cells_error"] == 0
+        assert summary["total_obs"] == 2
+        assert summary["lambda_time_s"] == 3.0
+
+    def test_result_object_named_by_shard_label(self, manifest, monkeypatch):
+        import zagg.runner as runner_mod
+
+        cfg, sm_path, shard, _data = manifest
+        fake = self._wire(monkeypatch, self._flat_body)
+        agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2)
+        grid = from_config(cfg)
+        proc = fake.events[-1]
+        name = proc["result_url"].rsplit("/", 1)[1]
+        assert name == f"{runner_mod.shard_label(grid, shard)}.json"
+
+    def test_tolerates_delayed_result_object(self, manifest, monkeypatch):
+        # The object appears only after two polls miss: the dispatcher keeps
+        # polling (issue #286) rather than recording the shard failed.
+        cfg, sm_path, _shard, _data = manifest
+        self._wire(monkeypatch, self._flat_body, delay=2)
+        summary = agg(
+            cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2
+        )
+        assert summary["cells_with_data"] == 1 and summary["cells_error"] == 0
+        assert summary["total_obs"] == 2
+
+    def test_sync_invocation_omits_result_channel(self, manifest, monkeypatch):
+        # Belt-and-suspenders on the byte-identical guarantee: invocation="sync"
+        # keeps the shard on RequestResponse with no result_url on the event.
+        import boto3
+
+        cfg, sm_path, _shard, _data = manifest
+
+        def responder(event):
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"timesteps": len(event["time_index"])}),
+            }
+
+        fake = _FakeLambdaClient(_lifecycle(responder))
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
+        agg(
+            cfg,
+            catalog=sm_path,
+            store="s3://bucket/out.zarr",
+            backend="lambda",
+            max_workers=2,
+            invocation="sync",
+        )
+        proc = [e for e in fake.events if e["mode"] == "process_raster"][0]
+        assert "result_url" not in proc
+
+    def test_hive_result_objects_suffix_window_label(self, manifest, monkeypatch):
+        # Hive windowed units (issue #247): two windows of one shard get
+        # DISTINCT result objects (label suffixed), so their async envelopes
+        # cannot clobber each other. Setup/coverage stay Event (issue #252),
+        # ping/finalize sync, and the two shards are Event (#286).
+        import zagg.runner as runner_mod
+
+        cfg, sm_path, shard, _data = manifest
+        cfg.output["store_layout"] = "hive"
+        cfg.output["windowing"] = {"schedule": "daily"}
+
+        def proc_body(event):
+            return {
+                "statusCode": 200,
+                "body": json.dumps(
+                    {"shard_key": event["shard_key"], "timesteps": 1, "cells_with_data": 7}
+                ),
+            }
+
+        fake = self._wire(monkeypatch, proc_body)
+        summary = agg(
+            cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2
+        )
+        procs = [e for e in fake.events if e["mode"] == "process_raster"]
+        assert len(procs) == 2  # two (shard, window) units
+        assert all(it == "Event" for m, it in fake.calls if m == "process_raster")
+        grid = from_config(cfg)
+        lbl = runner_mod.shard_label(grid, shard)
+        names = sorted(e["result_url"].rsplit("/", 1)[1] for e in procs)
+        assert names == sorted([f"{lbl}_20260713.json", f"{lbl}_20260718.json"])
+        assert summary["cells_with_data"] == 2 and summary["cells_error"] == 0

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -325,6 +325,12 @@ class TestRasterLambdaBackend:
     # orchestrator (the template rides the sync setup invoke), so these tests
     # no longer intercept open_store for the s3 URL — a regression to an
     # orchestrator-side write would surface as a real-S3 attempt.
+    #
+    # Issue #286: the shard fan-out now DEFAULTS to the async result-object
+    # channel; these tests pin ``invocation="sync"`` so they remain the
+    # byte-identical synchronous-transport regression suite (no result_url on
+    # the shard event, RequestResponse invoke). The async default is covered by
+    # TestRasterLambdaAsyncBackend / TestInvokeLambdaRaster.
 
     def test_events_and_summary(self, manifest, monkeypatch, tmp_path):
         import boto3
@@ -342,7 +348,12 @@ class TestRasterLambdaBackend:
         fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         summary = agg(
-            cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2
+            cfg,
+            catalog=sm_path,
+            store="s3://bucket/out.zarr",
+            backend="lambda",
+            max_workers=2,
+            invocation="sync",
         )
         assert summary["backend"] == "lambda"
         assert summary["total_cells"] == 1 and summary["cells_with_data"] == 1
@@ -383,7 +394,7 @@ class TestRasterLambdaBackend:
             return real_open(path, **kw)
 
         monkeypatch.setattr(runner_mod, "open_store", guard_open)
-        agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+        agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", invocation="sync")
         assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
         ping, setup = fake.events[0], fake.events[1]
         expected_config = {
@@ -418,7 +429,13 @@ class TestRasterLambdaBackend:
         fake = _FakeLambdaClient(responder)
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         with pytest.raises(RuntimeError, match="redeploy") as excinfo:
-            agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+            agg(
+                cfg,
+                catalog=sm_path,
+                store="s3://bucket/out.zarr",
+                backend="lambda",
+                invocation="sync",
+            )
         # The shared ping is pipeline-neutral (issue #264): a raster operator
         # must not get hive-worded guidance for a raster run.
         assert "hive" not in str(excinfo.value).lower()
@@ -449,7 +466,13 @@ class TestRasterLambdaBackend:
         fake = _FakeLambdaClient(responder)
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         with pytest.raises(RuntimeError, match="issue #264 raster setup branch"):
-            agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+            agg(
+                cfg,
+                catalog=sm_path,
+                store="s3://bucket/out.zarr",
+                backend="lambda",
+                invocation="sync",
+            )
         assert [e["mode"] for e in fake.events] == ["ping", "setup"]
 
     def test_lambda_profile_threads_key_and_rolls_up(self, manifest, monkeypatch, tmp_path):
@@ -493,6 +516,7 @@ class TestRasterLambdaBackend:
             backend="lambda",
             max_workers=2,
             profile=True,
+            invocation="sync",
         )
         assert summary["worker_stage_max"] == {
             "open": 1.0,
@@ -536,6 +560,7 @@ class TestRasterLambdaBackend:
                 "aws_secret_access_key": "SECRET_SNAKE",
             },
             output_endpoint_url="https://custom.r2.example.com",
+            invocation="sync",
         )
         assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
         for event in fake.events:
@@ -555,7 +580,13 @@ class TestRasterLambdaBackend:
         fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         with pytest.raises(RuntimeError, match="boom"):
-            agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+            agg(
+                cfg,
+                catalog=sm_path,
+                store="s3://bucket/out.zarr",
+                backend="lambda",
+                invocation="sync",
+            )
 
     def test_lambda_function_error_is_shard_error(self, manifest, monkeypatch, tmp_path):
         # A Lambda FunctionError (timeout/OOM/unhandled) is a deterministic shard
@@ -570,7 +601,13 @@ class TestRasterLambdaBackend:
         fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         with pytest.raises(RuntimeError, match="Lambda error"):
-            agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+            agg(
+                cfg,
+                catalog=sm_path,
+                store="s3://bucket/out.zarr",
+                backend="lambda",
+                invocation="sync",
+            )
         # deterministic FunctionError -> no retry
         assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
 
@@ -594,7 +631,9 @@ class TestRasterLambdaBackend:
         fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         monkeypatch.setattr(runner_mod.time, "sleep", lambda *a: None)
-        summary = agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+        summary = agg(
+            cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", invocation="sync"
+        )
         assert summary["cells_error"] == 0
         assert summary["cells_with_data"] == 1
         # first shard invoke raised (transient), retried once
@@ -617,7 +656,13 @@ class TestRasterLambdaBackend:
         fake = _FakeLambdaClient(lambda event: {"statusCode": 200, "body": "{}"})
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         with pytest.raises(ValueError, match="fullsphere"):
-            agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+            agg(
+                cfg,
+                catalog=sm_path,
+                store="s3://bucket/out.zarr",
+                backend="lambda",
+                invocation="sync",
+            )
         assert fake.events == []
 
     def test_lambda_datetime_only_time_index(self, tmp_path, monkeypatch):
@@ -652,7 +697,7 @@ class TestRasterLambdaBackend:
 
         fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+        agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", invocation="sync")
         assert set(seen["time_index"]) == {T0}
 
 
@@ -850,7 +895,12 @@ class TestRasterHiveLocalBackend:
 
 
 class TestRasterHiveLambdaBackend:
-    """Lambda raster hive dispatch (issue #247 phase 4): lifecycle + events."""
+    """Lambda raster hive dispatch (issue #247 phase 4): lifecycle + events.
+
+    Pinned ``invocation="sync"`` (issue #286): these exercise the hive
+    lifecycle under the synchronous shard transport. The async shard fan-out
+    (default) is covered by TestRasterLambdaAsyncBackend.
+    """
 
     def test_lifecycle_and_event_shapes(self, manifest, monkeypatch):
         # The hive manifest rides the issue #252 hybrid lifecycle: ping (read-
@@ -889,7 +939,12 @@ class TestRasterHiveLambdaBackend:
         fake = _FakeLambdaClient(responder)
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         summary = agg(
-            cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2
+            cfg,
+            catalog=sm_path,
+            store="s3://bucket/out.zarr",
+            backend="lambda",
+            max_workers=2,
+            invocation="sync",
         )
         assert summary["total_cells"] == 2  # two (shard, window) units
         assert summary["cells_with_data"] == 2
@@ -948,7 +1003,12 @@ class TestRasterHiveLambdaBackend:
         fake = _FakeLambdaClient(responder)
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         summary = agg(
-            cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2
+            cfg,
+            catalog=sm_path,
+            store="s3://bucket/out.zarr",
+            backend="lambda",
+            max_workers=2,
+            invocation="sync",
         )
         assert summary["cells_with_data"] == 1
 
@@ -988,7 +1048,14 @@ class TestRasterHiveLambdaBackend:
         fake = _FakeLambdaClient(responder)
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         with pytest.raises(RuntimeError, match="boom"):
-            agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2)
+            agg(
+                cfg,
+                catalog=sm_path,
+                store="s3://bucket/out.zarr",
+                backend="lambda",
+                max_workers=2,
+                invocation="sync",
+            )
 
         modes = [e["mode"] for e in fake.events]
         # Every shard 500s (two daily windows), so the run raises — but the
@@ -1013,7 +1080,7 @@ class TestRasterHiveLambdaBackend:
 
         fake = _FakeLambdaClient(_lifecycle(responder))
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
-        agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda")
+        agg(cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", invocation="sync")
         assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
         assert set(fake.events[-1]) == {
             "mode",
@@ -1073,7 +1140,12 @@ class TestRasterHiveLambdaBackend:
         fake = _FakeLambdaClient(responder)
         monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
         lam = agg(
-            cfg, catalog=sm_path, store="s3://bucket/out.zarr", backend="lambda", max_workers=2
+            cfg,
+            catalog=sm_path,
+            store="s3://bucket/out.zarr",
+            backend="lambda",
+            max_workers=2,
+            invocation="sync",
         )
         assert lam["cells_with_data"] == 2 and lam["cells_error"] == 0
         lam_root = str(s3root / "bucket/out.zarr")

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -1396,6 +1396,24 @@ class TestInvokeLambdaRaster:
         assert result["body"] == {}
         assert "no worker result" in result["error"]
 
+    def test_async_non_200_result_surfaces_error_like_sync(self):
+        # A landed non-200 envelope is a shard error, exactly as the sync branch
+        # maps ``raw.get("statusCode") != 200`` (parity, review fold).
+        from zagg import runner
+
+        client = self._client()
+        landed = ({"statusCode": 500, "body": json.dumps({"error": "boom"})}, None)
+        result = runner._invoke_lambda_raster(
+            client,
+            dict(self._EVENT),
+            function_name="process-shard",
+            result_url="s3://out/x.zarr.status/run1/12345.json",
+            result_fetch=lambda: landed,
+            poll_timeout_s=10,
+        )
+        assert result["error"] == "boom"
+        assert result["body"] == {"error": "boom"}
+
     def test_async_oversized_payload_raises_before_dispatch(self):
         from zagg import runner
 


### PR DESCRIPTION
Closes #286

## What

Gives the raster Lambda transport the issue-#151 async result-object channel, so a raster shard running longer than a GitHub runner's ~4 min synchronous-HTTP (NAT idle) tolerance no longer severs the dispatcher. The shard fan-out now **defaults to async** (`invocation="async"`): each shard fires `InvocationType="Event"` (fire-and-forget) and the dispatcher polls a per-shard result object the worker mirrors, exactly as the spatial path has since #151. `invocation="sync"` keeps the legacy synchronous `RequestResponse` transport (byte-identical events, no result object).

## Approach (mirrors the #151 spatial async path)

- **Worker mirror is already generic.** The handler-level `result_url` mirror (`lambda_handler` at `deployment/aws/lambda_handler.py:507-538`) covers **every** per-unit handler that falls through it — spatial `process`, temporal `process_event`, **and** raster `process_raster`. So a `process_raster` response is already mirrored to `result_url` whenever the event carries one; **no worker/handler code change was needed** for Phase 1 — only a test pinning that behavior. (This is why the diff touches no `deployment/aws/` code, per the golden rules.)
- **Dispatch** (`RasterStrategy._run_lambda_shards`): extracted the per-shard invoke into a module-level `_invoke_lambda_raster` — the raster twin of `_invoke_lambda_cell` — that supports both transports (sync `RequestResponse`, or async `Event` + poll via the shared `_poll_lambda_result` / `_result_fetcher`), reusing the 256 KB async-payload preflight and the transient-only retry rules. `_run_lambda_shards` builds the async result channel (`<store>.status/<run>/<shard_label>.json`, per-window suffix on hive) and reads the function timeout once for the poll deadline (`function_timeout + _ASYNC_POLL_MARGIN_S`).
- **Template write stays on the sync setup invoke (issue #264).** Only the **shard** fan-out goes async; the ping/setup (flat) and ping/async-setup/finalize (hive) lifecycle is unchanged, so the load-bearing template still lands before fan-out and an invoke-only dispatcher role (CI OIDC) is unaffected.
- **Plumbing:** threaded `invocation` through `RasterStrategy.run` → `_run_lambda_shards`. `agg` already forwarded `invocation`; `run_raster_benchmark.py` calls `agg` with defaults, so it goes async with no change.

## Phases

- [x] **Phase 1** — raster worker writes a result object (pinned by test; already generic at the handler level, no `deployment/aws/` change)
- [x] **Phase 2** — async Event dispatch + poll in the shard fan-out; template write stays on the sync setup invoke; 256 KB preflight + `invocation="sync"` fallback preserved
- [x] **Phase 3** — plumbing + tests (worker mirror, `_invoke_lambda_raster` sync/async unit, full-run poll + delayed-result, hive per-window naming, sync byte-identical)

## How tested

- `uv run pytest tests/test_raster_runner.py tests/test_lambda_raster_handler.py -q` → green.
- Full suite: **2405 passed, 35 skipped, 1 failed** — the single failure is `test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`, an **environmental** failure (the deploy build script can't resolve `zarr>=3.1.5` platform wheels in this sandbox); it is pre-existing and unrelated to this change.
- New tests: `TestInvokeLambdaRaster` (sync reads response / no `result_url`; FunctionError + non-200 as shard errors, no retry; async Event carries `result_url` + polls; tolerates a delayed result; missing-at-deadline is an error with **no** re-invoke; oversized async payload raises before dispatch; transient invoke fault retries then polls) and `TestRasterLambdaAsyncBackend` (default async threads the result channel with `[ping RequestResponse, setup RequestResponse, process_raster Event]`; result object named by shard label; delayed result tolerated end-to-end; `invocation="sync"` omits `result_url`; hive windowed units get distinct `_<window>.json` objects). Existing `TestRasterLambdaBackend` / `TestRasterHiveLambdaBackend` were pinned `invocation="sync"` and retained as the byte-identical synchronous-transport regression suite.
- `ruff check` + `ruff format` clean on the changed files.

## Questions for review

1. **Template sequencing (issue #264).** I kept the setup/template emission on its own **synchronous** invoke and made only the shard fan-out async — the simplest correct version, since the flat template is load-bearing before fan-out. I did not adopt the hive-style async-setup + finalize-backstop for the flat setup. Flagging in case you'd prefer the shard channel and setup to share one lifecycle.
2. **Deploy + CI re-run is the real confirmation.** These tests mock the Lambda client + result box (no AWS); the actual >4 min-shard fix is confirmed only by a deploy and a benchmark re-run on a GitHub runner.
3. **Pre-existing lint/type debt (not touched, per §4):** `mypy` reports 3 pre-existing errors in `runner.py:1775/1780/1861` (`_raster_windowed_units` / `windows_intersecting`) and `codespell` flags `runner.py:1309` `statics` — both pre-date this PR and are outside the diff. Flagging rather than fixing.
