### PR TITLE
Per-shard stats sidecar: schema, worker sidecars, run parquet (issue #297)

### DIFF
--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -143,9 +143,10 @@ def expected_object_counts(
         # Leaf fixed objects: leaf root zarr.json + group zarr.json + one
         # zarr.json per array, plus the in-leaf coverage.moc sidecar (written
         # for any populated leaf when the leaf has depth, i.e. child_order >
-        # parent_order).
+        # parent_order), plus the stats.json sidecar SIBLING to the leaf
+        # (issue #297 — one per successful shard, in the leaf's node dir).
         sidecar = 1 if grid.child_order > grid.parent_order else 0
-        lo = hi = 2 + len(members) + sidecar
+        lo = hi = 3 + len(members) + sidecar
         for m in members:
             blocks = m["blocks_per_shard"]
             hi += blocks
@@ -248,6 +249,13 @@ def store_object_counts(
             hive.shard_leaf_path("", int(k)).lstrip("/") + "/": grid.shard_label(int(k))
             for k in shard_keys
         }
+        # The per-shard stats sidecar (issue #297) is a SIBLING of the leaf
+        # .zarr — ``{node}/stats.json`` (``stats_{window}.json`` windowed) —
+        # so attribute it to the node's shard rather than pooling it in
+        # ``other``.
+        stats_of = {
+            prefix.rstrip("/").rsplit("/", 1)[0] + "/": label for prefix, label in leaf_of.items()
+        }
         for key in keys:
             if key in (hive.MANIFEST_NAME, hive.ROOT_COVERAGE_NAME):
                 metadata += 1
@@ -257,7 +265,14 @@ def store_object_counts(
                     per_shard[label] = per_shard.get(label, 0) + 1
                     break
             else:
-                other.append(key)
+                node, _, name = key.rpartition("/")
+                is_stats = name == "stats.json" or (
+                    name.startswith("stats_") and name.endswith(".json")
+                )
+                if is_stats and node + "/" in stats_of:
+                    per_shard[stats_of[node + "/"]] = per_shard.get(stats_of[node + "/"], 0) + 1
+                else:
+                    other.append(key)
     else:
         raise ValueError(f"unknown store_layout: {store_layout!r} (expected 'flat' or 'hive')")
 

--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -116,8 +116,11 @@ def expected_object_counts(
     if store_layout == "flat":
         _require_fullsphere(grid)
         members = _member_layouts(grid)
-        # Root zarr.json + group zarr.json + one zarr.json per array (exact).
-        metadata_min = metadata_max = 2 + len(members)
+        # Root zarr.json + group zarr.json + one zarr.json per array (exact),
+        # plus the OPTIONAL run-level stats parquet (issue #297) — fail-open,
+        # absent when the dispatcher role cannot PUT (the CI OIDC role).
+        metadata_min = 2 + len(members)
+        metadata_max = metadata_min + 1
         lo = hi = 0
         for m in members:
             blocks = m["blocks_per_shard"]
@@ -138,8 +141,10 @@ def expected_object_counts(
         # the floor is the manifest alone, the ceiling adds the MOC. A real
         # sharded-write bypass lands in the per-shard DATA counts (asserted
         # exactly in object_count_mismatch), never in this metadata window.
+        # ... plus the OPTIONAL run-level stats parquet (issue #297), same
+        # fail-open posture as the root MOC.
         metadata_min = 1
-        metadata_max = 1 + (1 if coverage_moc else 0)
+        metadata_max = 1 + (1 if coverage_moc else 0) + 1
         # Leaf fixed objects: leaf root zarr.json + group zarr.json + one
         # zarr.json per array, plus the in-leaf coverage.moc sidecar (written
         # for any populated leaf when the leaf has depth, i.e. child_order >
@@ -165,6 +170,11 @@ def expected_object_counts(
         "total_max": metadata_max + n_shards * hi,
         "exact": lo == hi,
     }
+
+
+def _is_run_parquet(key: str) -> bool:
+    """A store-root run-level stats parquet (issue #297): ``stats_*.parquet``."""
+    return "/" not in key and key.startswith("stats_") and key.endswith(".parquet")
 
 
 def list_store_keys(store_path: str, **store_kwargs) -> list[str]:
@@ -222,7 +232,7 @@ def store_object_counts(
         label_of = {int(grid.block_index(int(k))[0]): grid.shard_label(int(k)) for k in shard_keys}
         group = grid.group_path
         for key in keys:
-            if key == "zarr.json" or key.endswith("/zarr.json"):
+            if key == "zarr.json" or key.endswith("/zarr.json") or _is_run_parquet(key):
                 metadata += 1
                 continue
             parts = key.split("/")
@@ -257,7 +267,7 @@ def store_object_counts(
             prefix.rstrip("/").rsplit("/", 1)[0] + "/": label for prefix, label in leaf_of.items()
         }
         for key in keys:
-            if key in (hive.MANIFEST_NAME, hive.ROOT_COVERAGE_NAME):
+            if key in (hive.MANIFEST_NAME, hive.ROOT_COVERAGE_NAME) or _is_run_parquet(key):
                 metadata += 1
                 continue
             for prefix, label in leaf_of.items():

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -1123,6 +1123,10 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
                 "cells_with_data": meta.get("cells_with_data", 0),
                 "total_obs": meta["timesteps"],
                 "duration_s": time.time() - start_time,
+                # Read-volume counters (issue #297) for the stats record.
+                "raster_bytes_read": meta.get("raster_bytes_read"),
+                "raster_px_decoded": meta.get("raster_px_decoded"),
+                "raster_px_sampled": meta.get("raster_px_sampled"),
             }
             if meta.get("time_range") is not None:
                 body["time_range"] = meta["time_range"]
@@ -1222,6 +1226,10 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
             "cells_with_data": grid.cells_per_shard if wrote else 0,
             "total_obs": meta["timesteps"],
             "duration_s": time.time() - start_time,
+            # Read-volume counters (issue #297) for the stats record.
+            "raster_bytes_read": meta.get("raster_bytes_read"),
+            "raster_px_decoded": meta.get("raster_px_decoded"),
+            "raster_px_sampled": meta.get("raster_px_sampled"),
         }
         # Worker memory telemetry (issue #250): sampled per-invocation peak,
         # container high-water fallback (see the process-mode stamp).

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -1139,9 +1139,11 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
             if "phase_timings" in meta:
                 body["phase_timings"] = meta["phase_timings"]
             # Per-shard stats record (issue #297): envelope ride + the leaf
-            # sidecar (only when the unit wrote a leaf — timesteps > 0 means
-            # slabs streamed, so the leaf exists and is stamped). Fail-open on
-            # the sidecar PUT; the record still rides the envelope.
+            # sidecar (only when the unit wrote a leaf — ``leaf_written`` is the
+            # accurate signal, set iff a slab streamed and the leaf was stamped;
+            # a unit with acquisitions but no occupied cell writes no leaf, so
+            # ``timesteps`` alone would orphan a sidecar). Fail-open on the
+            # sidecar PUT; the record still rides the envelope.
             from zagg.telemetry import build_record, lambda_env, raster_granule_ids, write_sidecar
 
             record = build_record(
@@ -1152,7 +1154,7 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
                 lambda_config=lambda_env(),
             )
             body["stats"] = record
-            if meta["timesteps"]:
+            if meta.get("leaf_written"):
                 from zagg.hive import shard_leaf_path
 
                 try:

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -29,6 +29,12 @@ Event payload (default / process mode):
         Forwarded to ``process_shard`` so the worker fills the ``aoi_mask``
         column; absent when ``output.aoi_mask`` is off (the column is not
         allocated), keeping the flag-off event and outputs byte-identical.
+    "invoked_by": dict (optional, issue #297) -- {"arn", "userid"} caller
+        identity the dispatcher resolved once per run via sts
+        get-caller-identity; the worker copies it VERBATIM into the per-shard
+        stats record (sidecar + envelope). Workers cannot see the invoker
+        themselves (Event invokes carry no caller identity). Absent -> the
+        stats record carries null.
     "result_url": str (optional, issue #151) -- where to ALSO write this
         invocation's response envelope as JSON (e.g.
         "s3://bucket/out.zarr.status/<run_id>/<shard_label>.json", where the
@@ -1128,8 +1134,37 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
             body["max_memory_mb"] = (
                 sampled_peak if sampled_peak is not None else body["container_hwm_mb"]
             )
-            if profile and "phase_timings" in meta:
+            # Always-on collection (issue #297); the per-stage ``stages`` block
+            # inside stays gated on ``profile`` (raster.py).
+            if "phase_timings" in meta:
                 body["phase_timings"] = meta["phase_timings"]
+            # Per-shard stats record (issue #297): envelope ride + the leaf
+            # sidecar (only when the unit wrote a leaf — timesteps > 0 means
+            # slabs streamed, so the leaf exists and is stamped). Fail-open on
+            # the sidecar PUT; the record still rides the envelope.
+            from zagg.telemetry import build_record, lambda_env, raster_granule_ids, write_sidecar
+
+            record = build_record(
+                shard_key=shard_key,
+                metadata=body,
+                granule_ids=raster_granule_ids(event["granules"]),
+                invoked_by=event.get("invoked_by"),
+                lambda_config=lambda_env(),
+            )
+            body["stats"] = record
+            if meta["timesteps"]:
+                from zagg.hive import shard_leaf_path
+
+                try:
+                    window = event.get("window")
+                    leaf = shard_leaf_path(
+                        event["store_path"],
+                        shard_key,
+                        window=window["label"] if window else None,
+                    )
+                    write_sidecar(leaf, record, **_output_store_kwargs(event))
+                except Exception as e:
+                    logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
             return {"statusCode": 200, "body": json.dumps(body)}
 
         time_index = {k: int(v) for k, v in event["time_index"].items()}
@@ -1156,10 +1191,9 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
 
         def _write_slab(t_idx: int, slab: dict) -> None:
             nonlocal wrote, write_s
-            w0 = time.time() if profile else 0.0
+            w0 = time.time()
             write_raster_slab(store, grid, shard_key, t_idx, slab)
-            if profile:
-                write_s += time.time() - w0
+            write_s += time.time() - w0
             wrote = True
 
         _slabs, meta = process_raster_shard(
@@ -1195,13 +1229,25 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
         body["max_memory_mb"] = (
             sampled_peak if sampled_peak is not None else body["container_hwm_mb"]
         )
+        # Always-on sample/write split (issue #297); ``stages`` (issue #249)
+        # stays profile-gated verbosity.
+        body["phase_timings"] = {
+            "sample": (time.time() - start_time) - write_s,
+            "write": write_s,
+        }
         if profile:
-            total = time.time() - start_time
-            body["phase_timings"] = {
-                "sample": total - write_s,
-                "write": write_s,
-                "stages": stage_stats,
-            }
+            body["phase_timings"]["stages"] = stage_stats
+        # Stats record (issue #297): envelope ride only — a flat store has no
+        # per-shard leaf for a sidecar sibling (see the PR #302 discussion).
+        from zagg.telemetry import build_record, lambda_env, raster_granule_ids
+
+        body["stats"] = build_record(
+            shard_key=shard_key,
+            metadata=body,
+            granule_ids=raster_granule_ids(event["granules"]),
+            invoked_by=event.get("invoked_by"),
+            lambda_config=lambda_env(),
+        )
         return {"statusCode": 200, "body": json.dumps(body)}
     except Exception as e:
         logger.error(f"raster worker failed: {e}", exc_info=True)
@@ -1416,7 +1462,7 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 store = _get_store()
                 if store is None:
                     return  # template missing — recorded in write_error, skip the rest
-                _t0 = time.time() if profile else None
+                _t0 = time.time()
                 try:
                     # write_dataframe_to_zarr no-ops on an empty carrier, so no per-chunk
                     # emptiness check is needed. Use each chunk's own block_index.
@@ -1430,8 +1476,7 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                     logger.error(f"Failed to write zarr to {store_path}: {e}")
                     write_error["msg"] = f"Failed to write zarr: {e}"
                     return
-                if profile:
-                    _write_elapsed += time.time() - _t0
+                _write_elapsed += time.time() - _t0
 
             chunk_results = [] if sharded else None
             _df_out, metadata = process_shard(
@@ -1454,13 +1499,12 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             if sharded and chunk_results:
                 store = _get_store()
                 if store is not None:
-                    _write_t0 = time.time() if profile else None
+                    _write_t0 = time.time()
                     try:
                         write_shard_to_zarr(
                             chunk_results, store, grid=grid, shard_key=int(shard_key)
                         )
-                        if profile:
-                            _write_elapsed += time.time() - _write_t0
+                        _write_elapsed += time.time() - _write_t0
                     except Exception as e:
                         logger.error(f"Failed to write zarr to {store_path}: {e}")
                         write_error["msg"] = f"Failed to write zarr: {e}"
@@ -1471,14 +1515,13 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         if write_error:
             metadata["error"] = write_error["msg"]
 
-        # Record the write-phase timing (issue #100): read/index/aggregate come from
-        # ``process_shard``; ``write`` is the time spent in the streaming callback /
-        # sharded write. Only attach it on a clean write (no ``error``) so a time-to-
-        # failure is never folded in as a real write duration; the no-data path wrote
-        # nothing (``_write_elapsed`` stays 0) but also has no chunks, so writing 0 is
-        # harmless — gate on a populated ``phase_timings`` and no error to match the
-        # old "write absent on failure / no-data" contract.
-        if profile and not metadata.get("error") and "phase_timings" in metadata and store_box:
+        # Record the write-phase timing (issue #100; always-on collection since
+        # issue #297): read/index/aggregate come from ``process_shard``; ``write``
+        # is the time spent in the streaming callback / sharded write. Only attach
+        # it on a clean write (no ``error``) so a time-to-failure is never folded
+        # in as a real write duration; the no-data path wrote nothing and has no
+        # chunks — "write absent on failure / no-data" is unchanged.
+        if not metadata.get("error") and "phase_timings" in metadata and store_box:
             metadata["phase_timings"]["write"] = _write_elapsed
 
         # Peak worker RSS (issues #120, #141): captured here, after the write phase,
@@ -1504,6 +1547,36 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         metadata["cpu_seconds"] = round(
             (cpu_t1.user - cpu_t0.user) + (cpu_t1.system - cpu_t0.system), 3
         )
+
+        # Per-shard stats record (issue #297): rides the response envelope
+        # (``body["stats"]``) so the dispatcher builds the run parquet with no
+        # second S3 listing; hive leaves additionally get the ``stats.json``
+        # sidecar SIBLING to the leaf .zarr — success only (an error-free hive
+        # shard is by construction written + stamped). ``invoked_by`` is copied
+        # verbatim from the invoke payload (the dispatcher resolves it; the
+        # worker cannot). Fail-open: a sidecar PUT failure never fails a shard
+        # whose data landed — the record still rides the envelope.
+        from zagg.telemetry import build_record, lambda_env, write_sidecar
+
+        record = build_record(
+            shard_key=int(shard_key),
+            metadata=metadata,
+            granule_ids=event.get("granule_urls"),
+            invoked_by=event.get("invoked_by"),
+            lambda_config=lambda_env(),
+        )
+        metadata["stats"] = record
+        if get_store_layout(config) == "hive" and not metadata.get("error"):
+            from zagg.hive import shard_leaf_path
+
+            try:
+                window = event.get("window")
+                leaf = shard_leaf_path(
+                    store_path, int(shard_key), window=window["label"] if window else None
+                )
+                write_sidecar(leaf, record, **_output_store_kwargs(event))
+            except Exception as e:
+                logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
 
         # Log structured result
         logger.info(

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -891,15 +891,16 @@ def process_and_write_hive(
     the K carriers accumulate and the whole leaf is written once
     (``write_leaf_to_zarr`` — one ShardingCodec object per array), mirroring
     the flat sharded switch in ``runner._process_and_write``.
-    ``profile`` forwards to ``process_shard`` (issue #100), which fills
-    ``metadata["phase_timings"]`` with read/index/aggregate; the leaf write
-    work — interleaved with the stream (or a single post-stream pass when
-    sharded), plus the ragged/coverage/stamp finalize — accumulates into an
-    additive ``write`` phase alongside them (issue #249). Unlike the flat
-    path, the lazy leaf template emission counts as write: in hive the worker
-    owns its leaf's template PUTs (there is no dispatcher-side template), so
-    excluding them would hide real write-out cost. Default ``False`` makes
-    zero timing calls and leaves ``metadata`` unchanged — no probe tax.
+    Phase timings are always collected (issue #297; formerly the opt-in
+    ``profile`` gate of issues #100/#249): ``process_shard`` fills
+    ``metadata["phase_timings"]`` with read/index/aggregate, and the leaf
+    write work — interleaved with the stream (or a single post-stream pass
+    when sharded), plus the ragged/coverage/stamp finalize — accumulates into
+    an additive ``write`` phase alongside them. Unlike the flat path, the
+    lazy leaf template emission counts as write: in hive the worker owns its
+    leaf's template PUTs (there is no dispatcher-side template), so excluding
+    them would hide real write-out cost. ``profile`` is retained and
+    forwarded (it still gates dispatcher-side rollup verbosity).
 
     ``window`` (issue #246, D13/D15) is one dispatch unit's time window:
     ``{"label", "start", "end"}``, bounds half-open in DATASET units
@@ -983,14 +984,13 @@ def process_and_write_hive(
 
     def _write_chunk(block_index, carrier, ragged):
         nonlocal _write_elapsed
-        _t0 = time.time() if profile else None
+        _t0 = time.time()
         store = _leaf()
         local = leaf_block_index(grid, block_index, shard_key)
         write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=local)
         if ragged:
             ragged_chunks.append((local, ragged))
-        if profile:
-            _write_elapsed += time.time() - _t0
+        _write_elapsed += time.time() - _t0
 
     # Occupied-cell sink (issue #200): the worker already holds the shard's
     # populated cell words; collect them here to derive the stamp's coverage.
@@ -1025,10 +1025,9 @@ def process_and_write_hive(
     # the ``.zarr/`` prefix — same contract as the streaming path's first
     # ``_write_chunk``.
     if sharded and chunk_results and not metadata.get("error"):
-        _t0 = time.time() if profile else None
+        _t0 = time.time()
         write_leaf_to_zarr(chunk_results, _leaf(), grid=grid, shard_key=int(shard_key))
-        if profile:
-            _write_elapsed += time.time() - _t0
+        _write_elapsed += time.time() - _t0
     # Stamp ONLY a fully-written leaf: an errored shard (or one that streamed
     # no chunks) stays unstamped — debris by definition (D4). The stamp is the
     # last write, so its presence certifies everything before it landed — the
@@ -1038,7 +1037,7 @@ def process_and_write_hive(
     # The leaf write order is pinned: dense (streamed, or one object each when
     # sharded) -> ragged (one object, issue #209) -> coverage sidecar -> stamp.
     if "store" in box and not metadata.get("error"):
-        _t0 = time.time() if profile else None
+        _t0 = time.time()
         if not sharded:
             write_ragged_leaf_to_zarr(ragged_chunks, box["store"], grid=grid)
         words = np.concatenate(occupied) if occupied else None
@@ -1067,15 +1066,14 @@ def process_and_write_hive(
             window=window["label"] if window else None,
             time_range=time_range,
         )
-        if profile:
-            _write_elapsed += time.time() - _t0
+        _write_elapsed += time.time() - _t0
     # Write-phase split (issue #249): read/index/aggregate come from
     # ``process_shard``; ``write`` is the leaf write-out above (template +
     # dense chunks + ragged + coverage sidecar + stamp). Same gate as the flat
     # Lambda handler's issue #100 write bracket: only a clean, actually-written
     # shard carries it, so a time-to-failure never lands as a write duration
     # and a no-data shard (no leaf) stays write-less.
-    if profile and not metadata.get("error") and "phase_timings" in metadata and "store" in box:
+    if not metadata.get("error") and "phase_timings" in metadata and "store" in box:
         metadata["phase_timings"]["write"] = _write_elapsed
     return metadata
 

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -1125,6 +1125,12 @@ def process_and_write_raster_hive(
     # prefix, and a worker error raised out above, leaving debris (D4). Write
     # order is pinned: dense slabs -> coverage sidecar -> stamp.
     meta["cells_with_data"] = 0
+    # Accurate leaf-written signal for the stats-sidecar gate (issue #297): set
+    # iff a slab streamed (``"store" in box``), so both dispatchers gate the
+    # sidecar PUT on leaf existence rather than the ``timesteps`` proxy (a unit
+    # with acquisitions but no occupied cell writes no leaf). ``phase_timings``
+    # cannot serve as the gate — it rides only under ``profile``.
+    meta["leaf_written"] = "store" in box
     if "store" in box:
         _t0 = time.time()
         words = occupied[0] if occupied and occupied[0].size else None

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -230,6 +230,7 @@ async def _sample_one(
     fill=0,
     geom_cache: dict | None = None,
     stage_stats: dict | None = None,
+    io_stats: dict | None = None,
 ):
     """:func:`sample_asset_async` body, also returning the raster's center
     ``(lon, lat)`` — the ownership rule's tile-center input (#218).
@@ -249,6 +250,15 @@ async def _sample_one(
     between read and write, so it is atomic by the same argument as the
     ``geom_cache`` store below — no locks; the ``write_buffer`` sink threads
     never touch this dict.
+
+    ``io_stats`` (issue #297) accumulates the read-volume counters for the
+    per-shard stats record, in place and by the same on-loop ``+=`` argument:
+    ``bytes_read`` (compressed tile bytes fetched), ``px_decoded`` (pixels in
+    the decoded tiles — whole tiles are read to sample a few cells), and
+    ``px_sampled`` (cell samples actually gathered). Unlike ``stage_stats``
+    this is ALWAYS-ON in the shard workers (the counters are a ``len()`` and
+    two multiplies per asset — no timing calls); ``None`` (the public
+    ``sample_asset*`` path) counts nothing.
     """
     from async_tiff import TIFF
 
@@ -304,6 +314,9 @@ async def _sample_one(
     vr, vc = rows[valid], cols[valid]
     tr, tc = vr // th, vc // tw
 
+    if io_stats is not None:
+        io_stats["px_sampled"] += int(vr.size)
+
     if vr.size == 0:
         if prof:
             stage_stats["gather"] += time.time() - _t0
@@ -318,6 +331,9 @@ async def _sample_one(
         stage_stats["fetch"] += time.time() - _t0
         stage_stats["tiles"] += len(pairs)
         _t0 = time.time()
+    if io_stats is not None:
+        io_stats["bytes_read"] += sum(len(t.compressed_bytes) for t in tiles)
+        io_stats["px_decoded"] += len(pairs) * th * tw
     decoded = await asyncio.gather(*[t.decode() for t in tiles])
     if prof:
         stage_stats["decode"] += time.time() - _t0
@@ -394,6 +410,7 @@ async def sample_item_async(
     anonymous: bool = True,
     geom_cache: dict | None = None,
     stage_stats: dict | None = None,
+    io_stats: dict | None = None,
 ):
     """Sample every configured band of one STAC item, concurrently.
 
@@ -438,6 +455,7 @@ async def sample_item_async(
                 fill=bands[f]["fill_value"],
                 geom_cache=geom_cache,
                 stage_stats=stage_stats,
+                io_stats=io_stats,
             )
             for f in fields
         ]
@@ -675,6 +693,12 @@ def process_raster_shard(
     # same argument as the geom_cache store; allocated only when a sink was
     # passed, so the default path is unchanged.
     occupied_acc = np.zeros(len(cells), dtype=bool) if occupied_out is not None else None
+    # Read-volume counters (issue #297): always-on inputs for the stats
+    # record — compressed bytes fetched, pixels decoded (whole tiles), and
+    # cell samples gathered. Their sampled/decoded ratio is the extract's
+    # over-provision at read time; stored raw (associative sums), never as a
+    # ratio, per the mergeable-by-construction schema rule.
+    io_stats = {"bytes_read": 0, "px_decoded": 0, "px_sampled": 0}
 
     async def _run_all():
         sem = asyncio.Semaphore(k)
@@ -693,6 +717,7 @@ def process_raster_shard(
                             anonymous=anonymous,
                             geom_cache=geom_cache,
                             stage_stats=stage_stats,
+                            io_stats=io_stats,
                         )
                         for e in items
                     ]
@@ -760,6 +785,10 @@ def process_raster_shard(
         "granule_count": len(granules),
         "skipped": skipped,
         "timesteps": len(groups),
+        # Read-volume counters (issue #297) for the stats record.
+        "raster_bytes_read": io_stats["bytes_read"],
+        "raster_px_decoded": io_stats["px_decoded"],
+        "raster_px_sampled": io_stats["px_sampled"],
     }
     return slabs, metadata
 

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -332,7 +332,15 @@ async def _sample_one(
         stage_stats["tiles"] += len(pairs)
         _t0 = time.time()
     if io_stats is not None:
-        io_stats["bytes_read"] += sum(len(t.compressed_bytes) for t in tiles)
+        # compressed_bytes is one Buffer (chunky) or a list of Buffers (planar);
+        # normalize so bytes_read counts bytes, not buffers, if the single-band
+        # guard above (bits_per_sample != 1) is ever relaxed for multi-band COGs.
+        # A lone Buffer answers len() with its byte count; only the planar
+        # list/tuple needs per-buffer summing.
+        io_stats["bytes_read"] += sum(
+            sum(len(x) for x in cb) if isinstance(cb, (list, tuple)) else len(cb)
+            for cb in (t.compressed_bytes for t in tiles)
+        )
         io_stats["px_decoded"] += len(pairs) * th * tw
     decoded = await asyncio.gather(*[t.decode() for t in tiles])
     if prof:

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -703,9 +703,11 @@ def process_raster_shard(
     occupied_acc = np.zeros(len(cells), dtype=bool) if occupied_out is not None else None
     # Read-volume counters (issue #297): always-on inputs for the stats
     # record — compressed bytes fetched, pixels decoded (whole tiles), and
-    # cell samples gathered. Their sampled/decoded ratio is the extract's
-    # over-provision at read time; stored raw (associative sums), never as a
-    # ratio, per the mergeable-by-construction schema rule.
+    # cell samples gathered. Their decoded/sampled ratio reads as the extract's
+    # read-time over-provision only when the output grid is coarser than the
+    # source; a finer grid (more cells than source pixels) inverts it below 1.
+    # Stored raw (associative sums), never as a ratio, per the
+    # mergeable-by-construction schema rule.
     io_stats = {"bytes_read": 0, "px_decoded": 0, "px_sampled": 0}
 
     async def _run_all():

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -1056,11 +1056,11 @@ def process_and_write_raster_hive(
     sidecar (edge shards only; interior shards stamp ``"full"`` with no
     sidecar PUT) -> stamp. ``cells_with_data`` counts the occupied-cell
     union; ``granule_count`` the unit's acquisitions (asset-carrying
-    entries). ``profile`` mirrors the flat handler's issue #100/#249
-    convention: ``metadata["phase_timings"] = {"sample", "write", "stages"}``
-    with the leaf write-out (template + slabs + sidecar + stamp) as
-    ``write``; default makes no timing calls beyond a passed-through
-    ``stage_stats`` (the local dispatcher's debug-logging flavor).
+    entries). Phase timings are always collected (issue #297):
+    ``metadata["phase_timings"] = {"sample", "write"}`` with the leaf
+    write-out (template + slabs + sidecar + stamp) as ``write``; the
+    per-stage ``stages`` block (issue #249) stays gated on ``profile`` /
+    a passed ``stage_stats`` (the local dispatcher's debug-logging flavor).
     """
     from zagg.hive import (
         COVERAGE_SIDECAR,
@@ -1104,10 +1104,9 @@ def process_and_write_raster_hive(
 
     def _write_slab(t_idx, slab):
         nonlocal write_s
-        _t0 = time.time() if profile else None
+        _t0 = time.time()
         write_raster_leaf_slab(_leaf(), grid, t_idx, slab)
-        if profile:
-            write_s += time.time() - _t0
+        write_s += time.time() - _t0
 
     occupied: list = []
     _slabs, meta = process_raster_shard(
@@ -1127,7 +1126,7 @@ def process_and_write_raster_hive(
     # order is pinned: dense slabs -> coverage sidecar -> stamp.
     meta["cells_with_data"] = 0
     if "store" in box:
-        _t0 = time.time() if profile else None
+        _t0 = time.time()
         words = occupied[0] if occupied and occupied[0].size else None
         # D14 popcount: a fully-occupied subtree stamps encoding "full" — no
         # sidecar PUT. Gated on a windowed unit (/2 stores) so schedule-none
@@ -1158,17 +1157,19 @@ def process_and_write_raster_hive(
             window=label,
             time_range=time_range,
         )
-        if profile:
-            write_s += time.time() - _t0
-    # Phase split (issues #100/#249, the flat raster handler's convention):
-    # only a unit that actually wrote carries it, so a no-data unit stays
-    # write-less and sample/write always decompose this call's wall.
-    if profile and "store" in box:
+        write_s += time.time() - _t0
+    # Phase split (issues #100/#249; always-on collection since issue #297 —
+    # the stats sidecar needs complete timings by default): only a unit that
+    # actually wrote carries it, so a no-data unit stays write-less and
+    # sample/write always decompose this call's wall. The per-stage ``stages``
+    # block stays verbosity, gated on profiling/debug (a passed stage_stats).
+    if "store" in box:
         meta["phase_timings"] = {
             "sample": (time.time() - t_start) - write_s,
             "write": write_s,
-            "stages": stage_stats,
         }
+        if stage_stats is not None:
+            meta["phase_timings"]["stages"] = stage_stats
     return meta
 
 

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -206,12 +206,14 @@ def process_shard(
         be a read column (declared, e.g. the windowing ``time_field``) or the
         key is likewise omitted.
     profile : bool, optional
-        Opt-in per-phase timing (issue #100 phase 2). When ``True``, fills
-        ``metadata["phase_timings"]`` with ``read`` / ``index`` / ``aggregate``
-        wall-clock seconds (``time.time()`` deltas) for the in-worker stages.
-        Default ``False`` takes the current path unchanged — no added timing
-        calls, no ``phase_timings`` key — so the worker pays no probe tax on
-        ordinary runs. (The ``write`` phase runs in the lambda handler, outside
+        Retained knob from the opt-in era (issue #100 phase 2); phase-timing
+        COLLECTION is now always-on (issue #297): ``metadata["phase_timings"]``
+        always carries ``read`` / ``index`` / ``aggregate`` wall-clock seconds
+        (``time.time()`` deltas — a handful of calls per shard, no measurable
+        probe tax) so the per-shard stats sidecar is complete by default. The
+        flag still gates *verbosity* elsewhere (e.g. the dispatcher's summary
+        rollups and the raster per-stage stats); it no longer changes this
+        function's behavior. (The ``write`` phase runs in the caller, outside
         this function.)
 
     Returns
@@ -325,10 +327,11 @@ def process_shard(
     else:
         buffered = None
 
-    # Opt-in per-phase timing (issue #100). Only allocated when profiling so the
-    # default path stays byte-identical (no dict, no time.time() calls).
-    phase_timings: dict | None = {} if profile else None
-    _read_t0 = time.time() if profile else None
+    # Per-phase timing (issue #100; always-on collection since issue #297 —
+    # the stats sidecar needs complete timings by default, and the cost is a
+    # few time.time() calls per shard).
+    phase_timings: dict = {}
+    _read_t0 = time.time()
 
     # Granule fan-out width (issue #180). Resolved before any read so a bad
     # value is a loud config error, not N per-granule warnings. (Backend
@@ -495,8 +498,7 @@ def process_shard(
         # deliberately charges ALL group+merge cost to ``read`` — the tail
         # flush must not fall between phases and vanish from the accounting.
         buffered.flush()
-    if profile:
-        phase_timings["read"] = time.time() - _read_t0
+    phase_timings["read"] = time.time() - _read_t0
 
     if buffered.empty if buffered is not None else not all_reads:
         # Distinguish a genuinely-empty read from one where a group read raised
@@ -514,8 +516,7 @@ def process_shard(
             logger.info(f"  No data after filtering for shard {label} - skipping")
             metadata["error"] = "No data after filtering"
         metadata["duration_s"] = (datetime.now() - start_time).total_seconds()
-        if profile:
-            metadata["phase_timings"] = phase_timings
+        metadata["phase_timings"] = phase_timings
         return pd.DataFrame(), metadata
 
     data_vars = get_data_vars(config)
@@ -551,7 +552,7 @@ def process_shard(
             f"(the runner does)."
         )
 
-    _index_t0 = time.time() if profile else None
+    _index_t0 = time.time()
 
     # ---- Pool the shard's reads ONCE (shared across all K chunks) -------------
     # The shard is read+grouped a single time; only the ``chunk_precompute``
@@ -592,9 +593,8 @@ def process_shard(
                 np.fromiter(cell_to_slice.keys(), dtype=np.uint64, count=len(cell_to_slice))
             )
 
-    if profile:
-        phase_timings["index"] = time.time() - _index_t0
-        _aggregate_t0 = time.time()
+    phase_timings["index"] = time.time() - _index_t0
+    _aggregate_t0 = time.time()
 
     # ---- Aggregate + build one carrier per finer chunk -----------------------
     # ``iter_chunks`` is the K-chunk seam (issue #30 item 3); a minimal grid (e.g.
@@ -705,17 +705,16 @@ def process_shard(
         # remainder (defensive) and the cached grouped partition.
         buffered.close()
 
-    if profile:
-        phase_timings["aggregate"] = time.time() - _aggregate_t0
-        if spill_mode:
-            # The espg-approved /tmp throughput instrumentation (issue #217):
-            # exact bytes spilled plus the wall spent in partition appends and
-            # read-backs. Read-backs can land in either the read phase (block
-            # closes mid-read) or the aggregate phase (single-block reduce).
-            phase_timings["spill_write_s"] = buffered.spill_write_s
-            phase_timings["spill_read_s"] = buffered.spill_read_s
-            phase_timings["spill_bytes"] = buffered.spill_bytes
-        metadata["phase_timings"] = phase_timings
+    phase_timings["aggregate"] = time.time() - _aggregate_t0
+    if spill_mode:
+        # The espg-approved /tmp throughput instrumentation (issue #217):
+        # exact bytes spilled plus the wall spent in partition appends and
+        # read-backs. Read-backs can land in either the read phase (block
+        # closes mid-read) or the aggregate phase (single-block reduce).
+        phase_timings["spill_write_s"] = buffered.spill_write_s
+        phase_timings["spill_read_s"] = buffered.spill_read_s
+        phase_timings["spill_bytes"] = buffered.spill_bytes
+    metadata["phase_timings"] = phase_timings
 
     duration = (datetime.now() - start_time).total_seconds()
     logger.info(f"Completed shard {label} in {duration:.1f}s")

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2004,6 +2004,13 @@ def _write_run_stats(store_path, rows, *, run_id, store_kwargs, summary=None) ->
     CI OIDC benchmark role), and a missing parquet must never fail a run whose
     data landed — the leaf sidecars remain the durable per-shard truth.
     """
+    # Keep the summary key set deterministic (issue #297): ``run_stats_path``
+    # is always present, defaulting to None, and only rewritten to the real
+    # path once the PUT lands. A skipped/empty/fail-open write leaves it None
+    # rather than absent, so consumers (and TestSummaryKeysByteIdentical) see a
+    # stable schema regardless of write outcome.
+    if summary is not None:
+        summary["run_stats_path"] = None
     if not rows:
         return
     try:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1079,6 +1079,14 @@ class RasterStrategy:
         # resolved once per run, stamped into every shard event. Reuses the
         # module's client seam (a bare namespace with .client) so tests that
         # patch boto3.client intercept it like every other invoke.
+        #
+        # Seam divergence with the spatial ``_run_lambda`` (which passes a
+        # ``boto3.Session()`` instance) is DELIBERATE, keyed to the two test
+        # harnesses: the raster tests patch ``boto3.client`` (this module route
+        # hits the fake), the spatial tests patch ``boto3.Session`` (that route
+        # degrades to None via the shape-check). Unifying either direction would
+        # send real STS ``get-caller-identity`` from the other family's unit
+        # tests. ``_resolve_invoked_by`` accepts either (both expose ``.client``).
         invoked_by = _resolve_invoked_by(boto3, region)
         # Ping → setup, bracketed as template_s (the setup-ish wall the
         # benchmark splits from fan-out, issue #250). Flat: the template is
@@ -1967,6 +1975,13 @@ def _resolve_invoked_by(session, region) -> dict | None:
     carry no caller identity) and copies this verbatim into the sidecar; the
     run parquet carries it as a column. Fail-open: a failed resolve logs and
     the records carry ``null`` rather than failing the run.
+
+    ``session`` is any object exposing ``.client(service, region_name=...)`` —
+    the raster path passes the ``boto3`` module, the spatial path a
+    ``boto3.Session()`` instance. That per-path seam is deliberate (each rides
+    the mock its test harness patches); see the call sites. A stubbed/mocked
+    session that returns non-string identity fields degrades to ``None`` via
+    the shape-check below rather than stamping junk into persisted records.
     """
     try:
         ident = session.client("sts", region_name=region).get_caller_identity()
@@ -2585,6 +2600,11 @@ def _run_lambda(
     state: dict = {}
     # Caller identity for the per-shard stats records (issue #297): resolved
     # once per run, stamped into every cell event; workers copy it verbatim.
+    # Passes the run's ``session`` (not the module, as the raster path does) so
+    # this route rides the ``boto3.Session`` seam the spatial tests patch —
+    # their MagicMock session degrades to None via the shape-check, no network.
+    # See the matching note at the raster call site: the per-path seam is
+    # deliberate; unifying it would send real STS from one test family.
     invoked_by = _resolve_invoked_by(session, region)
 
     def _preflight(n):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -871,6 +871,7 @@ class RasterStrategy:
 
         stage_max: dict = {}
         stage_counts: dict = {}
+        stats_failures: list = []  # (shard_key, exception) — run-parquet rows (#297)
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {pool.submit(_one, pair): pair[0] for pair in cells}
             for fut in as_completed(futures):
@@ -880,6 +881,7 @@ class RasterStrategy:
                 except Exception as e:  # noqa: BLE001 - per-shard isolation, run continues
                     errors += 1
                     last_error = e
+                    stats_failures.append((int(futures[fut]), e))
                     logger.warning(f"raster shard {label} failed: {e}")
                     continue
                 ok_metas.append(meta)
@@ -918,6 +920,19 @@ class RasterStrategy:
                         logger.info(f"Wrote root coverage.moc ({len(envelope['ranges'])} ranges)")
                 except Exception as e:
                     logger.warning(f"root coverage.moc write failed (fail-open, D9): {e}")
+        # Run-level stats parquet (issue #297 phase 3), BEFORE the all-failed
+        # raise below so the failure evidence persists at the store root.
+        from zagg.telemetry import failure_record, flatten_record
+
+        rows = [flatten_record(m["stats"]) for m in ok_metas if m.get("stats")]
+        rows += [
+            flatten_record(
+                failure_record(shard_key=key, error=str(exc)),
+                error_class=type(exc).__name__,
+            )
+            for key, exc in stats_failures
+        ]
+        _write_run_stats(store_path, rows, run_id=uuid.uuid4().hex, store_kwargs=store_kwargs)
         # Per-shard isolation lets one bad shard be counted and skipped, but a
         # run where EVERY shard raised (e.g. a config band whose ``asset`` is
         # absent from every granule) would otherwise return a success-shaped,
@@ -1173,6 +1188,7 @@ class RasterStrategy:
         timesteps_written = 0
         last_error = None
         ok_units: list = []  # (shard_key, body) — coverage needs keys, rollups bodies
+        stats_failures: list = []  # (shard_key, error, body) — run-parquet rows (#297)
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {pool.submit(_one, pair): pair[0] for pair in cells}
             for fut in as_completed(futures):
@@ -1181,6 +1197,7 @@ class RasterStrategy:
                 if result["error"]:
                     errors += 1
                     last_error = result["error"]
+                    stats_failures.append((int(futures[fut]), result["error"], result["body"]))
                     logger.warning(f"raster shard {label} failed: {result['error']}")
                     continue
                 body = result["body"]
@@ -1239,6 +1256,29 @@ class RasterStrategy:
                         )
                 except Exception as e:
                     logger.warning(f"root coverage.moc dispatch failed (fail-open, D9): {e}")
+        # Run-level stats parquet (issue #297 phase 3), BEFORE the all-failed
+        # raise so the failure evidence persists at the store root. Success
+        # rows ride the envelopes' records; a failed unit's landed body may
+        # still carry duration until failure.
+        from zagg.telemetry import failure_record, flatten_record
+
+        rows = []
+        for key, body in ok_units:
+            record = body.get("stats")
+            if record is not None:
+                rows.append(flatten_record(record))
+        rows += [
+            flatten_record(
+                failure_record(shard_key=key, error=error, duration_s=body.get("duration_s"))
+            )
+            for key, error, body in stats_failures
+        ]
+        _write_run_stats(
+            store_path,
+            rows,
+            run_id=uuid.uuid4().hex,
+            store_kwargs=_output_store_kwargs(output_creds_event, region),
+        )
         if cells and errors == len(cells):
             raise RuntimeError(f"all {errors} raster shard(s) failed; last error: {last_error}")
         # Worker telemetry rollup (issue #250): billed durations and peak RSS,
@@ -1932,6 +1972,59 @@ def _resolve_invoked_by(session, region) -> dict | None:
         return None
 
 
+def _write_run_stats(store_path, rows, *, run_id, store_kwargs, summary=None) -> None:
+    """Fail-open write of the run-level stats parquet at the store root (#297).
+
+    One row per dispatched shard, failure rows included. Fail-open by design:
+    the dispatcher may hold an invoke-only role with no S3 write access (the
+    CI OIDC benchmark role), and a missing parquet must never fail a run whose
+    data landed — the leaf sidecars remain the durable per-shard truth.
+    """
+    if not rows:
+        return
+    try:
+        from zagg.telemetry import write_run_parquet
+
+        path = write_run_parquet(store_path, rows, run_id=run_id, store_kwargs=store_kwargs)
+        if summary is not None:
+            summary["run_stats_path"] = path
+        logger.info(f"Wrote run stats parquet ({len(rows)} rows): {path}")
+    except Exception as e:
+        logger.warning(f"run stats parquet write failed (fail-open, issue #297): {e}")
+
+
+def _lambda_result_rows(results) -> list:
+    """Run-parquet rows from the lambda dispatch's per-cell result dicts.
+
+    Success rows come from the envelope-ridden worker record
+    (``body["stats"]``); a 200 body from a worker predating the record falls
+    back to a dispatcher-built record over the same body; everything else is
+    a failure row (error, duration until failure, retry count).
+    """
+    from zagg.telemetry import build_record, failure_record, flatten_record
+
+    rows = []
+    for r in results:
+        body = r.get("body") or {}
+        record = body.get("stats")
+        if record is None:
+            if r.get("status_code") == 200 and not r.get("error"):
+                # Stale deployed worker (no record in the envelope): derive one
+                # from the body's counters so the row is not a false failure.
+                record = build_record(
+                    shard_key=r.get("shard_key") if r.get("shard_key") is not None else -1,
+                    metadata=body,
+                )
+            else:
+                record = failure_record(
+                    shard_key=r.get("shard_key"),
+                    error=r.get("error") or f"status {r.get('status_code')}",
+                    duration_s=r.get("lambda_duration") or r.get("wall_time"),
+                )
+        rows.append(flatten_record(record, retries=r.get("retries")))
+    return rows
+
+
 def _resolve_source_credentials(config) -> dict:
     """S3 read credentials for the source datasets, provider-selected.
 
@@ -2262,6 +2355,7 @@ def _run_local(
     executor.preflight(len(cells))
 
     n = len(cells)
+    stats_failures: list = []  # (shard_key, exception) — run-parquet failure rows (#297)
 
     def _accumulate(report, i, outcome):
         # _safe_label, not shard_label: a malformed key that failed the cell
@@ -2269,6 +2363,7 @@ def _run_local(
         label = _safe_label(grid, outcome["shard_key"])
         if not outcome["ok"]:
             report.cells_error += 1
+            stats_failures.append((outcome["shard_key"], outcome["error"]))
             logger.warning(f"  [{i}/{n}] {label}: ERROR {outcome['error']}")
             return
         meta = outcome["meta"]
@@ -2352,6 +2447,21 @@ def _run_local(
         "backend": "local",
         "results": report.results,
     }
+    # Run-level stats parquet (issue #297 phase 3): one row per shard from the
+    # metas' envelope records, failure rows from the raised-cell captures.
+    from zagg.telemetry import failure_record, flatten_record
+
+    rows = [flatten_record(m["stats"]) for m in report.results if m.get("stats")]
+    rows += [
+        flatten_record(
+            failure_record(shard_key=int(key), error=str(exc)),
+            error_class=type(exc).__name__,
+        )
+        for key, exc in stats_failures
+    ]
+    _write_run_stats(
+        store_path, rows, run_id=uuid.uuid4().hex, store_kwargs=store_kwargs, summary=summary
+    )
     logger.info(
         f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"
     )
@@ -2451,10 +2561,11 @@ def _run_lambda(
     # behind a ~4 min NAT idle timeout that severed every >250 s benchmark
     # target. The run_id keeps reruns into the same store from reading stale
     # results. ``invocation="sync"`` skips the channel (legacy RequestResponse).
+    run_id = uuid.uuid4().hex
     result_prefix = None
     result_box: dict = {}
     if invocation == "async":
-        result_prefix = f"{store_path.rstrip('/')}.status/{uuid.uuid4().hex}"
+        result_prefix = f"{store_path.rstrip('/')}.status/{run_id}"
         logger.info(f"Async worker results at {result_prefix}")
 
     # The dispatch lambda_client is built inside preflight() (once the probe
@@ -2913,6 +3024,16 @@ def _run_lambda(
     }
     if profile:
         summary["worker_phase_max"] = worker_phase_max
+    # Run-level stats parquet (issue #297 phase 3): success rows straight off
+    # the async result envelopes (no second S3 listing), failure rows from the
+    # dispatch results the RunReport accumulated.
+    _write_run_stats(
+        store_path,
+        _lambda_result_rows(report.results),
+        run_id=run_id,
+        store_kwargs=_output_store_kwargs(output_creds_event, region),
+        summary=summary,
+    )
     logger.info(
         f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"
     )

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -941,7 +941,9 @@ class RasterStrategy:
             )
             for key, exc in stats_failures
         ]
-        _write_run_stats(store_path, rows, run_id=uuid.uuid4().hex, store_kwargs=store_kwargs)
+        run_stats_path = _write_run_stats(
+            store_path, rows, run_id=uuid.uuid4().hex, store_kwargs=store_kwargs
+        )
         # Per-shard isolation lets one bad shard be counted and skipped, but a
         # run where EVERY shard raised (e.g. a config band whose ``asset`` is
         # absent from every granule) would otherwise return a success-shaped,
@@ -962,6 +964,7 @@ class RasterStrategy:
             "template_s": template_s,
             "store_path": store_path,
             "backend": "local",
+            "run_stats_path": run_stats_path,
         }
         if profile:
             # Straggler-maxed stage seconds + summed work counts (issue #250);
@@ -1290,7 +1293,7 @@ class RasterStrategy:
             )
             for key, error, body in stats_failures
         ]
-        _write_run_stats(
+        run_stats_path = _write_run_stats(
             store_path,
             rows,
             run_id=uuid.uuid4().hex,
@@ -1318,6 +1321,7 @@ class RasterStrategy:
             "max_memory_mb": max(mems) if mems else None,
             "store_path": store_path,
             "backend": "lambda",
+            "run_stats_path": run_stats_path,
         }
         if profile:
             # Straggler-maxed stage seconds (+ the write bucket) and summed
@@ -1996,13 +2000,18 @@ def _resolve_invoked_by(session, region) -> dict | None:
         return None
 
 
-def _write_run_stats(store_path, rows, *, run_id, store_kwargs, summary=None) -> None:
+def _write_run_stats(store_path, rows, *, run_id, store_kwargs, summary=None) -> str | None:
     """Fail-open write of the run-level stats parquet at the store root (#297).
 
     One row per dispatched shard, failure rows included. Fail-open by design:
     the dispatcher may hold an invoke-only role with no S3 write access (the
     CI OIDC benchmark role), and a missing parquet must never fail a run whose
     data landed — the leaf sidecars remain the durable per-shard truth.
+
+    Returns the written path, or ``None`` when the write was skipped/failed —
+    for callers whose summary dict does not exist yet at write time (the
+    raster paths persist the parquet BEFORE their all-failed raise, then fold
+    the returned path into the summary they build afterwards).
     """
     # Keep the summary key set deterministic (issue #297): ``run_stats_path``
     # is always present, defaulting to None, and only rewritten to the real
@@ -2012,7 +2021,7 @@ def _write_run_stats(store_path, rows, *, run_id, store_kwargs, summary=None) ->
     if summary is not None:
         summary["run_stats_path"] = None
     if not rows:
-        return
+        return None
     try:
         from zagg.telemetry import write_run_parquet
 
@@ -2020,8 +2029,10 @@ def _write_run_stats(store_path, rows, *, run_id, store_kwargs, summary=None) ->
         if summary is not None:
             summary["run_stats_path"] = path
         logger.info(f"Wrote run stats parquet ({len(rows)} rows): {path}")
+        return path
     except Exception as e:
         logger.warning(f"run stats parquet write failed (fail-open, issue #297): {e}")
+        return None
 
 
 def _lambda_result_rows(results) -> list:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -677,6 +677,7 @@ class RasterStrategy:
             write_raster_coords,
             write_raster_slab,
         )
+        from zagg.telemetry import build_record, raster_granule_ids, write_sidecar
 
         catalog_path = catalog or config.catalog
         if not catalog_path:
@@ -787,6 +788,7 @@ class RasterStrategy:
             shard_key, granules = pair[0], pair[1]
             window = pair[2] if len(pair) > 2 else None
             wrote = False
+            unit_t0 = time.time()
             # Per-stage sample profiling (issue #249), the local flavor of the
             # lambda handler's opt-in ``profile`` key: allocated when profiling
             # (issue #250) or when debug logging is on, so the default path
@@ -844,6 +846,27 @@ class RasterStrategy:
                 logger.debug(
                     f"raster shard {shard_label(grid, int(shard_key))} stages: {stage_stats}"
                 )
+            # Per-shard stats record (issue #297), the raster-local flavor:
+            # hive units that wrote a leaf (timesteps > 0 -> stamped) get the
+            # sidecar sibling; the record rides ``meta`` for the run parquet
+            # either way. Fail-open on the sidecar PUT.
+            meta.setdefault("duration_s", time.time() - unit_t0)
+            record = build_record(
+                shard_key=int(shard_key),
+                metadata=meta,
+                granule_ids=raster_granule_ids(granules),
+            )
+            meta["stats"] = record
+            if store_layout == "hive" and meta.get("timesteps"):
+                from zagg.hive import shard_leaf_path
+
+                try:
+                    leaf = shard_leaf_path(
+                        store_path, int(shard_key), window=window["label"] if window else None
+                    )
+                    write_sidecar(leaf, record, **store_kwargs)
+                except Exception as e:
+                    logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
             return meta, stage_stats, write_s
 
         stage_max: dict = {}
@@ -1028,6 +1051,11 @@ class RasterStrategy:
             result_prefix = f"{store_path.rstrip('/')}.status/{uuid.uuid4().hex}"
             function_timeout_s = _get_function_timeout_s(client, function_name)
             logger.info(f"Async raster results at {result_prefix}")
+        # Caller identity for the per-shard stats records (issue #297):
+        # resolved once per run, stamped into every shard event. Reuses the
+        # module's client seam (a bare namespace with .client) so tests that
+        # patch boto3.client intercept it like every other invoke.
+        invoked_by = _resolve_invoked_by(boto3, region)
         # Ping → setup, bracketed as template_s (the setup-ish wall the
         # benchmark splits from fan-out, issue #250). Flat: the template is
         # load-bearing before fan-out — workers write slabs into its arrays —
@@ -1098,10 +1126,12 @@ class RasterStrategy:
                 keys = {e.get("time_key") or e.get("datetime") for e in granules if e.get("assets")}
                 ev["time_index"] = {k: time_index[k] for k in keys}
             if profile:
-                # Opt-in (issue #250): the worker then emits phase_timings
-                # (write bucket + issue #249 stages). Absent -> the payload is
-                # byte-identical to the pre-profile path (the #100 convention).
+                # Opt-in (issue #250): the worker then adds the per-stage
+                # ``stages`` block to its (now always-on, issue #297)
+                # phase_timings.
                 ev["profile"] = True
+            if invoked_by is not None:
+                ev["invoked_by"] = invoked_by
             if output_creds_event is not None:
                 ev["output_credentials"] = output_creds_event
             return ev
@@ -1880,6 +1910,28 @@ def _raster_windowed_units(cells: list[tuple], windowing: dict) -> list:
     return units
 
 
+def _resolve_invoked_by(session, region) -> dict | None:
+    """Caller identity for the run's stats records (issue #297), or ``None``.
+
+    Resolved ONCE per run via ``sts get-caller-identity`` and stamped into
+    every invoke payload — the worker cannot see the invoker (Event invokes
+    carry no caller identity) and copies this verbatim into the sidecar; the
+    run parquet carries it as a column. Fail-open: a failed resolve logs and
+    the records carry ``null`` rather than failing the run.
+    """
+    try:
+        ident = session.client("sts", region_name=region).get_caller_identity()
+        arn, userid = ident["Arn"], ident["UserId"]
+        # Shape-check rather than trust: a stubbed/mocked session must degrade
+        # to None, not stamp junk into every worker's persisted record.
+        if not (isinstance(arn, str) and isinstance(userid, str)):
+            return None
+        return {"arn": arn, "userid": userid}
+    except Exception as e:
+        logger.warning(f"sts get-caller-identity failed; stats invoked_by omitted: {e}")
+        return None
+
+
 def _resolve_source_credentials(config) -> dict:
     """S3 read credentials for the source datasets, provider-selected.
 
@@ -2078,6 +2130,7 @@ def _run_local(
     # Build grid from the run config (single source of truth) and refuse a
     # shard map built for a different grid.
     from zagg.grids import from_config
+    from zagg.telemetry import build_record, write_sidecar
 
     grid = from_config(config)
     _check_signature(grid, catalog_data)
@@ -2176,6 +2229,27 @@ def _run_local(
                     handoff=handoff,
                     **extra,
                 )
+            # Per-shard stats record (issue #297): same schema as the Lambda
+            # worker's (no lambda config / caller identity on the local
+            # backend). Hive leaves get the stats.json sidecar SIBLING on
+            # success; the record rides ``meta`` for the run parquet either
+            # way. Fail-open on the sidecar PUT.
+            record = build_record(
+                shard_key=int(shard_key),
+                metadata=meta,
+                granule_ids=_resolve_urls(records, driver),
+            )
+            meta["stats"] = record
+            if store_layout == "hive" and not meta.get("error"):
+                from zagg.hive import shard_leaf_path
+
+                try:
+                    leaf = shard_leaf_path(
+                        store_path, int(shard_key), window=window["label"] if window else None
+                    )
+                    write_sidecar(leaf, record, **store_kwargs)
+                except Exception as e:
+                    logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
             return {"shard_key": shard_key, "ok": True, "meta": meta}
         except Exception as e:
             return {"shard_key": shard_key, "ok": False, "error": e}
@@ -2389,6 +2463,9 @@ def _run_lambda(
     # over a not-yet-built name.
     session = boto3.Session()
     state: dict = {}
+    # Caller identity for the per-shard stats records (issue #297): resolved
+    # once per run, stamped into every cell event; workers copy it verbatim.
+    invoked_by = _resolve_invoked_by(session, region)
 
     def _preflight(n):
         # Pre-flight concurrency probe: clamp workers to what local file
@@ -2504,6 +2581,7 @@ def _run_lambda(
             handoff=handoff,
             profile=profile,
             label=label,
+            invoked_by=invoked_by,
             **extra,
         )
 
@@ -3940,6 +4018,7 @@ def _invoke_lambda_cell(
     result_fetch=None,
     poll_timeout_s=None,
     label=None,
+    invoked_by=None,
 ):
     """Invoke Lambda for a single cell with retry logic.
 
@@ -4004,6 +4083,10 @@ def _invoke_lambda_cell(
     # it, staying byte-identical to the pre-handoff path (#130).
     if handoff and handoff != "pandas":
         event["handoff"] = handoff
+    # Caller identity for the stats record (issue #297); absent when the STS
+    # resolve failed (fail-open), keeping the event key optional.
+    if invoked_by is not None:
+        event["invoked_by"] = invoked_by
     # Async dispatch (issue #151): tell the worker where to mirror its response
     # envelope and fire-and-forget. Absent -> the legacy synchronous invoke.
     invocation_type = "RequestResponse"

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -854,6 +854,12 @@ class RasterStrategy:
             # writes no leaf, so ``timesteps`` alone would orphan a sidecar.
             # Fail-open on the sidecar PUT.
             meta.setdefault("duration_s", time.time() - unit_t0)
+            # A raster unit's obs tally is its timestep count (the raster
+            # obs-count convention). Mirror the Lambda handler, which injects
+            # ``total_obs`` before ``build_record``, so the same shard yields an
+            # identical ``n_obs`` across backends (the record's whole point is a
+            # backend-independent, mergeable row for the run parquet).
+            meta.setdefault("total_obs", meta.get("timesteps", 0))
             record = build_record(
                 shard_key=int(shard_key),
                 metadata=meta,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1116,6 +1116,15 @@ class RasterStrategy:
             raise ValueError(f"Unknown invocation: {invocation!r} (expected 'async' or 'sync')")
         function_name = _resolve_function_name(config, function_name)
         max_workers = min(max_workers or 64, len(cells)) or 1
+        # Pre-invoke cost ceiling (issue #298, rolled into #297 for the raster
+        # path): one invoke per unit, billed at the worker's memory for at
+        # most the function timeout — same math as the spatial/temporal paths.
+        memory_gb = _worker_memory_gb(config)
+        run_max_cost = max_cost_usd(len(cells), memory_gb, timeout_s=_DEFAULT_FUNCTION_TIMEOUT_S)
+        logger.info(
+            f"Max cost ceiling: ~${run_max_cost:.2f} ({len(cells)} units x {memory_gb:g} GB x "
+            f"{_DEFAULT_FUNCTION_TIMEOUT_S}s, {LAMBDA_ARCH})"
+        )
         client = boto3.client(
             "lambda",
             region_name=region,
@@ -1391,6 +1400,23 @@ class RasterStrategy:
         ok_bodies = [b for _k, b in ok_units]
         durations = [float(b["duration_s"]) for b in ok_bodies if b.get("duration_s") is not None]
         mems = [float(b["max_memory_mb"]) for b in ok_bodies if b.get("max_memory_mb") is not None]
+        # Actual-cost rollup (issues #298/#297): billed durations across
+        # successes AND landed failures (a failed unit's body still carries
+        # its duration until failure), priced like the spatial path. The
+        # structured cost block mirrors _run_lambda's; estimate_cost_usd is
+        # the Phase-3 stub (None until the #297/#299 history exists).
+        billed_s = sum(durations) + sum(
+            float(b["duration_s"])
+            for _k, _e, b in stats_failures
+            if b.get("duration_s") is not None
+        )
+        gb_seconds = billed_s * memory_gb
+        actual_cost = gb_seconds * LAMBDA_PRICE_PER_GB_SEC
+        cost_block = {
+            "max_cost_usd": run_max_cost,
+            "estimated_cost_usd": estimate_cost_usd(),
+            "actual_cost_usd": actual_cost,
+        }
         summary = {
             "total_cells": len(cells),
             "cells_with_data": shards_with_data,
@@ -1401,6 +1427,12 @@ class RasterStrategy:
             "wall_time_s": wall_time,
             "template_s": template_s,
             "lambda_time_s": sum(durations) if durations else None,
+            "gb_seconds": gb_seconds,
+            "price_per_gb_sec": LAMBDA_PRICE_PER_GB_SEC,
+            # Legacy flat key = the actual-cost rollup, matching the other
+            # lambda summaries' pre-#298 meaning.
+            "estimated_cost_usd": actual_cost,
+            "cost": cost_block,
             "worker_max_s": max(durations) if durations else None,
             "worker_median_s": statistics.median(durations) if durations else None,
             "max_memory_mb": max(mems) if mems else None,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -847,9 +847,12 @@ class RasterStrategy:
                     f"raster shard {shard_label(grid, int(shard_key))} stages: {stage_stats}"
                 )
             # Per-shard stats record (issue #297), the raster-local flavor:
-            # hive units that wrote a leaf (timesteps > 0 -> stamped) get the
-            # sidecar sibling; the record rides ``meta`` for the run parquet
-            # either way. Fail-open on the sidecar PUT.
+            # hive units that wrote a leaf get the sidecar sibling; the record
+            # rides ``meta`` for the run parquet either way. Gate on the
+            # accurate ``leaf_written`` signal (set iff a slab streamed) rather
+            # than ``timesteps`` — a unit with acquisitions but no occupied cell
+            # writes no leaf, so ``timesteps`` alone would orphan a sidecar.
+            # Fail-open on the sidecar PUT.
             meta.setdefault("duration_s", time.time() - unit_t0)
             record = build_record(
                 shard_key=int(shard_key),
@@ -857,7 +860,7 @@ class RasterStrategy:
                 granule_ids=raster_granule_ids(granules),
             )
             meta["stats"] = record
-            if store_layout == "hive" and meta.get("timesteps"):
+            if store_layout == "hive" and meta.get("leaf_written"):
                 from zagg.hive import shard_leaf_path
 
                 try:

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -21,6 +21,7 @@ them do object-store I/O and import their backends lazily.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import platform
 from datetime import datetime, timezone
@@ -64,6 +65,15 @@ def granules_sha256(granule_ids: Iterable[str] | None) -> str | None:
     if not ids:
         return None
     return hashlib.sha256("\n".join(ids).encode()).hexdigest()
+
+
+def raster_granule_ids(granules: Iterable[dict]) -> list:
+    """Catalog-identity inputs for a raster unit's stats record.
+
+    Raster ShardMap entries carry no granule URL; the stable per-acquisition
+    identity is the STAC item id when present, else the acquisition datetime.
+    """
+    return [e.get("id") or e.get("datetime") for e in granules if e.get("id") or e.get("datetime")]
 
 
 def lambda_env() -> dict | None:
@@ -191,3 +201,60 @@ def _zagg_version() -> str:
     import zagg
 
     return zagg.__version__
+
+
+# ---------------------------------------------------------------------------
+# Leaf sidecar I/O (phase 2) — one small JSON object per hive leaf, written by
+# the worker on success only, SIBLING to the leaf ``.zarr`` (never inside it:
+# the leaf stays vanilla zarr v3 and the D4 commit stamp stays its final write).
+# ---------------------------------------------------------------------------
+
+
+def sidecar_key(leaf_name: str) -> str:
+    """Sidecar object name for a leaf zarr basename.
+
+    Bare leaves get :data:`SIDECAR_NAME`; windowed leaves (issue #246) get
+    ``stats_{window}.json`` — a hive node directory holds every window's leaf
+    of its one shard, so a bare ``stats.json`` would self-clobber across
+    windows. Mirrors the ``{full_id}_{window}.zarr`` leaf naming.
+    """
+    from zagg.windows import split_leaf_name
+
+    _full_id, window = split_leaf_name(leaf_name)
+    if window is None:
+        return SIDECAR_NAME
+    stem, ext = SIDECAR_NAME.rsplit(".", 1)
+    return f"{stem}_{window}.{ext}"
+
+
+def sidecar_path(leaf_path: str) -> str:
+    """Absolute path of a leaf's stats sidecar (sibling of the ``.zarr``)."""
+    prefix, _, name = leaf_path.rstrip("/").rpartition("/")
+    return f"{prefix}/{sidecar_key(name)}"
+
+
+def write_sidecar(leaf_path: str, record: dict, **store_kwargs) -> None:
+    """PUT ``record`` as the leaf's stats sidecar (success path only, #297)."""
+    import obstore
+
+    from zagg.store import open_object_store
+
+    prefix, _, name = leaf_path.rstrip("/").rpartition("/")
+    obstore.put(
+        open_object_store(prefix, **store_kwargs), sidecar_key(name), json.dumps(record).encode()
+    )
+
+
+def read_sidecar(leaf_path: str, **store_kwargs) -> dict | None:
+    """The leaf's stats sidecar record, or ``None`` when absent."""
+    import obstore
+    from obstore.exceptions import NotFoundError
+
+    from zagg.store import open_object_store
+
+    prefix, _, name = leaf_path.rstrip("/").rpartition("/")
+    try:
+        data = obstore.get(open_object_store(prefix, **store_kwargs), sidecar_key(name)).bytes()
+    except (FileNotFoundError, NotFoundError):
+        return None
+    return json.loads(bytes(data))

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -41,7 +41,7 @@ SIDECAR_NAME = "stats.json"
 # Merge dispositions (associative + commutative by construction). Floats sum,
 # so equality across fold orders holds up to FP summation order.
 _SUM_KEYS = ("n_shards", "n_granules", "n_obs", "cells_with_data", "duration_s")
-_SUM_OR_NONE_KEYS = ("gb_seconds", "est_cost_usd")
+_SUM_OR_NONE_KEYS = ("gb_seconds", "est_cost_usd", "spill_bytes")
 _MAX_OR_NONE_KEYS = ("max_memory_mb", "container_hwm_mb")
 _EQ_OR_NONE_KEYS = (
     "shard_key",
@@ -121,11 +121,18 @@ def build_record(
     if lambda_config and lambda_config.get("memory_mb"):
         gb_seconds = duration_s * lambda_config["memory_mb"] / 1024.0
         est_cost = gb_seconds * LAMBDA_PRICE_PER_GB_SEC
-    phase_timings = {
+    phase_entries = {
         k: float(v)
         for k, v in (metadata.get("phase_timings") or {}).items()
         if isinstance(v, (int, float)) and not isinstance(v, bool)
     }
+    # Byte-volume metrics (the spill instrumentation, issue #217) must not ride
+    # in the seconds-only phase block: the run parquet flattens phase_timings to
+    # seconds-typed columns, where a byte count would mislead cost/latency
+    # queries. Split any ``*_bytes`` entries out; surface spill volume on its own
+    # summed field (issue #297).
+    spill_bytes = phase_entries.get("spill_bytes")
+    phase_timings = {k: v for k, v in phase_entries.items() if not k.endswith("_bytes")}
     granule_ids = list(granule_ids) if granule_ids is not None else None
     n_granules = metadata.get("granule_count")
     if n_granules is None:
@@ -142,6 +149,7 @@ def build_record(
         "cells_with_data": int(metadata.get("cells_with_data") or 0),
         "phase_timings": phase_timings,
         "duration_s": duration_s,
+        "spill_bytes": spill_bytes,
         "gb_seconds": gb_seconds,
         "est_cost_usd": est_cost,
         "max_memory_mb": _opt_float(metadata.get("max_memory_mb")),

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -27,7 +27,7 @@ import platform
 from datetime import datetime, timezone
 from typing import Any, Iterable
 
-from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC
+from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC, LAMBDA_PRICE_PER_GB_SEC_BY_ARCH
 
 #: Version stamped into every record; bump on any key change (issue #297).
 SCHEMA_VERSION = 1
@@ -37,6 +37,11 @@ SCHEMA_VERSION = 1
 #: — mirroring the ``{full_id}_{window}.zarr`` leaf naming so two windows of one
 #: shard cannot clobber each other's sidecar.
 SIDECAR_NAME = "stats.json"
+
+#: ``platform.machine()`` spellings -> the #298 price-table arch keys, so the
+#: worker-side record prices with the same table the dispatcher's cost block
+#: uses. An unmapped/absent arch falls back to the flat default rate.
+_ARCH_ALIASES = {"aarch64": "arm64", "arm64": "arm64", "x86_64": "x86_64", "amd64": "x86_64"}
 
 # Merge dispositions (associative + commutative by construction). Floats sum,
 # so equality across fold orders holds up to FP summation order.
@@ -127,7 +132,10 @@ def build_record(
     gb_seconds = est_cost = None
     if lambda_config and lambda_config.get("memory_mb"):
         gb_seconds = duration_s * lambda_config["memory_mb"] / 1024.0
-        est_cost = gb_seconds * LAMBDA_PRICE_PER_GB_SEC
+        # Arch-keyed rate (issue #298's price table, folded in here): the
+        # record prices with the same table as the dispatcher's cost block.
+        arch = _ARCH_ALIASES.get(str(lambda_config.get("arch") or "").lower())
+        est_cost = gb_seconds * LAMBDA_PRICE_PER_GB_SEC_BY_ARCH.get(arch, LAMBDA_PRICE_PER_GB_SEC)
     phase_entries = {
         k: float(v)
         for k, v in (metadata.get("phase_timings") or {}).items()

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -217,6 +217,115 @@ def _zagg_version() -> str:
     return zagg.__version__
 
 
+def failure_record(*, shard_key=None, error, duration_s=None) -> dict:
+    """Skeleton record for a shard with no worker record (issue #297 phase 3).
+
+    Timed-out / OOM / dropped shards write no sidecar and return no envelope
+    record; the dispatcher still owes the run parquet a row (error, duration
+    until failure). Built through :func:`build_record` so the row shape and
+    schema version cannot drift from real records; ``shard_key`` may be
+    unknown (``None``) when the failure predates key resolution.
+    """
+    record = build_record(
+        shard_key=shard_key if shard_key is not None else -1,
+        metadata={"error": str(error) or "unknown failure", "duration_s": duration_s},
+    )
+    if shard_key is None:
+        record["shard_key"] = None
+    return record
+
+
+#: Scalar record fields copied straight into a parquet row (flatten order).
+_ROW_SCALARS = (
+    "schema_version",
+    "shard_key",
+    "template_hash",
+    "zagg_version",
+    "n_shards",
+    "n_granules",
+    "granules_sha256",
+    "n_obs",
+    "cells_with_data",
+    "duration_s",
+    "gb_seconds",
+    "est_cost_usd",
+    "spill_bytes",
+    "max_memory_mb",
+    "container_hwm_mb",
+    "timestamp",
+    "success",
+    "error",
+)
+
+
+def flatten_record(record: dict, *, retries=None, error_class=None) -> dict:
+    """One run-parquet row from a stats record (issue #297 phase 3).
+
+    Nested blocks flatten to columns duckdb/Athena can query directly:
+    ``phase_timings`` -> ``phase_{name}``, ``lambda`` -> ``lambda_memory_mb``
+    / ``lambda_arch`` / ``lambda_function_variant``, ``invoked_by`` ->
+    ``invoked_by`` (the ARN) + ``invoked_by_userid``. ``retries`` is the
+    dispatcher's attempt count for the shard; ``error_class`` defaults to the
+    error string's leading token (callers with the real exception type pass
+    it explicitly).
+    """
+    row = {key: record.get(key) for key in _ROW_SCALARS}
+    error = record.get("error")
+    if error_class is None and error:
+        error_class = str(error).split(":", 1)[0]
+    row["error_class"] = error_class
+    row["retries"] = retries
+    for name, secs in (record.get("phase_timings") or {}).items():
+        row[f"phase_{name}"] = secs
+    lam = record.get("lambda") or {}
+    row["lambda_memory_mb"] = lam.get("memory_mb")
+    row["lambda_arch"] = lam.get("arch")
+    row["lambda_function_variant"] = lam.get("function_variant")
+    ident = record.get("invoked_by") or {}
+    row["invoked_by"] = ident.get("arn")
+    row["invoked_by_userid"] = ident.get("userid")
+    return row
+
+
+def run_parquet_key(run_id: str, timestamp: str | None = None) -> str:
+    """Store-root object name of a run's stats parquet: run id + timestamp."""
+    ts = timestamp or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"stats_{run_id}_{ts}.parquet"
+
+
+def write_run_parquet(
+    store_root: str, rows: list, *, run_id: str, store_kwargs: dict | None = None
+) -> str:
+    """PUT the run-level stats parquet at the store root (issue #297 phase 3).
+
+    One row per dispatched shard — successes from the workers' records
+    (envelope-ridden, no second S3 listing), failures from the dispatcher's
+    :class:`~zagg.dispatch.RunReport` via :func:`failure_record`. Written with
+    the core ``fastparquet`` engine (the :mod:`zagg.catalog.extract`
+    precedent — pyarrow stays off the worker path, issue #130);
+    ``object_encoding="utf8"`` pins string columns that may be all-null in a
+    given run (e.g. ``invoked_by`` locally). Returns the object's full path.
+    """
+    import tempfile
+
+    import obstore
+    import pandas as pd
+
+    from zagg.store import open_object_store
+
+    if not rows:
+        raise ValueError("write_run_parquet requires at least one row")
+    key = run_parquet_key(run_id)
+    df = pd.DataFrame(rows)
+    with tempfile.TemporaryDirectory() as tmp:
+        local = os.path.join(tmp, key)
+        df.to_parquet(local, engine="fastparquet", index=False, object_encoding="utf8")
+        with open(local, "rb") as fh:
+            data = fh.read()
+    obstore.put(open_object_store(store_root, **(store_kwargs or {})), key, data)
+    return f"{store_root.rstrip('/')}/{key}"
+
+
 # ---------------------------------------------------------------------------
 # Leaf sidecar I/O (phase 2) — one small JSON object per hive leaf, written by
 # the worker on success only, SIBLING to the leaf ``.zarr`` (never inside it:

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -41,7 +41,14 @@ SIDECAR_NAME = "stats.json"
 # Merge dispositions (associative + commutative by construction). Floats sum,
 # so equality across fold orders holds up to FP summation order.
 _SUM_KEYS = ("n_shards", "n_granules", "n_obs", "cells_with_data", "duration_s")
-_SUM_OR_NONE_KEYS = ("gb_seconds", "est_cost_usd", "spill_bytes")
+_SUM_OR_NONE_KEYS = (
+    "gb_seconds",
+    "est_cost_usd",
+    "spill_bytes",
+    "raster_bytes_read",
+    "raster_px_decoded",
+    "raster_px_sampled",
+)
 _MAX_OR_NONE_KEYS = ("max_memory_mb", "container_hwm_mb")
 _EQ_OR_NONE_KEYS = (
     "shard_key",
@@ -150,6 +157,13 @@ def build_record(
         "phase_timings": phase_timings,
         "duration_s": duration_s,
         "spill_bytes": spill_bytes,
+        # Raster read-volume counters (issue #297): compressed bytes fetched,
+        # pixels decoded (whole tiles), cell samples gathered. Stored raw —
+        # the extract's over-provision (px_decoded / px_sampled) is derived at
+        # read, never stored (mergeable-by-construction). None off-raster.
+        "raster_bytes_read": _opt_int(metadata.get("raster_bytes_read")),
+        "raster_px_decoded": _opt_int(metadata.get("raster_px_decoded")),
+        "raster_px_sampled": _opt_int(metadata.get("raster_px_sampled")),
         "gb_seconds": gb_seconds,
         "est_cost_usd": est_cost,
         "max_memory_mb": _opt_float(metadata.get("max_memory_mb")),
@@ -211,6 +225,10 @@ def _opt_float(value) -> float | None:
     return float(value) if value is not None else None
 
 
+def _opt_int(value) -> int | None:
+    return int(value) if value is not None else None
+
+
 def _zagg_version() -> str:
     import zagg
 
@@ -250,6 +268,9 @@ _ROW_SCALARS = (
     "gb_seconds",
     "est_cost_usd",
     "spill_bytes",
+    "raster_bytes_read",
+    "raster_px_decoded",
+    "raster_px_sampled",
     "max_memory_mb",
     "container_hwm_mb",
     "timestamp",

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -181,7 +181,13 @@ def merge(records: Iterable[dict]) -> dict:
     out: dict[str, Any] = {"schema_version": SCHEMA_VERSION}
     for key in _EQ_OR_NONE_KEYS:
         first = records[0].get(key)
-        out[key] = first if all(r.get(key) == first for r in records) else None
+        if all(r.get(key) == first for r in records):
+            # Defensively copy dict values (``lambda``/``invoked_by``) so a
+            # rolled-up record never aliases a leaf's nested dict, mirroring
+            # build_record (issue #297).
+            out[key] = dict(first) if isinstance(first, dict) else first
+        else:
+            out[key] = None
     for key in _SUM_KEYS:
         out[key] = sum(r.get(key) or 0 for r in records)
     phase_timings: dict[str, float] = {}

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -1,0 +1,193 @@
+"""Per-shard stats record: standardized schema + mergeable fold (issue #297).
+
+One versioned record per processed shard, built from the worker's existing
+``metadata`` dict. Two consumers, one source: the JSON **sidecar** written as a
+SIBLING object next to a hive leaf ``.zarr`` (``stats.json``; the
+``{hash}.stats.json`` naming arrives with issue #299 — ``template_hash`` is a
+nullable placeholder until then), and the **run-level parquet** the dispatcher
+writes at the store root (one row per shard, failure rows included).
+
+The schema is mergeable by construction: only associative stats (counts, sums,
+min/max — no stored means/medians), so the up-tree rollup is
+:func:`merge` — a fold that is associative and commutative up to float
+summation order. Identity-like fields (``shard_key``, ``granules_sha256``,
+``invoked_by``, ...) merge as equal-or-``None``: a mismatch collapses to
+``None`` (absorbing), which keeps the fold associative.
+
+``build_record``/``merge`` are pure (no I/O); the sidecar/parquet helpers below
+them do object-store I/O and import their backends lazily.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC
+
+#: Version stamped into every record; bump on any key change (issue #297).
+SCHEMA_VERSION = 1
+
+#: Leaf sidecar object name (sibling of the leaf ``.zarr``, not inside it).
+#: Windowed leaves (issue #246) suffix the window label — ``stats_{window}.json``
+#: — mirroring the ``{full_id}_{window}.zarr`` leaf naming so two windows of one
+#: shard cannot clobber each other's sidecar.
+SIDECAR_NAME = "stats.json"
+
+# Merge dispositions (associative + commutative by construction). Floats sum,
+# so equality across fold orders holds up to FP summation order.
+_SUM_KEYS = ("n_shards", "n_granules", "n_obs", "cells_with_data", "duration_s")
+_SUM_OR_NONE_KEYS = ("gb_seconds", "est_cost_usd")
+_MAX_OR_NONE_KEYS = ("max_memory_mb", "container_hwm_mb")
+_EQ_OR_NONE_KEYS = (
+    "shard_key",
+    "template_hash",
+    "granules_sha256",
+    "zagg_version",
+    "lambda",
+    "invoked_by",
+    "error",
+)
+
+
+def granules_sha256(granule_ids: Iterable[str] | None) -> str | None:
+    """Catalog identity of a shard: sha256 over its sorted granule ids.
+
+    Ids are whatever uniquely names the shard's inputs (granule URLs for the
+    aggregation path, item ids/datetimes for raster). Sorted so the hash is
+    order-independent; ``None``/empty -> ``None`` (no catalog identity).
+    """
+    ids = sorted(str(g) for g in granule_ids) if granule_ids else []
+    if not ids:
+        return None
+    return hashlib.sha256("\n".join(ids).encode()).hexdigest()
+
+
+def lambda_env() -> dict | None:
+    """The executing Lambda's config block, or ``None`` off-Lambda.
+
+    Read from the standard runtime env vars — the worker needs no event key
+    for this. ``function_variant`` is the deployed function name (the ``-disk``
+    / benchmark twins are distinct names); request ids / function ARNs are
+    deliberately omitted (account-identifying, add nothing — issue #297).
+    """
+    memory = os.environ.get("AWS_LAMBDA_FUNCTION_MEMORY_SIZE")
+    if not memory:
+        return None
+    return {
+        "memory_mb": int(memory),
+        "arch": platform.machine(),
+        "function_variant": os.environ.get("AWS_LAMBDA_FUNCTION_NAME"),
+    }
+
+
+def build_record(
+    *,
+    shard_key,
+    metadata: dict,
+    granule_ids: Iterable[str] | None = None,
+    invoked_by: dict | None = None,
+    lambda_config: dict | None = None,
+) -> dict:
+    """Build one shard's stats record from the worker's ``metadata`` dict.
+
+    ``metadata`` is the existing worker result (``process_shard`` /
+    ``process_and_write_hive`` / the raster metas): ``total_obs``,
+    ``cells_with_data``, ``duration_s``, ``phase_timings``, and the memory
+    telemetry keys when the caller stamped them. ``invoked_by`` is copied
+    VERBATIM from the invoke payload — the dispatcher resolves it via
+    ``sts get-caller-identity`` once per run; workers cannot see the invoker.
+    ``lambda_config`` is :func:`lambda_env` on Lambda, ``None`` locally;
+    when present it prices ``gb_seconds`` / ``est_cost_usd`` from
+    ``duration_s`` (the billed-duration approximation the dispatcher's cost
+    estimate already uses).
+    """
+    error = metadata.get("error")
+    duration_s = float(metadata.get("duration_s") or 0.0)
+    gb_seconds = est_cost = None
+    if lambda_config and lambda_config.get("memory_mb"):
+        gb_seconds = duration_s * lambda_config["memory_mb"] / 1024.0
+        est_cost = gb_seconds * LAMBDA_PRICE_PER_GB_SEC
+    phase_timings = {
+        k: float(v)
+        for k, v in (metadata.get("phase_timings") or {}).items()
+        if isinstance(v, (int, float)) and not isinstance(v, bool)
+    }
+    granule_ids = list(granule_ids) if granule_ids is not None else None
+    n_granules = metadata.get("granule_count")
+    if n_granules is None:
+        n_granules = len(granule_ids or [])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "shard_key": int(shard_key),
+        "template_hash": None,  # nullable until issue #299 lands the hasher
+        "zagg_version": _zagg_version(),
+        "n_shards": 1,
+        "n_granules": int(n_granules),
+        "granules_sha256": granules_sha256(granule_ids),
+        "n_obs": int(metadata.get("total_obs") or 0),
+        "cells_with_data": int(metadata.get("cells_with_data") or 0),
+        "phase_timings": phase_timings,
+        "duration_s": duration_s,
+        "gb_seconds": gb_seconds,
+        "est_cost_usd": est_cost,
+        "max_memory_mb": _opt_float(metadata.get("max_memory_mb")),
+        "container_hwm_mb": _opt_float(metadata.get("container_hwm_mb")),
+        "lambda": dict(lambda_config) if lambda_config else None,
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "success": not error,
+        "error": str(error) if error else None,
+        "invoked_by": dict(invoked_by) if invoked_by else None,
+    }
+
+
+def merge(records: Iterable[dict]) -> dict:
+    """Fold stats records into one (associative + commutative; issue #297).
+
+    Counts/sums sum, memory high-waters max, ``timestamp`` takes the latest,
+    ``success`` ANDs, ``phase_timings`` sums per key over the key union, and
+    identity fields keep their common value or collapse to ``None`` on any
+    mismatch (``None`` is absorbing, which is what keeps the fold
+    associative). ``merge([r]) == r`` up to key order. Raises ``ValueError``
+    on an empty iterable or a ``schema_version`` mismatch.
+    """
+    records = list(records)
+    if not records:
+        raise ValueError("merge requires at least one record")
+    versions = {r.get("schema_version") for r in records}
+    if versions != {SCHEMA_VERSION}:
+        raise ValueError(f"cannot merge stats records with schema_version(s) {sorted(versions)}")
+    out: dict[str, Any] = {"schema_version": SCHEMA_VERSION}
+    for key in _EQ_OR_NONE_KEYS:
+        first = records[0].get(key)
+        out[key] = first if all(r.get(key) == first for r in records) else None
+    for key in _SUM_KEYS:
+        out[key] = sum(r.get(key) or 0 for r in records)
+    phase_timings: dict[str, float] = {}
+    for r in records:
+        for name, secs in (r.get("phase_timings") or {}).items():
+            phase_timings[name] = phase_timings.get(name, 0.0) + secs
+    out["phase_timings"] = phase_timings
+    for key in _SUM_OR_NONE_KEYS:
+        vals = [r.get(key) for r in records if r.get(key) is not None]
+        out[key] = sum(vals) if vals else None
+    for key in _MAX_OR_NONE_KEYS:
+        vals = [r.get(key) for r in records if r.get(key) is not None]
+        out[key] = max(vals) if vals else None
+    stamps = [r.get("timestamp") for r in records if r.get("timestamp") is not None]
+    out["timestamp"] = max(stamps) if stamps else None
+    out["success"] = all(bool(r.get("success")) for r in records)
+    return out
+
+
+def _opt_float(value) -> float | None:
+    return float(value) if value is not None else None
+
+
+def _zagg_version() -> str:
+    import zagg
+
+    return zagg.__version__

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -166,9 +166,11 @@ def build_record(
         "duration_s": duration_s,
         "spill_bytes": spill_bytes,
         # Raster read-volume counters (issue #297): compressed bytes fetched,
-        # pixels decoded (whole tiles), cell samples gathered. Stored raw —
-        # the extract's over-provision (px_decoded / px_sampled) is derived at
-        # read, never stored (mergeable-by-construction). None off-raster.
+        # pixels decoded (whole tiles), cell samples gathered. Stored raw — the
+        # px_decoded / px_sampled ratio is derived at read, never stored
+        # (mergeable-by-construction). That ratio reads as read-time
+        # over-provision only when the output grid is coarser than the source; a
+        # finer grid can push it below 1. None off-raster.
         "raster_bytes_read": _opt_int(metadata.get("raster_bytes_read")),
         "raster_px_decoded": _opt_int(metadata.get("raster_px_decoded")),
         "raster_px_sampled": _opt_int(metadata.get("raster_px_sampled")),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -60,17 +62,22 @@ def _no_s3_run_stats(monkeypatch):
     The dispatcher's run-level parquet write (issue #297) is fail-open in
     production, but a unit test driving a lambda-path harness with an
     ``s3://`` store path must not attempt a live PUT (ambient local
-    credentials could reach a real bucket). Local-path writes stay live so
-    the parquet wiring is still integration-tested; a test that wants the
-    s3 branch re-patches ``zagg.runner._write_run_stats`` itself.
+    credentials could reach a real bucket). Relative local store paths are
+    skipped too: tests using ``"./out.zarr"`` would otherwise scribble
+    accumulating ``stats_*.parquet`` files into the repo working directory.
+    Absolute ``tmp_path`` stores stay live so the parquet wiring is still
+    integration-tested; a test that wants the s3 branch re-patches
+    ``zagg.runner._write_run_stats`` itself.
     """
     from zagg import runner
 
     real = runner._write_run_stats
 
     def guard(store_path, rows, *, summary=None, **kwargs):
-        if str(store_path).startswith("s3://"):
-            # Skip the live PUT, but mirror the real helper's schema contract
+        sp = str(store_path)
+        if sp.startswith("s3://") or not os.path.isabs(sp):
+            # Skip the live PUT (real S3, or a relative path that would land in
+            # the repo cwd), but mirror the real helper's schema contract
             # (issue #297): a skipped write still leaves ``run_stats_path``
             # present (None), so the summary key set stays deterministic.
             if summary is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,9 +68,14 @@ def _no_s3_run_stats(monkeypatch):
 
     real = runner._write_run_stats
 
-    def guard(store_path, rows, **kwargs):
+    def guard(store_path, rows, *, summary=None, **kwargs):
         if str(store_path).startswith("s3://"):
+            # Skip the live PUT, but mirror the real helper's schema contract
+            # (issue #297): a skipped write still leaves ``run_stats_path``
+            # present (None), so the summary key set stays deterministic.
+            if summary is not None:
+                summary["run_stats_path"] = None
             return
-        return real(store_path, rows, **kwargs)
+        return real(store_path, rows, summary=summary, **kwargs)
 
     monkeypatch.setattr(runner, "_write_run_stats", guard)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,3 +51,26 @@ def point_words(n, seed, lat0=45.0, lon0=45.0, spread=1e-4):
     lats = lat0 + rng.uniform(-spread, spread, n)
     lons = lon0 + rng.uniform(-spread, spread, n)
     return morton_words(MortonIndexArray.from_latlon(lats, lons, points=True))
+
+
+@pytest.fixture(autouse=True)
+def _no_s3_run_stats(monkeypatch):
+    """Keep unit tests hermetic: never PUT the run stats parquet to real S3.
+
+    The dispatcher's run-level parquet write (issue #297) is fail-open in
+    production, but a unit test driving a lambda-path harness with an
+    ``s3://`` store path must not attempt a live PUT (ambient local
+    credentials could reach a real bucket). Local-path writes stay live so
+    the parquet wiring is still integration-tested; a test that wants the
+    s3 branch re-patches ``zagg.runner._write_run_stats`` itself.
+    """
+    from zagg import runner
+
+    real = runner._write_run_stats
+
+    def guard(store_path, rows, **kwargs):
+        if str(store_path).startswith("s3://"):
+            return
+        return real(store_path, rows, **kwargs)
+
+    monkeypatch.setattr(runner, "_write_run_stats", guard)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2068,14 +2068,15 @@ def test_hive_config_expected_counts_root_moc_optional():
     # 4 arrays (cell_ids/morton/count/h_tdigest): leaf root+group zarr.json (2)
     # + 4 array zarr.json + 4 sharded data objects + coverage sidecar +
     # stats.json sibling (issue #297) = 12.
-    # Store root: morton_hive.json (always) + coverage.moc (optional) -> [1, 2].
+    # Store root: morton_hive.json (always) + coverage.moc (optional) + the
+    # run stats parquet (optional, issue #297) -> [1, 3].
     assert exp == {
-        "metadata": 2,
+        "metadata": 3,
         "metadata_min": 1,
         "per_shard_min": 12,
         "per_shard_max": 12,
         "total_min": 13,
-        "total_max": 14,
+        "total_max": 15,
         "exact": True,
     }
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2066,15 +2066,16 @@ def test_hive_config_expected_counts_root_moc_optional():
         grid, n_shards=1, store_layout="hive", coverage_moc=True
     )
     # 4 arrays (cell_ids/morton/count/h_tdigest): leaf root+group zarr.json (2)
-    # + 4 array zarr.json + 4 sharded data objects + coverage sidecar = 11.
+    # + 4 array zarr.json + 4 sharded data objects + coverage sidecar +
+    # stats.json sibling (issue #297) = 12.
     # Store root: morton_hive.json (always) + coverage.moc (optional) -> [1, 2].
     assert exp == {
         "metadata": 2,
         "metadata_min": 1,
-        "per_shard_min": 11,
-        "per_shard_max": 11,
-        "total_min": 12,
-        "total_max": 13,
+        "per_shard_min": 12,
+        "per_shard_max": 12,
+        "total_min": 13,
+        "total_max": 14,
         "exact": True,
     }
 

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -549,10 +549,11 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
         root, grid=grid, shard_keys=[shard], store_layout="hive"
     )
     # Exact: per leaf = root+group zarr.json (2) + one zarr.json AND one data
-    # object per array + the coverage sidecar; store root = manifest + MOC.
+    # object per array + the coverage sidecar + the stats.json sibling
+    # (issue #297); store root = manifest + MOC.
     n_arrays = len(grid.shard_spec().members)
     assert expected["exact"] is True
-    assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1
+    assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 1
     assert expected["metadata"] == 2
     assert measured["objects_total"] == expected["total_max"]
     assert measured["objects_other"] == 0

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -106,13 +106,14 @@ def test_expected_counts_live_matrix_config():
     # zarr.json objects, then exactly one object per array per shard.
     config = load_config(str(BENCH / "configs" / "atl03_tdigest_healpix_o9.yaml"))
     exp = bench_objects.expected_object_counts(from_config(config), n_shards=1)
+    # metadata ceiling adds the optional run-level stats parquet (issue #297).
     assert exp == {
-        "metadata": 6,
+        "metadata": 7,
         "metadata_min": 6,
         "per_shard_min": 4,
         "per_shard_max": 4,
         "total_min": 10,
-        "total_max": 10,
+        "total_max": 11,
         "exact": True,
     }
 
@@ -122,10 +123,10 @@ def test_expected_counts_aoimask_config_adds_one_array():
     # sharded object per shard.
     config = load_config(str(BENCH / "configs" / "atl03_tdigest_healpix_o9_aoimask.yaml"))
     exp = bench_objects.expected_object_counts(from_config(config), n_shards=4)
-    assert exp["metadata"] == 7
+    assert exp["metadata"] == 8
     assert exp["per_shard_min"] == exp["per_shard_max"] == 5
     assert exp["exact"] is True
-    assert exp["total_max"] == 7 + 4 * 5
+    assert exp["total_max"] == 8 + 4 * 5
 
 
 def test_expected_counts_unsharded_is_bounded_not_exact():
@@ -133,7 +134,7 @@ def test_expected_counts_unsharded_is_bounded_not_exact():
     # chunks are omitted), ragged 0..K -- a bounded, non-exact expectation.
     exp = bench_objects.expected_object_counts(_grid(sharded=False), n_shards=1)
     k = 16
-    assert exp["metadata"] == 6
+    assert exp["metadata"] == 7
     assert exp["exact"] is False
     assert exp["per_shard_min"] == 3  # one populated chunk x 3 dense arrays
     assert exp["per_shard_max"] == 4 * k
@@ -161,8 +162,10 @@ def test_flat_sharded_store_matches_model(tmp_path):
     measured = bench_objects.store_object_counts(root, grid=grid, shard_keys=words)
     expected = bench_objects.expected_object_counts(grid, n_shards=2)
     assert expected["exact"] is True
-    assert measured["objects_total"] == expected["total_max"] == 6 + 2 * 4
-    assert measured["objects_metadata"] == expected["metadata"] == 6
+    # Direct writes (no runner) -> no run parquet, so the floor of the
+    # issue-#297-widened metadata window is what lands.
+    assert measured["objects_total"] == expected["total_min"] == 6 + 2 * 4
+    assert measured["objects_metadata"] == expected["metadata_min"] == 6
     assert measured["objects_other"] == 0
     assert measured["objects_per_shard"] == {_KEY_A: 4, _KEY_B: 4}
     assert bench_objects.object_count_mismatch(measured, expected) is None
@@ -302,7 +305,8 @@ def test_hive_store_matches_model(tmp_path, monkeypatch):
     # K == 1 leaf: every per-array count is deterministic, so the hive model
     # is exact here and the real store matches it object-for-object.
     assert expected["exact"] is True
-    assert measured["objects_metadata"] == expected["metadata"] == 2
+    # Through the runner: manifest + root MOC + the run stats parquet (#297).
+    assert measured["objects_metadata"] == expected["metadata"] == 3
     assert measured["objects_other"] == 0
     assert list(measured["objects_per_shard"]) == [_KEY_A]
     assert measured["objects_total"] == expected["total_max"]
@@ -380,7 +384,7 @@ def test_measure_objects_end_to_end(tmp_path):
     payload = run_benchmark._measure_objects(cfg, grid, root, word, region="us-west-2")
     assert payload == {
         "objects_total": 10,  # 6 metadata + 4 shard objects
-        "objects_expected": 10,
+        "objects_expected": 11,  # ceiling includes the optional run parquet (#297)
         "objects_per_shard": {_KEY_A: 4},
         "objects_mismatch": None,
     }
@@ -406,7 +410,7 @@ def test_measure_objects_flags_bypass(tmp_path):
     )
     assert payload["objects_mismatch"] is not None
     assert payload["objects_total"] == 6 + 64  # metadata + 16 chunks x 4 arrays
-    assert payload["objects_expected"] == 10
+    assert payload["objects_expected"] == 11  # ceiling includes the run parquet (#297)
 
 
 # --- review folds (PR #242) ---------------------------------------------------
@@ -550,11 +554,11 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     )
     # Exact: per leaf = root+group zarr.json (2) + one zarr.json AND one data
     # object per array + the coverage sidecar + the stats.json sibling
-    # (issue #297); store root = manifest + MOC.
+    # (issue #297); store root = manifest + MOC + the run stats parquet.
     n_arrays = len(grid.shard_spec().members)
     assert expected["exact"] is True
     assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 1
-    assert expected["metadata"] == 2
+    assert expected["metadata"] == 3
     assert measured["objects_total"] == expected["total_max"]
     assert measured["objects_other"] == 0
     assert bench_objects.object_count_mismatch(measured, expected) is None

--- a/tests/test_coverage_root.py
+++ b/tests/test_coverage_root.py
@@ -290,11 +290,14 @@ class TestLocalRootCoverage:
 
         root, _shard = self._agg(monkeypatch, tmp_path, coverage_moc=False)
         assert hive.read_root_coverage(root) is None
-        # Root carries the manifest plus the successful shard's node dir (its
-        # stats sidecar, issue #297) — but no coverage.moc.
+        # Root carries the manifest, the successful shard's node dir (its
+        # stats sidecar) and the run stats parquet (issue #297) — but no
+        # coverage.moc.
         listing = sorted(os.listdir(root))
         assert hive.ROOT_COVERAGE_NAME not in listing
-        assert listing[-1] == hive.MANIFEST_NAME and len(listing) == 2
+        assert hive.MANIFEST_NAME in listing
+        assert any(n.startswith("stats_") and n.endswith(".parquet") for n in listing)
+        assert len(listing) == 3
 
 
 class TestLambdaCoverageDispatch:

--- a/tests/test_coverage_root.py
+++ b/tests/test_coverage_root.py
@@ -290,7 +290,11 @@ class TestLocalRootCoverage:
 
         root, _shard = self._agg(monkeypatch, tmp_path, coverage_moc=False)
         assert hive.read_root_coverage(root) is None
-        assert sorted(os.listdir(root)) == [hive.MANIFEST_NAME]
+        # Root carries the manifest plus the successful shard's node dir (its
+        # stats sidecar, issue #297) — but no coverage.moc.
+        listing = sorted(os.listdir(root))
+        assert hive.ROOT_COVERAGE_NAME not in listing
+        assert listing[-1] == hive.MANIFEST_NAME and len(listing) == 2
 
 
 class TestLambdaCoverageDispatch:

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -929,11 +929,11 @@ class TestProcessAndWriteHiveSharded:
 
 
 class TestHiveProfileWritePhase:
-    """Issue #249 (PR #256): opt-in ``profile`` adds an additive ``write``
-    phase to the hive worker's ``phase_timings``, next to process_shard's
-    read/index/aggregate — the same split the flat Lambda handler has carried
-    since issue #100. Default off: zero timing calls and byte-identical
-    output."""
+    """Issues #249/#297: the hive worker's ``phase_timings`` carry an additive
+    ``write`` phase next to process_shard's read/index/aggregate — the same
+    split the flat Lambda handler has carried since issue #100. Collection is
+    always-on since issue #297 (the stats sidecar needs complete timings);
+    ``profile`` no longer changes this function's metadata."""
 
     _grid = TestProcessAndWriteHive._grid
     _carrier = TestProcessAndWriteHive._carrier
@@ -944,13 +944,12 @@ class TestHiveProfileWritePhase:
     _SHARD_PHASES = {"read": 1.0, "index": 0.5, "aggregate": 0.25}
 
     def _profiled_fake(self, grid, ragged=None, error=None):
-        """Streaming fake honoring the real profile contract: seeds
-        ``metadata['phase_timings']`` only when ``profile=True`` arrives."""
+        """Streaming fake honoring the real (always-on, issue #297) contract:
+        ``metadata['phase_timings']`` is always seeded."""
 
         def fake(g, shard_key, urls, **kwargs):
             meta = self._meta(shard_key, error=error)
-            if kwargs.get("profile"):
-                meta["phase_timings"] = dict(self._SHARD_PHASES)
+            meta["phase_timings"] = dict(self._SHARD_PHASES)
             if error is None:
                 carrier = self._carrier(grid, shard_key)
                 kwargs["write_chunk"](grid.block_index(int(shard_key)), carrier, ragged or {})
@@ -977,9 +976,9 @@ class TestHiveProfileWritePhase:
         )
         return grid, shard, root, meta
 
-    def test_profile_adds_nonnegative_write_phase(self, monkeypatch, cfg, tmp_path):
+    def test_write_phase_added_nonnegative(self, monkeypatch, cfg, tmp_path):
         fake = self._profiled_fake(self._grid(cfg), ragged={"h": ([np.array([1.0, 2.0])], [0])})
-        _grid, _shard, _root, meta = self._run(monkeypatch, cfg, tmp_path, fake, profile=True)
+        _grid, _shard, _root, meta = self._run(monkeypatch, cfg, tmp_path, fake)
         timings = meta["phase_timings"]
         # Additive: the process_shard phases keep their names and values.
         assert set(timings) == {"read", "index", "aggregate", "write"}
@@ -1010,7 +1009,6 @@ class TestHiveProfileWritePhase:
             str(tmp_path / "store"),
             cfg,
             store_kwargs={},
-            profile=True,
         )
         assert meta["phase_timings"]["write"] >= 0.0
         assert set(meta["phase_timings"]) == {"read", "index", "aggregate", "write"}
@@ -1019,41 +1017,28 @@ class TestHiveProfileWritePhase:
         # Same gate as the flat handler (issue #100): a shard that wrote no
         # leaf carries no write phase — read/index/aggregate stay as reported.
         fake = self._profiled_fake(self._grid(cfg), error="No granules found")
-        _grid, _shard, root, meta = self._run(monkeypatch, cfg, tmp_path, fake, profile=True)
+        _grid, _shard, root, meta = self._run(monkeypatch, cfg, tmp_path, fake)
         assert meta["phase_timings"] == self._SHARD_PHASES
         assert "write" not in meta["phase_timings"]
 
-    def test_default_path_makes_no_timing_calls(self, monkeypatch, cfg, tmp_path):
-        # The issue #249 zero-overhead gate, hive edition: without profile the
-        # write path must never call time.time(). Rebind hive.py's module-level
-        # ``time`` name to a booby trap — only this module's calls are caught.
-        class _Boom:
-            @staticmethod
-            def time():
-                raise AssertionError("time.time() called on the unprofiled hive write path")
-
-        monkeypatch.setattr(hive, "time", _Boom)
+    def test_default_path_collects_write_phase(self, monkeypatch, cfg, tmp_path):
+        # Always-on collection (issue #297): the write bracket is stamped
+        # without any profile flag — the sidecar record is complete by default.
         fake = self._profiled_fake(self._grid(cfg), ragged={"h": ([np.array([1.0, 2.0])], [0])})
         _grid, shard, root, meta = self._run(monkeypatch, cfg, tmp_path, fake)
-        assert "phase_timings" not in meta
+        assert set(meta["phase_timings"]) == {"read", "index", "aggregate", "write"}
         # The leaf still landed, fully stamped.
         from zagg.store import open_store
 
         leaf = hive.shard_leaf_path(root, shard)
         assert hive.read_commit(open_store(leaf))["complete"] is True
 
-    def test_sharded_default_path_makes_no_timing_calls(self, monkeypatch, cfg, tmp_path):
-        # Sharded edition of the trap (review finding): the post-stream
-        # write_leaf_to_zarr bracket must also make zero time.time() calls
-        # when profile is off — the streaming trap above never executes it.
+    def test_sharded_default_path_stamps_write_when_timed(self, monkeypatch, cfg, tmp_path):
+        # Sharded edition: the post-stream write_leaf_to_zarr bracket lands in
+        # the always-on write bucket too (a fake without phase_timings gets no
+        # write key — the "populated phase_timings" gate is unchanged).
         import zagg.processing as processing
 
-        class _Boom:
-            @staticmethod
-            def time():
-                raise AssertionError("time.time() called on the unprofiled sharded write path")
-
-        monkeypatch.setattr(hive, "time", _Boom)
         sharded_helper = TestProcessAndWriteHiveSharded()
         grid = sharded_helper._grid(cfg)
         fake = _sharded_accumulate_fake(grid, sharded_helper._chunk_carrier, self._meta)
@@ -1063,8 +1048,9 @@ class TestHiveProfileWritePhase:
         meta = hive.process_and_write_hive(
             shard, ["s3://b/g1.h5"], grid, {}, root, cfg, store_kwargs={}
         )
+        # The fake seeds no phase_timings, so none appear (the write stamp
+        # rides an existing dict); the sharded leaf still landed, stamped.
         assert "phase_timings" not in meta
-        # The sharded leaf still landed, fully stamped.
         from zagg.store import open_store
 
         leaf = hive.shard_leaf_path(root, shard)
@@ -1102,10 +1088,12 @@ class TestHiveProfileWritePhase:
                 assert on == off
             else:
                 assert outs["on"][rel] == outs["off"][rel], rel
-        # And the metadata differs ONLY by the phase_timings sub-dict.
+        # And the metadata matches modulo the wall-clock timing VALUES
+        # (collection is always-on since issue #297, so both carry the keys).
         on_meta = {k: v for k, v in leaves["on"].items() if k != "phase_timings"}
-        assert on_meta == leaves["off"]
-        assert "phase_timings" not in leaves["off"]
+        off_meta = {k: v for k, v in leaves["off"].items() if k != "phase_timings"}
+        assert on_meta == off_meta
+        assert set(leaves["on"]["phase_timings"]) == set(leaves["off"]["phase_timings"])
 
 
 class TestLeafBlockIndex:
@@ -1174,8 +1162,16 @@ class TestRunnerWiring:
         assert calls == [(shard, root)]
         # The run wrote ONLY the manifest at the root — no shared zarr
         # template (D5). The root coverage.moc (issue #200 phase 3,
-        # default-on for hive) is the only other root object.
-        assert sorted(os.listdir(root)) == [hive.ROOT_COVERAGE_NAME, hive.MANIFEST_NAME]
+        # default-on for hive) is the only other root object, plus the
+        # successful shard's node dir carrying its stats sidecar (issue #297;
+        # the mocked worker wrote no leaf, so the node holds only stats.json).
+        listing = sorted(os.listdir(root))
+        node = listing[0]
+        assert listing == [node, hive.ROOT_COVERAGE_NAME, hive.MANIFEST_NAME]
+        from zagg.telemetry import read_sidecar
+
+        leaf = hive.shard_leaf_path(root, shard)
+        assert read_sidecar(leaf)["shard_key"] == shard
         assert hive.read_manifest(root)["shard_order"] == 6
 
     def test_local_hive_finalize_backstop_restores_lost_manifest(self, monkeypatch, cfg, tmp_path):

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -1167,7 +1167,9 @@ class TestRunnerWiring:
         # the mocked worker wrote no leaf, so the node holds only stats.json).
         listing = sorted(os.listdir(root))
         node = listing[0]
-        assert listing == [node, hive.ROOT_COVERAGE_NAME, hive.MANIFEST_NAME]
+        parquets = [n for n in listing if n.startswith("stats_") and n.endswith(".parquet")]
+        assert len(parquets) == 1  # run-level stats parquet (issue #297 phase 3)
+        assert listing == [node, hive.ROOT_COVERAGE_NAME, hive.MANIFEST_NAME, parquets[0]]
         from zagg.telemetry import read_sidecar
 
         leaf = hive.shard_leaf_path(root, shard)

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -153,6 +153,18 @@ class TestProcessEventDispatch:
         assert resp["statusCode"] == 200
         assert captured["shard_key"] == 12345
 
+    def test_flat_body_carries_stats_record_no_sidecar(self, handler_mod, monkeypatch):
+        # Issue #297: flat layouts have no per-shard leaf, so no sidecar
+        # object — but the record still rides the envelope for the parquet.
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        event["invoked_by"] = {"arn": "arn:aws:iam::123:user/x", "userid": "AIDAEXAMPLE"}
+        resp, _captured = self._run(handler_mod, monkeypatch, event)
+        body = json.loads(resp["body"])
+        assert body["stats"]["schema_version"] == 1
+        assert body["stats"]["shard_key"] == 12345
+        assert body["stats"]["invoked_by"] == event["invoked_by"]
+
     def test_handoff_event_key_forwarded_to_worker(self, handler_mod, monkeypatch):
         # issue #130: an explicit handoff event key reaches process_shard so the
         # deployed worker selects the named carrier (the key still wins, #132 wire (A)).
@@ -896,6 +908,8 @@ class TestProcessHive:
                 "granule_count": 1,
                 "files_processed": 1,
                 "duration_s": 0.0,
+                # Mirrors the real worker's always-on collection (issue #297).
+                "phase_timings": {"read": 0.0, "index": 0.0, "aggregate": 0.0},
                 "error": None,
             }
 
@@ -1038,6 +1052,66 @@ class TestProcessHive:
         for name, vals in coords.items():
             df[name] = vals
         return df
+
+    def test_hive_event_writes_stats_sidecar(self, handler_mod, monkeypatch, tmp_path):
+        # Issue #297: on success the worker writes the stats record as a
+        # SIBLING of the leaf .zarr, byte-equal to the envelope's
+        # body["stats"], with invoked_by copied verbatim from the event.
+        import zagg.processing as processing
+        from zagg import hive
+        from zagg.telemetry import granules_sha256, read_sidecar
+
+        grid = self._grid()
+        monkeypatch.setattr(processing, "process_shard", self._streaming_fake(grid))
+        event = self._event(tmp_path)
+        event["invoked_by"] = {"arn": "arn:aws:iam::123:user/x", "userid": "AIDAEXAMPLE"}
+        resp = handler_mod._handle_process(event, _context())
+        assert resp["statusCode"] == 200, resp["body"]
+        body = json.loads(resp["body"])
+
+        leaf = hive.shard_leaf_path(event["store_path"], self._WORD)
+        record = read_sidecar(leaf)
+        assert record == body["stats"]
+        assert record["schema_version"] == 1
+        assert record["shard_key"] == self._WORD
+        assert record["template_hash"] is None
+        assert record["success"] is True and record["error"] is None
+        assert record["n_obs"] == 7 and record["cells_with_data"] == 5
+        assert record["n_granules"] == 1
+        assert record["granules_sha256"] == granules_sha256(event["granule_urls"])
+        assert record["invoked_by"] == event["invoked_by"]
+        # Memory telemetry is stamped BEFORE the record is built (issue #141
+        # sampler / ru_maxrss fallback), so the sidecar carries it.
+        assert record["max_memory_mb"] is not None
+        assert record["container_hwm_mb"] is not None
+        # Always-on write bracket (issue #297) flows into the record too.
+        assert "write" in record["phase_timings"]
+
+    def test_hive_no_data_shard_writes_no_sidecar(self, handler_mod, monkeypatch, tmp_path):
+        import zagg.processing as processing
+        from zagg import hive
+        from zagg.telemetry import read_sidecar
+
+        def no_data_fake(g, shard_key, urls, **kwargs):
+            return pd.DataFrame(), {
+                "shard_key": int(shard_key),
+                "cells_with_data": 0,
+                "total_obs": 0,
+                "granule_count": 1,
+                "files_processed": 1,
+                "duration_s": 0.0,
+                "error": "No data after filtering",
+            }
+
+        monkeypatch.setattr(processing, "process_shard", no_data_fake)
+        event = self._event(tmp_path)
+        resp = handler_mod._handle_process(event, _context())
+        body = json.loads(resp["body"])
+        # The record still rides the envelope (failure row material for the
+        # run parquet) but no sidecar object exists — success only.
+        assert body["stats"]["success"] is False
+        leaf = hive.shard_leaf_path(event["store_path"], self._WORD)
+        assert read_sidecar(leaf) is None
 
     def test_hive_worker_death_leaves_debris_then_retry_cleans(
         self, handler_mod, monkeypatch, tmp_path

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -549,11 +549,13 @@ class TestProcessRasterHiveMode:
         # Always-on sample/write collection flows into the record.
         assert {"sample", "write"} <= set(record["phase_timings"])
         assert record["max_memory_mb"] is not None
-        # Read-volume counters (issue #297): whole tiles are fetched+decoded
-        # to sample the shard's cells, so decoded pixels bound samples and the
-        # over-provision ratio is derivable at read.
+        # Read-volume counters (issue #297): whole tiles are fetched+decoded to
+        # sample the shard's cells. The decoded/sampled ratio reads as
+        # over-provision only when the output grid is coarser than the source; a
+        # finer grid (e.g. HEALPix o16+ vs 10 m S2) can invert it, so assert each
+        # counter is positive rather than pinning their order.
         assert record["raster_bytes_read"] > 0
-        assert record["raster_px_decoded"] >= record["raster_px_sampled"] > 0
+        assert record["raster_px_decoded"] > 0 and record["raster_px_sampled"] > 0
 
     def test_hive_no_leaf_writes_no_orphan_sidecar(self, handler_mod, tmp_path, monkeypatch):
         # Issue #297 fold: a unit with acquisitions (timesteps > 0) but no slab

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -550,6 +550,37 @@ class TestProcessRasterHiveMode:
         assert {"sample", "write"} <= set(record["phase_timings"])
         assert record["max_memory_mb"] is not None
 
+    def test_hive_no_leaf_writes_no_orphan_sidecar(self, handler_mod, tmp_path, monkeypatch):
+        # Issue #297 fold: a unit with acquisitions (timesteps > 0) but no slab
+        # streamed writes no leaf .zarr — so it must NOT get an orphan
+        # stats.json sibling. The sidecar gate keys on the accurate
+        # ``leaf_written`` signal, not the ``timesteps`` proxy.
+        from zagg import hive
+        from zagg.processing import raster as raster_mod
+        from zagg.telemetry import read_sidecar
+
+        def _no_slab(grid_, shard_key, granules, config, time_index, *, on_slab=None, **kw):
+            # Report an acquisition but stream nothing: ``on_slab`` is never
+            # called, so ``process_and_write_raster_hive`` leaves ``store`` out
+            # of its box and never opens/stamps the leaf.
+            return {}, {
+                "shard_key": int(shard_key),
+                "granule_count": len(granules),
+                "skipped": 0,
+                "timesteps": 1,
+            }
+
+        monkeypatch.setattr(raster_mod, "process_raster_shard", _no_slab)
+        event = self._hive_event(tmp_path)
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200, resp
+        body = json.loads(resp["body"])
+        assert body["timesteps"] == 1  # acquisitions present ...
+        assert "stats" in body  # ... the record still rides the envelope ...
+        # ... but no leaf was written, so no sidecar sibling exists.
+        leaf = hive.shard_leaf_path(event["store_path"], event["shard_key"])
+        assert read_sidecar(leaf) is None
+
     def test_hive_missing_params_omit_time_index(self, handler_mod):
         # A hive event needs no time_index: the 400 for an empty hive event
         # names the other four requirements only.

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -549,6 +549,11 @@ class TestProcessRasterHiveMode:
         # Always-on sample/write collection flows into the record.
         assert {"sample", "write"} <= set(record["phase_timings"])
         assert record["max_memory_mb"] is not None
+        # Read-volume counters (issue #297): whole tiles are fetched+decoded
+        # to sample the shard's cells, so decoded pixels bound samples and the
+        # over-provision ratio is derivable at read.
+        assert record["raster_bytes_read"] > 0
+        assert record["raster_px_decoded"] >= record["raster_px_sampled"] > 0
 
     def test_hive_no_leaf_writes_no_orphan_sidecar(self, handler_mod, tmp_path, monkeypatch):
         # Issue #297 fold: a unit with acquisitions (timesteps > 0) but no slab

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -239,9 +239,7 @@ class TestProcessRasterResultMirror:
         # unaffected.
         event, _grid, _data = raster_event
         called = []
-        monkeypatch.setattr(
-            handler_mod, "_write_result", lambda *a: called.append(a) or True
-        )
+        monkeypatch.setattr(handler_mod, "_write_result", lambda *a: called.append(a) or True)
         resp = handler_mod.lambda_handler(event, MagicMock())
         assert called == []
         assert resp["statusCode"] == 200
@@ -414,10 +412,15 @@ class TestRasterPhaseTimings:
         assert pt["write"] > 0.0
         assert pt["sample"] + pt["write"] == pytest.approx(body["duration_s"], rel=0.05)
 
-    def test_no_profile_key_no_timings(self, handler_mod, raster_event):
+    def test_no_profile_key_still_collects_sample_write(self, handler_mod, raster_event):
+        # Always-on collection (issue #297): the sample/write split is emitted
+        # without the profile key; the per-stage ``stages`` verbosity stays
+        # profile-gated.
         event, _grid, _data = raster_event
         resp = handler_mod.lambda_handler(event, MagicMock())
-        assert "phase_timings" not in json.loads(resp["body"])
+        body = json.loads(resp["body"])
+        assert set(body["phase_timings"]) == {"sample", "write"}
+        assert body["phase_timings"]["write"] > 0.0
 
     def test_profile_emits_stage_split(self, handler_mod, raster_event):
         # Issue #249: the sample bucket split per stage + counts, additive
@@ -436,8 +439,10 @@ class TestRasterPhaseTimings:
         assert sum(stages[k] for k in floats) > 0.0
 
     def test_no_profile_passes_no_stage_stats(self, handler_mod, raster_event, monkeypatch):
-        # Zero-overhead gate: without ``profile`` the worker must receive
-        # stage_stats=None so the sample path makes no timing calls at all.
+        # The per-stage gate survives always-on collection (issue #297):
+        # without ``profile`` the worker receives stage_stats=None so the
+        # sample path makes no per-stage timing calls, and the emitted
+        # phase_timings carry no ``stages`` block.
         import zagg.processing.raster as raster_mod
 
         event, _grid, _data = raster_event
@@ -456,7 +461,7 @@ class TestRasterPhaseTimings:
         resp = handler_mod.lambda_handler(event, MagicMock())
         assert resp["statusCode"] == 200, resp
         assert seen["stage_stats"] is None
-        assert "phase_timings" not in json.loads(resp["body"])
+        assert "stages" not in json.loads(resp["body"])["phase_timings"]
 
 
 class TestProcessRasterHiveMode:
@@ -521,6 +526,29 @@ class TestProcessRasterHiveMode:
         leaf = hive.shard_leaf_path(event["store_path"], event["shard_key"])
         stamp = hive.read_commit(leaf)
         assert stamp and stamp["spec"] == "morton-hive/1" and "window" not in stamp
+
+    def test_hive_leaf_gets_stats_sidecar(self, handler_mod, tmp_path):
+        # Issue #297: the raster hive worker writes the stats record SIBLING
+        # to the leaf .zarr, equal to the envelope's body["stats"], with
+        # invoked_by copied verbatim.
+        from zagg import hive
+        from zagg.telemetry import read_sidecar
+
+        event = self._hive_event(tmp_path)
+        event["invoked_by"] = {"arn": "arn:aws:iam::123:user/x", "userid": "AIDAEXAMPLE"}
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200, resp
+        body = json.loads(resp["body"])
+        leaf = hive.shard_leaf_path(event["store_path"], event["shard_key"])
+        record = read_sidecar(leaf)
+        assert record == body["stats"]
+        assert record["schema_version"] == 1
+        assert record["success"] is True
+        assert record["invoked_by"] == event["invoked_by"]
+        assert record["n_granules"] == 1
+        # Always-on sample/write collection flows into the record.
+        assert {"sample", "write"} <= set(record["phase_timings"])
+        assert record["max_memory_mb"] is not None
 
     def test_hive_missing_params_omit_time_index(self, handler_mod):
         # A hive event needs no time_index: the 400 for an empty hive event

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -856,6 +856,15 @@ class TestRasterHiveLocalBackend:
         np.testing.assert_array_equal(
             hive.root_coverage_words(cov), np.asarray([shard], dtype=np.uint64)
         )
+        # Stats sidecar (issue #297): SIBLING of the leaf, success only; the
+        # local backend carries no lambda config / caller identity.
+        from zagg.telemetry import read_sidecar
+
+        record = read_sidecar(leaf)
+        assert record["schema_version"] == 1 and record["success"] is True
+        assert record["shard_key"] == int(shard)
+        assert record["invoked_by"] is None and record["lambda"] is None
+        assert {"sample", "write"} <= set(record["phase_timings"])
 
     def test_windowed_daily_leaves(self, tmp_path, manifest):
         from zagg import hive

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -865,6 +865,10 @@ class TestRasterHiveLocalBackend:
         assert record["shard_key"] == int(shard)
         assert record["invoked_by"] is None and record["lambda"] is None
         assert {"sample", "write"} <= set(record["phase_timings"])
+        # n_obs is the unit's timestep count (raster obs-count convention),
+        # matching the Lambda backend's ``total_obs`` injection — a raster
+        # shard cannot yield n_obs=timesteps on Lambda and 0 locally (#297).
+        assert record["n_obs"] == red.shape[0] == 2
 
     def test_windowed_daily_leaves(self, tmp_path, manifest):
         from zagg import hive

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -1271,7 +1271,12 @@ class TestRasterHiveIdempotency:
         assert summary["cells_with_data"] == 1
         store = Path(cfg.output["store"])
         grid = from_config(cfg)
-        assert sorted(p.name for p in store.iterdir()) == sorted(["zarr.json", grid.group_path])
+        # The run-level stats parquet (issue #297) now rides at the store
+        # root on every backend; still no hive artifacts anywhere in the tree.
+        root_names = sorted(p.name for p in store.iterdir())
+        parquets = [n for n in root_names if n.startswith("stats_") and n.endswith(".parquet")]
+        assert len(parquets) == 1
+        assert root_names == sorted(["zarr.json", grid.group_path, parquets[0]])
         names = {p.name for p in store.rglob("*")}
         assert "morton_hive.json" not in names
         assert "coverage.moc" not in names

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -358,6 +358,9 @@ class TestRasterLambdaBackend:
         assert summary["backend"] == "lambda"
         assert summary["total_cells"] == 1 and summary["cells_with_data"] == 1
         assert summary["cells_error"] == 0
+        # The key is unconditional (issue #297) — None here because the
+        # conftest guard skips the live s3 PUT in unit tests.
+        assert "run_stats_path" in summary and summary["run_stats_path"] is None
         assert summary["total_obs"] == 2
         assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
         # No profile -> the payload stays byte-identical (no key) and the
@@ -865,6 +868,11 @@ class TestRasterHiveLocalBackend:
         assert record["shard_key"] == int(shard)
         assert record["invoked_by"] is None and record["lambda"] is None
         assert {"sample", "write"} <= set(record["phase_timings"])
+        # Read-volume counters (issue #297) ride the local record too.
+        assert record["raster_bytes_read"] > 0
+        assert record["raster_px_decoded"] >= record["raster_px_sampled"] > 0
+        # And the raster summary carries the run parquet path (spatial parity).
+        assert summary["run_stats_path"].endswith(".parquet")
         # n_obs is the unit's timestep count (raster obs-count convention),
         # matching the Lambda backend's ``total_obs`` injection — a raster
         # shard cannot yield n_obs=timesteps on Lambda and 0 locally (#297).

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -960,9 +960,11 @@ class TestRasterHiveLocalBackend:
         assert record["shard_key"] == int(shard)
         assert record["invoked_by"] is None and record["lambda"] is None
         assert {"sample", "write"} <= set(record["phase_timings"])
-        # Read-volume counters (issue #297) ride the local record too.
+        # Read-volume counters (issue #297) ride the local record too. Order of
+        # decoded vs sampled is regime-bound (a grid finer than the source
+        # inverts it), so assert each counter is positive, not their ratio.
         assert record["raster_bytes_read"] > 0
-        assert record["raster_px_decoded"] >= record["raster_px_sampled"] > 0
+        assert record["raster_px_decoded"] > 0 and record["raster_px_sampled"] > 0
         # And the raster summary carries the run parquet path (spatial parity).
         assert summary["run_stats_path"].endswith(".parquet")
         # n_obs is the unit's timestep count (raster obs-count convention),

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -436,6 +436,73 @@ class TestRasterLambdaBackend:
         assert summary["lambda_time_s"] == 30.0 and summary["max_memory_mb"] is None
         assert summary["template_s"] >= 0.0
 
+    def test_mixed_fanout_bills_landed_failure(self, tmp_path, monkeypatch):
+        # Issue #297: the actual-cost rollup bills LANDED failures — a unit
+        # whose non-200 envelope still carried a ``duration_s`` — alongside the
+        # successes, priced identically. A mixed fan-out (one 200 @ 30 s, one
+        # 500 @ 12 s) pins the failed-unit-billing term so deleting it fails
+        # here, and guards against the ok/failed lists double-counting a unit.
+        # ``lambda_time_s`` stays the ok-only worker-latency stat, and one
+        # failure among two units must NOT trip the all-failed raise.
+        import boto3
+
+        from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC
+
+        cfg = _cfg(tmp_path)
+        _write_tiff(tmp_path / "s0.tif", _index_raster())
+        _write_tiff(
+            tmp_path / "s1.tif",
+            np.full((96, 96), 777, dtype=np.uint16),
+            origin=(ORIGIN[0] + 7000.0, ORIGIN[1]),
+        )
+        shard0 = _shard_for_raster_at(0.0)
+        shard1 = _shard_for_raster_at(7000.0)
+        grid = from_config(cfg)
+        sm = ShardMap(
+            grid.spatial_signature(),
+            [shard0, shard1],
+            [
+                [_entry("g0", str(tmp_path / "s0.tif"), T0, "dt-1")],
+                [_entry("g1", str(tmp_path / "s1.tif"), T1, "dt-2")],
+            ],
+            {"collection": "s2-test"},
+        )
+        sm_path = str(tmp_path / "sm2.json")
+        sm.to_json(sm_path)
+
+        def responder(event):
+            if event["shard_key"] == shard0:
+                body = {"timesteps": 1, "cells_with_data": 4096, "duration_s": 30.0}
+                return {"statusCode": 200, "body": json.dumps(body)}
+            # Landed failure: a non-200 envelope that still carries its billed
+            # duration (the worker ran, then raised before success).
+            return {
+                "statusCode": 500,
+                "body": json.dumps({"error": "boom", "duration_s": 12.0}),
+            }
+
+        fake = _FakeLambdaClient(_lifecycle(responder))
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
+        summary = agg(
+            cfg,
+            catalog=sm_path,
+            store="s3://bucket/out.zarr",
+            backend="lambda",
+            max_workers=2,
+            invocation="sync",
+        )
+        # One failed, one succeeded — a partial failure, so no all-failed raise.
+        assert summary["cells_error"] == 1 and summary["cells_with_data"] == 1
+        # gb_seconds / actual cost bill BOTH the 30 s success and the 12 s
+        # landed failure: (30 + 12) s x 4 GB x the arm64 rate.
+        assert summary["gb_seconds"] == pytest.approx((30.0 + 12.0) * 4.0)
+        expected_cost = (30.0 + 12.0) * 4.0 * LAMBDA_PRICE_PER_GB_SEC
+        assert summary["cost"]["actual_cost_usd"] == pytest.approx(expected_cost)
+        assert summary["estimated_cost_usd"] == pytest.approx(expected_cost)
+        # lambda_time_s is the ok-only worker-latency stat — the failure's
+        # duration bills but never enters the latency rollup.
+        assert summary["lambda_time_s"] == pytest.approx(30.0)
+
     def test_on_progress_ticks_on_lambda_fanout(self, manifest, monkeypatch):
         # Progress hook (issue #298 fold): the lambda raster fan-out ticks once
         # per completed shard -- 1-based, total = shard count, cost=None (the

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -389,7 +389,11 @@ class TestRasterLambdaBackend:
             assert event["shard_key"] == shard
             assert set(event["time_index"]) == {"dt-1", "dt-2"}
             assert event["config"]["data_source"]["reader"] == "raster"
-            body = {"timesteps": len(event["time_index"]), "cells_with_data": 4096}
+            body = {
+                "timesteps": len(event["time_index"]),
+                "cells_with_data": 4096,
+                "duration_s": 30.0,
+            }
             return {"statusCode": 200, "body": json.dumps(body)}
 
         fake = _FakeLambdaClient(_lifecycle(responder))
@@ -408,14 +412,28 @@ class TestRasterLambdaBackend:
         # The key is unconditional (issue #297) — None here because the
         # conftest guard skips the live s3 PUT in unit tests.
         assert "run_stats_path" in summary and summary["run_stats_path"] is None
+        # Cost block (issue #298, rolled into the raster path here): the
+        # pre-invoke ceiling, the deferred estimate stub, and the billed
+        # rollup — 30 s x 4 GB x the arm64 rate — with the legacy flat key
+        # keeping the actual-cost meaning like the other lambda summaries.
+        from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC
+
+        assert summary["gb_seconds"] == pytest.approx(30.0 * 4.0)
+        expected_cost = 30.0 * 4.0 * LAMBDA_PRICE_PER_GB_SEC
+        assert summary["estimated_cost_usd"] == pytest.approx(expected_cost)
+        cost = summary["cost"]
+        assert cost["actual_cost_usd"] == pytest.approx(expected_cost)
+        assert cost["estimated_cost_usd"] is None  # Phase-3 stub
+        assert cost["max_cost_usd"] == pytest.approx(1 * 4.0 * 900 * LAMBDA_PRICE_PER_GB_SEC)
         assert summary["total_obs"] == 2
         assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
         # No profile -> the payload stays byte-identical (no key) and the
         # profile rollups stay out of the summary (issue #250).
         assert "profile" not in fake.events[-1]
         assert "worker_stage_max" not in summary
-        # Always-on telemetry rollups are null-safe on a body without them.
-        assert summary["lambda_time_s"] is None and summary["max_memory_mb"] is None
+        # Telemetry rollups: duration lands, memory stays null-safe on a
+        # body without it.
+        assert summary["lambda_time_s"] == 30.0 and summary["max_memory_mb"] is None
         assert summary["template_s"] >= 0.0
 
     def test_on_progress_ticks_on_lambda_fanout(self, manifest, monkeypatch):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1513,6 +1513,7 @@ class TestSummaryKeysByteIdentical:
         "worker_cold_starts",
         "worker_warm_starts",
         "worker_rss_start_max_by_gen",
+        "run_stats_path",  # run-level stats parquet (issue #297 phase 3)
     }
 
     def test_local_summary_keys_and_counts(self, monkeypatch, atl06_config):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1421,6 +1421,7 @@ class TestSummaryKeysByteIdentical:
         "store_path",
         "backend",
         "results",
+        "run_stats_path",  # run-level stats parquet (issue #297 phase 3)
     }
     _LAMBDA_KEYS = {
         "total_cells",
@@ -3361,6 +3362,38 @@ class TestProfilePlumbing:
         )
         runner.agg(atl06_config, catalog="ignored", store="./out.zarr", backend="local")
         assert captured["handoff"] == "pandas"
+
+
+class TestRunStatsRows:
+    """Run-parquet row building from lambda dispatch results (issue #297)."""
+
+    def test_success_stale_and_failure_rows(self):
+        from zagg.runner import _lambda_result_rows
+        from zagg.telemetry import build_record
+
+        rec = build_record(shard_key=1, metadata={"total_obs": 5, "duration_s": 1.0})
+        results = [
+            {"shard_key": 1, "status_code": 200, "body": {"stats": rec}, "retries": 0},
+            # Stale deployed worker: 200 body without a record — derived row.
+            {"shard_key": 2, "status_code": 200, "body": {"total_obs": 3, "duration_s": 2.0}},
+            # Failure: error + duration-until-failure + retry count.
+            {
+                "shard_key": 3,
+                "status_code": None,
+                "body": {},
+                "error": "Lambda timeout: Task timed out",
+                "retries": 3,
+                "lambda_duration": 0,
+                "wall_time": 42.0,
+            },
+        ]
+        rows = _lambda_result_rows(results)
+        assert [r["shard_key"] for r in rows] == [1, 2, 3]
+        assert rows[0]["success"] is True and rows[0]["retries"] == 0
+        assert rows[1]["success"] is True and rows[1]["n_obs"] == 3
+        assert rows[2]["success"] is False
+        assert rows[2]["error_class"] == "Lambda timeout"
+        assert rows[2]["duration_s"] == 42.0 and rows[2]["retries"] == 3
 
 
 class TestWorkerPhaseTimings:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3364,8 +3364,8 @@ class TestProfilePlumbing:
 
 
 class TestWorkerPhaseTimings:
-    """``process_shard(profile=...)`` emits ``phase_timings`` only when set, and
-    leaves the default metadata unchanged otherwise (issue #100 phase 2)."""
+    """``process_shard`` collects ``phase_timings`` always-on (issue #297; the
+    opt-in ``profile`` gate of issue #100 no longer gates collection)."""
 
     def _run(self, monkeypatch, *, profile, with_data=True):
         import numpy as np
@@ -3434,9 +3434,10 @@ class TestWorkerPhaseTimings:
         )
         return meta
 
-    def test_no_phase_timings_by_default(self, monkeypatch):
+    def test_phase_timings_present_by_default(self, monkeypatch):
+        # Always-on collection (issue #297): no profile flag needed.
         meta = self._run(monkeypatch, profile=False)
-        assert "phase_timings" not in meta
+        assert set(meta["phase_timings"]) == {"read", "index", "aggregate"}
 
     def test_phase_timings_present_when_profiled(self, monkeypatch):
         meta = self._run(monkeypatch, profile=True)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -517,7 +517,9 @@ class TestInvokeLambdaCellEvent:
 
     _CREDS = {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"}
 
-    def _captured_event(self, *, child_order, profile=False, aoi_payload=None, handoff="pandas"):
+    def _captured_event(
+        self, *, child_order, profile=False, aoi_payload=None, handoff="pandas", invoked_by=None
+    ):
         from unittest.mock import MagicMock
 
         from zagg.runner import _invoke_lambda_cell
@@ -543,6 +545,7 @@ class TestInvokeLambdaCellEvent:
             profile=profile,
             aoi_payload=aoi_payload,
             handoff=handoff,
+            invoked_by=invoked_by,
         )
         return json.loads(client.invoke.call_args.kwargs["Payload"])
 
@@ -595,6 +598,65 @@ class TestInvokeLambdaCellEvent:
         # path; no "handoff" key is added (#130).
         event = self._captured_event(child_order=12, handoff="pandas")
         assert "handoff" not in event
+
+    def test_invoked_by_adds_event_key(self):
+        # issue #297: the dispatcher-resolved caller identity threads into the
+        # cell event so the worker copies it verbatim into the stats sidecar.
+        ident = {"arn": "arn:aws:iam::123:user/x", "userid": "AIDAEXAMPLE"}
+        event = self._captured_event(child_order=12, invoked_by=ident)
+        assert event["invoked_by"] == ident
+
+    def test_default_event_has_no_invoked_by_key(self):
+        # Fail-open resolve (None): no "invoked_by" key, so the event stays
+        # byte-identical to the pre-#297 path.
+        event = self._captured_event(child_order=12, invoked_by=None)
+        assert "invoked_by" not in event
+
+
+class TestResolveInvokedBy:
+    """``_resolve_invoked_by`` (issue #297): STS caller identity, or ``None``.
+
+    The spatial ``_run_lambda`` passes a ``boto3.Session()`` here — the raster
+    ``_run_lambda_shards`` passes the ``boto3`` module — so the resolver is
+    exercised through the same ``.client`` seam both call sites use. Fail-open:
+    a stubbed/mocked/raising session must never stamp junk into the persisted
+    records, so it degrades to ``None``.
+    """
+
+    def _session(self, ident=None, *, raises=False):
+        from unittest.mock import MagicMock
+
+        session = MagicMock()
+        sts = session.client.return_value
+        if raises:
+            sts.get_caller_identity.side_effect = RuntimeError("no creds")
+        else:
+            sts.get_caller_identity.return_value = ident
+        return session
+
+    def test_real_identity_threads_through(self):
+        from zagg.runner import _resolve_invoked_by
+
+        session = self._session({"Arn": "arn:aws:iam::123:user/x", "UserId": "AIDAEXAMPLE"})
+        assert _resolve_invoked_by(session, "us-west-2") == {
+            "arn": "arn:aws:iam::123:user/x",
+            "userid": "AIDAEXAMPLE",
+        }
+        session.client.assert_called_once_with("sts", region_name="us-west-2")
+
+    def test_mock_identity_degrades_to_none(self):
+        # A bare MagicMock session (the spatial-test seam) returns non-string
+        # Arn/UserId; the shape-check rejects it rather than stamping junk.
+        from unittest.mock import MagicMock
+
+        from zagg.runner import _resolve_invoked_by
+
+        assert _resolve_invoked_by(MagicMock(), "us-west-2") is None
+
+    def test_sts_failure_degrades_to_none(self):
+        from zagg.runner import _resolve_invoked_by
+
+        assert _resolve_invoked_by(self._session(raises=True), "us-west-2") is None
 
 
 class TestInvokeLambdaCellRetry:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -107,6 +107,25 @@ class TestBuildRecord:
         ident = {"arn": "arn:aws:sts::123:assumed-role/x/y", "userid": "AROA:me"}
         assert _record(invoked_by=ident)["invoked_by"] == ident
 
+    def test_raster_counters_default_none_and_populate(self):
+        # Off-raster records carry the read-volume fields as None (issue #297).
+        rec = _record()
+        assert rec["raster_bytes_read"] is None
+        assert rec["raster_px_decoded"] is None
+        assert rec["raster_px_sampled"] is None
+        rec = build_record(
+            shard_key=1,
+            metadata={
+                "duration_s": 1.0,
+                "raster_bytes_read": 2048,
+                "raster_px_decoded": 4096,
+                "raster_px_sampled": 100,
+            },
+        )
+        assert rec["raster_bytes_read"] == 2048
+        assert rec["raster_px_decoded"] == 4096
+        assert rec["raster_px_sampled"] == 100
+
     def test_non_numeric_phase_entries_dropped(self):
         rec = _record(phases={"sample": 3.0, "write": 1.0, "stages": {"open": 2}})
         assert rec["phase_timings"] == {"sample": 3.0, "write": 1.0}
@@ -205,6 +224,25 @@ class TestMerge:
     def test_success_ands(self):
         assert merge([_record(1), _record(2, error="boom")])["success"] is False
 
+    def test_raster_counters_fold(self):
+        # Read-volume counters sum; a mixed raster/non-raster fold sums only
+        # the populated part (None-aware, like the cost fields).
+        a = build_record(
+            shard_key=1,
+            metadata={"raster_bytes_read": 100, "raster_px_decoded": 10, "raster_px_sampled": 2},
+        )
+        b = build_record(
+            shard_key=2,
+            metadata={"raster_bytes_read": 900, "raster_px_decoded": 30, "raster_px_sampled": 6},
+        )
+        m = merge([a, b])
+        assert m["raster_bytes_read"] == 1000
+        assert m["raster_px_decoded"] == 40
+        assert m["raster_px_sampled"] == 8
+        mixed = merge([a, _record(3)])
+        assert mixed["raster_bytes_read"] == 100  # None drops out of the sum
+        assert merge([_record(1), _record(2)])["raster_bytes_read"] is None
+
     def test_associative(self):
         a = _record(1, n_obs=10, duration=1.5, memory=100.0)
         b = _record(2, n_obs=20, duration=2.5, memory=None)
@@ -275,6 +313,7 @@ class TestRunParquet:
         assert row["lambda_function_variant"] == "zagg-process-shard"
         assert row["invoked_by"] == ident["arn"]
         assert row["invoked_by_userid"] == ident["userid"]
+        assert "raster_bytes_read" in row  # read-volume columns always present
         assert "phase_timings" not in row and "lambda" not in row  # flattened away
 
     def test_failure_record_and_error_class(self):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -76,6 +76,7 @@ class TestBuildRecord:
         assert rec["cells_with_data"] == 7
         assert rec["duration_s"] == 12.5
         assert rec["phase_timings"] == {"read": 8.0, "index": 1.0, "aggregate": 2.0}
+        assert rec["spill_bytes"] is None  # no spill instrumentation off-Lambda
         assert rec["max_memory_mb"] == 512.0
         assert rec["success"] is True
         assert rec["error"] is None
@@ -105,6 +106,27 @@ class TestBuildRecord:
     def test_non_numeric_phase_entries_dropped(self):
         rec = _record(phases={"sample": 3.0, "write": 1.0, "stages": {"open": 2}})
         assert rec["phase_timings"] == {"sample": 3.0, "write": 1.0}
+
+    def test_spill_bytes_split_out_of_timings(self):
+        # The spill instrumentation (issue #217) stamps byte counts alongside
+        # the ``*_s`` seconds in ``phase_timings``; the record keeps timings
+        # seconds-only and surfaces the volume on its own top-level field.
+        rec = _record(
+            phases={
+                "read": 8.0,
+                "aggregate": 2.0,
+                "spill_write_s": 0.5,
+                "spill_read_s": 0.25,
+                "spill_bytes": 4096.0,
+            }
+        )
+        assert rec["phase_timings"] == {
+            "read": 8.0,
+            "aggregate": 2.0,
+            "spill_write_s": 0.5,
+            "spill_read_s": 0.25,
+        }
+        assert rec["spill_bytes"] == pytest.approx(4096.0)
 
     def test_granules_sha256_order_independent(self):
         assert granules_sha256(["b", "a"]) == granules_sha256(["a", "b"])

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -5,11 +5,15 @@ import pytest
 from zagg.telemetry import (
     SCHEMA_VERSION,
     build_record,
+    failure_record,
+    flatten_record,
     granules_sha256,
     merge,
     read_sidecar,
+    run_parquet_key,
     sidecar_key,
     sidecar_path,
+    write_run_parquet,
     write_sidecar,
 )
 
@@ -254,3 +258,77 @@ class TestSidecarIO:
     def test_read_absent_returns_none(self, tmp_path):
         (tmp_path / "-4").mkdir()
         assert read_sidecar(str(tmp_path / "-4" / "-4.zarr")) is None
+
+
+class TestRunParquet:
+    """Run-level parquet rows (issue #297 phase 3): flattened records plus
+    dispatcher-built failure rows, round-trippable by fastparquet and pyarrow."""
+
+    def test_flatten_record_columns(self):
+        cfg = {"memory_mb": 4096, "arch": "aarch64", "function_variant": "zagg-process-shard"}
+        ident = {"arn": "arn:aws:iam::1:user/x", "userid": "AIDA1"}
+        row = flatten_record(_record(7, lambda_config=cfg, invoked_by=ident), retries=2)
+        assert row["shard_key"] == 7 and row["success"] is True
+        assert row["retries"] == 2 and row["error_class"] is None
+        assert row["phase_read"] == 8.0 and row["phase_aggregate"] == 2.0
+        assert row["lambda_memory_mb"] == 4096
+        assert row["lambda_function_variant"] == "zagg-process-shard"
+        assert row["invoked_by"] == ident["arn"]
+        assert row["invoked_by_userid"] == ident["userid"]
+        assert "phase_timings" not in row and "lambda" not in row  # flattened away
+
+    def test_failure_record_and_error_class(self):
+        rec = failure_record(shard_key=9, error="Lambda timeout: Task timed out", duration_s=901.0)
+        assert rec["success"] is False and rec["duration_s"] == 901.0
+        row = flatten_record(rec, retries=3)
+        assert row["error_class"] == "Lambda timeout"  # derived from the string
+        row = flatten_record(rec, error_class="TimeoutError")
+        assert row["error_class"] == "TimeoutError"  # explicit wins
+        assert failure_record(shard_key=None, error="boom")["shard_key"] is None
+
+    def test_run_parquet_key_shape(self):
+        key = run_parquet_key("abc123", timestamp="20260718T010203Z")
+        assert key == "stats_abc123_20260718T010203Z.parquet"
+
+    def test_round_trip(self, tmp_path):
+        import pandas as pd
+
+        rows = [
+            flatten_record(
+                _record(
+                    1,
+                    lambda_config={"memory_mb": 4096, "arch": "aarch64", "function_variant": "f"},
+                    invoked_by={"arn": "arn:x", "userid": "u"},
+                ),
+                retries=0,
+            ),
+            flatten_record(_record(2)),  # local flavor: all-None identity columns
+            flatten_record(
+                failure_record(shard_key=3, error="Lambda OOM: killed", duration_s=100.0),
+                retries=2,
+            ),
+        ]
+        root = str(tmp_path / "store")
+        path = write_run_parquet(root, rows, run_id="deadbeef")
+        assert path.startswith(root + "/stats_deadbeef_")
+
+        df = pd.read_parquet(path, engine="fastparquet")
+        assert len(df) == 3
+        assert set(df["shard_key"]) == {1, 2, 3}
+        by_key = df.set_index("shard_key")
+        assert bool(by_key.loc[3, "success"]) is False
+        assert by_key.loc[3, "error_class"] == "Lambda OOM"
+        assert by_key.loc[3, "retries"] == 2
+        assert by_key.loc[1, "invoked_by"] == "arn:x"
+        assert pd.isna(by_key.loc[2, "invoked_by"])
+        assert by_key.loc[1, "gb_seconds"] > 0
+
+        # pyarrow (the duckdb/Athena reader family) round-trips it too.
+        pa_parquet = pytest.importorskip("pyarrow.parquet")
+        table = pa_parquet.read_table(path)
+        assert table.num_rows == 3
+        assert "invoked_by" in table.column_names
+
+    def test_empty_rows_raise(self, tmp_path):
+        with pytest.raises(ValueError, match="at least one"):
+            write_run_parquet(str(tmp_path), [], run_id="x")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,162 @@
+"""Tests for the per-shard stats schema + merge fold (issue #297 phase 1)."""
+
+import pytest
+
+from zagg.telemetry import SCHEMA_VERSION, build_record, granules_sha256, merge
+
+
+def _record(
+    shard_key=101,
+    *,
+    n_obs=1000,
+    cells=7,
+    duration=12.5,
+    granules=("s3://b/g1.h5", "s3://b/g2.h5"),
+    phases=None,
+    memory=512.0,
+    lambda_config=None,
+    invoked_by=None,
+    error=None,
+):
+    metadata = {
+        "shard_key": shard_key,
+        "total_obs": n_obs,
+        "cells_with_data": cells,
+        "granule_count": len(granules),
+        "duration_s": duration,
+        "max_memory_mb": memory,
+        "container_hwm_mb": memory + 100 if memory is not None else None,
+        "phase_timings": {"read": 8.0, "index": 1.0, "aggregate": 2.0}
+        if phases is None
+        else phases,
+        "error": error,
+    }
+    return build_record(
+        shard_key=shard_key,
+        metadata=metadata,
+        granule_ids=list(granules),
+        invoked_by=invoked_by,
+        lambda_config=lambda_config,
+    )
+
+
+def _assert_records_close(a, b):
+    assert set(a) == set(b)
+    for key in a:
+        va, vb = a[key], b[key]
+        if isinstance(va, float):
+            assert va == pytest.approx(vb), key
+        elif key == "phase_timings":
+            assert set(va) == set(vb)
+            for phase in va:
+                assert va[phase] == pytest.approx(vb[phase]), phase
+        else:
+            assert va == vb, key
+
+
+class TestBuildRecord:
+    def test_schema_fields(self):
+        rec = _record()
+        assert rec["schema_version"] == SCHEMA_VERSION
+        assert rec["shard_key"] == 101
+        assert rec["template_hash"] is None  # placeholder until issue #299
+        assert rec["n_shards"] == 1
+        assert rec["n_granules"] == 2
+        assert rec["granules_sha256"] == granules_sha256(["s3://b/g1.h5", "s3://b/g2.h5"])
+        assert rec["n_obs"] == 1000
+        assert rec["cells_with_data"] == 7
+        assert rec["duration_s"] == 12.5
+        assert rec["phase_timings"] == {"read": 8.0, "index": 1.0, "aggregate": 2.0}
+        assert rec["max_memory_mb"] == 512.0
+        assert rec["success"] is True
+        assert rec["error"] is None
+        assert rec["invoked_by"] is None
+        assert rec["lambda"] is None
+        assert rec["gb_seconds"] is None  # unmetered off-Lambda
+        assert rec["est_cost_usd"] is None
+        assert isinstance(rec["zagg_version"], str)
+        assert rec["timestamp"].endswith("+00:00")
+
+    def test_error_marks_failure(self):
+        rec = _record(error="No data after filtering")
+        assert rec["success"] is False
+        assert rec["error"] == "No data after filtering"
+
+    def test_lambda_config_prices_cost(self):
+        cfg = {"memory_mb": 4096, "arch": "aarch64", "function_variant": "zagg-process-shard"}
+        rec = _record(duration=10.0, lambda_config=cfg)
+        assert rec["lambda"] == cfg
+        assert rec["gb_seconds"] == pytest.approx(40.0)
+        assert rec["est_cost_usd"] == pytest.approx(40.0 * 0.0000133334)
+
+    def test_invoked_by_copied_verbatim(self):
+        ident = {"arn": "arn:aws:sts::123:assumed-role/x/y", "userid": "AROA:me"}
+        assert _record(invoked_by=ident)["invoked_by"] == ident
+
+    def test_non_numeric_phase_entries_dropped(self):
+        rec = _record(phases={"sample": 3.0, "write": 1.0, "stages": {"open": 2}})
+        assert rec["phase_timings"] == {"sample": 3.0, "write": 1.0}
+
+    def test_granules_sha256_order_independent(self):
+        assert granules_sha256(["b", "a"]) == granules_sha256(["a", "b"])
+        assert granules_sha256([]) is None
+        assert granules_sha256(None) is None
+
+
+class TestMerge:
+    def test_single_record_is_identity(self):
+        rec = _record()
+        _assert_records_close(merge([rec]), rec)
+
+    def test_sums_and_maxes(self):
+        a = _record(1, n_obs=10, cells=2, duration=1.0, memory=100.0)
+        b = _record(2, n_obs=20, cells=3, duration=2.0, memory=300.0)
+        m = merge([a, b])
+        assert m["n_shards"] == 2
+        assert m["n_obs"] == 30
+        assert m["cells_with_data"] == 5
+        assert m["n_granules"] == 4
+        assert m["duration_s"] == pytest.approx(3.0)
+        assert m["max_memory_mb"] == 300.0
+        assert m["container_hwm_mb"] == 400.0
+        assert m["phase_timings"]["read"] == pytest.approx(16.0)
+        assert m["timestamp"] == max(a["timestamp"], b["timestamp"])
+        assert m["success"] is True
+
+    def test_identity_fields_collapse_to_none_on_mismatch(self):
+        a = _record(1)
+        b = _record(2, granules=("s3://b/g3.h5",))
+        m = merge([a, b])
+        assert m["shard_key"] is None  # differing shards -> no single identity
+        assert m["granules_sha256"] is None
+        assert m["zagg_version"] == a["zagg_version"]  # shared value survives
+
+    def test_success_ands(self):
+        assert merge([_record(1), _record(2, error="boom")])["success"] is False
+
+    def test_associative(self):
+        a = _record(1, n_obs=10, duration=1.5, memory=100.0)
+        b = _record(2, n_obs=20, duration=2.5, memory=None)
+        c = _record(3, n_obs=30, duration=3.5, memory=900.0, error="x")
+        _assert_records_close(merge([merge([a, b]), c]), merge([a, merge([b, c])]))
+
+    def test_commutative(self):
+        a = _record(1, phases={"read": 1.0})
+        b = _record(2, phases={"read": 2.0, "write": 0.5})
+        _assert_records_close(merge([a, b]), merge([b, a]))
+
+    def test_merge_of_children_equals_direct(self):
+        records = [_record(k, n_obs=k * 10, duration=float(k)) for k in range(1, 7)]
+        direct = merge(records)
+        grouped = merge([merge(records[:2]), merge(records[2:5]), merge(records[5:])])
+        _assert_records_close(grouped, direct)
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one"):
+            merge([])
+
+    def test_schema_version_mismatch_raises(self):
+        good, bad = _record(1), _record(2)
+        bad["schema_version"] = 2
+        with pytest.raises(ValueError, match="schema_version"):
+            merge([good, bad])

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -2,7 +2,16 @@
 
 import pytest
 
-from zagg.telemetry import SCHEMA_VERSION, build_record, granules_sha256, merge
+from zagg.telemetry import (
+    SCHEMA_VERSION,
+    build_record,
+    granules_sha256,
+    merge,
+    read_sidecar,
+    sidecar_key,
+    sidecar_path,
+    write_sidecar,
+)
 
 
 def _record(
@@ -160,3 +169,30 @@ class TestMerge:
         bad["schema_version"] = 2
         with pytest.raises(ValueError, match="schema_version"):
             merge([good, bad])
+
+
+class TestSidecarIO:
+    """The leaf sidecar is a SIBLING of the leaf ``.zarr`` (issue #297):
+    ``stats.json`` bare, ``stats_{window}.json`` windowed (a node dir holds
+    every window's leaf of its one shard)."""
+
+    def test_sidecar_key_bare_and_windowed(self):
+        assert sidecar_key("-4211322.zarr") == "stats.json"
+        assert sidecar_key("-4211322_20260713.zarr") == "stats_20260713.json"
+
+    def test_sidecar_path_is_sibling_not_inside_leaf(self):
+        leaf = "/root/-4/2/1/1/3/2/2/-4211322.zarr"
+        assert sidecar_path(leaf) == "/root/-4/2/1/1/3/2/2/stats.json"
+
+    def test_write_read_roundtrip(self, tmp_path):
+        leaf = str(tmp_path / "-4" / "2" / "-42.zarr")
+        rec = _record()
+        write_sidecar(leaf, rec)
+        assert read_sidecar(leaf) == rec
+        # Sibling object, never inside the leaf prefix.
+        assert (tmp_path / "-4" / "2" / "stats.json").exists()
+        assert not (tmp_path / "-4" / "2" / "-42.zarr").exists()
+
+    def test_read_absent_returns_none(self, tmp_path):
+        (tmp_path / "-4").mkdir()
+        assert read_sidecar(str(tmp_path / "-4" / "-4.zarr")) is None

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -154,6 +154,42 @@ class TestMerge:
         assert m["timestamp"] == max(a["timestamp"], b["timestamp"])
         assert m["success"] is True
 
+    def test_cost_fields_fold(self):
+        price = 0.0000133334
+        cfg_a = {"memory_mb": 4096, "arch": "aarch64", "function_variant": "zagg-process-shard"}
+        cfg_b = {"memory_mb": 2048, "arch": "aarch64", "function_variant": "zagg-process-shard"}
+        a = _record(1, duration=10.0, lambda_config=cfg_a)  # 40 gb-s
+        b = _record(2, duration=5.0, lambda_config=cfg_b)  # 10 gb-s
+        m = merge([a, b])
+        # _SUM_OR_NONE fold of populated cost: parts add.
+        assert m["gb_seconds"] == pytest.approx(50.0)
+        assert m["est_cost_usd"] == pytest.approx(50.0 * price)
+        # Differing lambda blocks collapse to None (absorbing identity).
+        assert m["lambda"] is None
+
+    def test_cost_fields_shared_lambda_survives(self):
+        cfg = {"memory_mb": 4096, "arch": "aarch64", "function_variant": "zagg-process-shard"}
+        a = _record(1, duration=10.0, lambda_config=cfg)
+        b = _record(2, duration=5.0, lambda_config=cfg)
+        m = merge([a, b])
+        assert m["lambda"] == cfg
+        # ... but as a defensive copy, not an alias of either input's dict.
+        assert m["lambda"] is not a["lambda"]
+        assert m["lambda"] is not b["lambda"]
+        assert m["gb_seconds"] == pytest.approx(60.0)  # (10+5) * 4096/1024
+
+    def test_cost_fields_mixed_populated_and_none(self):
+        price = 0.0000133334
+        cfg = {"memory_mb": 4096, "arch": "aarch64", "function_variant": "zagg-process-shard"}
+        metered = _record(1, duration=10.0, lambda_config=cfg)  # 40 gb-s
+        unmetered = _record(2, duration=5.0, lambda_config=None)  # gb_seconds None
+        m = merge([metered, unmetered])
+        # Only the populated record contributes to the sum.
+        assert m["gb_seconds"] == pytest.approx(40.0)
+        assert m["est_cost_usd"] == pytest.approx(40.0 * price)
+        # One populated + one None lambda block -> mismatch -> None.
+        assert m["lambda"] is None
+
     def test_identity_fields_collapse_to_none_on_mismatch(self):
         a = _record(1)
         b = _record(2, granules=("s3://b/g3.h5",))

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -103,6 +103,13 @@ class TestBuildRecord:
         assert rec["gb_seconds"] == pytest.approx(40.0)
         assert rec["est_cost_usd"] == pytest.approx(40.0 * 0.0000133334)
 
+    def test_unknown_arch_falls_back_to_default_rate(self):
+        # The record prices via the #298 arch table; an unmapped arch uses the
+        # flat default rate instead of raising in a worker.
+        cfg = {"memory_mb": 1024, "arch": "riscv64", "function_variant": "f"}
+        rec = _record(duration=10.0, lambda_config=cfg)
+        assert rec["est_cost_usd"] == pytest.approx(10.0 * 0.0000133334)
+
     def test_invoked_by_copied_verbatim(self):
         ident = {"arn": "arn:aws:sts::123:assumed-role/x/y", "userid": "AROA:me"}
         assert _record(invoked_by=ident)["invoked_by"] == ident


### PR DESCRIPTION
Closes #297

Per-shard stats sidecar: a versioned, mergeable-by-construction record built from what workers already report, persisted two ways from one source — a `stats.json` sidecar SIBLING to each hive leaf `.zarr` (success only), and a run-level parquet at the store root (one row per shard, failure rows included). Decisions ratified on the issue thread (sibling placement, `stats.json` naming until #299's `{hash}.stats.json`, envelope ride, `invoked_by` resolved dispatcher-side via `sts get-caller-identity`) are implemented as agreed.

## Approach

- **`src/zagg/telemetry.py`** (new): `SCHEMA_VERSION = 1` record schema + `build_record` (pure builder from the existing worker `metadata` dict) + `merge` — an associative/commutative fold. Only associative stats are stored (counts, sums, min/max); identity-like fields (`shard_key`, `granules_sha256`, `invoked_by`, `lambda`, ...) merge as equal-or-`None` with `None` absorbing, which is what keeps the fold associative. `template_hash` is a nullable placeholder until #299 lands the hasher. Catalog identity is granule count + sha256 over the sorted granule ids.
- **Phase-timing collection is now always-on** in workers (the issue #297 decision: drop the `profile` gate for *collection*; `profile` still gates the verbose raster per-stage `stages` block and the summary rollups). `process_shard`, `process_and_write_hive`, `process_and_write_raster_hive`, and both Lambda per-unit handlers now always emit `phase_timings`.
- **Sidecar + envelope**: on success, the worker writes the record as a sibling of the leaf `.zarr` (`stats.json`; windowed leaves get `stats_{window}.json` so two windows of one shard cannot collide — mirrors the `{full_id}_{window}.zarr` leaf naming). The record also rides the response envelope (`body["stats"]`) so the async dispatcher builds the run parquet with no second S3 listing. `invoked_by` is resolved once per run by the dispatcher (`sts get-caller-identity` → ARN + userid), stamped into the invoke payload, and copied verbatim by the worker. Request ids / function ARNs of the run itself are omitted per the issue decision.
- **Run parquet**: one row per shard at the store root, `stats_{run_id}_{timestamp}.parquet`, written fail-open by the dispatcher from the `RunReport` results (spatial local + lambda) and the raster fan-out loops — including failure rows (error class, duration until failure, retry count) that have no sidecar. Written with the core `fastparquet` engine (pyarrow stays off the worker path per the #130 pivot); readable by pyarrow/duckdb.
- CloudWatch structured logging is unchanged.

## Phases

- [x] Phase 1 — schema + merge fold, pure/no-I/O (`src/zagg/telemetry.py`; unit tests for fold associativity/commutativity, merge-of-children == direct)
- [x] Phase 2 — workers write the leaf sidecar + envelope ride + always-on timing collection (`processing/worker.py`, `processing/raster.py`, `hive.py`, `deployment/aws/lambda_handler.py` application code, local-runner call sites; tests against the local-store path)
- [x] Phase 3 — run-level parquet from the dispatcher rollup (`runner.py` reading the `RunReport`), failure rows included; parquet round-trip test (fastparquet write, pyarrow + fastparquet read-back)
- [x] Follow-up (thread): raster read-volume counters (`raster_bytes_read` / `raster_px_decoded` / `raster_px_sampled`) in the record; raster summaries carry `run_stats_path`
- [x] Scope addition (directed on the PR #303 thread): `main` merged in post-#303 (merge, not rebase — pushed history is never rewritten; espg's "rebase" wording achieved via merge) and the #298 cost block extended to the **raster** Lambda path (`cost: {max, estimated, actual}` + `gb_seconds`/`price_per_gb_sec`), with the worker record pricing through the same arch-keyed table. The **temporal** path already received its cost block in PR #303 itself (`_run_lambda_events`) — verified, nothing further to add; local backends stay unmetered by design (parity with the spatial local path).

## Testing

- `tests/test_telemetry.py`: schema fields, cost pricing from the lambda config block, `invoked_by` verbatim copy, non-numeric phase entries dropped; merge identity, sums/maxes, equal-or-`None` collapse, success AND-fold, associativity, commutativity, merge-of-children == direct, empty/schema-version error paths.
- Phase 2: sidecar round-trip + windowed naming units; spatial hive Lambda handler writes the sibling record equal to `body["stats"]` with `invoked_by` verbatim; no-data hive shard writes no sidecar (record still rides the envelope); flat spatial carries envelope record only; raster hive Lambda + local backends checked end-to-end; hive/raster/worker phase-timing tests updated for always-on collection; object-count model tests updated (+1 per-shard object).
- Phase 3: `flatten_record` column mapping (phase/lambda/invoked_by flattening), `failure_record` + error-class derivation, parquet write/read round-trip (fastparquet + pyarrow), `_lambda_result_rows` success/stale-worker/failure branches, root listings across hive + flat pins updated; an autouse conftest guard keeps unit tests from PUT-ing the run parquet to real S3 (local-path writes stay live so the wiring is integration-tested).
- Full suite green locally (`ruff check`, `ruff format --check`, `pytest`) except two pre-existing items, both unrelated and untouched: `test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` (this machine's `pip` resolves for CPython 3.10, so `zarr>=3.1.5` cannot resolve) and a `ruff` `N818` on `src/zagg/registry.py:64` (`UnknownCapability`) that trips the full `select=[..., N]` config but not the CI lint bot's `E,F,W,I` selection.

## Questions for review

0. **`.github/scripts/bench_objects.py` was touched** (a CI benchmark *model* script, not a workflow): the sidecar is a new known per-leaf object, so the object-count model had to learn it (classify the node-sibling `stats*.json` as per-shard; expected per-shard +1) or every hive benchmark run and `test_benchmark_objects` would flag it as a stray object. Change is minimal and test-covered; flagging because CLAUDE.md is conservative about `.github/` — please eyeball that hunk.
1. ~~Flat layouts get no sidecar object~~ — **resolved on the thread**: hive is becoming the default; flat keeps the envelope record + parquet row only.
2. **Windowed sidecar naming**: the ratified name is `stats.json`, but a windowed store puts every window's leaf of a shard in one node directory, so a bare `stats.json` would self-clobber. Implemented `stats_{window}.json` for windowed leaves (bare leaves keep `stats.json` exactly). Both converge to `{hash}.stats.json` under #299.
3. **Local runs carry `invoked_by: null`** — the STS resolve is done only on the lambda dispatch paths (a local run may have no AWS credentials at all). Rows/records from local runs have a null identity column.
4. ~~Raster summaries don't carry `run_stats_path`~~ — **resolved on the thread**: all four summaries now carry it unconditionally (`None` when the fail-open write skipped, path on success); the raster parquet is still written before the all-failed raise. Follow-up on the thread also added the raster read-volume counters `raster_bytes_read` / `raster_px_decoded` / `raster_px_sampled` to the record (over-provision = decoded/sampled, derived at read).
5. ~~Overlap with the #298 PR~~ — **resolved**: PR #303 merged to main and `main` is merged into this branch (b3fec5f, clean); `telemetry.build_record` now prices via #303's `LAMBDA_PRICE_PER_GB_SEC_BY_ARCH` table so there is one rate source.
