### PR TITLE
base process-shard = 4 GB + disk for spill; revert raster→-disk (issue #284 option 2)

### DIFF
--- a/.github/scripts/run_raster_benchmark.py
+++ b/.github/scripts/run_raster_benchmark.py
@@ -84,19 +84,6 @@ def run_target(
     if target.get("store_layout"):
         config.output["store_layout"] = target["store_layout"]
         validate_config(config)
-    # Worker-variant selection (issue #284): a raster target may pin the
-    # pre-provisioned worker variant so the release raster leg dispatches to the
-    # SAME function production runs (and the tdigest leg) use -- the disk-spill
-    # variant -- instead of the bare base. Mirrors run_benchmark.run_target's
-    # suffix resolution: base name + ``-<memory>`` + ``-disk`` when extra_disk.
-    # Absent -> the base function name, unchanged.
-    resolved_function_name = function_name
-    worker = target.get("worker")
-    if worker:
-        config.worker = dict(worker)
-        resolved_function_name = (
-            function_name + f"-{worker['memory']}" + ("-disk" if worker.get("extra_disk") else "")
-        )
     grid = from_config(config)
 
     cat = Catalog.from_geoparquet(str(_resolve(base, target["catalog"])))
@@ -109,7 +96,7 @@ def run_target(
     print(
         f"[{name}] shards={len(cells)} granules(total pairs)={sum(counts)} "
         f"per-shard={sorted(counts)} shardmap_build={build_s:.1f}s "
-        f"-> {resolved_function_name} @ {region}",
+        f"-> {function_name} @ {region}",
         flush=True,
     )
 
@@ -152,7 +139,7 @@ def run_target(
         backend="lambda",
         morton_cell=None,  # ALL shards over the AOI
         region=region,
-        function_name=resolved_function_name,
+        function_name=function_name,
         overwrite=True,
         profile=True,
         max_retries=1,  # a failed shard is a failure -- never re-pay (#119)

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -256,6 +256,14 @@ Resources:
       Architectures: [!Ref Architecture]
       MemorySize: !Ref MemorySize
       Timeout: !Ref Timeout
+      # Base process-shard IS the production worker: 4 GB + ephemeral disk so the
+      # spill streaming path (issue #217) runs on it, and deploy/benchmarks/raster
+      # all target this one function (issue #284 option 2). 6144 MB = the
+      # WorkerDiskTmp 4096-key value (memory + 2048); hardcoded, not FindInMap,
+      # because MemorySize is a free param (no AllowedValues) — keep in sync with
+      # the WorkerDiskTmp 4096 entry if the base memory default changes.
+      EphemeralStorage:
+        Size: 6144
       Role: !If [ShouldCreateRole, !GetAtt ExecutionRole.Arn, !Ref ExecutionRoleArn]
       Layers: [!Ref DepsLayer]
       Environment:

--- a/tests/data/benchmark/targets_raster_neon.json
+++ b/tests/data/benchmark/targets_raster_neon.json
@@ -1,31 +1,26 @@
 {
- "description": "Raster release benchmark targets (issue #250 restructure, espg-approved on PR #256): the Sentinel-2 pipeline over the NEON SERC AOP box, one year of 2025 datatakes, recorded PER RELEASE next to the point-pipeline leg (targets_full_aoi_neon.json). run_raster_benchmark.py builds the shardmap from the PINNED catalog catalogs/cat_s2_neon_2025.parquet (85 Earth Search c1 items, 2025-01-01..2025-12-31, the AOI-scoped STAC query espg's operational S2 SERC run pins) so the release harness runs offline (no STAC) and the granule set is FIXED across releases -- the series tracks CODE change, not catalog drift. Rebuild via zagg.catalog.sources.STACSource(assets=[red,green,blue,nir,scl], time_key=s2:datatake_id) over the AOI + year and Catalog.to_geoparquet. The harness owns its own per-shard mode=process_raster dispatch (profile: true) because zagg.runner's raster lambda transport does not thread profile or surface per-shard phase_timings; it captures the issue #249 stage set (open/geometry/fetch/decode/gather + write) per PR #256. Layout: the live leg is store_layout: hive -- the production default for HEALPix raster since issues #247/#253, with the #237 promotion ratified by @espg on issue #272 (the flat interop profile is deprecated). No strict AOI binary mask (issue #101 is point-path-only) -- the AOI scoping is the catalog's STAC-query clip.",
- "aoi": {
-  "file": "AOP_NEON.geojson",
-  "name": "NEON SERC AOP box"
- },
- "temporal": {
-  "start": "2025-01-01",
-  "end": "2025-12-31"
- },
- "dispatch": {
-  "region": "us-west-2",
-  "function_name": "process-shard",
-  "note": "Default dispatch target; the workflow overrides region/function from the shared BENCHMARK_* repo vars, exactly as the point-pipeline release leg does."
- },
- "targets": {
-  "raster_s2_neon_2025": {
-   "config": "configs/s2_neon_o9.yaml",
-   "catalog": "catalogs/cat_s2_neon_2025.parquet",
-   "pipeline": "raster",
-   "grid_type": "healpix",
-   "grid_size": "o9",
-   "collection": "sentinel-2-c1-l2a",
-   "worker": {
-    "memory": 4096,
-    "extra_disk": true
-   }
+  "description": "Raster release benchmark targets (issue #250 restructure, espg-approved on PR #256): the Sentinel-2 pipeline over the NEON SERC AOP box, one year of 2025 datatakes, recorded PER RELEASE next to the point-pipeline leg (targets_full_aoi_neon.json). run_raster_benchmark.py builds the shardmap from the PINNED catalog catalogs/cat_s2_neon_2025.parquet (85 Earth Search c1 items, 2025-01-01..2025-12-31, the AOI-scoped STAC query espg's operational S2 SERC run pins) so the release harness runs offline (no STAC) and the granule set is FIXED across releases -- the series tracks CODE change, not catalog drift. Rebuild via zagg.catalog.sources.STACSource(assets=[red,green,blue,nir,scl], time_key=s2:datatake_id) over the AOI + year and Catalog.to_geoparquet. The harness owns its own per-shard mode=process_raster dispatch (profile: true) because zagg.runner's raster lambda transport does not thread profile or surface per-shard phase_timings; it captures the issue #249 stage set (open/geometry/fetch/decode/gather + write) per PR #256. Layout: the live leg is store_layout: hive -- the production default for HEALPix raster since issues #247/#253, with the #237 promotion ratified by @espg on issue #272 (the flat interop profile is deprecated). No strict AOI binary mask (issue #101 is point-path-only) -- the AOI scoping is the catalog's STAC-query clip.",
+  "aoi": {
+    "file": "AOP_NEON.geojson",
+    "name": "NEON SERC AOP box"
+  },
+  "temporal": {
+    "start": "2025-01-01",
+    "end": "2025-12-31"
+  },
+  "dispatch": {
+    "region": "us-west-2",
+    "function_name": "process-shard",
+    "note": "Default dispatch target; the workflow overrides region/function from the shared BENCHMARK_* repo vars, exactly as the point-pipeline release leg does."
+  },
+  "targets": {
+    "raster_s2_neon_2025": {
+      "config": "configs/s2_neon_o9.yaml",
+      "catalog": "catalogs/cat_s2_neon_2025.parquet",
+      "pipeline": "raster",
+      "grid_type": "healpix",
+      "grid_size": "o9",
+      "collection": "sentinel-2-c1-l2a"
+    }
   }
- }
 }
-


### PR DESCRIPTION
Refs #284. Fixes the base-vs-fleet split surfaced by the failed 0.37.0 deploy + raster benchmark.

## Problem
`LAMBDA_PROD_FUNCTION_NAME`/the raster benchmark were pointed at `process-shard-4096-disk`, which broke two workflows: the release role can't `PublishLayerVersion` on `process-shard-4096-disk-deps` (that layer doesn't exist — the `-disk` variants are CFN-managed and share the stack's single `DepsLayer`), and the benchmark role couldn't invoke it. Root cause: the IAM roles and `deploy_lambda.sh`'s layer model are scoped to the **base `process-shard`** only; the `-disk` variants are benchmark A/B instruments, not deploy targets.

## Fix (option 2 — espg-directed)
Make the **base `process-shard` itself** the production worker, so deploy, benchmarks, and raster all target the one function the roles + `deploy_lambda.sh` already handle:
- **`template.yaml`**: add `EphemeralStorage: Size: 6144` (4 GB + 2 GB, matching the `WorkerDiskTmp` 4096 rule) to the base `ProcessFn`, so the spill streaming path (#217) runs on it. Hardcoded (not `FindInMap`) because `MemorySize` is a free param.
- **Revert #291** (commit `0e40638`): raster benchmark drops its `worker` block and goes back to the base `process-shard` — which now has the disk. `#289`'s async transport already makes raster green on the base.

`LAMBDA_PROD_FUNCTION_NAME` has already been reverted to `process-shard` (the var that broke the deploy job).

## Not touched / intentionally kept
- `c36d721` (benchmark role invoke wildcard `process-shard*`/`process-shard-test*`) stays — it's correct for the *benchmark* role (the per-merge spill benchmark invokes `process-shard-test-4096-disk`) and is harmless here.
- The sized/`-disk` variant fleet stays as-is (benchmark A/B instruments).

## Deploy
Requires a **standup** (CloudFormation stack update of `template.yaml`) to apply the base function's new `EphemeralStorage` — deploy is espg's.

## Questions for review
- Ephemeral size hardcoded at 6144; flagged inline to keep in sync with `WorkerDiskTmp[4096]` if the base memory default changes.
