### PR TITLE
raster benchmark: dispatch to the -disk prod variant, matching tdigest/prod (issue #284)

### DIFF
--- a/.github/scripts/run_raster_benchmark.py
+++ b/.github/scripts/run_raster_benchmark.py
@@ -84,6 +84,19 @@ def run_target(
     if target.get("store_layout"):
         config.output["store_layout"] = target["store_layout"]
         validate_config(config)
+    # Worker-variant selection (issue #284): a raster target may pin the
+    # pre-provisioned worker variant so the release raster leg dispatches to the
+    # SAME function production runs (and the tdigest leg) use -- the disk-spill
+    # variant -- instead of the bare base. Mirrors run_benchmark.run_target's
+    # suffix resolution: base name + ``-<memory>`` + ``-disk`` when extra_disk.
+    # Absent -> the base function name, unchanged.
+    resolved_function_name = function_name
+    worker = target.get("worker")
+    if worker:
+        config.worker = dict(worker)
+        resolved_function_name = (
+            function_name + f"-{worker['memory']}" + ("-disk" if worker.get("extra_disk") else "")
+        )
     grid = from_config(config)
 
     cat = Catalog.from_geoparquet(str(_resolve(base, target["catalog"])))
@@ -96,7 +109,7 @@ def run_target(
     print(
         f"[{name}] shards={len(cells)} granules(total pairs)={sum(counts)} "
         f"per-shard={sorted(counts)} shardmap_build={build_s:.1f}s "
-        f"-> {function_name} @ {region}",
+        f"-> {resolved_function_name} @ {region}",
         flush=True,
     )
 
@@ -139,7 +152,7 @@ def run_target(
         backend="lambda",
         morton_cell=None,  # ALL shards over the AOI
         region=region,
-        function_name=function_name,
+        function_name=resolved_function_name,
         overwrite=True,
         profile=True,
         max_retries=1,  # a failed shard is a failure -- never re-pay (#119)

--- a/tests/data/benchmark/targets_raster_neon.json
+++ b/tests/data/benchmark/targets_raster_neon.json
@@ -1,26 +1,31 @@
 {
-  "description": "Raster release benchmark targets (issue #250 restructure, espg-approved on PR #256): the Sentinel-2 pipeline over the NEON SERC AOP box, one year of 2025 datatakes, recorded PER RELEASE next to the point-pipeline leg (targets_full_aoi_neon.json). run_raster_benchmark.py builds the shardmap from the PINNED catalog catalogs/cat_s2_neon_2025.parquet (85 Earth Search c1 items, 2025-01-01..2025-12-31, the AOI-scoped STAC query espg's operational S2 SERC run pins) so the release harness runs offline (no STAC) and the granule set is FIXED across releases -- the series tracks CODE change, not catalog drift. Rebuild via zagg.catalog.sources.STACSource(assets=[red,green,blue,nir,scl], time_key=s2:datatake_id) over the AOI + year and Catalog.to_geoparquet. The harness owns its own per-shard mode=process_raster dispatch (profile: true) because zagg.runner's raster lambda transport does not thread profile or surface per-shard phase_timings; it captures the issue #249 stage set (open/geometry/fetch/decode/gather + write) per PR #256. Layout: the live leg is store_layout: hive -- the production default for HEALPix raster since issues #247/#253, with the #237 promotion ratified by @espg on issue #272 (the flat interop profile is deprecated). No strict AOI binary mask (issue #101 is point-path-only) -- the AOI scoping is the catalog's STAC-query clip.",
-  "aoi": {
-    "file": "AOP_NEON.geojson",
-    "name": "NEON SERC AOP box"
-  },
-  "temporal": {
-    "start": "2025-01-01",
-    "end": "2025-12-31"
-  },
-  "dispatch": {
-    "region": "us-west-2",
-    "function_name": "process-shard",
-    "note": "Default dispatch target; the workflow overrides region/function from the shared BENCHMARK_* repo vars, exactly as the point-pipeline release leg does."
-  },
-  "targets": {
-    "raster_s2_neon_2025": {
-      "config": "configs/s2_neon_o9.yaml",
-      "catalog": "catalogs/cat_s2_neon_2025.parquet",
-      "pipeline": "raster",
-      "grid_type": "healpix",
-      "grid_size": "o9",
-      "collection": "sentinel-2-c1-l2a"
-    }
+ "description": "Raster release benchmark targets (issue #250 restructure, espg-approved on PR #256): the Sentinel-2 pipeline over the NEON SERC AOP box, one year of 2025 datatakes, recorded PER RELEASE next to the point-pipeline leg (targets_full_aoi_neon.json). run_raster_benchmark.py builds the shardmap from the PINNED catalog catalogs/cat_s2_neon_2025.parquet (85 Earth Search c1 items, 2025-01-01..2025-12-31, the AOI-scoped STAC query espg's operational S2 SERC run pins) so the release harness runs offline (no STAC) and the granule set is FIXED across releases -- the series tracks CODE change, not catalog drift. Rebuild via zagg.catalog.sources.STACSource(assets=[red,green,blue,nir,scl], time_key=s2:datatake_id) over the AOI + year and Catalog.to_geoparquet. The harness owns its own per-shard mode=process_raster dispatch (profile: true) because zagg.runner's raster lambda transport does not thread profile or surface per-shard phase_timings; it captures the issue #249 stage set (open/geometry/fetch/decode/gather + write) per PR #256. Layout: the live leg is store_layout: hive -- the production default for HEALPix raster since issues #247/#253, with the #237 promotion ratified by @espg on issue #272 (the flat interop profile is deprecated). No strict AOI binary mask (issue #101 is point-path-only) -- the AOI scoping is the catalog's STAC-query clip.",
+ "aoi": {
+  "file": "AOP_NEON.geojson",
+  "name": "NEON SERC AOP box"
+ },
+ "temporal": {
+  "start": "2025-01-01",
+  "end": "2025-12-31"
+ },
+ "dispatch": {
+  "region": "us-west-2",
+  "function_name": "process-shard",
+  "note": "Default dispatch target; the workflow overrides region/function from the shared BENCHMARK_* repo vars, exactly as the point-pipeline release leg does."
+ },
+ "targets": {
+  "raster_s2_neon_2025": {
+   "config": "configs/s2_neon_o9.yaml",
+   "catalog": "catalogs/cat_s2_neon_2025.parquet",
+   "pipeline": "raster",
+   "grid_type": "healpix",
+   "grid_size": "o9",
+   "collection": "sentinel-2-c1-l2a",
+   "worker": {
+    "memory": 4096,
+    "extra_disk": true
+   }
   }
+ }
 }
+


### PR DESCRIPTION
Refs #284.

The release **raster** benchmark leg dispatched to the bare `process-shard`, while the **tdigest** leg (and production runs, and now the auto-deploy target `LAMBDA_PROD_FUNCTION_NAME`) use the disk-spill variant `process-shard-4096-disk`. This aligns raster to the same production function.

## What
- `run_raster_benchmark.run_target` now mirrors `run_benchmark.run_target`'s worker-suffix resolution: a target's `worker: {memory, extra_disk}` block resolves the invoked function to `base + -<memory>[-disk]`. Absent → the base name, byte-identical to before.
- `targets_raster_neon.json`'s target gains `worker: {memory: 4096, extra_disk: true}`.

## Why
`LAMBDA_PROD_FUNCTION_NAME` was just pointed at `process-shard-4096-disk` (the function production actually runs — spill on the disk worker). The raster release leg should benchmark the same function the point/tdigest leg and prod use, not the vestigial bare base.

## Tested
`run_raster_benchmark.py --dry-run` resolves `-> process-shard-4096-disk @ us-west-2` (was `process-shard`). ruff clean. Memory tier unchanged (4 GB), so the cost model is unaffected.

## Note
This commit originally rode PR #289 but was pushed after that PR merged (orphaned); re-landed here on current `main`.
