### PR TITLE
ShardMap.reproject: derive a shard map at another HEALPix order (issue #294)

### DIFF
--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -608,9 +608,12 @@ class ShardMap:
         re-intersected at ``target_order`` (the same ``morton_coverage_moc``
         machinery :meth:`build` uses), restricted to that shard's own
         descendant cells (``generate_morton_children(shard_key,
-        target_order)``) so the result reproduces the direct
-        :meth:`build` at the finer order exactly, at a fraction of the cost
-        (only this shard's granules, not the whole catalog). Refine always
+        target_order)``). In the interior this reproduces the direct
+        :meth:`build` at the finer order; at a region/AOI boundary it may
+        **over-include** child shards a region-restricted direct build would
+        drop (the #101 whole-shard overhang class -- reproject applies no
+        region clip), but it never drops a real intersection. Costs only this
+        shard's granules, not the whole catalog. Refine always
         re-intersects via the mortie MOC path regardless of the source's
         ``backend`` (a spherely-built source is not reproduced by it), so the
         derived map records ``backend="mortie"``.

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -722,6 +722,9 @@ class ShardMap:
         }
         meta["total_shards"] = len(new_keys)
         meta["total_pairs"] = sum(len(g) for g in new_granules)
+        # The dropped per-shard AOI mask (aoi_mask=None below) must not still be
+        # advertised in the derived map's metadata.
+        meta.pop("aoi_mask", None)
         return ShardMap(target_grid.spatial_signature(), new_keys, new_granules, meta, None)
 
     def to_json(self, path: str) -> None:

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -725,6 +725,16 @@ class ShardMap:
         # The dropped per-shard AOI mask (aoi_mask=None below) must not still be
         # advertised in the derived map's metadata.
         meta.pop("aoi_mask", None)
+        # This reproject ran no timed build, so the source build's timing must
+        # not describe the derived map.
+        meta.pop("build_wall_s", None)
+        if method == "refine":
+            meta["mortie_order"] = mortie_order
+        else:
+            # Coarsen is a pure regroup: no geometry backend and no order-based
+            # build ran, so the source's ``backend``/``mortie_order`` don't apply.
+            meta.pop("backend", None)
+            meta.pop("mortie_order", None)
         return ShardMap(target_grid.spatial_signature(), new_keys, new_granules, meta, None)
 
     def to_json(self, path: str) -> None:

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -610,7 +610,10 @@ class ShardMap:
         descendant cells (``generate_morton_children(shard_key,
         target_order)``) so the result reproduces the direct
         :meth:`build` at the finer order exactly, at a fraction of the cost
-        (only this shard's granules, not the whole catalog).
+        (only this shard's granules, not the whole catalog). Refine always
+        re-intersects via the mortie MOC path regardless of the source's
+        ``backend`` (a spherely-built source is not reproduced by it), so the
+        derived map records ``backend="mortie"``.
         """
         from mortie import clip2order, generate_morton_children
 
@@ -729,6 +732,10 @@ class ShardMap:
         # not describe the derived map.
         meta.pop("build_wall_s", None)
         if method == "refine":
+            # Refine re-intersects via the mortie MOC path (``_intersect_mortie``)
+            # regardless of the source's backend -- a spherely-built (exact-S2)
+            # source is not reproduced by it -- so record what actually ran.
+            meta["backend"] = "mortie"
             meta["mortie_order"] = mortie_order
         else:
             # Coarsen is a pure regroup: no geometry backend and no order-based

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -562,6 +562,168 @@ class ShardMap:
             meta["aoi_mask"] = True
         return cls(grid.spatial_signature(), shard_keys, granules, meta, aoi_mask)
 
+    def reproject(self, target_grid, catalog=None) -> "ShardMap":
+        """Derive a ShardMap at ``target_grid``'s ``parent_order`` (issue #294).
+
+        HEALPix nesting means a shard map at one order is derivable from
+        another **without touching the source catalog again** in the coarsen
+        direction, and with only a scoped (per-shard) re-intersection in the
+        refine direction -- either is far cheaper than a full
+        :meth:`build` over the whole catalog.
+
+        Parameters
+        ----------
+        target_grid : HealpixGrid
+            Grid to reproject onto. Must share ``child_order`` (the leaf
+            resolution) with the source grid -- reprojecting across different
+            DGGS resolutions isn't meaningful, only the shard (dispatch) order
+            changes.
+        catalog : Catalog, optional
+            Required only when refining (``target_grid.parent_order >`` this
+            map's ``parent_order``): the shard map itself stores only
+            ``{"id", "s3", "https"}`` per granule, not footprint geometry, so
+            recovering which finer cell each granule falls in needs the
+            granule records (``catalog.granule_records()``) back.
+
+        Returns
+        -------
+        ShardMap
+            New map at ``target_grid.parent_order``. ``metadata`` records the
+            source order and ``reproject: {method: "coarsen"|"refine"|"noop"}``.
+
+        Notes
+        -----
+        **Coarsen** (``target_order < source_order``): pure regroup, exact,
+        no geometry. Each source shard's key coarsens via
+        ``mortie.clip2order(target_order, shard_key)``; shards sharing a
+        coarse parent are grouped and their granule lists unioned, deduplicated
+        by granule ``id`` (a granule spanning multiple children counts once in
+        the parent). Exact because footprint-to-cell assignment nests: a
+        granule intersects a coarse cell iff it intersects one of its finer
+        children.
+
+        **Refine** (``target_order > source_order``): cannot be a pure
+        regroup -- the coarse map never recorded which child cell a granule
+        fell in. Instead, for each source shard, its own granules are
+        re-intersected at ``target_order`` (the same ``morton_coverage_moc``
+        machinery :meth:`build` uses), restricted to that shard's own
+        descendant cells (``generate_morton_children(shard_key,
+        target_order)``) so the result reproduces the direct
+        :meth:`build` at the finer order exactly, at a fraction of the cost
+        (only this shard's granules, not the whole catalog).
+        """
+        from mortie import clip2order, generate_morton_children
+
+        target_order = getattr(target_grid, "parent_order", None)
+        target_child_order = getattr(target_grid, "child_order", None)
+        if target_order is None or target_child_order is None:
+            raise ValueError(
+                "reproject: target_grid must be a HEALPix grid (parent_order/child_order)"
+            )
+        source_order = self.grid_signature.get("parent_order")
+        source_child_order = self.grid_signature.get("child_order")
+        if source_order is None or self.grid_signature.get("type") != "healpix":
+            raise ValueError("reproject: source ShardMap must be a HEALPix grid_signature")
+        if source_child_order != target_child_order:
+            raise ValueError(
+                f"reproject: child_order must match (source={source_child_order}, "
+                f"target={target_child_order}) -- reproject only changes the shard "
+                "(parent_order), not the leaf DGGS resolution"
+            )
+        if not (0 <= target_order <= target_child_order):
+            raise ValueError(
+                f"reproject: target_order {target_order} outside [0, child_order="
+                f"{target_child_order}]"
+            )
+
+        if target_order == source_order:
+            meta = dict(self.metadata or {})
+            meta["reproject"] = {
+                "source_parent_order": int(source_order),
+                "target_parent_order": int(target_order),
+                "method": "noop",
+            }
+            return ShardMap(
+                target_grid.spatial_signature(),
+                list(self.shard_keys),
+                [list(g) for g in self.granules],
+                meta,
+                self.aoi_mask,
+            )
+
+        if target_order < source_order:
+            # ── coarsen: pure regroup, exact, no geometry ────────────────
+            keys = np.asarray([int(k) for k in self.shard_keys], dtype=np.uint64)
+            parents = clip2order(target_order, keys)
+            groups: Dict[int, List[int]] = {}
+            for i, p in enumerate(parents.tolist()):
+                groups.setdefault(int(p), []).append(i)
+
+            new_keys = sorted(groups)
+            new_granules = []
+            for k in new_keys:
+                seen: dict = {}
+                for i in groups[k]:
+                    for g in self.granules[i]:
+                        seen[g["id"]] = g
+                new_granules.append(list(seen.values()))
+            method = "coarsen"
+        else:
+            # ── refine: scoped re-intersection (needs source footprints) ─
+            if catalog is None:
+                raise ValueError(
+                    "reproject: refine (target_order > source_order) needs the source "
+                    "Catalog for granule footprints -- the ShardMap itself only stores "
+                    "{id, s3, https}, not geometry. Pass catalog=<Catalog>."
+                )
+            records_by_id = {r["id"]: r for r in catalog.granule_records()}
+            footprint = self.metadata.get("footprint", "swath")
+            product = (self.metadata.get("collection") or "").split("_")[0].upper()
+            mortie_order = _resolve_mortie_order(None, target_grid)
+
+            new_granules_map: Dict[int, dict] = {}
+            for shard_key, gran_list in zip(self.shard_keys, self.granules):
+                ids = [g["id"] for g in gran_list]
+                missing = [gid for gid in ids if gid not in records_by_id]
+                if missing:
+                    extra = "..." if len(missing) > 5 else ""
+                    raise ValueError(
+                        f"reproject: refine needs footprints for all granules in the source "
+                        f"map, but the catalog is missing {len(missing)} of them (e.g. "
+                        f"{missing[:5]}{extra})"
+                    )
+                sub_records = [records_by_id[gid] for gid in ids]
+                descendants = set(
+                    int(s) for s in generate_morton_children(int(shard_key), target_order)
+                )
+                shard_to_idx = _intersect_mortie(
+                    sub_records,
+                    target_grid,
+                    descendants,
+                    order=mortie_order,
+                    footprint=footprint,
+                    product=product,
+                )
+                for k, idxs in shard_to_idx.items():
+                    bucket = new_granules_map.setdefault(int(k), {})
+                    for i in idxs:
+                        entry = _granule_entry(sub_records[i])
+                        bucket[entry["id"]] = entry
+
+            new_keys = sorted(new_granules_map)
+            new_granules = [list(new_granules_map[k].values()) for k in new_keys]
+            method = "refine"
+
+        meta = dict(self.metadata or {})
+        meta["reproject"] = {
+            "source_parent_order": int(source_order),
+            "target_parent_order": int(target_order),
+            "method": method,
+        }
+        meta["total_shards"] = len(new_keys)
+        meta["total_pairs"] = sum(len(g) for g in new_granules)
+        return ShardMap(target_grid.spatial_signature(), new_keys, new_granules, meta, None)
+
     def to_json(self, path: str) -> None:
         """Write the manifest as JSON."""
         from pathlib import Path

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -652,7 +652,7 @@ class ShardMap:
             return ShardMap(
                 target_grid.spatial_signature(),
                 list(self.shard_keys),
-                [list(g) for g in self.granules],
+                [[_granule_entry(g) for g in shard] for shard in self.granules],
                 meta,
                 self.aoi_mask,
             )
@@ -671,7 +671,7 @@ class ShardMap:
                 seen: dict = {}
                 for i in groups[k]:
                     for g in self.granules[i]:
-                        seen[g["id"]] = g
+                        seen[g["id"]] = _granule_entry(g)
                 new_granules.append(list(seen.values()))
             method = "coarsen"
         else:

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -958,16 +958,30 @@ class TestReproject:
 
     def test_coarsen_dedups_granule_spanning_multiple_children(self, fine_grid, coarse_grid):
         # A granule wide enough to land in >=2 fine shards under the same
-        # coarse parent must count once in the coarsened granule list.
+        # coarse parent must count once in the coarsened granule list. Force
+        # and assert the dedup scenario is real -- otherwise the union-across-
+        # children branch never runs and the test proves nothing.
+        from mortie import clip2order
+
         cat = _catalog([_item("Gwide", -76.60, -76.52)])
         sm_fine = ShardMap.build(cat, fine_grid, backend="mortie")
-        gs_fine = _granule_shards(sm_fine)
-        assert len(gs_fine["Gwide"]) >= 1  # sanity: built onto >=1 fine shard
+        fine_shards = _granule_shards(sm_fine)["Gwide"]
+        assert len(fine_shards) >= 2, "Gwide must span >=2 fine shards to exercise dedup"
+
+        # >=2 of those fine shards must coarsen to a common parent, else the
+        # coarsen path never unions Gwide across children.
+        fine_arr = np.asarray([int(k) for k in fine_shards], dtype=np.uint64)
+        parents = clip2order(11, fine_arr).tolist()
+        shared = {int(p) for p in parents if parents.count(p) >= 2}
+        assert shared, "no coarse parent gathers >=2 of Gwide's fine shards"
 
         sm_coarse = sm_fine.reproject(coarse_grid)
         gs_coarse = _granule_shards(sm_coarse)
-        assert len(gs_coarse["Gwide"]) >= 1
-        # No duplicate ids within any single coarsened shard's granule list.
+        # The union collapsed >=2 fine children into one coarse shard, so Gwide's
+        # coarse shard count is strictly fewer than its fine count.
+        assert len(gs_coarse["Gwide"]) < len(fine_shards)
+        assert shared <= gs_coarse["Gwide"]
+        # And it appears exactly once within each coarsened shard's granule list.
         for gran_list in sm_coarse.granules:
             ids = [g["id"] for g in gran_list]
             assert len(ids) == len(set(ids))

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -928,6 +928,98 @@ class TestBeamFootprintBehavior:
             ShardMap.build(cat, grid, backend="spherely", footprint="beams")
 
 
+class TestReproject:
+    """``ShardMap.reproject`` (issue #294): derive a map at another HEALPix
+    order without rebuilding from the catalog -- coarsen is a pure regroup,
+    refine is a scoped re-intersection using the source catalog's footprints.
+    """
+
+    @pytest.fixture
+    def fine_grid(self):
+        return HealpixGrid(12, 14, layout="fullsphere")
+
+    @pytest.fixture
+    def coarse_grid(self):
+        return HealpixGrid(11, 14, layout="fullsphere")
+
+    def test_coarsen_matches_direct_build(self, catalog, fine_grid, coarse_grid):
+        sm_fine = ShardMap.build(catalog, fine_grid, backend="mortie")
+        sm_coarse_direct = ShardMap.build(catalog, coarse_grid, backend="mortie")
+        sm_coarse_reproj = sm_fine.reproject(coarse_grid)
+
+        assert sorted(sm_coarse_reproj.shard_keys) == sorted(sm_coarse_direct.shard_keys)
+        assert _granule_shards(sm_coarse_reproj) == _granule_shards(sm_coarse_direct)
+        assert sm_coarse_reproj.grid_signature == coarse_grid.spatial_signature()
+        assert sm_coarse_reproj.metadata["reproject"] == {
+            "source_parent_order": 12,
+            "target_parent_order": 11,
+            "method": "coarsen",
+        }
+
+    def test_coarsen_dedups_granule_spanning_multiple_children(self, fine_grid, coarse_grid):
+        # A granule wide enough to land in >=2 fine shards under the same
+        # coarse parent must count once in the coarsened granule list.
+        cat = _catalog([_item("Gwide", -76.60, -76.52)])
+        sm_fine = ShardMap.build(cat, fine_grid, backend="mortie")
+        gs_fine = _granule_shards(sm_fine)
+        assert len(gs_fine["Gwide"]) >= 1  # sanity: built onto >=1 fine shard
+
+        sm_coarse = sm_fine.reproject(coarse_grid)
+        gs_coarse = _granule_shards(sm_coarse)
+        assert len(gs_coarse["Gwide"]) >= 1
+        # No duplicate ids within any single coarsened shard's granule list.
+        for gran_list in sm_coarse.granules:
+            ids = [g["id"] for g in gran_list]
+            assert len(ids) == len(set(ids))
+
+    def test_refine_reproduces_build(self, catalog, fine_grid, coarse_grid):
+        sm_coarse = ShardMap.build(catalog, coarse_grid, backend="mortie")
+        sm_fine_direct = ShardMap.build(catalog, fine_grid, backend="mortie")
+        sm_fine_reproj = sm_coarse.reproject(fine_grid, catalog=catalog)
+
+        assert sorted(sm_fine_reproj.shard_keys) == sorted(sm_fine_direct.shard_keys)
+        assert _granule_shards(sm_fine_reproj) == _granule_shards(sm_fine_direct)
+        assert sm_fine_reproj.grid_signature == fine_grid.spatial_signature()
+        assert sm_fine_reproj.metadata["reproject"]["method"] == "refine"
+
+    def test_refine_without_catalog_raises(self, catalog, coarse_grid, fine_grid):
+        sm_coarse = ShardMap.build(catalog, coarse_grid, backend="mortie")
+        with pytest.raises(ValueError, match="needs the source Catalog"):
+            sm_coarse.reproject(fine_grid)
+
+    def test_round_trip_coarsen_then_refine(self, catalog, fine_grid, coarse_grid):
+        sm_fine = ShardMap.build(catalog, fine_grid, backend="mortie")
+        sm_coarse = sm_fine.reproject(coarse_grid)
+        sm_round = sm_coarse.reproject(fine_grid, catalog=catalog)
+
+        assert sorted(sm_round.shard_keys) == sorted(sm_fine.shard_keys)
+        assert _granule_shards(sm_round) == _granule_shards(sm_fine)
+
+    def test_same_order_returns_copy(self, catalog, fine_grid):
+        sm = ShardMap.build(catalog, fine_grid, backend="mortie")
+        sm2 = sm.reproject(fine_grid)
+        assert sm2 is not sm
+        assert sm2.shard_keys == sm.shard_keys
+        assert sm2.granules == sm.granules
+        assert sm2.metadata["reproject"] == {
+            "source_parent_order": 12,
+            "target_parent_order": 12,
+            "method": "noop",
+        }
+
+    def test_mismatched_child_order_rejected(self, catalog, fine_grid):
+        sm = ShardMap.build(catalog, fine_grid, backend="mortie")
+        other_leaf = HealpixGrid(11, 17, layout="fullsphere")  # different child_order
+        with pytest.raises(ValueError, match="child_order must match"):
+            sm.reproject(other_leaf)
+
+    def test_non_healpix_signature_rejected(self, catalog, grid, fake_spherely):
+        sm = ShardMap.build(catalog, grid, backend="spherely")  # RectilinearGrid
+        hp = HealpixGrid(11, 14, layout="fullsphere")
+        with pytest.raises(ValueError, match="HEALPix"):
+            sm.reproject(hp)
+
+
 class TestIsBeamProduct:
     def test_known_beam_products(self):
         from zagg.catalog.beams import is_beam_product


### PR DESCRIPTION
Closes #294.

Derives a shard map at another HEALPix order from an existing one, instead of rebuilding from the 555k-granule catalog per order (the CONUS #202 / 88S #148 order sweeps).

## What
`ShardMap.reproject(target_grid, catalog=None) -> ShardMap`, both directions relative to the source `parent_order`:
- **Coarsen** (target < source): pure regroup — `mortie.clip2order(target, key)` per shard, group by parent, dedup-union children's granule lists by id. Exact by HEALPix nesting; O(#shards), no geometry.
- **Refine** (target > source): scoped re-intersection via `_intersect_mortie` restricted to each source shard's own descendants — needs `catalog=` for footprints (raises a clear `ValueError` naming the requirement if omitted). Reproduces the direct `ShardMap.build` at the finer order without touching the full catalog.
- Same order: no-op copy. Guards reject mismatched `child_order` / non-HEALPix signatures; refreshes `grid_signature`.

## Tested (`tests/test_shardmap.py::TestReproject`, 8 cases)
coarsen-matches-direct-build, dedup, refine-reproduces-build, refine-without-catalog raises, round-trip, no-op, mismatched-child_order, non-HEALPix rejection. `pytest tests/test_shardmap.py` → 70 passed, 1 skipped (pre-existing spherely skip); ruff clean.

## Real-world validation
Built the CONUS o7 map (3,276 shards) and derived o6 by `reproject` coarsen (883 shards; per-shard `max(children) <= union <= sum(children)` held for all 883). Reprojected o7→o8 (refine) matched the committed direct o8 build on **95/100** shards; the 5 diffs are legitimate CONUS-polygon-boundary overhang (some o7 parents straddle the edge; a few o8 children fall just outside the region-restricted direct build's candidate set — `reproject` has no region arg, by design). Same overhang class as issue #101.

## Questions for review
- Refine's region-independence: `reproject` intentionally has no polygon/region argument, so refining a boundary-straddling shard can keep a child the region-restricted direct build dropped. Acceptable (it never drops a real intersection), but flagging the semantics.
