### PR TITLE
Invoke cost reporting (max/estimated/actual) and notebook dispatch wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The notebooks under `notebooks/` run on [Binder](https://mybinder.org/v2/gh/engl
 | `rasterized_zarr.ipynb` | Rasterize the published HEALPix store to an 8 km polar-stereo grid | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/englacial/zagg/main?urlpath=lab/tree/notebooks/rasterized_zarr.ipynb) |
 | `jupyterhub_example.ipynb` | Drive the API from a science hub; read & visualize a published result | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/englacial/zagg/main?urlpath=lab/tree/notebooks/jupyterhub_example.ipynb) |
 | `cryocloud_example.ipynb` | End-to-end ISMIP6 read + **AWS Lambda fan-out** on CryoCloud | **not Binder-runnable** (needs live AWS + Earthdata credentials) |
+| `cost_reporting.ipynb` | Max / estimated / actual invoke cost + progress-bar dispatch wrapper | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/englacial/zagg/main?urlpath=lab/tree/notebooks/cost_reporting.ipynb) |
 
 `cryocloud_example.ipynb` is the only Lambda demo; it dispatches to a deployed AWS Lambda and reads private-account S3 via the CryoCloud IRSA role, so it cannot run on Binder.
 

--- a/notebooks/cost_reporting.ipynb
+++ b/notebooks/cost_reporting.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Invoke cost reporting: max -> progress -> actual\n",
+    "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/englacial/zagg/main?urlpath=lab/tree/notebooks/cost_reporting.ipynb)\n",
+    "\n",
+    "_Runs end-to-end on [Binder](https://mybinder.org/v2/gh/englacial/zagg/main?urlpath=lab/tree/notebooks/cost_reporting.ipynb): it reads only a small shard-map fixture checked into the git tree -- no cloud data, no credentials. The one step Binder cannot do (invoke AWS Lambda) is replayed with a stand-in, clearly marked below._\n",
+    "\n",
+    "A zagg Lambda fan-out spends real money, so every run reports three cost figures (issue #298):\n",
+    "\n",
+    "| figure | when | meaning |\n",
+    "|---|---|---|\n",
+    "| **max** | before any invoke | hard ceiling: `n_units x rate(arch) x memory_gb x 900 s` -- every unit is one Lambda invocation billed at the configured memory for at most the function timeout |\n",
+    "| **estimated** | before any invoke | prior-run history estimate (pilot-first); currently a `None` placeholder -- deferred behind the stats-sidecar and template-hash issues |\n",
+    "| **actual** | after the run | rollup of billed durations: `sum(duration_s) x memory_gb x rate` |\n",
+    "\n",
+    "The ceiling is exact and cheap: it needs only the shard map (how many units) and the config (which worker memory)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Max cost, before any invoke\n",
+    "\n",
+    "`zagg.notebook.max_cost_preview` resolves the ceiling from a shard map + config with the same unit accounting the dispatcher uses (cell selection, windowed-unit expansion). The fixture below is a 4-shard ATL03 shard map from the test tree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from zagg.config import default_config\n",
+    "from zagg.notebook import format_max_cost, max_cost_preview\n",
+    "\n",
+    "\n",
+    "def find(rel):\n",
+    "    \"\"\"Resolve a repo file whether we run from the repo root or notebooks/.\"\"\"\n",
+    "    for base in (Path.cwd(), Path.cwd().parent):\n",
+    "        if (base / rel).exists():\n",
+    "            return str(base / rel)\n",
+    "    raise FileNotFoundError(rel)\n",
+    "\n",
+    "\n",
+    "shardmap = find(\"tests/data/benchmark/shardmaps/sm_healpix_o9.json\")\n",
+    "config = default_config(\"atl06\")\n",
+    "\n",
+    "preview = max_cost_preview(config, shardmap)\n",
+    "print(format_max_cost(preview))\n",
+    "preview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ceiling scales with the worker-size variant the config selects (the `worker:` block, issue #235):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for memory_mb in (2048, 4096, 8192):\n",
+    "    config.worker = {\"memory\": memory_mb}\n",
+    "    p = max_cost_preview(config, shardmap)\n",
+    "    print(f\"worker {memory_mb} MB -> ceiling ${p['max_cost_usd']:.4f}\")\n",
+    "config.worker = None  # back to the default 4 GB worker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Estimated cost (deferred)\n",
+    "\n",
+    "The estimator is an interface stub for now: **tier 1 (pilot-first)** scales prior actuals for the *same* template hash by per-shard granule/obs counts (the dev -> single-shard test -> fleet workflow means a pilot run usually exists); **tier 2** falls back to a cross-template regression on per-shard `n_obs`. Both need the per-shard stats sidecars and template-hash identity to exist first, so until those land the stub returns `None` and `cost[\"estimated_cost_usd\"]` stays a placeholder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from zagg.dispatch import estimate_cost_usd\n",
+    "\n",
+    "print(estimate_cost_usd())  # None until the sidecar history exists"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Progress + report\n",
+    "\n",
+    "`zagg.notebook.run` wraps `zagg.agg` with a per-unit progress bar (tqdm when importable, logging otherwise; the running cost rides the postfix) and returns a `RunView` -- a summary dict with a rich HTML repr. The notebook path is **informational only**: it displays the ceiling and never prompts (the blocking yes/no gate is CLI-only).\n",
+    "\n",
+    "Binder cannot invoke AWS Lambda, so the cell below substitutes a stand-in `agg` that replays a realistic run summary while ticking the same `on_progress` callback a real Lambda fan-out drives -- the wrapper code path (ceiling display, bar, `RunView`) is exactly the one a real run exercises."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from unittest.mock import patch\n",
+    "\n",
+    "from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC\n",
+    "\n",
+    "MEMORY_GB = 4.0\n",
+    "DURATIONS = {-231928: 41.0, -231921: 63.0, -231920: 55.0, -231913: 48.0}  # simulated billed seconds\n",
+    "\n",
+    "\n",
+    "def replay_agg(config, *, on_progress=None, **kwargs):\n",
+    "    \"\"\"Stand-in for zagg.agg: replays a recorded-style Lambda run summary.\"\"\"\n",
+    "    total, cost = len(DURATIONS), 0.0\n",
+    "    for i, duration in enumerate(DURATIONS.values(), 1):\n",
+    "        time.sleep(0.3)  # a real shard takes seconds-to-minutes\n",
+    "        cost += duration * MEMORY_GB * LAMBDA_PRICE_PER_GB_SEC\n",
+    "        if on_progress is not None:\n",
+    "            on_progress(i, total, cost)\n",
+    "    lambda_time = sum(DURATIONS.values())\n",
+    "    actual = lambda_time * MEMORY_GB * LAMBDA_PRICE_PER_GB_SEC\n",
+    "    return {\n",
+    "        \"backend\": \"lambda\",\n",
+    "        \"store_path\": \"s3://example-bucket/atl03_serc.zarr\",\n",
+    "        \"total_cells\": total,\n",
+    "        \"cells_with_data\": total,\n",
+    "        \"cells_error\": 0,\n",
+    "        \"total_obs\": 1_284_055,\n",
+    "        \"wall_time_s\": 71.2,\n",
+    "        \"lambda_time_s\": lambda_time,\n",
+    "        \"cost\": {\n",
+    "            \"max_cost_usd\": preview[\"max_cost_usd\"],\n",
+    "            \"estimated_cost_usd\": None,\n",
+    "            \"actual_cost_usd\": actual,\n",
+    "        },\n",
+    "        \"results\": [\n",
+    "            {\"shard_key\": k, \"status_code\": 200, \"error\": None, \"lambda_duration\": d}\n",
+    "            for k, d in DURATIONS.items()\n",
+    "        ],\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "from zagg import notebook\n",
+    "\n",
+    "with patch(\"zagg.runner.agg\", replay_agg):\n",
+    "    report = notebook.run(config, catalog=shardmap, backend=\"lambda\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report  # RunView: cost block, counters, failures render as HTML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cost = report[\"cost\"]\n",
+    "assert cost[\"max_cost_usd\"] >= cost[\"actual_cost_usd\"]  # the ceiling always bounds the bill\n",
+    "cost"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running it for real\n",
+    "\n",
+    "Against a deployed fleet the call is the same, minus the stand-in:\n",
+    "\n",
+    "```python\n",
+    "from zagg import load_config, notebook\n",
+    "\n",
+    "config = load_config(\"atl03_serc.yaml\")\n",
+    "report = notebook.run(\n",
+    "    config,\n",
+    "    catalog=\"shardmap_atl03_serc.json\",\n",
+    "    backend=\"lambda\",\n",
+    "    store=\"s3://your-bucket/atl03_serc.zarr\",\n",
+    ")\n",
+    "report  # max / estimated / actual + per-shard failures\n",
+    "```\n",
+    "\n",
+    "From the command line the same run **blocks on the ceiling** with a yes/no prompt; `--yes`/`-y` skips it for scripted runs:\n",
+    "\n",
+    "```console\n",
+    "$ python -m zagg --config atl03_serc.yaml --catalog shardmap_atl03_serc.json --backend lambda\n",
+    "Max cost ceiling: ~$0.19 (4 units x 4 GB x 900s, arm64)\n",
+    "Proceed with Lambda fan-out? [y/N] y\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/zagg/__main__.py
+++ b/src/zagg/__main__.py
@@ -10,8 +10,10 @@ Usage:
 import argparse
 import json
 import logging
+import sys
 
 from zagg.config import load_config
+from zagg.notebook import confirm_max_cost, max_cost_preview
 from zagg.runner import agg, normalize_output_credentials
 
 
@@ -81,6 +83,13 @@ examples:
         "worker: block's variant suffix (issue #235). Resolved in the runner "
         "so the config selection is not silently masked.",
     )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip the max-cost confirmation prompt before a Lambda fan-out "
+        "(issue #298). The ceiling is still printed.",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -96,6 +105,22 @@ examples:
         # Accept camelCase, snake_case, or STS PascalCase key spellings.
         output_credentials = normalize_output_credentials(output_credentials)
         output_endpoint_url = output_credentials.get("endpointUrl")
+
+    # Max-cost gate (issue #298): a Lambda fan-out spends real money, so the
+    # CLI blocks on the pre-invoke ceiling with a yes/no prompt; --yes/-y
+    # skips. Dry runs invoke nothing, and a run with no resolvable catalog is
+    # about to raise agg's own error -- both bypass the gate. The notebook
+    # wrapper (zagg.notebook) never blocks; this prompt is CLI-only.
+    if args.backend == "lambda" and not args.dry_run and (args.catalog or config.catalog):
+        preview = max_cost_preview(
+            config,
+            args.catalog,
+            max_cells=args.max_cells,
+            morton_cell=args.morton_cell,
+        )
+        if not confirm_max_cost(preview, assume_yes=args.yes):
+            print("Aborted: max-cost gate declined (rerun with --yes to skip the prompt).")
+            sys.exit(1)
 
     results = agg(
         config,

--- a/src/zagg/__main__.py
+++ b/src/zagg/__main__.py
@@ -12,7 +12,7 @@ import json
 import logging
 import sys
 
-from zagg.config import load_config
+from zagg.config import get_pipeline_type, load_config
 from zagg.notebook import confirm_max_cost, max_cost_preview
 from zagg.runner import agg, normalize_output_credentials
 
@@ -109,9 +109,17 @@ examples:
     # Max-cost gate (issue #298): a Lambda fan-out spends real money, so the
     # CLI blocks on the pre-invoke ceiling with a yes/no prompt; --yes/-y
     # skips. Dry runs invoke nothing, and a run with no resolvable catalog is
-    # about to raise agg's own error -- both bypass the gate. The notebook
+    # about to raise agg's own error -- both bypass the gate. Temporal configs
+    # have no shardmap ceiling (max_cost_preview raises for them) and via the
+    # CLI carry no events source, so agg would raise anyway -- the gate only
+    # engages for the catalog-driven kinds (spatial/raster). The notebook
     # wrapper (zagg.notebook) never blocks; this prompt is CLI-only.
-    if args.backend == "lambda" and not args.dry_run and (args.catalog or config.catalog):
+    if (
+        args.backend == "lambda"
+        and not args.dry_run
+        and (args.catalog or config.catalog)
+        and get_pipeline_type(config) != "temporal"
+    ):
         preview = max_cost_preview(
             config,
             args.catalog,

--- a/src/zagg/dispatch.py
+++ b/src/zagg/dispatch.py
@@ -368,6 +368,12 @@ def estimate_cost_usd(catalog_data=None, *, template_hash=None, history=None) ->
     returns ``None`` and the run's ``cost.estimated_cost_usd`` stays a
     placeholder.
 
+    The temporal event fan-out has no shardmap (its fan-out unit is the
+    event, resolved at call time, not a catalog shard), so
+    ``_run_lambda_events`` wires this stub with no ``catalog_data`` and its
+    estimate stays ``None`` until an event-history tier exists -- out of
+    scope for issue #298; both tiers below key on per-shard counts.
+
     Two tiers, tried in order once wired:
 
     * **Tier 1 -- pilot-first.** Prior actuals for the *same* template hash at

--- a/src/zagg/dispatch.py
+++ b/src/zagg/dispatch.py
@@ -337,7 +337,7 @@ LAMBDA_PRICE_PER_GB_SEC = LAMBDA_PRICE_PER_GB_SEC_BY_ARCH[LAMBDA_ARCH]
 
 
 def max_cost_usd(
-    n_shards: int,
+    n_units: int,
     memory_gb: float,
     *,
     timeout_s: float,
@@ -346,15 +346,16 @@ def max_cost_usd(
     """Hard ceiling on a fan-out's Lambda bill, computable before any invoke.
 
     Every work unit is one Lambda invocation billed at ``memory_gb`` for at
-    most the function timeout, so ``n_shards * rate(arch) * memory_gb *
-    timeout_s`` bounds one clean pass over the shardmap (issue #298).
+    most the function timeout, so ``n_units * rate(arch) * memory_gb *
+    timeout_s`` bounds one invoke per work unit (issue #298). A work unit is
+    a shard on the spatial path and an event on the tabular/temporal path.
     Transient-fault retries (:data:`LAMBDA_RETRY`, rare) re-bill a unit and
     are deliberately not folded in -- the ceiling prices the run as planned,
     not the worst-case retry storm. ``arch`` keys the price table
     (:data:`LAMBDA_PRICE_PER_GB_SEC_BY_ARCH`); an unknown arch raises
     ``KeyError`` rather than pricing silently wrong.
     """
-    return n_shards * LAMBDA_PRICE_PER_GB_SEC_BY_ARCH[arch] * memory_gb * timeout_s
+    return n_units * LAMBDA_PRICE_PER_GB_SEC_BY_ARCH[arch] * memory_gb * timeout_s
 
 
 class LambdaExecutor:

--- a/src/zagg/dispatch.py
+++ b/src/zagg/dispatch.py
@@ -358,7 +358,12 @@ def max_cost_usd(
     return n_units * LAMBDA_PRICE_PER_GB_SEC_BY_ARCH[arch] * memory_gb * timeout_s
 
 
-def estimate_cost_usd(catalog_data=None, *, template_hash=None, history=None) -> float | None:
+def estimate_cost_usd(
+    catalog_data: dict | None = None,
+    *,
+    template_hash: str | None = None,
+    history: list | None = None,
+) -> float | None:
     """Estimated run cost from prior-run history (issue #298 Phase 3 -- stub).
 
     Interface placeholder for the pilot-first estimator ratified on issue

--- a/src/zagg/dispatch.py
+++ b/src/zagg/dispatch.py
@@ -77,6 +77,13 @@ class RunReport:
     counters; cost is accumulated per-result via :meth:`Executor.measure_cost`.
     ``runner.py`` reads this to build the public summary dict and to print cost
     -- this module never formats or prints.
+
+    The run-level cost block (issue #298) is stamped by the runner, not the
+    loop: ``max_cost_usd`` is the pre-invoke ceiling (:func:`max_cost_usd`),
+    ``actual_cost_usd`` the post-run rollup of billed durations, and
+    ``estimated_cost_usd`` the prior-history estimate (``None`` until the
+    issue #297/#299 sidecar history exists). All three stay ``None`` on runs
+    that carry no metered cost (local backend).
     """
 
     results: list[dict] = field(default_factory=list)
@@ -84,6 +91,9 @@ class RunReport:
     cells_error: int = 0
     total_obs: int = 0
     cost: CellCost = field(default_factory=CellCost)
+    max_cost_usd: float | None = None
+    estimated_cost_usd: float | None = None
+    actual_cost_usd: float | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -313,12 +323,38 @@ class LocalExecutor:
         self._pool.shutdown()
 
 
-# arm64 Lambda pricing, $/GB-second, and the function's memory in GB. Matches
-# the constants inlined into ``_run_lambda`` before this extraction; surfaced
-# here so :meth:`LambdaExecutor.measure_cost` and the runner's presentation
-# read one source.
+# Lambda pricing, $/GB-second, keyed by CPU architecture, and the default
+# function memory in GB. The deployed fleet is arm64-only (template.yaml
+# ``Architecture`` default; no x86_64 variant is stood up), so the table
+# carries one row -- an x86_64 deployment adds its rate here (issue #298).
+# ``LAMBDA_PRICE_PER_GB_SEC`` stays the flat arm64 constant so
+# :meth:`LambdaExecutor.measure_cost` and the runner's presentation keep
+# reading one source, byte-identical to the pre-table path.
+LAMBDA_ARCH = "arm64"
+LAMBDA_PRICE_PER_GB_SEC_BY_ARCH = {"arm64": 0.0000133334}
 LAMBDA_MEMORY_GB = 4.0  # issue #193: production worker sized to 4 GB (2.3 vCPU)
-LAMBDA_PRICE_PER_GB_SEC = 0.0000133334
+LAMBDA_PRICE_PER_GB_SEC = LAMBDA_PRICE_PER_GB_SEC_BY_ARCH[LAMBDA_ARCH]
+
+
+def max_cost_usd(
+    n_shards: int,
+    memory_gb: float,
+    *,
+    timeout_s: float,
+    arch: str = LAMBDA_ARCH,
+) -> float:
+    """Hard ceiling on a fan-out's Lambda bill, computable before any invoke.
+
+    Every work unit is one Lambda invocation billed at ``memory_gb`` for at
+    most the function timeout, so ``n_shards * rate(arch) * memory_gb *
+    timeout_s`` bounds one clean pass over the shardmap (issue #298).
+    Transient-fault retries (:data:`LAMBDA_RETRY`, rare) re-bill a unit and
+    are deliberately not folded in -- the ceiling prices the run as planned,
+    not the worst-case retry storm. ``arch`` keys the price table
+    (:data:`LAMBDA_PRICE_PER_GB_SEC_BY_ARCH`); an unknown arch raises
+    ``KeyError`` rather than pricing silently wrong.
+    """
+    return n_shards * LAMBDA_PRICE_PER_GB_SEC_BY_ARCH[arch] * memory_gb * timeout_s
 
 
 class LambdaExecutor:

--- a/src/zagg/dispatch.py
+++ b/src/zagg/dispatch.py
@@ -358,6 +358,45 @@ def max_cost_usd(
     return n_units * LAMBDA_PRICE_PER_GB_SEC_BY_ARCH[arch] * memory_gb * timeout_s
 
 
+def estimate_cost_usd(catalog_data=None, *, template_hash=None, history=None) -> float | None:
+    """Estimated run cost from prior-run history (issue #298 Phase 3 -- stub).
+
+    Interface placeholder for the pilot-first estimator ratified on issue
+    #298; the implementation is deferred behind issues #297 (per-shard stats
+    sidecars) and #299 (template-hash identity), which create the history it
+    reads. Until both land there is nothing to estimate from, so this always
+    returns ``None`` and the run's ``cost.estimated_cost_usd`` stays a
+    placeholder.
+
+    Two tiers, tried in order once wired:
+
+    * **Tier 1 -- pilot-first.** Prior actuals for the *same* template hash at
+      any shard (the dev -> single-shard test -> fleet workflow means a pilot
+      run usually exists), scaled to the remaining shards by per-shard
+      granule/observation counts from the shardmap. One measured shard scaled
+      by relative shard size is a much tighter prior than a global fit.
+    * **Tier 2 -- cross-template regression (fallback).** No same-hash pilot:
+      regress cost on per-shard ``n_obs`` across the sidecar history of other
+      templates.
+
+    Parameters
+    ----------
+    catalog_data : dict, optional
+        The loaded shardmap: per-shard granule/obs counts for the tier-1
+        scaling and the tier-2 regressors.
+    template_hash : str, optional
+        The run's template identity (issue #299) used to select tier-1 priors.
+    history : optional
+        Prior-run sidecar records (issue #297) to estimate from.
+
+    Returns
+    -------
+    float or None
+        ``None`` until the sidecar history exists.
+    """
+    return None
+
+
 class LambdaExecutor:
     """Fan out one synchronous boto3 ``invoke`` per unit (the rich backend).
 

--- a/src/zagg/notebook.py
+++ b/src/zagg/notebook.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import html
 import logging
 
-from zagg.config import PipelineConfig, get_windowing
+from zagg.config import PipelineConfig, get_pipeline_type, get_store_layout, get_windowing
 from zagg.dispatch import LAMBDA_ARCH, max_cost_usd
 
 logger = logging.getLogger(__name__)
@@ -40,13 +40,30 @@ def max_cost_preview(
 ) -> dict:
     """Resolve the pre-invoke cost ceiling from shardmap + config alone.
 
-    Mirrors ``_run_lambda``'s unit accounting -- cell selection
-    (``max_cells``/``morton_cell``) and the issue #246 windowed-unit expansion
-    -- so the previewed ceiling equals the one the run logs before fan-out.
+    Mirrors the dispatching path's unit accounting -- cell selection
+    (``max_cells``/``morton_cell``) and the windowed-unit expansion -- so the
+    previewed ceiling equals the one the run logs before fan-out. The unit
+    accounting branches on pipeline kind exactly as :func:`~zagg.runner.agg`:
+    the spatial path expands with :func:`~zagg.runner._windowed_units` (issue
+    #246); the ``reader: raster`` re-route mirrors ``RasterStrategy.run``, whose
+    windowed fan-out (:func:`~zagg.runner._raster_windowed_units`, issue #247)
+    fires only on the hive layout and groups by acquisition, so its unit count
+    differs from the spatial expansion for a windowed-raster config. A temporal
+    run has no shardmap ceiling -- its fan-out unit is the ``events=`` item
+    resolved at call time, not a catalog shard -- so this raises ``ValueError``.
     Returns ``{n_units, memory_gb, arch, timeout_s, max_cost_usd}``. No AWS
     access and no grid-signature check: this is display math, not dispatch.
     """
     from zagg import runner
+
+    kind = get_pipeline_type(config)
+    if kind == "temporal":
+        raise ValueError(
+            "temporal runs take events=; no shardmap ceiling (the fan-out unit "
+            "is the event, resolved at call time, not a catalog shard)"
+        )
+    if kind == "spatial" and (config.data_source or {}).get("reader") == "raster":
+        kind = "raster"
 
     catalog_path = catalog or config.catalog
     if not catalog_path:
@@ -54,7 +71,12 @@ def max_cost_preview(
     catalog_data = runner._load_catalog(catalog_path)
     cells = runner._select_cells(catalog_data, morton_cell=morton_cell, max_cells=max_cells)
     windowing = get_windowing(config)
-    if windowing is not None:
+    if kind == "raster":
+        # Mirror RasterStrategy.run: windowed fan-out only on the hive layout;
+        # otherwise one unit per selected cell (cells == _select_cells).
+        if get_store_layout(config) == "hive" and windowing is not None:
+            cells = runner._raster_windowed_units(cells, windowing)
+    elif windowing is not None:
         cells = runner._windowed_units(cells, windowing, (config.bounds or {}).get("temporal"))
     memory_gb = runner._worker_memory_gb(config)
     timeout_s = runner._DEFAULT_FUNCTION_TIMEOUT_S

--- a/src/zagg/notebook.py
+++ b/src/zagg/notebook.py
@@ -269,7 +269,13 @@ def run(config: PipelineConfig, **kwargs) -> RunView:
 
     total = None
     if kwargs.get("events") is not None:
-        total = len(list(kwargs["events"]))
+        # Materialize once and rebind: a one-shot iterable (generator) would be
+        # exhausted by the count, then forwarded empty to agg -- TemporalStrategy's
+        # ``list(events)`` would yield [] and the run would silently process zero
+        # events. List/tuple inputs are unchanged by the round-trip.
+        events = list(kwargs["events"])
+        kwargs["events"] = events
+        total = len(events)
     elif kwargs.get("catalog") or config.catalog:
         preview = max_cost_preview(
             config,

--- a/src/zagg/notebook.py
+++ b/src/zagg/notebook.py
@@ -1,0 +1,289 @@
+"""Notebook-facing dispatch wrapper: progress bar + rich run report (issue #298).
+
+:func:`run` wraps :func:`zagg.runner.agg` with a per-shard progress bar driven
+by the runner's ``on_progress`` callback (one tick per completed work unit,
+with the running Lambda cost in the postfix) and returns a :class:`RunView`
+whose ``_repr_html_`` renders the cost block, run counters, and failures in
+Jupyter. The notebook path **never blocks on cost** (ratified on issue #298):
+the pre-invoke ceiling is displayed, not confirmed. The CLI's yes/no gate
+(:func:`confirm_max_cost`) lives here too and is wired in ``zagg.__main__``
+behind ``--yes``/``-y``.
+
+tqdm is an *optional* import -- it already rides the dependency closure on
+orchestrator installs (earthaccess -> pqdm -> tqdm) but is deliberately not a
+zagg dependency: a bar when importable, a logging fallback otherwise. Workers
+never import this module, so the ``lambda`` extra is untouched.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+
+from zagg.config import PipelineConfig, get_windowing
+from zagg.dispatch import LAMBDA_ARCH, max_cost_usd
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pre-invoke ceiling
+# ---------------------------------------------------------------------------
+
+
+def max_cost_preview(
+    config: PipelineConfig,
+    catalog: str | None = None,
+    *,
+    max_cells: int | None = None,
+    morton_cell: str | None = None,
+) -> dict:
+    """Resolve the pre-invoke cost ceiling from shardmap + config alone.
+
+    Mirrors ``_run_lambda``'s unit accounting -- cell selection
+    (``max_cells``/``morton_cell``) and the issue #246 windowed-unit expansion
+    -- so the previewed ceiling equals the one the run logs before fan-out.
+    Returns ``{n_units, memory_gb, arch, timeout_s, max_cost_usd}``. No AWS
+    access and no grid-signature check: this is display math, not dispatch.
+    """
+    from zagg import runner
+
+    catalog_path = catalog or config.catalog
+    if not catalog_path:
+        raise ValueError("No catalog specified (pass catalog= or set catalog: in config)")
+    catalog_data = runner._load_catalog(catalog_path)
+    cells = runner._select_cells(catalog_data, morton_cell=morton_cell, max_cells=max_cells)
+    windowing = get_windowing(config)
+    if windowing is not None:
+        cells = runner._windowed_units(cells, windowing, (config.bounds or {}).get("temporal"))
+    memory_gb = runner._worker_memory_gb(config)
+    timeout_s = runner._DEFAULT_FUNCTION_TIMEOUT_S
+    return {
+        "n_units": len(cells),
+        "memory_gb": memory_gb,
+        "arch": LAMBDA_ARCH,
+        "timeout_s": timeout_s,
+        "max_cost_usd": max_cost_usd(len(cells), memory_gb, timeout_s=timeout_s),
+    }
+
+
+def format_max_cost(preview: dict) -> str:
+    """One-line ceiling summary shared by the CLI gate and the notebook display."""
+    return (
+        f"Max cost ceiling: ~${preview['max_cost_usd']:.2f} "
+        f"({preview['n_units']} units x {preview['memory_gb']:g} GB x "
+        f"{preview['timeout_s']:g}s, {preview['arch']})"
+    )
+
+
+def confirm_max_cost(preview: dict, *, assume_yes: bool = False, prompt=None) -> bool:
+    """CLI gate: print the ceiling, ask yes/no. ``assume_yes`` (``--yes``) skips.
+
+    Returns ``True`` to proceed. ``prompt`` defaults to ``input`` (resolved at
+    call time, injectable for tests). Only the CLI blocks -- the notebook path
+    calls :func:`max_cost_preview` for display and never this.
+    """
+    print(format_max_cost(preview))
+    if assume_yes:
+        return True
+    ask = prompt if prompt is not None else input
+    answer = ask("Proceed with Lambda fan-out? [y/N] ")
+    return answer.strip().lower() in ("y", "yes")
+
+
+# ---------------------------------------------------------------------------
+# Progress
+# ---------------------------------------------------------------------------
+
+
+class _LogProgress:
+    """Logging fallback when tqdm is not importable: one line per ~10%.
+
+    ``update`` takes the runner's ``on_progress`` triple verbatim, so the
+    sink IS the callback (``on_progress=progress.update``).
+    """
+
+    def __init__(self, total: int, desc: str):
+        self._total = max(int(total), 1)
+        self._desc = desc
+        self._step = max(self._total // 10, 1)
+
+    def update(self, done: int, total: int, cost_usd: float | None) -> None:
+        if total != self._total:  # adopt the runner's authoritative total
+            self._total = max(int(total), 1)
+            self._step = max(self._total // 10, 1)
+        if done % self._step == 0 or done == self._total:
+            cost = f", ~${cost_usd:.2f}" if cost_usd is not None else ""
+            logger.info(f"{self._desc}: {done}/{self._total}{cost}")
+
+    def close(self) -> None:
+        pass
+
+
+class _TqdmProgress:
+    """tqdm-backed bar; running Lambda cost rides the postfix."""
+
+    def __init__(self, total: int, desc: str, tqdm_cls):
+        self._bar = tqdm_cls(total=total, desc=desc, unit="unit")
+
+    def update(self, done: int, total: int, cost_usd: float | None) -> None:
+        if self._bar.total != total:  # adopt the runner's authoritative total
+            self._bar.total = total
+        # done is the absolute completion count (dispatch's 1-based index);
+        # completion order is nondeterministic so set n rather than += 1.
+        self._bar.n = done
+        if cost_usd is not None:
+            self._bar.set_postfix_str(f"~${cost_usd:.2f}", refresh=False)
+        self._bar.refresh()
+
+    def close(self) -> None:
+        self._bar.close()
+
+
+def _make_progress(total: int, desc: str = "shards"):
+    """A progress sink: tqdm bar when importable, logging fallback otherwise.
+
+    The sink's ``update(done, total, cost_usd)`` matches the runner's
+    ``on_progress`` contract exactly; ``total`` here just pre-sizes the bar
+    (the callback's total wins if they differ).
+    """
+    try:
+        from tqdm.auto import tqdm
+    except ImportError:
+        return _LogProgress(total, desc)
+    return _TqdmProgress(total, desc, tqdm)
+
+
+# ---------------------------------------------------------------------------
+# Run wrapper + report view
+# ---------------------------------------------------------------------------
+
+#: Errors that mean "nothing to do", not "something broke" -- excluded from the
+#: failures table, matching ``_run_lambda``'s error counting.
+_BENIGN_ERRORS = ("No granules found", "No data after filtering")
+
+#: Row cap for the per-shard table in ``_repr_html_``; full detail stays in
+#: ``summary["results"]``.
+_HTML_MAX_ROWS = 20
+
+
+class RunView:
+    """A run summary with a rich Jupyter repr; plain-dict access delegates.
+
+    Wraps the exact dict :func:`zagg.runner.agg` returns (``summary``);
+    ``view["cells_with_data"]`` etc. keep working, so the wrapper adds
+    display without changing the data contract.
+    """
+
+    def __init__(self, summary: dict):
+        self.summary = summary
+
+    def __getitem__(self, key):
+        return self.summary[key]
+
+    def get(self, key, default=None):
+        return self.summary.get(key, default)
+
+    def __repr__(self):
+        s = self.summary
+        done = s.get("cells_with_data", s.get("events_with_data"))
+        errs = s.get("cells_error", s.get("events_error"))
+        return f"RunView(backend={s.get('backend')!r}, with_data={done}, errors={errs})"
+
+    def _failures(self) -> list[dict]:
+        rows = []
+        for r in self.summary.get("results") or []:
+            error = r.get("error")
+            if error and str(error) not in _BENIGN_ERRORS:
+                rows.append(r)
+        return rows
+
+    def _repr_html_(self) -> str:
+        s = self.summary
+        esc = html.escape
+        out = ["<div><h3>zagg run</h3>"]
+        out.append(
+            f"<p><b>backend:</b> {esc(str(s.get('backend')))} &nbsp; "
+            f"<b>store:</b> <code>{esc(str(s.get('store_path')))}</code></p>"
+        )
+
+        # Cost block (issue #298): lambda runs carry summary["cost"]; local
+        # runs have no metered cost.
+        cost = s.get("cost")
+        out.append("<table><tr><th>cost</th><th>USD</th></tr>")
+        if cost:
+            for key, label in (
+                ("max_cost_usd", "max (pre-invoke ceiling)"),
+                ("estimated_cost_usd", "estimated (prior runs)"),
+                ("actual_cost_usd", "actual (billed-duration rollup)"),
+            ):
+                val = cost.get(key)
+                shown = f"${val:.4f}" if val is not None else "n/a"
+                out.append(f"<tr><td>{label}</td><td>{shown}</td></tr>")
+        else:
+            out.append("<tr><td colspan=2>no metered cost (local run)</td></tr>")
+        out.append("</table>")
+
+        # Counters: spatial keys with the temporal spellings as fallback.
+        rows = [
+            ("units", s.get("total_cells", s.get("total_events"))),
+            ("with data", s.get("cells_with_data", s.get("events_with_data"))),
+            ("errors", s.get("cells_error", s.get("events_error"))),
+            ("observations", s.get("total_obs", s.get("timesteps_processed"))),
+            ("wall time (s)", s.get("wall_time_s")),
+            ("lambda time (s)", s.get("lambda_time_s")),
+        ]
+        out.append("<table><tr><th>run</th><th></th></tr>")
+        for label, val in rows:
+            if val is None:
+                continue
+            shown = f"{val:,.1f}" if isinstance(val, float) else f"{val:,}"
+            out.append(f"<tr><td>{label}</td><td>{shown}</td></tr>")
+        out.append("</table>")
+
+        failures = self._failures()
+        if failures:
+            out.append(f"<h4>failures ({len(failures)})</h4>")
+            out.append("<table><tr><th>unit</th><th>error</th></tr>")
+            for r in failures[:_HTML_MAX_ROWS]:
+                key = r.get("shard_key", r.get("event_key"))
+                out.append(f"<tr><td>{esc(str(key))}</td><td>{esc(str(r.get('error')))}</td></tr>")
+            if len(failures) > _HTML_MAX_ROWS:
+                out.append(f"<tr><td colspan=2>... {len(failures) - _HTML_MAX_ROWS} more</td></tr>")
+            out.append("</table>")
+        out.append("</div>")
+        return "".join(out)
+
+
+def run(config: PipelineConfig, **kwargs) -> RunView:
+    """Invoke :func:`zagg.runner.agg` with a progress bar; return a :class:`RunView`.
+
+    Accepts every ``agg`` keyword unchanged. On ``backend="lambda"`` the
+    pre-invoke cost ceiling is *displayed* first (informational only -- this
+    path never prompts, per issue #298; the blocking gate is CLI-only). The
+    bar total is the previewed unit count for catalog runs and ``len(events)``
+    for temporal runs; when neither is resolvable the bar degrades to an
+    unsized tqdm (or the logging fallback).
+    """
+    from zagg import runner
+
+    total = None
+    if kwargs.get("events") is not None:
+        total = len(list(kwargs["events"]))
+    elif kwargs.get("catalog") or config.catalog:
+        preview = max_cost_preview(
+            config,
+            kwargs.get("catalog"),
+            max_cells=kwargs.get("max_cells"),
+            morton_cell=kwargs.get("morton_cell"),
+        )
+        total = preview["n_units"]
+        if kwargs.get("backend") == "lambda":
+            print(format_max_cost(preview))
+
+    progress = _make_progress(total if total is not None else 0)
+    try:
+        summary = runner.agg(config, on_progress=progress.update, **kwargs)
+    finally:
+        progress.close()
+    return RunView(summary)

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -56,6 +56,7 @@ from zagg.dispatch import (
     LocalExecutor,
     PreflightReport,
     dispatch,
+    estimate_cost_usd,
     max_cost_usd,
 )
 from zagg.grids.base import shard_label
@@ -1617,7 +1618,9 @@ def _run_lambda_events(
 
     # Structured cost block (issue #298), mirroring the spatial summary; the
     # legacy flat ``estimated_cost_usd`` key keeps the actual-cost rollup.
+    # estimate_cost_usd is the Phase-3 stub (None until #297/#299 land).
     report.max_cost_usd = run_max_cost
+    report.estimated_cost_usd = estimate_cost_usd()
     report.actual_cost_usd = estimated_cost
     cost_block = {
         "max_cost_usd": run_max_cost,
@@ -2907,11 +2910,12 @@ def _run_lambda(
     estimated_cost = gb_seconds * price_per_gb_sec
 
     # Structured cost block (issue #298): the pre-invoke ceiling, the deferred
-    # prior-history estimate (None until issues #297/#299 land the sidecar
-    # history), and the billed-duration rollup. The legacy flat
-    # ``estimated_cost_usd`` summary key keeps its pre-#298 meaning (the
-    # actual-cost rollup) for existing consumers.
+    # prior-history estimate (the estimate_cost_usd stub -- None until issues
+    # #297/#299 land the sidecar history), and the billed-duration rollup. The
+    # legacy flat ``estimated_cost_usd`` summary key keeps its pre-#298
+    # meaning (the actual-cost rollup) for existing consumers.
     report.max_cost_usd = run_max_cost
+    report.estimated_cost_usd = estimate_cost_usd(catalog_data)
     report.actual_cost_usd = estimated_cost
     cost_block = {
         "max_cost_usd": run_max_cost,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2384,6 +2384,12 @@ def _run_lambda(
     logger.info(f"Processing {len(cells)} of {len(all_shards)} cells (lambda)")
 
     if dry_run:
+        # The pre-invoke cost ceiling is deliberately not surfaced here: the
+        # windowed-unit expansion below runs after this return, so a ceiling on
+        # the pre-windowing shard count would undercount temporal runs (wrong
+        # direction for an upper bound). The phase-2 CLI gate (issue #298) adds
+        # a precompute helper that expands units first and owns the dry-run
+        # ceiling; this path stays a pure shard/granule preview until then.
         return _dry_run_summary(cells, store_path)
 
     # Temporal fan-out (issue #246 phase 5): one work unit per (shard,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -47,6 +47,7 @@ from zagg.config import (
     get_windowing,
 )
 from zagg.dispatch import (
+    LAMBDA_ARCH,
     LAMBDA_MEMORY_GB,
     LAMBDA_PRICE_PER_GB_SEC,
     LAMBDA_RETRY,
@@ -55,6 +56,7 @@ from zagg.dispatch import (
     LocalExecutor,
     PreflightReport,
     dispatch,
+    max_cost_usd,
 )
 from zagg.grids.base import shard_label
 from zagg.grids.morton import morton_word
@@ -91,6 +93,24 @@ def _resolve_function_name(config: PipelineConfig, function_name: str | None) ->
     if worker.get("extra_disk"):
         suffix += "-disk"
     return base + suffix
+
+
+def _worker_memory_gb(config: PipelineConfig) -> float:
+    """Billed memory (GB) of the worker this run dispatches to (issue #298).
+
+    The optional ``worker:`` block selects a pre-provisioned ``-<memory>``
+    variant (issue #235, MB); absent block -> the base function's
+    :data:`~zagg.dispatch.LAMBDA_MEMORY_GB`. Keys both the pre-invoke cost
+    ceiling and the actual-cost rollup so the two use one memory figure. An
+    explicit ``function_name`` kwarg can dispatch to a differently-sized
+    function than the config declares; cost math still keys off the config
+    (the pre-#298 rollup hardcoded 4 GB regardless, so this only narrows the
+    gap).
+    """
+    worker = config.worker
+    if worker and worker.get("memory"):
+        return worker["memory"] / 1024.0
+    return LAMBDA_MEMORY_GB
 
 
 def agg(
@@ -1369,6 +1389,14 @@ def _run_lambda_events(
 
     n = len(event_list)
     logger.info(f"Processing {n} events (lambda)")
+    # Pre-invoke cost ceiling (issue #298), same math as the spatial path: one
+    # invoke per event, each billed at most to the function timeout.
+    memory_gb = _worker_memory_gb(config)
+    run_max_cost = max_cost_usd(n, memory_gb, timeout_s=_DEFAULT_FUNCTION_TIMEOUT_S)
+    logger.info(
+        f"Max cost ceiling: ~${run_max_cost:.2f} ({n} events x {memory_gb:g} GB x "
+        f"{_DEFAULT_FUNCTION_TIMEOUT_S}s, {LAMBDA_ARCH})"
+    )
     if max_workers is None:
         # The AR-repo orchestrator's default fan-out width (one storm per
         # worker); the preflight probe clamps it to account concurrency anyway.
@@ -1452,6 +1480,9 @@ def _run_lambda_events(
         # Tabular output has no metadata to consolidate; keep the executor
         # contract without a finalize invoke.
         finalize_fn=lambda: None,
+        # Per-event cost tracks the worker variant actually billed (issue #298);
+        # without a worker: block this is the default 4.0, byte-identical.
+        memory_gb=memory_gb,
     )
     executor.preflight(n)
     max_workers = state["workers"]
@@ -1511,10 +1542,21 @@ def _run_lambda_events(
     )
 
     # Cost presentation mirrors the spatial path: one multiply over the summed
-    # per-event durations the report accumulated.
+    # per-event durations the report accumulated. memory_gb resolved
+    # pre-fan-out via _worker_memory_gb (issue #298).
     total_lambda_time = report.cost.compute_time_s
-    gb_seconds = total_lambda_time * LAMBDA_MEMORY_GB
+    gb_seconds = total_lambda_time * memory_gb
     estimated_cost = gb_seconds * LAMBDA_PRICE_PER_GB_SEC
+
+    # Structured cost block (issue #298), mirroring the spatial summary; the
+    # legacy flat ``estimated_cost_usd`` key keeps the actual-cost rollup.
+    report.max_cost_usd = run_max_cost
+    report.actual_cost_usd = estimated_cost
+    cost_block = {
+        "max_cost_usd": run_max_cost,
+        "estimated_cost_usd": report.estimated_cost_usd,
+        "actual_cost_usd": estimated_cost,
+    }
 
     # Failed events keep their error detail (rows carry successes only), so a
     # caller can see *which* events failed and why, not just the count --
@@ -1540,6 +1582,7 @@ def _run_lambda_events(
         "gb_seconds": gb_seconds,
         "price_per_gb_sec": LAMBDA_PRICE_PER_GB_SEC,
         "estimated_cost_usd": estimated_cost,
+        "cost": cost_block,
         "function_timeout_s": state.get("function_timeout_s", _DEFAULT_FUNCTION_TIMEOUT_S),
         "store_path": store_path,
         "output_path": output_path,
@@ -2350,6 +2393,18 @@ def _run_lambda(
     if windowing is not None:
         cells = _windowed_units(cells, windowing, (config.bounds or {}).get("temporal"))
 
+    # Pre-invoke cost ceiling (issue #298): every unit is one invoke billed at
+    # the worker's memory for at most the function timeout, so the bill is
+    # bounded from the shardmap + config alone, before any fan-out. Priced with
+    # the deployed-default timeout constant — the live function Timeout is only
+    # readable after preflight builds the client.
+    memory_gb = _worker_memory_gb(config)
+    run_max_cost = max_cost_usd(len(cells), memory_gb, timeout_s=_DEFAULT_FUNCTION_TIMEOUT_S)
+    logger.info(
+        f"Max cost ceiling: ~${run_max_cost:.2f} ({len(cells)} units x {memory_gb:g} GB x "
+        f"{_DEFAULT_FUNCTION_TIMEOUT_S}s, {LAMBDA_ARCH})"
+    )
+
     # Authenticate (for per-cell source reads inside the Lambda)
     s3_creds = _resolve_source_credentials(config)
 
@@ -2570,6 +2625,9 @@ def _run_lambda(
         preflight_fn=_preflight,
         pool_factory=ThreadPoolExecutor,
         finalize_fn=_finalize_fn,
+        # Per-cell cost tracks the worker variant actually billed (issue #298);
+        # without a worker: block this is the default 4.0, byte-identical.
+        memory_gb=memory_gb,
     )
     # preflight() runs the probe, builds the sized client, and sizes the pool.
     executor.preflight(len(cells))
@@ -2761,11 +2819,26 @@ def _run_lambda(
     # ULP of estimated_cost_usd -- stays byte-identical to the pre-refactor path
     # (summing per-cell cost_usd would diverge in FP). Runner owns presentation;
     # the per-cell CellCost.cost_usd is for the report's structured breakdown.
+    # memory_gb resolved pre-fan-out via _worker_memory_gb (issue #298): the
+    # default function keeps 4.0 (byte-identical); a worker: variant now bills
+    # at its actual size instead of the old flat constant.
     total_lambda_time = report.cost.compute_time_s
-    memory_gb = LAMBDA_MEMORY_GB
     gb_seconds = total_lambda_time * memory_gb
     price_per_gb_sec = LAMBDA_PRICE_PER_GB_SEC
     estimated_cost = gb_seconds * price_per_gb_sec
+
+    # Structured cost block (issue #298): the pre-invoke ceiling, the deferred
+    # prior-history estimate (None until issues #297/#299 land the sidecar
+    # history), and the billed-duration rollup. The legacy flat
+    # ``estimated_cost_usd`` summary key keeps its pre-#298 meaning (the
+    # actual-cost rollup) for existing consumers.
+    report.max_cost_usd = run_max_cost
+    report.actual_cost_usd = estimated_cost
+    cost_block = {
+        "max_cost_usd": run_max_cost,
+        "estimated_cost_usd": report.estimated_cost_usd,
+        "actual_cost_usd": estimated_cost,
+    }
 
     # Worker-runtime distribution (issue #100). Wall time on a parallel fan-out
     # tracks the *straggler*, not the mean, so surface max / median / pstdev of
@@ -2818,6 +2891,7 @@ def _run_lambda(
         "gb_seconds": gb_seconds,
         "price_per_gb_sec": price_per_gb_sec,
         "estimated_cost_usd": estimated_cost,
+        "cost": cost_block,
         "setup_s": setup_s,
         "fanout_s": fanout_s,
         "finalize_s": finalize_s,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -95,6 +95,24 @@ def _resolve_function_name(config: PipelineConfig, function_name: str | None) ->
     return base + suffix
 
 
+def _with_progress(accumulate, on_progress, total, *, metered=False):
+    """Wrap a dispatch accumulator with the optional progress hook (issue #298).
+
+    ``on_progress(done, total, cost_usd)`` fires after each unit is folded in;
+    ``cost_usd`` is the report's running metered rollup on Lambda paths
+    (``metered=True``) and ``None`` where nothing is billed. ``None`` hook ->
+    the accumulator is returned untouched, keeping the default path identical.
+    """
+    if on_progress is None:
+        return accumulate
+
+    def wrapped(report, i, result):
+        accumulate(report, i, result)
+        on_progress(i, total, report.cost.cost_usd if metered else None)
+
+    return wrapped
+
+
 def _worker_memory_gb(config: PipelineConfig) -> float:
     """Billed memory (GB) of the worker this run dispatches to (issue #298).
 
@@ -135,6 +153,7 @@ def agg(
     invocation: str = "async",
     force_cold: bool = False,
     events=None,
+    on_progress=None,
 ) -> dict:
     """Run the aggregation pipeline.
 
@@ -259,6 +278,15 @@ def agg(
         invoke per event (see :func:`_run_lambda_events`). Ignored by the
         spatial path. Until the event reader + catalog land, the caller
         supplies events directly (e.g. from a notebook).
+    on_progress : Callable[[int, int, float | None], None], optional
+        Per-completed-unit progress hook (issue #298): called from the
+        dispatch accumulator with ``(done, total, cost_usd)`` -- the 1-based
+        completion count, the unit total, and the running metered cost
+        (``None`` on paths with no metered cost: local backends and the
+        raster fan-out, which carries no per-unit pricing). Drives
+        ``zagg.notebook``'s progress bar; must be cheap and must not raise
+        (it runs on the dispatch thread). Default ``None`` -- no callback,
+        byte-identical prior behavior.
     Returns
     -------
     dict
@@ -296,6 +324,7 @@ def agg(
         invocation=invocation,
         force_cold=force_cold,
         events=events,
+        on_progress=on_progress,
     )
 
 
@@ -331,6 +360,7 @@ class SpatialStrategy:
         invocation="async",
         force_cold=False,
         events=None,
+        on_progress=None,
     ):
         # Resolve catalog and store
         catalog_path = catalog or config.catalog
@@ -386,6 +416,7 @@ class SpatialStrategy:
                 output_credentials=output_credentials,
                 output_endpoint_url=resolved_endpoint,
                 handoff=resolved_handoff,
+                on_progress=on_progress,
             )
         elif backend == "lambda":
             if max_workers is None:
@@ -415,6 +446,7 @@ class SpatialStrategy:
                 max_retries=max_retries,
                 invocation=invocation,
                 force_cold=force_cold,
+                on_progress=on_progress,
             )
         else:
             raise ValueError(f"Unknown backend: {backend!r} (expected 'local' or 'lambda')")
@@ -458,6 +490,7 @@ class TemporalStrategy:
         invocation="async",
         force_cold=False,
         events=None,
+        on_progress=None,
     ):
         from zagg.config import collection_options
         from zagg.temporal import prepare_collection, process_event, specs_from_config
@@ -501,6 +534,7 @@ class TemporalStrategy:
                 max_retries=max_retries,
                 invocation=invocation,
                 force_cold=force_cold,
+                on_progress=on_progress,
             )
 
         if max_workers is None:
@@ -554,13 +588,15 @@ class TemporalStrategy:
                 {"event_key": event_key, "results": outcome["results"], "meta": outcome["meta"]}
             )
 
+        accumulate = _with_progress(_accumulate, on_progress, n)
+
         start_time = time.time()
         try:
             report = dispatch(
                 executor,
                 event_list,
                 retry=LOCAL_RETRY,
-                accumulate=_accumulate,
+                accumulate=accumulate,
             )
         finally:
             executor.shutdown()
@@ -686,6 +722,7 @@ class RasterStrategy:
         output_endpoint_url,
         profile=False,
         invocation="async",
+        on_progress=None,
         **_ignored,
     ):
         from zagg.processing.raster import (
@@ -764,6 +801,7 @@ class RasterStrategy:
                 dataset={"short_name": md.get("short_name"), "version": md.get("version")},
                 profile=profile,
                 invocation=invocation,
+                on_progress=on_progress,
             )
 
         # Local backend: template emission stays orchestrator-owned (the
@@ -870,7 +908,7 @@ class RasterStrategy:
         stage_counts: dict = {}
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {pool.submit(_one, pair): pair[0] for pair in cells}
-            for fut in as_completed(futures):
+            for i, fut in enumerate(as_completed(futures), 1):
                 label = shard_label(grid, futures[fut])
                 try:
                     meta, stage_stats, write_s = fut.result()
@@ -879,6 +917,10 @@ class RasterStrategy:
                     last_error = e
                     logger.warning(f"raster shard {label} failed: {e}")
                     continue
+                finally:
+                    # Progress hook (issue #298): local raster has no metered cost.
+                    if on_progress is not None:
+                        on_progress(i, len(cells), None)
                 ok_metas.append(meta)
                 if meta["timesteps"]:
                     shards_with_data += 1
@@ -967,6 +1009,7 @@ class RasterStrategy:
         dataset=None,
         profile=False,
         invocation="async",
+        on_progress=None,
     ):
         """Fan shards out, one ``mode="process_raster"`` invoke each.
 
@@ -1165,9 +1208,13 @@ class RasterStrategy:
         ok_units: list = []  # (shard_key, body) — coverage needs keys, rollups bodies
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {pool.submit(_one, pair): pair[0] for pair in cells}
-            for fut in as_completed(futures):
+            for i, fut in enumerate(as_completed(futures), 1):
                 label = shard_label(grid, futures[fut])
                 result = fut.result()
+                # Progress hook (issue #298): the raster fan-out has no
+                # per-unit pricing rollup, so the running cost rides as None.
+                if on_progress is not None:
+                    on_progress(i, len(cells), None)
                 if result["error"]:
                     errors += 1
                     last_error = result["error"]
@@ -1306,6 +1353,7 @@ def _run_lambda_events(
     max_retries=3,
     invocation="async",
     force_cold=False,
+    on_progress=None,
 ):
     """Fan the temporal pipeline out one event per Lambda invoke (issue #12, Phase 8).
 
@@ -1518,12 +1566,14 @@ def _run_lambda_events(
             rate = i / elapsed if elapsed > 0 else 0
             logger.info(f"  [{i:4d}/{n}] {rate:.1f} events/s")
 
+    accumulate = _with_progress(_accumulate, on_progress, n, metered=True)
+
     try:
         report = dispatch(
             executor,
             event_list,
             retry=LAMBDA_RETRY,
-            accumulate=_accumulate,
+            accumulate=accumulate,
             on_submit_error=lambda e: raise_for_fd_exhaustion(e, max_workers),
         )
     finally:
@@ -2088,6 +2138,7 @@ def _run_local(
     output_credentials=None,
     output_endpoint_url=None,
     handoff="arrow",
+    on_progress=None,
 ):
     """Run processing locally via the generic dispatch loop on a thread pool.
 
@@ -2251,13 +2302,15 @@ def _run_local(
             if i % 10 == 0 or n <= 20:
                 logger.info(f"  [{i}/{n}] {label}: {obs:,} obs")
 
+    accumulate = _with_progress(_accumulate, on_progress, n)
+
     start_time = time.time()
     try:
         report = dispatch(
             executor,
             cells,
             retry=LOCAL_RETRY,
-            accumulate=_accumulate,
+            accumulate=accumulate,
         )
     finally:
         executor.shutdown()
@@ -2347,6 +2400,7 @@ def _run_lambda(
     max_retries=3,
     invocation="async",
     force_cold=False,
+    on_progress=None,
 ):
     """Run processing via AWS Lambda invocation.
 
@@ -2726,12 +2780,14 @@ def _run_lambda(
             rate = i / elapsed if elapsed > 0 else 0
             logger.info(f"  [{i:4d}/{n}] {rate:.1f} cells/s")
 
+    accumulate = _with_progress(_accumulate, on_progress, n, metered=True)
+
     try:
         report = dispatch(
             executor,
             cells,
             retry=LAMBDA_RETRY,
-            accumulate=_accumulate,
+            accumulate=accumulate,
             # _invoke_lambda_cell already re-raises FD exhaustion with ulimit
             # guidance; this is a backstop for exhaustion that surfaces outside
             # the cell body (e.g. at submit time). Other exceptions propagate.

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -102,13 +102,19 @@ def _with_progress(accumulate, on_progress, total, *, metered=False):
     ``cost_usd`` is the report's running metered rollup on Lambda paths
     (``metered=True``) and ``None`` where nothing is billed. ``None`` hook ->
     the accumulator is returned untouched, keeping the default path identical.
+    The counters/results are already folded before the hook runs, so a raising
+    hook is swallowed (losing only the tick): a cosmetic progress display must
+    not unwind a paid fan-out mid-flight.
     """
     if on_progress is None:
         return accumulate
 
     def wrapped(report, i, result):
         accumulate(report, i, result)
-        on_progress(i, total, report.cost.cost_usd if metered else None)
+        try:
+            on_progress(i, total, report.cost.cost_usd if metered else None)
+        except Exception:  # noqa: BLE001 - progress is cosmetic, never fatal
+            logger.warning("on_progress hook raised; ignoring", exc_info=True)
 
     return wrapped
 
@@ -284,9 +290,10 @@ def agg(
         completion count, the unit total, and the running metered cost
         (``None`` on paths with no metered cost: local backends and the
         raster fan-out, which carries no per-unit pricing). Drives
-        ``zagg.notebook``'s progress bar; must be cheap and must not raise
-        (it runs on the dispatch thread). Default ``None`` -- no callback,
-        byte-identical prior behavior.
+        ``zagg.notebook``'s progress bar; it runs on the dispatch thread, so it
+        must be cheap. A raising hook is caught and logged, never propagated --
+        a cosmetic progress display must not unwind a paid fan-out mid-flight.
+        Default ``None`` -- no callback, byte-identical prior behavior.
     Returns
     -------
     dict
@@ -918,9 +925,14 @@ class RasterStrategy:
                     logger.warning(f"raster shard {label} failed: {e}")
                     continue
                 finally:
-                    # Progress hook (issue #298): local raster has no metered cost.
+                    # Progress hook (issue #298): local raster has no metered
+                    # cost. A raising hook is swallowed -- progress is cosmetic
+                    # and must not unwind the run (mirrors _with_progress).
                     if on_progress is not None:
-                        on_progress(i, len(cells), None)
+                        try:
+                            on_progress(i, len(cells), None)
+                        except Exception:  # noqa: BLE001 - progress is cosmetic, never fatal
+                            logger.warning("on_progress hook raised; ignoring", exc_info=True)
                 ok_metas.append(meta)
                 if meta["timesteps"]:
                     shards_with_data += 1
@@ -1212,9 +1224,14 @@ class RasterStrategy:
                 label = shard_label(grid, futures[fut])
                 result = fut.result()
                 # Progress hook (issue #298): the raster fan-out has no
-                # per-unit pricing rollup, so the running cost rides as None.
+                # per-unit pricing rollup, so the running cost rides as None. A
+                # raising hook is swallowed -- progress is cosmetic and must not
+                # unwind a paid fan-out (mirrors _with_progress).
                 if on_progress is not None:
-                    on_progress(i, len(cells), None)
+                    try:
+                        on_progress(i, len(cells), None)
+                    except Exception:  # noqa: BLE001 - progress is cosmetic, never fatal
+                        logger.warning("on_progress hook raised; ignoring", exc_info=True)
                 if result["error"]:
                     errors += 1
                     last_error = result["error"]

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -13,8 +13,10 @@ from concurrent.futures import Future, ThreadPoolExecutor
 import pytest
 
 from zagg.dispatch import (
+    LAMBDA_ARCH,
     LAMBDA_MEMORY_GB,
     LAMBDA_PRICE_PER_GB_SEC,
+    LAMBDA_PRICE_PER_GB_SEC_BY_ARCH,
     LAMBDA_RETRY,
     LOCAL_RETRY,
     CellCost,
@@ -25,6 +27,7 @@ from zagg.dispatch import (
     RunReport,
     dispatch,
     lambda_classify,
+    max_cost_usd,
     never_classify,
 )
 
@@ -132,6 +135,46 @@ class TestLambdaExecutor:
         ex = self._make(finalize_fn=_fin)
         ex.finalize()
         assert called["n"] == 1
+
+
+class TestMaxCostUsd:
+    """Pre-invoke cost ceiling math against the price table (issue #298)."""
+
+    def test_matches_price_table(self):
+        # 100 shards x 4 GB x 900 s at the arm64 rate.
+        expected = 100 * LAMBDA_PRICE_PER_GB_SEC_BY_ARCH["arm64"] * 4.0 * 900
+        assert max_cost_usd(100, 4.0, timeout_s=900) == pytest.approx(expected)
+
+    def test_scales_with_memory_variant(self):
+        # An 8 GB worker: variant (issue #235) doubles the 4 GB ceiling.
+        four = max_cost_usd(10, 4.0, timeout_s=900)
+        eight = max_cost_usd(10, 8.0, timeout_s=900)
+        assert eight == pytest.approx(2 * four)
+
+    def test_default_arch_is_the_deployed_fleet(self):
+        # Only arm64 is deployed (template.yaml Architecture default); the
+        # flat constant must stay an alias into the table.
+        assert LAMBDA_ARCH == "arm64"
+        assert LAMBDA_PRICE_PER_GB_SEC == LAMBDA_PRICE_PER_GB_SEC_BY_ARCH[LAMBDA_ARCH]
+        assert max_cost_usd(1, 1.0, timeout_s=1, arch="arm64") == pytest.approx(
+            LAMBDA_PRICE_PER_GB_SEC
+        )
+
+    def test_unknown_arch_raises(self):
+        # Pricing must fail loudly, never silently fall back to another rate.
+        with pytest.raises(KeyError):
+            max_cost_usd(1, 4.0, timeout_s=900, arch="riscv")
+
+    def test_zero_shards_costs_nothing(self):
+        assert max_cost_usd(0, 4.0, timeout_s=900) == 0.0
+
+    def test_run_report_cost_fields_default_none(self):
+        # Local runs never stamp the block; the defaults must read as "no
+        # metered cost", and finalize()'s empty-report contract still holds.
+        report = RunReport()
+        assert report.max_cost_usd is None
+        assert report.estimated_cost_usd is None
+        assert report.actual_cost_usd is None
 
 
 class TestDispatchLoop:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -168,6 +168,14 @@ class TestMaxCostUsd:
     def test_zero_shards_costs_nothing(self):
         assert max_cost_usd(0, 4.0, timeout_s=900) == 0.0
 
+    def test_estimator_stub_returns_none(self):
+        # Phase-3 interface stub (pilot-first / regression tiers): always None
+        # until issues #297/#299 land the sidecar history it reads.
+        from zagg.dispatch import estimate_cost_usd
+
+        assert estimate_cost_usd() is None
+        assert estimate_cost_usd({"shard_keys": [1]}, template_hash="abc", history=[]) is None
+
     def test_run_report_cost_fields_default_none(self):
         # Local runs never stamp the block; the defaults must read as "no
         # metered cost", and finalize()'s empty-report contract still holds.

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -241,6 +241,39 @@ class TestRunWrapper:
         notebook.run(default_config("atl06"), events=[{"event_key": "a"}, {"event_key": "b"}])
         assert totals == [2]
 
+    def test_events_generator_not_exhausted_by_count(self, monkeypatch):
+        # A one-shot generator must survive to agg: run() counts it once for the
+        # bar total, then rebinds the materialized list so TemporalStrategy's
+        # list(events) still sees every event (issue #298 fold).
+        totals = []
+        seen = {}
+
+        class _Recorder:
+            def update(self, done, total, cost_usd):
+                pass
+
+            def close(self):
+                pass
+
+        def _factory(total, desc="shards"):
+            totals.append(total)
+            return _Recorder()
+
+        def _fake_agg(config, *, events=None, on_progress=None, **k):
+            seen["events"] = list(events)
+            return {"backend": "local"}
+
+        monkeypatch.setattr("zagg.runner.agg", _fake_agg)
+        monkeypatch.setattr(notebook, "_make_progress", _factory)
+        gen = (e for e in ({"event_key": "a"}, {"event_key": "b"}, {"event_key": "c"}))
+        notebook.run(default_config("atl06"), events=gen)
+        assert totals == [3]
+        assert seen["events"] == [
+            {"event_key": "a"},
+            {"event_key": "b"},
+            {"event_key": "c"},
+        ]
+
 
 class TestConfirmMaxCost:
     def test_yes_answer_proceeds(self, capsys):

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,0 +1,332 @@
+"""Tests for the notebook dispatch wrapper + CLI cost gate (issue #298).
+
+Covers the pre-invoke ceiling preview (in-tree shardmap, no AWS), the
+tqdm-present and tqdm-absent progress paths, the :class:`~zagg.notebook.RunView`
+HTML report, the non-blocking notebook ``run`` wrapper, and the blocking
+CLI-only ``--yes``-skippable confirm gate.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from zagg import notebook
+from zagg.config import default_config
+from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC_BY_ARCH
+
+# 4-shard ATL03 shardmap checked into the tree (benchmark fixture).
+SHARDMAP = str(Path(__file__).parent / "data" / "benchmark" / "shardmaps" / "sm_healpix_o9.json")
+
+
+def _preview_stub():
+    return {
+        "n_units": 4,
+        "memory_gb": 4.0,
+        "arch": "arm64",
+        "timeout_s": 900,
+        "max_cost_usd": 0.192,
+    }
+
+
+def _lambda_summary():
+    return {
+        "backend": "lambda",
+        "store_path": "s3://bucket/x.zarr",
+        "total_cells": 3,
+        "cells_with_data": 2,
+        "cells_error": 1,
+        "total_obs": 100,
+        "wall_time_s": 12.5,
+        "lambda_time_s": 30.0,
+        "cost": {"max_cost_usd": 0.5, "estimated_cost_usd": None, "actual_cost_usd": 0.01},
+        "results": [
+            {"shard_key": 1, "status_code": 200, "error": None},
+            {"shard_key": 2, "status_code": 200, "error": "No granules found"},
+            {"shard_key": 3, "status_code": 500, "error": "boom <tag>"},
+        ],
+    }
+
+
+class TestMaxCostPreview:
+    def test_preview_from_in_tree_shardmap(self):
+        cfg = default_config("atl06")
+        preview = notebook.max_cost_preview(cfg, SHARDMAP)
+        assert preview["n_units"] == 4
+        assert preview["memory_gb"] == 4.0
+        assert preview["arch"] == "arm64"
+        assert preview["timeout_s"] == 900
+        rate = LAMBDA_PRICE_PER_GB_SEC_BY_ARCH["arm64"]
+        assert preview["max_cost_usd"] == pytest.approx(4 * rate * 4.0 * 900)
+
+    def test_max_cells_clamps_units(self):
+        cfg = default_config("atl06")
+        preview = notebook.max_cost_preview(cfg, SHARDMAP, max_cells=2)
+        assert preview["n_units"] == 2
+
+    def test_worker_variant_scales_ceiling(self):
+        cfg = default_config("atl06")
+        base = notebook.max_cost_preview(cfg, SHARDMAP)
+        cfg.worker = {"memory": 8192}
+        assert notebook.max_cost_preview(cfg, SHARDMAP)["max_cost_usd"] == pytest.approx(
+            2 * base["max_cost_usd"]
+        )
+
+    def test_no_catalog_raises(self):
+        cfg = default_config("atl06")
+        cfg.catalog = None
+        with pytest.raises(ValueError, match="catalog"):
+            notebook.max_cost_preview(cfg)
+
+    def test_format_max_cost_line(self):
+        line = notebook.format_max_cost(_preview_stub())
+        assert "Max cost ceiling: ~$0.19" in line
+        assert "4 units x 4 GB x 900s, arm64" in line
+
+
+class TestProgressFactory:
+    def test_tqdm_present_returns_bar(self):
+        # tqdm rides the test env's dependency closure (earthaccess -> pqdm).
+        progress = notebook._make_progress(10)
+        assert isinstance(progress, notebook._TqdmProgress)
+        progress.update(3, 10, 1.5)
+        assert progress._bar.n == 3
+        progress.update(10, 10, None)
+        assert progress._bar.n == 10
+        progress.close()
+
+    def test_tqdm_bar_adopts_runner_total(self):
+        # An unsized wrapper (total unknown up front) adopts the callback's
+        # authoritative total on the first tick.
+        progress = notebook._make_progress(0)
+        progress.update(1, 7, None)
+        assert progress._bar.total == 7
+        progress.close()
+
+    def test_tqdm_absent_falls_back_to_logging(self, monkeypatch, caplog):
+        # None in sys.modules makes `from tqdm.auto import tqdm` raise
+        # ImportError -- the "not installed" path without uninstalling.
+        monkeypatch.setitem(sys.modules, "tqdm", None)
+        monkeypatch.setitem(sys.modules, "tqdm.auto", None)
+        progress = notebook._make_progress(10)
+        assert isinstance(progress, notebook._LogProgress)
+        with caplog.at_level("INFO", logger="zagg.notebook"):
+            progress.update(3, 10, 0.5)
+            progress.update(10, 10, 1.25)
+        assert "3/10" in caplog.text
+        assert "10/10" in caplog.text
+        assert "$1.25" in caplog.text
+        progress.close()
+
+    def test_logging_fallback_handles_unmetered_cost(self, monkeypatch, caplog):
+        monkeypatch.setitem(sys.modules, "tqdm", None)
+        monkeypatch.setitem(sys.modules, "tqdm.auto", None)
+        progress = notebook._make_progress(2)
+        with caplog.at_level("INFO", logger="zagg.notebook"):
+            progress.update(2, 2, None)
+        assert "2/2" in caplog.text
+        assert "$" not in caplog.text
+
+
+class TestRunView:
+    def test_repr_html_renders_cost_block(self):
+        html_out = notebook.RunView(_lambda_summary())._repr_html_()
+        assert "$0.5000" in html_out  # max ceiling
+        assert "n/a" in html_out  # estimated: None placeholder until #297/#299
+        assert "$0.0100" in html_out  # actual rollup
+
+    def test_repr_html_failures_escaped_and_benign_excluded(self):
+        html_out = notebook.RunView(_lambda_summary())._repr_html_()
+        assert "boom &lt;tag&gt;" in html_out
+        # Benign "nothing to do" outcomes are not failures (matches the
+        # runner's error counting).
+        assert "No granules found" not in html_out
+
+    def test_local_summary_shows_no_metered_cost(self):
+        view = notebook.RunView(
+            {
+                "backend": "local",
+                "store_path": "./x.zarr",
+                "total_cells": 1,
+                "cells_with_data": 1,
+                "cells_error": 0,
+                "total_obs": 5,
+                "wall_time_s": 1.0,
+                "results": [],
+            }
+        )
+        html_out = view._repr_html_()
+        assert "no metered cost" in html_out
+        assert "$" not in html_out
+
+    def test_dict_access_delegates(self):
+        view = notebook.RunView(_lambda_summary())
+        assert view["backend"] == "lambda"
+        assert view.get("missing") is None
+        assert "with_data=2" in repr(view)
+
+
+class TestRunWrapper:
+    def test_drives_progress_from_agg_callback(self, monkeypatch):
+        recorded = []
+
+        class _Recorder:
+            def update(self, done, total, cost_usd):
+                recorded.append((done, total, cost_usd))
+
+            def close(self):
+                recorded.append("closed")
+
+        def fake_agg(config, *, on_progress=None, **kwargs):
+            for i in (1, 2):
+                on_progress(i, 2, 0.25 * i)
+            return _lambda_summary()
+
+        monkeypatch.setattr("zagg.runner.agg", fake_agg)
+        monkeypatch.setattr(notebook, "_make_progress", lambda total, desc="shards": _Recorder())
+        view = notebook.run(default_config("atl06"), catalog=SHARDMAP, backend="local")
+        assert isinstance(view, notebook.RunView)
+        assert recorded == [(1, 2, 0.25), (2, 2, 0.5), "closed"]
+
+    def test_lambda_backend_prints_ceiling_and_never_prompts(self, monkeypatch, capsys):
+        # The notebook path is informational only (ratified on issue #298):
+        # any input() call is a failure.
+        import builtins
+
+        def _no_prompt(*a, **k):
+            raise AssertionError("notebook path must never prompt")
+
+        monkeypatch.setattr(builtins, "input", _no_prompt)
+        monkeypatch.setattr("zagg.runner.agg", lambda config, **k: _lambda_summary())
+        view = notebook.run(default_config("atl06"), catalog=SHARDMAP, backend="lambda")
+        out = capsys.readouterr().out
+        assert "Max cost ceiling" in out
+        assert view["backend"] == "lambda"
+
+    def test_progress_closed_when_agg_raises(self, monkeypatch):
+        closed = []
+
+        class _Recorder:
+            def update(self, done, total, cost_usd):
+                pass
+
+            def close(self):
+                closed.append(True)
+
+        def fake_agg(config, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("zagg.runner.agg", fake_agg)
+        monkeypatch.setattr(notebook, "_make_progress", lambda total, desc="shards": _Recorder())
+        with pytest.raises(RuntimeError, match="boom"):
+            notebook.run(default_config("atl06"), catalog=SHARDMAP, backend="local")
+        assert closed == [True]
+
+    def test_events_run_sizes_bar_from_event_count(self, monkeypatch):
+        totals = []
+
+        class _Recorder:
+            def update(self, done, total, cost_usd):
+                pass
+
+            def close(self):
+                pass
+
+        def _factory(total, desc="shards"):
+            totals.append(total)
+            return _Recorder()
+
+        monkeypatch.setattr("zagg.runner.agg", lambda config, **k: {"backend": "local"})
+        monkeypatch.setattr(notebook, "_make_progress", _factory)
+        notebook.run(default_config("atl06"), events=[{"event_key": "a"}, {"event_key": "b"}])
+        assert totals == [2]
+
+
+class TestConfirmMaxCost:
+    def test_yes_answer_proceeds(self, capsys):
+        assert notebook.confirm_max_cost(_preview_stub(), prompt=lambda q: "y") is True
+        assert "Max cost ceiling" in capsys.readouterr().out
+
+    def test_default_empty_answer_declines(self, capsys):
+        assert notebook.confirm_max_cost(_preview_stub(), prompt=lambda q: "") is False
+
+    def test_no_answer_declines(self, capsys):
+        assert notebook.confirm_max_cost(_preview_stub(), prompt=lambda q: "n") is False
+
+    def test_assume_yes_skips_prompt_but_prints(self, capsys):
+        def _boom(q):
+            raise AssertionError("--yes must skip the prompt")
+
+        assert notebook.confirm_max_cost(_preview_stub(), assume_yes=True, prompt=_boom) is True
+        assert "Max cost ceiling" in capsys.readouterr().out
+
+
+class TestCliGate:
+    """The __main__ gate blocks a Lambda fan-out until confirmed; --yes skips."""
+
+    def _drive(self, monkeypatch, argv, answer=None, assume_called=None):
+        import zagg.__main__ as cli
+
+        called = {"agg": False}
+
+        def _fake_agg(config, **kwargs):
+            called["agg"] = True
+            return _lambda_summary()
+
+        cfg = default_config("atl06")
+        cfg.catalog = SHARDMAP
+        monkeypatch.setattr(cli, "agg", _fake_agg)
+        monkeypatch.setattr(cli, "load_config", lambda path: cfg)
+        if answer is not None:
+            import builtins
+
+            monkeypatch.setattr(builtins, "input", lambda q: answer)
+        monkeypatch.setattr("sys.argv", argv)
+        return cli, called
+
+    def test_declined_gate_aborts_before_agg(self, monkeypatch, capsys):
+        cli, called = self._drive(
+            monkeypatch,
+            ["zagg", "--config", "c.yaml", "--backend", "lambda"],
+            answer="",
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+        assert exc_info.value.code == 1
+        assert called["agg"] is False
+        assert "Aborted" in capsys.readouterr().out
+
+    def test_confirmed_gate_proceeds(self, monkeypatch, capsys):
+        cli, called = self._drive(
+            monkeypatch,
+            ["zagg", "--config", "c.yaml", "--backend", "lambda"],
+            answer="y",
+        )
+        cli.main()
+        assert called["agg"] is True
+
+    def test_yes_flag_skips_prompt(self, monkeypatch, capsys):
+        import builtins
+
+        def _boom(q):
+            raise AssertionError("--yes must skip the prompt")
+
+        monkeypatch.setattr(builtins, "input", _boom)
+        cli, called = self._drive(
+            monkeypatch,
+            ["zagg", "--config", "c.yaml", "--backend", "lambda", "--yes"],
+        )
+        cli.main()
+        assert called["agg"] is True
+        assert "Max cost ceiling" in capsys.readouterr().out
+
+    def test_local_backend_never_gated(self, monkeypatch, capsys):
+        import builtins
+
+        def _boom(q):
+            raise AssertionError("local backend must not prompt")
+
+        monkeypatch.setattr(builtins, "input", _boom)
+        cli, called = self._drive(monkeypatch, ["zagg", "--config", "c.yaml"])
+        cli.main()
+        assert called["agg"] is True

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -83,6 +83,53 @@ class TestMaxCostPreview:
         assert "Max cost ceiling: ~$0.19" in line
         assert "4 units x 4 GB x 900s, arm64" in line
 
+    def test_temporal_config_has_no_shardmap_ceiling(self):
+        # A temporal run's fan-out unit is the event, not a catalog shard, so
+        # there is no shardmap ceiling to preview -- raise rather than bill a
+        # meaningless shard-based figure (issue #298 fold).
+        cfg = default_config("atl06")
+        cfg.pipeline = {"type": "temporal"}
+        with pytest.raises(ValueError, match="temporal runs take events="):
+            notebook.max_cost_preview(cfg, SHARDMAP)
+
+    def test_raster_nonwindowed_counts_selected_cells(self, monkeypatch):
+        # reader: raster on a flat (non-hive) layout fans out one unit per
+        # selected cell (cells == _select_cells); the spatial windowed
+        # expansion must never run on a raster config.
+        from zagg import runner
+
+        cfg = default_config("atl06")
+        cfg.data_source["reader"] = "raster"
+        cfg.output["store_layout"] = "flat"
+        monkeypatch.setattr(
+            runner,
+            "_windowed_units",
+            lambda *a, **k: pytest.fail("spatial _windowed_units ran on a raster config"),
+        )
+        preview = notebook.max_cost_preview(cfg, SHARDMAP)
+        assert preview["n_units"] == 4
+
+    def test_windowed_raster_uses_raster_units(self, monkeypatch):
+        # A windowed hive raster mirrors RasterStrategy.run: the (shard, window)
+        # count comes from _raster_windowed_units, never the spatial
+        # _windowed_units -- their membership rules differ (issue #247 fold).
+        from zagg import runner
+
+        cfg = default_config("atl06")
+        cfg.data_source["reader"] = "raster"
+        cfg.output["store_layout"] = "hive"
+        cfg.output["windowing"] = {"schedule": "monthly"}
+        monkeypatch.setattr(
+            runner, "_raster_windowed_units", lambda cells, windowing: [object()] * 7
+        )
+        monkeypatch.setattr(
+            runner,
+            "_windowed_units",
+            lambda *a, **k: pytest.fail("spatial _windowed_units ran on a raster config"),
+        )
+        preview = notebook.max_cost_preview(cfg, SHARDMAP)
+        assert preview["n_units"] == 7
+
 
 class TestProgressFactory:
     def test_tqdm_present_returns_bar(self):
@@ -363,3 +410,31 @@ class TestCliGate:
         cli, called = self._drive(monkeypatch, ["zagg", "--config", "c.yaml"])
         cli.main()
         assert called["agg"] is True
+
+    def test_temporal_backend_skips_gate(self, monkeypatch, capsys):
+        # Temporal configs have no shardmap ceiling (max_cost_preview raises)
+        # and no CLI events source, so the gate skips them outright: no prompt,
+        # no ceiling printed, straight to agg (issue #298 fold).
+        import builtins
+
+        import zagg.__main__ as cli
+
+        called = {"agg": False}
+
+        def _fake_agg(config, **kwargs):
+            called["agg"] = True
+            return _lambda_summary()
+
+        def _boom(q):
+            raise AssertionError("temporal runs have no shardmap ceiling -- no prompt")
+
+        cfg = default_config("atl06")
+        cfg.catalog = SHARDMAP
+        cfg.pipeline = {"type": "temporal"}
+        monkeypatch.setattr(cli, "agg", _fake_agg)
+        monkeypatch.setattr(cli, "load_config", lambda path: cfg)
+        monkeypatch.setattr(builtins, "input", _boom)
+        monkeypatch.setattr("sys.argv", ["zagg", "--config", "c.yaml", "--backend", "lambda"])
+        cli.main()
+        assert called["agg"] is True
+        assert "Max cost ceiling" not in capsys.readouterr().out

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -209,6 +209,53 @@ class TestRasterAgg:
             np.testing.assert_array_equal(got[valid], data[rows[valid], cols[valid]])
             assert (got[~valid] == 0).all()
 
+    def test_local_on_progress_ticks_including_failed_shard(self, tmp_path):
+        # Progress hook (issue #298 fold): the local raster loop ticks once per
+        # completed shard -- 1-based, monotone, total = shard count, cost=None
+        # (no metered cost) -- and the tick sits in a finally after the bare
+        # except/continue, so a FAILED shard still ticks. Two shards, one of
+        # which raises: its lone granule's asset map lacks the configured band.
+        cfg = _cfg(tmp_path)
+        data0 = _index_raster()
+        _write_tiff(tmp_path / "s0.tif", data0)
+        shard0 = _shard_for_raster_at(0.0)
+        shard1 = _shard_for_raster_at(7000.0)
+        assert shard0 != shard1
+        grid = from_config(cfg)
+        # shard1's granule carries assets WITHOUT the configured "red" band, so
+        # sample_item_async raises for that shard only (shard0 still writes).
+        bad = {
+            "id": "g1",
+            "s3": None,
+            "https": None,
+            "assets": {"green": str(tmp_path / "s0.tif")},
+            "datetime": T0,
+            "time_key": "dt-1",
+        }
+        sm = ShardMap(
+            grid.spatial_signature(),
+            [shard0, shard1],
+            [[_entry("g0", str(tmp_path / "s0.tif"), T0, "dt-1")], [bad]],
+            {"collection": "s2-test"},
+        )
+        path = str(tmp_path / "sm_fail.json")
+        sm.to_json(path)
+
+        ticks = []
+        summary = agg(
+            cfg,
+            catalog=path,
+            backend="local",
+            max_workers=1,
+            on_progress=lambda done, total, cost: ticks.append((done, total, cost)),
+        )
+        assert summary["cells_error"] == 1
+        assert summary["cells_with_data"] == 1
+        # Both shards tick (the failing one included), 1-based and monotone.
+        assert [t[0] for t in ticks] == [1, 2]
+        assert all(t[1] == 2 for t in ticks)  # runner's authoritative total
+        assert all(t[2] is None for t in ticks)  # local raster: no metered cost
+
     def test_signature_mismatch_raises(self, tmp_path, manifest):
         # A ShardMap built under a different grid (parent 9 / child 15) than the
         # run config (parent 10 / child 16) must be refused by _check_signature.
@@ -367,6 +414,33 @@ class TestRasterLambdaBackend:
         # Always-on telemetry rollups are null-safe on a body without them.
         assert summary["lambda_time_s"] is None and summary["max_memory_mb"] is None
         assert summary["template_s"] >= 0.0
+
+    def test_on_progress_ticks_on_lambda_fanout(self, manifest, monkeypatch):
+        # Progress hook (issue #298 fold): the lambda raster fan-out ticks once
+        # per completed shard -- 1-based, total = shard count, cost=None (the
+        # raster fan-out carries no per-unit pricing rollup). The lifecycle
+        # invokes (ping/setup) never tick; only the process_raster fan-out does.
+        import boto3
+
+        cfg, sm_path, shard, _data = manifest
+
+        def responder(event):
+            body = {"timesteps": len(event["time_index"]), "cells_with_data": 4096}
+            return {"statusCode": 200, "body": json.dumps(body)}
+
+        fake = _FakeLambdaClient(_lifecycle(responder))
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
+        ticks = []
+        agg(
+            cfg,
+            catalog=sm_path,
+            store="s3://bucket/out.zarr",
+            backend="lambda",
+            max_workers=2,
+            invocation="sync",
+            on_progress=lambda done, total, cost: ticks.append((done, total, cost)),
+        )
+        assert ticks == [(1, 1, None)]
 
     def test_lifecycle_order_and_setup_event_pinned(self, manifest, monkeypatch):
         # The wire-level pin of the raster lifecycle (issue #264): ping →

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2532,6 +2532,19 @@ class TestTemporalStrategy:
         assert by_key["storm1"]["results"]["max_t2m"] == pytest.approx(5.0)
         assert by_key["storm2"]["results"]["max_t2m"] == pytest.approx(9.0)
 
+    def test_on_progress_fires_per_event_with_no_metered_cost(self):
+        # Progress hook (issue #298 phase 2) on the temporal local path: one
+        # call per event; local carries no metered cost, so cost rides as None.
+        from zagg.runner import agg
+
+        seen = []
+        agg(
+            _temporal_config(),
+            events=_synthetic_events(),
+            on_progress=lambda done, total, cost: seen.append((done, total, cost)),
+        )
+        assert sorted(seen) == [(1, 2, None), (2, 2, None)]
+
     def test_max_cells_truncates_events(self):
         from zagg.runner import agg
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2545,6 +2545,20 @@ class TestTemporalStrategy:
         )
         assert sorted(seen) == [(1, 2, None), (2, 2, None)]
 
+    def test_raising_on_progress_hook_does_not_unwind_run(self):
+        # A cosmetic progress display must not kill a run mid-flight: a hook
+        # that raises is caught and logged by _with_progress, the run completes
+        # normally and still returns its summary (issue #298 fold).
+        from zagg.runner import agg
+
+        def _boom(done, total, cost):
+            raise RuntimeError("hook boom")
+
+        summary = agg(_temporal_config(), events=_synthetic_events(), on_progress=_boom)
+        assert summary["backend"] == "local"
+        assert summary["total_events"] == 2
+        assert summary["events_with_data"] == 2
+
     def test_max_cells_truncates_events(self):
         from zagg.runner import agg
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1432,6 +1432,9 @@ class TestSummaryKeysByteIdentical:
         "gb_seconds",
         "price_per_gb_sec",
         "estimated_cost_usd",
+        # Structured max/estimated/actual block (issue #298); the flat
+        # estimated_cost_usd key above keeps its legacy actual-rollup meaning.
+        "cost",
         "store_path",
         "backend",
         "function_name",

--- a/tests/test_runner_concurrency.py
+++ b/tests/test_runner_concurrency.py
@@ -195,6 +195,87 @@ class TestCostBlock:
         assert runner._worker_memory_gb(cfg) == 2.0
 
 
+class TestCostBlockEvents:
+    """Structured cost block on the tabular events path (issue #298).
+
+    The events path (``_run_lambda_events``) carries its own copy of the
+    phase-1 cost logic -- the pre-invoke ceiling, the ``memory_gb`` fed to the
+    ``LambdaExecutor``, the ``gb_seconds`` rollup, and the ``cost`` block -- so
+    it needs its own coverage; ``TestCostBlock`` only drives the spatial
+    ``_run_lambda``. Mocks mirror that harness: 3 events, each billing a 1 s
+    duration, no live AWS.
+    """
+
+    def _events(self, n=3):
+        return [{"event_key": f"e{i}", "event_mask_uri": f"s3://b/m{i}.npy"} for i in range(n)]
+
+    def _run(self, monkeypatch, cfg, n=3, duration=1.0):
+        monkeypatch.setattr(
+            runner,
+            "compute_available_workers",
+            lambda requested, *a, **k: (n, _report(n)),
+        )
+        monkeypatch.setattr(
+            runner,
+            "_invoke_lambda_event",
+            lambda client, ev, *a, **k: {
+                "status_code": 200,
+                "body": {"timesteps_processed": 1, "results": {}, "meta": {}},
+                "error": None,
+                "event_key": ev["event_key"],
+                "lambda_duration": duration,
+            },
+        )
+        # No real tabular write; return a sentinel path like the real writer.
+        monkeypatch.setattr(runner, "_write_tabular_output", lambda *a, **k: "s3://out/x.parquet")
+        return runner._run_lambda_events(
+            cfg,
+            self._events(n),
+            "s3://out/x.parquet",
+            max_workers=n,
+            region="us-west-2",
+            function_name="process-shard",
+            invocation="sync",
+        )
+
+    def _cfg(self):
+        from zagg.config import PipelineConfig
+
+        # output.format must be tabular (not the "zarr" default) to clear the
+        # temporal guard; mirrors the events-path seam test.
+        return PipelineConfig(output={"format": "parquet"})
+
+    def test_cost_block_shape_and_ceiling(self, lambda_env, monkeypatch):
+        from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC, max_cost_usd
+
+        summary = self._run(monkeypatch, self._cfg())
+        cost = summary["cost"]
+        # Ceiling: 3 events x 4 GB x 900 s, computable pre-invoke.
+        assert cost["max_cost_usd"] == pytest.approx(max_cost_usd(3, 4.0, timeout_s=900))
+        # Estimated stays a None placeholder until issues #297/#299 land.
+        assert cost["estimated_cost_usd"] is None
+        # Actual mirrors the legacy rollup key (3 x 1 s x 4 GB x rate).
+        assert cost["actual_cost_usd"] == pytest.approx(3 * 1.0 * 4.0 * LAMBDA_PRICE_PER_GB_SEC)
+        assert cost["actual_cost_usd"] == summary["estimated_cost_usd"]
+
+    def test_max_bounds_actual(self, lambda_env, monkeypatch):
+        # Even at the worst billed duration (the 900 s timeout), the pre-invoke
+        # ceiling bounds the rollup.
+        summary = self._run(monkeypatch, self._cfg(), duration=900.0)
+        cost = summary["cost"]
+        assert cost["max_cost_usd"] >= cost["actual_cost_usd"]
+
+    def test_worker_variant_prices_its_memory(self, lambda_env, monkeypatch):
+        # A worker: 8192 variant (issue #235) bills 8 GB in both the gb_seconds
+        # rollup and the ceiling -- guarding against a revert to flat 4 GB.
+        cfg = self._cfg()
+        cfg.worker = {"memory": 8192}
+        summary = self._run(monkeypatch, cfg)
+        assert summary["gb_seconds"] == pytest.approx(3 * 1.0 * 8.0)
+        base = self._run(monkeypatch, self._cfg())
+        assert summary["cost"]["max_cost_usd"] == pytest.approx(2 * base["cost"]["max_cost_usd"])
+
+
 class TestFdExhaustionSurfaces:
     def test_errno_24_in_future_reraised_with_guidance(self, lambda_env, monkeypatch):
         monkeypatch.setattr(

--- a/tests/test_runner_concurrency.py
+++ b/tests/test_runner_concurrency.py
@@ -123,7 +123,7 @@ class TestCostBlock:
     a 1 s billed duration, no live AWS.
     """
 
-    def _run(self, monkeypatch, cfg, duration=1.0):
+    def _run(self, monkeypatch, cfg, duration=1.0, **extra):
         monkeypatch.setattr(
             runner,
             "compute_available_workers",
@@ -152,6 +152,7 @@ class TestCostBlock:
             dry_run=False,
             region="us-west-2",
             function_name="process-shard",
+            **extra,
         )
 
     def _flat_cfg(self):
@@ -193,6 +194,22 @@ class TestCostBlock:
         cfg = self._flat_cfg()
         cfg.worker = {"memory": 2048}
         assert runner._worker_memory_gb(cfg) == 2.0
+
+    def test_on_progress_fires_per_completed_shard(self, lambda_env, monkeypatch):
+        # Progress hook (issue #298 phase 2): one call per completed unit with
+        # the 1-based done count, the unit total, and the running metered cost.
+        from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC
+
+        seen = []
+        self._run(
+            monkeypatch,
+            self._flat_cfg(),
+            on_progress=lambda done, total, cost: seen.append((done, total, cost)),
+        )
+        assert [(d, t) for d, t, _ in seen] == [(1, 4), (2, 4), (3, 4), (4, 4)]
+        costs = [c for _, _, c in seen]
+        assert costs == sorted(costs)  # running rollup only grows
+        assert costs[-1] == pytest.approx(4 * 1.0 * 4.0 * LAMBDA_PRICE_PER_GB_SEC)
 
 
 class TestCostBlockEvents:

--- a/tests/test_runner_concurrency.py
+++ b/tests/test_runner_concurrency.py
@@ -116,6 +116,85 @@ class TestProbeClampsWorkers:
         assert summary["cells_with_data"] == 4
 
 
+class TestCostBlock:
+    """Structured cost block in the lambda summary (issue #298).
+
+    Reuses the mocked ``_run_lambda`` harness above: 4 shards, each reporting
+    a 1 s billed duration, no live AWS.
+    """
+
+    def _run(self, monkeypatch, cfg, duration=1.0):
+        monkeypatch.setattr(
+            runner,
+            "compute_available_workers",
+            lambda requested, *a, **k: (4, _report(4)),
+        )
+        monkeypatch.setattr(
+            runner,
+            "_invoke_lambda_cell",
+            lambda *a, **k: {
+                "status_code": 200,
+                "body": {"total_obs": 5},
+                "error": None,
+                "lambda_duration": duration,
+                "shard_key": 0,
+            },
+        )
+        return runner._run_lambda(
+            cfg,
+            _catalog(),
+            "s3://out/x.zarr",
+            12,
+            max_cells=None,
+            morton_cell=None,
+            max_workers=4,
+            overwrite=False,
+            dry_run=False,
+            region="us-west-2",
+            function_name="process-shard",
+        )
+
+    def _flat_cfg(self):
+        cfg = default_config("atl06")
+        cfg.output["store_layout"] = "flat"
+        return cfg
+
+    def test_cost_block_shape_and_ceiling(self, lambda_env, monkeypatch):
+        from zagg.dispatch import LAMBDA_PRICE_PER_GB_SEC, max_cost_usd
+
+        summary = self._run(monkeypatch, self._flat_cfg())
+        cost = summary["cost"]
+        # Ceiling: 4 shards x 4 GB x 900 s, computable pre-invoke.
+        assert cost["max_cost_usd"] == pytest.approx(max_cost_usd(4, 4.0, timeout_s=900))
+        # Estimated stays a None placeholder until issues #297/#299 land.
+        assert cost["estimated_cost_usd"] is None
+        # Actual mirrors the legacy rollup key (4 x 1 s x 4 GB x rate).
+        assert cost["actual_cost_usd"] == pytest.approx(4 * 1.0 * 4.0 * LAMBDA_PRICE_PER_GB_SEC)
+        assert cost["actual_cost_usd"] == summary["estimated_cost_usd"]
+
+    def test_max_bounds_actual(self, lambda_env, monkeypatch):
+        # Property: even at the worst billed duration (the 900 s function
+        # timeout), the pre-invoke ceiling bounds the rollup.
+        summary = self._run(monkeypatch, self._flat_cfg(), duration=900.0)
+        cost = summary["cost"]
+        assert cost["max_cost_usd"] >= cost["actual_cost_usd"]
+
+    def test_worker_variant_prices_its_memory(self, lambda_env, monkeypatch):
+        # A worker: 8192 variant (issue #235) bills 8 GB, not the flat 4.
+        cfg = self._flat_cfg()
+        cfg.worker = {"memory": 8192}
+        summary = self._run(monkeypatch, cfg)
+        assert summary["gb_seconds"] == pytest.approx(4 * 1.0 * 8.0)
+        base = self._run(monkeypatch, self._flat_cfg())
+        assert summary["cost"]["max_cost_usd"] == pytest.approx(2 * base["cost"]["max_cost_usd"])
+
+    def test_worker_memory_gb_resolution(self):
+        assert runner._worker_memory_gb(self._flat_cfg()) == 4.0
+        cfg = self._flat_cfg()
+        cfg.worker = {"memory": 2048}
+        assert runner._worker_memory_gb(cfg) == 2.0
+
+
 class TestFdExhaustionSurfaces:
     def test_errno_24_in_future_reraised_with_guidance(self, lambda_env, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
Closes #298

Invoke cost reporting (max / estimated / actual) in the run return, plus a notebook-facing dispatch wrapper with a progress bar. Design per the plan comment and follow-ups on #298: new module for the wrapper, CLI gates on max cost with a skippable prompt while the notebook call never blocks, tqdm via optional import, and the Phase-3 estimator stubbed only (deferred behind #297/#299).

## Approach

**Cost block (phase 1).** `dispatch.py` gains an arch-keyed price table (`LAMBDA_PRICE_PER_GB_SEC_BY_ARCH`) and `max_cost_usd(n_shards, memory_gb, timeout_s, arch)` — the pre-invoke ceiling `n_shards × rate(arch) × memory_gb × 900 s`, computable from shardmap + config alone. `RunReport` carries `max_cost_usd` / `estimated_cost_usd` / `actual_cost_usd` (stamped by the runner). Both Lambda paths (`_run_lambda`, `_run_lambda_events`) log the ceiling before fan-out and add a structured `summary["cost"] = {max_cost_usd, estimated_cost_usd: None, actual_cost_usd}` block. The legacy flat `estimated_cost_usd` summary key keeps its pre-existing meaning (the billed-duration rollup) for existing consumers.

**One-arch price table.** Only arm64 is deployed (`deployment/aws/template.yaml` `Architecture` default `arm64`; no x86_64 variant is stood up, and `runner.py`'s pricing comment already says "arm64 pricing"), so the table carries a single arm64 row with the arch recorded — an x86_64 deployment adds its rate as a second entry. An unknown arch raises `KeyError` instead of pricing silently wrong.

**Worker-variant memory.** `_worker_memory_gb(config)` resolves the billed memory from the config's `worker:` block (issue #235 variants 2048/4096/8192 MB), defaulting to the flat 4 GB constant. It now also feeds `LambdaExecutor.measure_cost` and the rollup, so a `worker: {memory: 8192}` run bills 8 GB instead of the old hardcoded 4 — a small behavioral fix; the default path is byte-identical.

**Notebook wrapper + progress (phase 2).** New `src/zagg/notebook.py` (per the ratified decision — `dispatch.py` stays free of UI concerns): `run()` wraps `agg` and returns a `RunView` with a `_repr_html_` cost/counters/failures report; `max_cost_preview()` resolves the ceiling from shardmap + config with the same unit accounting as `_run_lambda` (cell selection + windowed-unit expansion); `confirm_max_cost()` is the blocking yes/no gate, wired CLI-only in `__main__` behind `--yes`/`-y` (the notebook path only displays — it never prompts, and a test asserts `input` is unreachable there). Progress rides a new `on_progress(done, total, cost_usd)` callback threaded through `agg` into every fan-out accumulator (spatial local/lambda, temporal local/lambda via a shared `_with_progress` wrapper; raster local/lambda loops tick with `cost_usd=None` since that path has no per-unit pricing). tqdm is an optional import (`tqdm.auto`): bar when importable, logging fallback otherwise — no dependency changes, `lambda` extra untouched.

**Estimator stub + example notebook (phase 3).** `dispatch.estimate_cost_usd(catalog_data, template_hash=None, history=None)` is the interface stub for the ratified pilot-first estimator: tier 1 scales same-template-hash prior actuals by per-shard granule/obs counts; tier 2 falls back to cross-template regression on `n_obs`. It always returns `None` until issues #297/#299 land the history it reads; both Lambda cost blocks now populate `estimated_cost_usd` through it so the wiring point exists. The example notebook is `notebooks/cost_reporting.ipynb` (repo convention places example notebooks under `notebooks/` with a README table row + Binder badge, not `docs/` — see Questions): Binder-runnable, reads only the in-tree `sm_healpix_o9.json` fixture, and shows max → progress → actual with the one non-Binder-able step (a live Lambda invoke) replayed by a clearly-labeled stand-in `agg` that drives the identical wrapper code path. Executed end-to-end locally (all cells green, `max >= actual` asserted in-notebook).

## Phases

- [x] Phase 1 — cost block in the run return: price table + `max_cost_usd` in `dispatch.py`, `RunReport` cost fields, ceiling logged pre-fan-out, `summary["cost"]` on both Lambda paths, tests.
- [x] Phase 2 — notebook wrapper (`src/zagg/notebook.py`): tqdm-or-logging progress from the dispatch result stream, `_repr_html_` report object, CLI confirm gate with `--yes`/`-y`.
- [x] Phase 3 — estimator stub (pilot-first / regression tiers, returns None; deferred behind #297/#299) + example notebook.

## Testing

- `tests/test_dispatch.py::TestMaxCostUsd`: ceiling math vs the price table, memory-variant scaling, arm64 alias pinning, unknown-arch `KeyError`, `RunReport` defaults.
- `tests/test_runner_concurrency.py::TestCostBlock`: mocked `_run_lambda` — cost-block shape, `max >= actual` at the worst billed duration (900 s), worker-variant pricing, `_worker_memory_gb` resolution.
- `tests/test_runner.py::TestSummaryKeysByteIdentical`: pinned Lambda key set extended with the new `cost` key (the one intended summary-shape change).
- `tests/test_notebook.py`: ceiling preview against the in-tree `sm_healpix_o9.json` shardmap (unit count, memory-variant scaling, `max_cells` clamp), tqdm-present and tqdm-absent (`sys.modules` shim) progress paths, `RunView` HTML (cost block, escaping, benign-error exclusion, local no-metered-cost), the non-blocking wrapper (progress driven from a stubbed `agg`, bar closed on raise, `input` unreachable), and the CLI gate (decline aborts pre-`agg` with exit 1, confirm proceeds, `--yes` skips, local backend never gated).
- `on_progress` plumbing: per-completed-shard callback on the mocked spatial Lambda harness (running cost monotone, final == actual rollup) and on the temporal local path (`cost_usd=None`).
- Local: `ruff check` / `ruff format --check` / full `pytest -q` — green except the pre-existing failures noted below.

## Questions for review

1. **Overlap with the PR for #297** (branch `claude/297-stats-sidecar`): both touch `runner.py` and `dispatch.py` (`RunReport`). The cost-block changes here are kept minimal and self-contained; whichever PR merges second rebases.
2. **Timeout constant.** The ceiling prices with `_DEFAULT_FUNCTION_TIMEOUT_S` (900 s, the template default and Lambda hard cap) rather than the live `function_timeout_s`, which is only readable after preflight builds the client — the issue specifies a pre-invoke ceiling, so the constant is used. A function deployed with a shorter Timeout would make the ceiling conservative, never low.
3. **Raster path.** `RasterStrategy._run_lambda_shards` computes no cost today (no `gb_seconds`/`estimated_cost_usd` in its summary), so it gets no cost block in this PR either — adding one there is mechanical if wanted.
4. **Notebook location.** The task sketch said "under docs/", but the repo convention (README "Example Notebooks" table, Binder badges pointing at `lab/tree/notebooks`, `.binder/` config) keeps runnable notebooks in `notebooks/` — followed the convention; happy to move it if docs/ is preferred.
5. Pre-existing failures on clean `main`, not touched per §4: `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` (local docker-dependent build), ruff `N818` on `src/zagg/registry.py:64` (`UnknownCapability`), and format drift in `tests/test_lambda_raster_handler.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zYV2pvzhVp8cv7e7H4JY3


