### PR TITLE
sparse_coverage doc amendment: D16 morton-only storage + O10 discriminator

### DIFF
--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -820,16 +820,25 @@ rollup leaves all leaf reads intact.
   provenance attrs; the pyramid is the store's resolution axis, partially
   materialized. Reader support is gated on mortie#116 mixed-order morton
   (tracked as moczarr#8); the schema needs no bump — this is what the
-  coordinate system was built for. Open sub-point (deferred pending
-  discussion, espg leans recorded 2026-07-20): how a `none`
-  (non-composable) field behaves — the recorded lean is **per-field
-  exclusion from coarser materializations** (composable fields roll up;
-  non-composable fields exist only at native resolution — matching
-  #201's "which fields degrade" question) rather than min-semantics
-  pinning the whole product; and whether `none` fields are permitted at
-  all — lean: allowed, with a **loud warning** at template validation.
-  Per-field exclusion makes "resolution of a product" per-field, which
-  readers must handle; not ratified.
+  coordinate system was built for. Sub-point **ruled** (espg-ratified
+  in-session, 2026-07-20, on the #201 thread): `none` (non-composable)
+  fields are **allowed, with a loud warning** at template validation,
+  and at overview orders the default is **per-field exclusion** —
+  composable fields roll up, `none` fields exist only at native
+  resolution (min-semantics product pinning rejected; "resolution of a
+  product" is per-field, which readers handle via the manifest's
+  per-family declarations). An **explicitly declared derived summary**
+  is available as the opt-in: e.g. an auto-digest of a roster field's
+  raw values **under a different field name** at overview orders, so
+  overview schema never silently differs from source; the declaration
+  lives in the **pyramid block, never the semantic core** (leaf truth is
+  unchanged — two products differing only in overview-summary
+  declarations are the same product), and derived fields carry their own
+  composability class and O11 hashes. Deterministic subsampling
+  (seeded reservoir per cell, seed = f(cell, window, field) for O11
+  reproducibility) is **deferred** until a concrete consumer (the #265
+  HHDC class) asks; concatenation ("roster pyramids") is **rejected** —
+  volume never shrinks, every level duplicates the raw data beneath it.
 
 ### 8.2 Open for review (input needed)
 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -625,7 +625,10 @@ rollup leaves all leaf reads intact.
   is **mergeable by construction** — only associative stats (counts, sums,
   min/max, t-digests; never stored means) — so up-tree rollups are a pure
   fold (D22). The record also rides the async result envelope; the
-  dispatcher writes a **run-level parquet at the store root** (one row per
+  dispatcher writes a **run-level parquet at the product root** — a run maps
+  to one template ⇒ one product tree (D7/D19), so it lands under `{hash}/`,
+  never the multi-product store root, whose node invariant admits only
+  `{hash}.yaml` + `{hash}/` — with one row per
   shard, *including failure rows* sourced from the run report — sidecars
   exist only on success; CloudWatch structured logs remain the failure
   forensics channel). Sidecars omit account-identifying fields (request

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -154,8 +154,14 @@ products by listing `{store_root}/` and reading each
   no objects (D4/D5), their run records are distinct by name
   (timestamp + run id, D20), and the manifest precheck admits both
   (frozen keys match by construction under D19). Same-(shard, window)
-  concurrency degrades to D4 semantics — last writer wins; the loser's
-  partial output is stamped-over or remains ignorable debris. Interior
+  concurrency is **out of contract**: *sequential* re-runs give clean D4
+  last-writer-wins replacement, but a leaf is several objects (per-array
+  ShardingCodec objects D17, the ragged object D18, root attrs, coverage
+  sidecar) and S3 PUTs are not transactional across them — two
+  *simultaneous* different-content co-writers can interleave those objects
+  and leave a stamped-but-torn leaf, which is neither replacement nor
+  ignorable debris. Detection is content verification (the O11 hash) or a
+  re-run; the supported contract stays shard-disjoint. Interior
   rollups may go stale during any of this, which D22's generation stamps
   make detectable, never silently wrong. Cross-product concurrency shares
   nothing at all.
@@ -936,7 +942,9 @@ registry — CI coverage should be auditable against this list:
   no-op) and nothing-load-bearing (deleting every rollup leaves leaf
   reads green).
 - **Merge-fold algebra** (D20): associativity/commutativity of the stats
-  record fold; merge-of-children == direct.
+  record fold; merge-of-children == direct — exactly for count/sum/min/max,
+  up to the approximate class (`np.isclose`) for order-dependent t-digest
+  members (cf. D24).
 - **Semantic-hash canonicalization** (D19): syntactic edits (whitespace,
   key order, comments) never change the hash; packaging-knob edits
   (orders, chunking, worker size, streaming mode) never change the hash;

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -551,10 +551,12 @@ rollup leaves all leaf reads intact.
   the manifest's `shard_order` (tree/dispatch order) is unrelated and stays.
   Full flat-machinery removal remains gated on the O3 reader (the #251
   phase-2 gate).
-- **D18 — Ragged output = sharded vlen-bytes** (espg-ratified in-session,
-  recorded on
-  [#209](https://github.com/englacial/zagg/issues/209#issuecomment-4940116927);
-  tracking [#210](https://github.com/englacial/zagg/issues/210)). Ragged
+- **D18 — Ragged output = sharded vlen-bytes** (measurement + recommendation
+  on
+  [#209](https://github.com/englacial/zagg/issues/209#issuecomment-4940116927),
+  with espg's in-session ratification of the vlen-bytes adoption recorded in
+  the [#210](https://github.com/englacial/zagg/issues/210) body; tracking
+  [#210](https://github.com/englacial/zagg/issues/210)). Ragged
   t-digest arrays store as `bytes` dtype + vlen-bytes codec under the
   ShardingCodec — one object per shard, 2-GET single-cell reads — with
   element interpretation as an attrs convention and a **golden-bytes framing

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -353,6 +353,11 @@ new wiring on the read side.
 4. Within the leaf zarr, the `morton` coordinate locates the observation(s)
    in the containing cell.
 
+(Under D24 a target's orders may be regionally heterogeneous — the
+declared sets bound them; the *leaf's* actual orders come from its
+morton words / MOC, and the truncation predicate is unchanged.
+Mixed-order reader support is gated on mortie#116 / moczarr#8.)
+
 Per-observation LISTs are forbidden in the join loop: at 2,000 workers ×
 millions of photons the walk is the robustness path, not the join path (D10).
 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -5,8 +5,9 @@ temporal-partitioning amendments (D13–D15) ratified on
 [#237](https://github.com/englacial/zagg/issues/237); morton-only-storage
 amendment ratified on
 [#262](https://github.com/englacial/zagg/issues/262) (D16; open item O10
-carved from it); 2026-07 consolidation (D17–D24, O3 resolved, O11–O13
-opened, §8.3 test-obligations index added)
+carved from it); 2026-07 consolidation (D17–D24; O3/O11 resolved, O8
+constants blessed, O12–O13 opened, D23 tokens ratified, §8.3
+test-obligations index added)
 recording decisions settled on the
 [#251](https://github.com/englacial/zagg/issues/251)/[#236](https://github.com/englacial/zagg/issues/236)/[#209](https://github.com/englacial/zagg/issues/209)
 and [#296](https://github.com/englacial/zagg/issues/296)-family threads —
@@ -69,13 +70,14 @@ what zagg consumes:
                                     the manifest path_grouping param, D21)
       {window}.zarr/             <- leaf, basename = time window (D23,
                                     morton-hive/3); `all.zarr` for
-                                    schedule: none (reserved token — lean).
+                                    schedule: none (reserved token, ratified;
+                                    excluded from the window grammar).
                                     /1–/2 stores keep {full_id}.zarr and
                                     {full_id}_{window}.zarr (D3/D13)
-      stats_{window}.json        <- per-shard stats sidecar, sibling; ratified
-                                    D20 naming (stats.json for schedule: none).
-                                    D23 lean, not ratified: {window}.stats.json
-                                    / all.stats.json (follow-up to #302)
+      {window}.stats.json        <- per-shard stats sidecar, sibling (D20,
+                                    D23-aligned for /3; all.stats.json for
+                                    schedule: none). /1–/2 stores keep
+                                    stats_{window}.json / stats.json
       <sub-shardmap JSON>        <- leaf sub-map for sweep rollups (D22)
 ```
 
@@ -769,12 +771,15 @@ rollup leaves all leaf reads intact.
   D20 sidecar `shard_key` (an fsck pays one GET per leaf); D3's
   "unambiguous if moved" softens to "recoverable from attrs" — the moved
   case reduces to a downloader that materializes the prefix tree into
-  folder names (espg-noted in-session). **Leans recorded, not ratified**:
-  the `schedule: none` reserved token — proposal `all.zarr` (reads as
-  all-time; cannot collide with the digit-shaped window grammar;
-  `none.zarr` matches the schedule literal but reads worse) — and the
-  sidecar alignment `{window}.stats.json` / `all.stats.json` (D20
-  naming; follow-up to the merged PR #302). Rejected alternative: time
+  folder names (espg-noted in-session). **Both leans ratified**
+  (espg, in-session 2026-07-20): the `schedule: none` reserved token is
+  **`all`** (`all.zarr`; reads as all-time; cannot collide with the
+  digit-shaped window grammar; excluded from the window grammar forever
+  on the mortie spec page), and the sidecar aligns to
+  **`{window}.stats.json` / `all.stats.json`** for `/3` stores (the
+  spec-keyed seam shipped in PR #307 makes both a constant flip; `/1`–`/2`
+  stores keep the frozen `stats_{window}.json` / `stats.json` names).
+  Rejected alternative: time
   as a *path* level (`{name}/{window}/{morton…}`) would make
   window-scoped ops prefix-cheap but duplicates the morton tree per
   window and shatters the dominant read — a time series at a location —
@@ -877,7 +882,12 @@ rollup leaves all leaf reads intact.
   a third value, `"full"`). Bit convention (frozen
   with the mortie spec, golden-vector-pinned on PR #208): bit i = the i-th
   shard-subtree cell in ascending packed-word order (base-4 D1 digit tail,
-  digits 1..4 → 0..3), MSB-first per byte.
+  digits 1..4 → 0..3), MSB-first per byte. *Addendum (espg-blessed
+  in-session, 2026-07-20 — closing the #276 item-5 flag)*: the PR #208
+  contract constants stand as-shipped — the bitmap bit convention and the
+  root-MOC range ordering are **contract** (both golden-vector-pinned);
+  zstd level 3 is **non-normative** (any zstd level decodes identically;
+  only "zstd stream" is contract).
 - **O9 — end-of-run root MOC default**: **RESOLVED — on** for hive stores
   ([espg](https://github.com/englacial/zagg/issues/200#issuecomment-4938859764):
   coverage MOCs are the default for healpix templates; PR #208 implements
@@ -895,21 +905,31 @@ rollup leaves all leaf reads intact.
   documented point-id/area-word parse non-injectivity at order 29; field
   name, values, and placement to be frozen with the mortie spec page
   ([mortie#62](https://github.com/espg/mortie/issues/62)).
-- **O11 — logical content hash of outputs** (carved from D19; **proposal
-  awaiting espg sign-off** — espg asked for expanded context on
-  [#299](https://github.com/englacial/zagg/issues/299#issuecomment-5017263033),
-  expansion posted
-  [in reply](https://github.com/englacial/zagg/issues/299#issuecomment-5017334704)).
-  Proposal: per-array sha256 over *decoded* values (raw C-order bytes at the
-  declared dtype, after decompression — never stored object bytes, which
-  churn on codec/library upgrades), recorded in the D20 sidecar as
-  `{array_name: hash}` plus one combined hash. Exact bytes, no float
-  tolerance: any value change — including flagged code changes that pass
-  `np.isclose` (the PR #282 class) — flips the hash by design;
+- **O11 — logical content hash of outputs: RESOLVED — adopted as
+  proposed** (espg-ratified in-session, 2026-07-20; carved from D19,
+  discussion trail on
+  [#299](https://github.com/englacial/zagg/issues/299#issuecomment-5017263033)
+  and
+  [the expansion](https://github.com/englacial/zagg/issues/299#issuecomment-5017334704)).
+  Per-array sha256 over *decoded* values — **"per-array" means per named
+  zarr array (variable) in the leaf** (each data field, the ragged bytes
+  array, `morton`, every coordinate), hashed over that array's full
+  decoded contents (raw C-order bytes at the declared dtype, after
+  decompression); the ShardingCodec's inner chunks and the
+  one-object-per-array packaging are invisible to it by construction —
+  never stored object bytes, which churn on codec/library upgrades.
+  Recorded in the D20 sidecar as `{array_name: hash}` plus one combined
+  hash (hash of the sorted per-array hashes). **Computed at write**,
+  in-worker (the data is already in memory — near-free); **scope: all
+  arrays including coordinates** (cheap, deterministic). Exact bytes, no
+  float tolerance: any value change — including flagged code changes that
+  pass `np.isclose` (the PR #282 class) — flips the hash by design;
   interpretation pairs the hash with the sidecar's recorded zagg version.
-  Motivation: outputs have been byte-identical between runs in practice, so
-  this turns D19's "probably already ran" dedup into a verifiable claim
-  without folding catalog identity into leaf names.
+  Three jobs: the verification half of D19's `semantic_hash` ("intended
+  identical" vs "actually byte-identical"); the mismatch localizer
+  ("only `h_li_tdigest` differs in this leaf"); and the detection
+  mechanism for stamped-but-torn leaves under the §2 concurrency
+  contract's out-of-contract case.
 - **O12 — retention/expiration (proposal, espg-directed to record
   2026-07-20)**: **product-level** retention is a *prefix* lifecycle rule
   (one rule per `{name}/` — delete or transition a whole product); 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -5,7 +5,7 @@ temporal-partitioning amendments (D13–D15) ratified on
 [#237](https://github.com/englacial/zagg/issues/237); morton-only-storage
 amendment ratified on
 [#262](https://github.com/englacial/zagg/issues/262) (D16; open item O10
-carved from it); 2026-07 consolidation (D17–D22, O3 resolved, O11 opened)
+carved from it); 2026-07 consolidation (D17–D23, O3 resolved, O11 opened)
 recording decisions settled on the
 [#251](https://github.com/englacial/zagg/issues/251)/[#236](https://github.com/englacial/zagg/issues/236)/[#209](https://github.com/englacial/zagg/issues/209)
 and [#296](https://github.com/englacial/zagg/issues/296)-family threads —
@@ -64,12 +64,14 @@ what zagg consumes:
     <run records (parquet)>      <- run-level telemetry, one row/shard (D20)
     {sign+base}/{d1}/{d2}/.../   <- one digit per level (D2; digit-chunking is
                                     the manifest path_grouping param, D21)
-      {full_id}.zarr/            <- self-describing leaf (D3), zarr v3; dense
-                                    arrays via ShardingCodec (D17)
-      {full_id}_{window}.zarr/   <- time-windowed leaf (D13); naming frozen on
-                                    the mortie spec page (morton-hive/2)
-      stats.json                 <- per-shard stats sidecar, sibling (D20;
-                                    stats_{window}.json for windowed leaves)
+      {window}.zarr/             <- leaf, basename = time window (D23,
+                                    morton-hive/3); `all.zarr` for
+                                    schedule: none (reserved token — lean).
+                                    /1–/2 stores keep {full_id}.zarr and
+                                    {full_id}_{window}.zarr (D3/D13)
+      {window}.stats.json        <- per-shard stats sidecar, sibling (D20,
+                                    naming aligned by D23; all.stats.json
+                                    for the degenerate case)
       <sub-shardmap JSON>        <- leaf sub-map for sweep rollups (D22)
 ```
 
@@ -90,8 +92,10 @@ bare store; `{hash}.yaml` entries ⇒ product directory).
 - **Full morton id at the leaf** (D3): `.../1/2/3/-31123.zarr/` is
   self-describing without parsing its path, greppable in inventories,
   unambiguous if moved. (Unchanged by D19 — product identity lives at the
-  product *root*, above the tree, so leaf naming and the within-product
-  walk semantics survive untouched.)
+  product *root*, above the tree. *Superseded by D23 for `morton-hive/3`
+  stores*: the basename becomes the time window; the full id stays
+  recoverable from the path arithmetically and from the stamp/sidecar
+  `shard_key`.)
 - **Time-windowed leaves** (D13, ratified on
   [#237](https://github.com/englacial/zagg/issues/237)): a store whose
   manifest declares a temporal window schedule (§3) partitions each shard's
@@ -112,7 +116,8 @@ bare store; `{hash}.yaml` entries ⇒ product directory).
   schedule lives in the manifest (D10 preserved). The no-partitioning
   degenerate case (`schedule: none`) keeps the bare `{full_id}.zarr` name and
   is byte-identical to the pre-D13 layout — a `morton-hive/1` store *is* a
-  `/2` store with `schedule: none`.
+  `/2` store with `schedule: none`. (Leaf *naming* is revised by D23 for
+  `morton-hive/3` stores; the windowing semantics here are unchanged.)
 - **Node invariant**: below a product root, a node contains *only* digit
   children (`[1-4]/`), `*.zarr` objects, and the declared leaf-adjacent
   sidecars — the per-shard stats record (D20) and the sub-shardmap JSON
@@ -177,7 +182,8 @@ again during a run. Contents:
 - **Temporal block** (D15, ratified on
   [#237](https://github.com/englacial/zagg/issues/237)): a store carrying this
   block declares `spec: "morton-hive/2"` (the version string of D6 covers these
-  temporal/windowed-leaf extensions). It records time
+  temporal/windowed-leaf extensions; `/3` = the same semantics under D23
+  window-only leaf naming). It records time
   encoding/units/epoch/calendar, the membership timestamp field, the **window
   schedule** (`none` | `yearly` | `monthly` | `daily` | explicit range list;
   `quarterly` grammar-reserved), and the append policy. Label grammar and
@@ -474,7 +480,9 @@ rollup leaves all leaf reads intact.
   — grammar and boundary semantics recorded on the
   [mortie spec page](https://github.com/espg/mortie/issues/62#issuecomment-4986809092)
   as part of `morton-hive/2`. (Unchanged by D19 — leaf naming survives the
-  product-root design intact.) Reserved (lean, not decided): §7
+  product-root design intact. *Naming revised by D23 for `morton-hive/3`*:
+  the basename becomes the window alone; the `/2` grammar stays frozen for
+  `/2` stores.) Reserved (lean, not decided): §7
   overview/pyramid zarrs inherit window naming (per-window overviews, with
   an optional all-time overview as a derived artifact).
 - **D14 — Coverage `encoding: "full"` fast path**
@@ -669,6 +677,36 @@ rollup leaves all leaf reads intact.
   direction of `ShardMap.reproject` and its no-region semantics are still
   under review on PR #295 — the sweep depends only on the exact coarsen
   direction.)
+- **D23 — Leaf basename = time window (`{window}.zarr`), `morton-hive/3`**
+  (espg-proposed and ratified in-session, 2026-07-20; recorded here and on
+  the PR #306 thread). Completes the axis separation D19 began: product =
+  root prefix (D19), space = digit path (D1/D2), **time = basename** —
+  each identity axis in exactly one place, none encoded twice. This
+  removes the last path/basename redundancy (the #296 observation that
+  started the naming work, applied to its final instance): the morton id
+  currently appears in both the path and the leaf name. Listing a shard
+  node returns the temporal inventory directly (`2019.zarr`,
+  `2020.zarr`, …) — what append planning and time-series discovery
+  actually ask. Spec bump to `morton-hive/3` under D6 versioning: `/1`
+  and `/2` stores remain valid forever under their frozen grammars;
+  readers discriminate by the manifest `spec` string; the `/3` grammar is
+  to be re-frozen on the mortie spec page
+  ([mortie#62](https://github.com/espg/mortie/issues/62)). Costs accepted
+  with the decision: the name==path self-check moves to the stamp attrs /
+  D20 sidecar `shard_key` (an fsck pays one GET per leaf); D3's
+  "unambiguous if moved" softens to "recoverable from attrs" — the moved
+  case reduces to a downloader that materializes the prefix tree into
+  folder names (espg-noted in-session). **Leans recorded, not ratified**:
+  the `schedule: none` reserved token — proposal `all.zarr` (reads as
+  all-time; cannot collide with the digit-shaped window grammar;
+  `none.zarr` matches the schedule literal but reads worse) — and the
+  sidecar alignment `{window}.stats.json` / `all.stats.json` (D20
+  naming; follow-up to the merged PR #302). Rejected alternative: time
+  as a *path* level (`{hash}/{window}/{morton…}`) would make
+  window-scoped ops prefix-cheap but duplicates the morton tree per
+  window and shatters the dominant read — a time series at a location —
+  across W prefixes; reads dominate window expiry, so time stays at the
+  leaf.
 
 ### 8.2 Open for review (input needed)
 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -5,7 +5,7 @@ temporal-partitioning amendments (D13–D15) ratified on
 [#237](https://github.com/englacial/zagg/issues/237); morton-only-storage
 amendment ratified on
 [#262](https://github.com/englacial/zagg/issues/262) (D16; open item O10
-carved from it); 2026-07 consolidation (D17–D23, O3 resolved, O11 opened)
+carved from it); 2026-07 consolidation (D17–D24, O3 resolved, O11 opened)
 recording decisions settled on the
 [#251](https://github.com/englacial/zagg/issues/251)/[#236](https://github.com/englacial/zagg/issues/236)/[#209](https://github.com/englacial/zagg/issues/209)
 and [#296](https://github.com/englacial/zagg/issues/296)-family threads —
@@ -57,11 +57,13 @@ what zagg consumes:
 
 ```
 {store_root}/                    <- multi-product form (D19): a directory of
-  {hash}.yaml                       stores + a content-addressed registry
-  {hash}/                        <- product root: each product subtree is a
-    morton_hive.json                COMPLETE morton-hive store — bare-named
+  {name}/                        <- NAMED product root — each product subtree
+    morton_hive.json                is a COMPLETE morton-hive store: bare-named
     coverage.moc                    manifest (§3) + optional root MOC (§4, O9)
-    <run records (parquet)>      <- run-level telemetry, one row/shard (D20)
+    aggregation.yaml             <- canonical semantic core (D19); its hash is
+                                    a frozen manifest key, not a path name
+    <run records (parquet)>      <- run-level telemetry, one row/shard;
+                                    timestamp-first names (D20)
     {sign+base}/{d1}/{d2}/.../   <- one digit per level (D2; digit-chunking is
                                     the manifest path_grouping param, D21)
       {window}.zarr/             <- leaf, basename = time window (D23,
@@ -77,10 +79,14 @@ what zagg consumes:
 ```
 
 A bare single-product store (today's layout — `morton_hive.json` at the
-store root, no `{hash}/` level) remains fully valid: the D19 product root is
+store root, no `{name}/` level) remains fully valid: the D19 product root is
 *additive*, and a product subtree is byte-identical to a bare store. A
 reader distinguishes the two forms by what sits at the root (a manifest ⇒
-bare store; `{hash}.yaml` entries ⇒ product directory).
+bare store; only name-shaped prefixes ⇒ product directory). Product names
+must not match the base-component grammar (`-?[1-6]`) so the walker's child
+classification stays unambiguous; gridlook and other viewers enumerate
+products by listing `{store_root}/` and reading each
+`{name}/morton_hive.json` directly — no name↔hash translation layer.
 
 - **Ids are morton decimal strings** (D1): sign + base digit (constant width,
   12 values `1..6`/`-1..-6`), then one digit per order, digits `1-4`, never
@@ -124,9 +130,9 @@ bare store; `{hash}.yaml` entries ⇒ product directory).
   sidecars — the per-shard stats record (D20) and the sub-shardmap JSON
   (D22) — with nothing else, ever: the walker's child classification
   depends on the name set being closed. The product root alone also carries
-  the manifest, MOC objects, and run-level telemetry records (D20); the
-  *store* root of a multi-product directory carries only `{hash}.yaml`
-  registry entries and `{hash}/` product roots (D19).
+  the manifest, MOC objects, the semantic core (`aggregation.yaml`, D19),
+  and run-level telemetry records (D20); the *store* root of a
+  multi-product directory carries only `{name}/` product roots (D19).
 - **Termination condition**: S3 has no empty directories (a prefix exists iff
   ≥1 object lies beneath it) and LIST is strongly consistent, so a
   delimiter-LIST returning no digit-shaped children is a definitive "nothing
@@ -166,13 +172,21 @@ again during a run. Contents:
 - `spec`: convention version string (e.g. `"morton-hive/1"`) — the convention
   itself is versioned from day one (D6).
 - Dataset identity (short name, product/version).
-- `cell_order`, `shard_order` (and, if a store permits region-dependent shard
-  orders, the allowed set).
+- `cell_order`, `shard_order` — each as a declared **allowed set/range**
+  when the store permits region-dependent orders (D24: shard order is pure
+  packaging; cell order is a resolution axis with per-leaf truth in the
+  morton words + MOC). The allowed sets are the frozen keys; runs within
+  the set pass the append precheck.
+- `semantic_hash` (D19): sha256 of the canonical semantic core — a frozen
+  key, so reusing a product name with different aggregation semantics
+  refuses up front, exactly as an order mismatch does.
 - Split schedule (implicit under D2: one digit per level to `shard_order`;
   recorded explicitly for forward compatibility).
 - `path_grouping` (D21): how many morton digits each path component chunks.
   Existing stores are retroactively `1`; new stores default `1`; changing the
   default later is a parameter flip for new stores, never a schema break.
+  When compared as a frozen key, an absent field normalizes to `1` on both
+  sides, so appends to pre-D21 stores never refuse on it.
 - Rollup/pyramid declaration (D22 extends the original overview-only form):
   which ancestor orders carry which derived artifact family — overview
   zarrs, stats rollups, sub-shardmap rollups — declared **per artifact
@@ -580,55 +594,69 @@ rollup leaves all leaf reads intact.
   metadata-only. This is the second noted soft-exception to "vanilla zarr
   v3" leaves (after the §4 coverage sidecar): plain zarr readers see opaque
   bytes, not garbage.
-- **D19 — Template-hash product roots: a multi-product store is a
-  directory of stores + a registry** (concept settled across
+- **D19 — Named product roots + semantic-core hash: a multi-product store
+  is a directory of stores; the name is the address, the hash is the
+  integrity check** (concept settled across
   [#296](https://github.com/englacial/zagg/issues/296#issuecomment-5014826849)
   and [#299](https://github.com/englacial/zagg/issues/299) — espg
   on-thread:
-  [naming + registry + per-product manifests](https://github.com/englacial/zagg/issues/299#issuecomment-5017263033);
-  **hash-first revision espg-ratified in-session 2026-07-20**, superseding
-  the earlier leaf-basename form recorded in this PR's phase 2 —
-  trade study on the PR #306 thread). Each product lives under its own
-  root prefix `{hash}/`, where hash = truncated sha256 (12 hex; collision
-  domain is products-within-one-store) of the **canonicalized** agg
-  template (parse YAML → sorted-key JSON → hash; never raw bytes). A
-  product subtree is a *complete, unmodified* morton-hive store —
-  bare-named manifest and MOC, `{full_id}.zarr` leaves under `/1`–`/2`
-  grammars (`{window}.zarr` under `/3` — D23; D3 and D13's grammar
-  untouched by D19) — so existing single-product stores are
-  already valid and the change is **additive, not breaking**; readers
-  distinguish the two root forms by content (manifest ⇒ bare store,
-  `{hash}.yaml` entries ⇒ product directory). The template itself is
-  written beside each product root as `{hash}.yaml` — a content-addressed
-  registry designed so a future external/community registry is a pure
-  file-merge superset; root listing is product discovery. Rationale for
-  hash-first over leaf-basename colocation: S3's only cheap scoping
-  primitive is the prefix, and product-scoped operations (delete,
-  lifecycle/expiration, access policy, inventory) dominate in practice —
-  under colocation each would need per-object tagging or the
-  out-of-contract full enumeration; under hash-first each is one prefix
-  rule. Cost prediction for appending new shards to a product is likewise
-  greatly simplified (espg-noted in-session, 2026-07-20): the product root
-  scopes its own telemetry history — the D20 run records and sidecars all
-  sit under one prefix — so the pilot-first cost estimator's priors (the
-  #298 design) are exactly the product's own records: same template, same
-  per-observation cost profile, no cross-product filtering. Within-product
-  walk/terminal semantics revert to the proven
-  single-product forms, and per-product artifacts keep bare names (one
-  less naming surface for readers to get wrong). What hash-first gives
-  up — a single spatial prefix spanning all products — serves no planned
-  workload: cross-product reads are manifest + MOC + truncation
-  arithmetic (§5) and never depended on physical colocation. **Catalog
-  identity lives in the sidecar, never the name**: granule count + sha256
-  of sorted granule ids + zagg version; dedup/`has_run` consults the
-  computed path *and* sidecar (a catalog-grown shard is "stale", not
-  "hit") — the template hash alone proves identity only for a frozen
-  catalog. Immutable-provenance naming (product root
-  `{hash}+{catalog-hash}/`) is an opt-in for frozen-catalog archival
-  runs; default stays template-hash-only. The output content hash that
-  makes dedup *verifiable* is O11 (proposal). D7 generalizes cleanly:
-  "one store per dataset" becomes "one product tree per template" under a
-  shared root, with cross-product joins unchanged.
+  [registry + per-product manifests](https://github.com/englacial/zagg/issues/299#issuecomment-5017263033);
+  revision history, all espg-ratified in-session 2026-07-20, trade
+  studies on the PR #306 thread: leaf-hash basenames (phase 2) →
+  hash-named product roots (phase 3) → **named roots with the hash demoted
+  to metadata (this revision)**). Each product lives under its own
+  human-readable root prefix `{name}/`; a product subtree is a *complete,
+  unmodified* morton-hive store — bare-named manifest and MOC,
+  `{full_id}.zarr` leaves under `/1`–`/2` grammars (`{window}.zarr` under
+  `/3` — D23) — so existing single-product stores are already valid and
+  the change is **additive, not breaking**. Readers distinguish the two
+  root forms by content (manifest ⇒ bare store; name-shaped prefixes ⇒
+  product directory; names must not match the base-component grammar);
+  viewers enumerate products by listing the root and reading each
+  `{name}/morton_hive.json` — no name↔hash translation layer.
+  **Identity is split**: the *name* addresses the product; the
+  **`semantic_hash`** verifies it — sha256 over the canonicalized
+  **output-defining subset only**: the `aggregation` block (functions +
+  params + dtypes + fills + ragged kinds), the `data_source` semantics
+  (dataset/product, groups, coordinates, variables, filters), and the
+  grid *type + indexing scheme*. Excluded as packaging: cell order (a
+  resolution axis — D24), parent/shard order, `chunk_inner`/`sharded`,
+  worker size, streaming mode (merge-vs-spill lands `np.isclose` and
+  shares one store, with the actual mode recorded per-run), and read
+  knobs — hashing the whole template would have made o8 and o9 runs
+  different products and blocked mixed-order processing. The hash is a
+  **frozen manifest key** (reusing a name with different aggregation
+  semantics refuses up front, like any frozen-key mismatch) and is
+  recorded in leaf attrs and D20 sidecars. The *literal* template is
+  deliberately **not** the product-level record (it carries run-varying
+  packaging): the product root holds the canonical semantic core as
+  `aggregation.yaml` (deterministic, valid YAML); each run archives its
+  literal template with its run record, and sidecars carry the run id to
+  join back. (This factoring formalizes a seam the code already has:
+  `spatial_signature` vs `output_field_signature`, the #89 split.)
+  Rationale for product-root prefixes (unchanged from the hash-first
+  study): S3's only cheap scoping primitive is the prefix, and
+  product-scoped operations (delete, lifecycle/expiration, access policy,
+  inventory) dominate — each is one prefix rule. Cost prediction for
+  appending new shards is likewise scoped (espg-noted in-session): the
+  product root holds its own telemetry history, so the pilot-first
+  estimator's priors (the #298 design) are exactly the product's own
+  records. What a shared spatial tree would have offered — one prefix
+  spanning all products — serves no planned workload (§5 reads are
+  arithmetic). **Catalog identity lives in the sidecar, never the name**:
+  granule count + sha256 of sorted granule ids + zagg version;
+  dedup/`has_run` consults the computed path, the `semantic_hash`, *and*
+  the sidecar catalog identity (a catalog-grown shard is "stale", not
+  "hit"). Immutable-provenance naming (product root
+  `{name}+{catalog-hash}/`) stays an opt-in for frozen-catalog archival
+  runs. The output content hash that makes dedup *verifiable* is O11
+  (proposal; it complements the semantic hash — "intended identical" vs
+  "actually byte-identical"). A community registry maps names → semantic
+  cores + hashes; cross-deployment name collisions are disambiguated by
+  the hash in metadata rather than prevented by unreadable paths. D7
+  generalizes cleanly: "one store per dataset" becomes "one product tree
+  per semantic core" under a shared root, with cross-product joins
+  unchanged.
 - **D20 — Per-shard telemetry sidecar + run records** (espg on-thread:
   [sibling placement + envelope ride](https://github.com/englacial/zagg/issues/297#issuecomment-5016910923),
   [caller identity](https://github.com/englacial/zagg/issues/297#issuecomment-5016901381);
@@ -644,13 +672,19 @@ rollup leaves all leaf reads intact.
   min/max, t-digests; never stored means) — so up-tree rollups are a pure
   fold (D22). The record also rides the async result envelope; the
   dispatcher writes a **run-level parquet at the product root** — a run maps
-  to one template ⇒ one product tree (D7/D19), so it lands under `{hash}/`,
+  to one product ⇒ one product tree (D7/D19), so it lands under `{name}/`,
   never the multi-product store root, whose node invariant admits only
-  `{hash}.yaml` + `{hash}/` — with one row per
+  `{name}/` product roots — with one row per
   shard, *including failure rows* sourced from the run report — sidecars
   exist only on success; CloudWatch structured logs remain the failure
-  forensics channel). Sidecars omit account-identifying fields (request
-  ids, ARNs beyond the caller identity).
+  forensics channel). Run-record names are **timestamp-first**
+  (`stats_{timestamp}_{run_id}.parquet`) so lexicographic listing is
+  chronological and time-range queries prune on keys before reading;
+  per-user scoping stays the `invoked_by` *column* (names stay stable
+  identifiers). Sidecars carry the `run_id` (joining leaf → run record →
+  that run's archived literal template, D19) and the D19 `semantic_hash`;
+  they omit account-identifying fields (request ids, ARNs beyond the
+  caller identity).
 - **D21 — `path_grouping` is a manifest parameter, not a layout**
   (espg-ratified in-session, recorded on
   [#300](https://github.com/englacial/zagg/issues/300#issuecomment-5017464707)).
@@ -706,11 +740,42 @@ rollup leaves all leaf reads intact.
   `none.zarr` matches the schedule literal but reads worse) — and the
   sidecar alignment `{window}.stats.json` / `all.stats.json` (D20
   naming; follow-up to the merged PR #302). Rejected alternative: time
-  as a *path* level (`{hash}/{window}/{morton…}`) would make
+  as a *path* level (`{name}/{window}/{morton…}`) would make
   window-scoped ops prefix-cheap but duplicates the morton tree per
   window and shatters the dominant read — a time series at a location —
   across W prefixes; reads dominate window expiry, so time stays at the
   leaf.
+- **D24 — Resolution polymorphism: cell order is a query/packaging axis,
+  not product identity** (espg-proposed and ratified in-session,
+  2026-07-20; rationale recorded on the PR #306 thread). Aggregation
+  *composes* across orders — finer cells fold to coarser under the same
+  merge law (exactly for count/sum/min/max; `np.isclose` for t-digest,
+  whose merge is order-dependent — the same epistemic class as
+  merge-vs-spill, already ruled one-store) — so a product's cell order is
+  excluded from the D19 `semantic_hash`, and one product tree may carry
+  **regionally heterogeneous resolution** (e.g. o19 cells in polar
+  shards, o17 mid-latitude). The design had already committed to the
+  pillars: D22's rollup==direct obligation *is* the composition claim;
+  D16 chose morton words because they carry order intrinsically; D11's
+  `role` attr anticipated coarse *source*; the #217 mergeable-reducer
+  machinery provides per-aggregator merge laws. Consequences frozen with
+  the decision: (1) **composability class** — `exact | approximate |
+  none` — is declared in the semantic core, derived from the product's
+  aggregator set; a `none` product pins its cell order (resolution *is*
+  identity there) and refuses mixed-order appends. (2) Per (shard,
+  window) there is **one resolution at a time**: heterogeneity is
+  regional, across shards. A same-cell-order rerun is D4 idempotent
+  replacement; **writing a different cell order into an occupied leaf
+  refuses with a useful error** (espg-directed) — intentional
+  re-resolution means rerunning at a parent order that isn't occupied, or
+  explicitly clearing the leaf. (3) Manifest `cell_order` and
+  `shard_order` become declared allowed sets/ranges (§3); per-leaf truth
+  is the morton words + MOC. (4) Coarse source and sweep-built overviews
+  unify — the same multi-order tree, distinguished only by `role`/
+  provenance attrs; the pyramid is the store's resolution axis, partially
+  materialized. Reader support is gated on mortie#116 mixed-order morton
+  (tracked as moczarr#8); the schema needs no bump — this is what the
+  coordinate system was built for.
 
 ### 8.2 Open for review (input needed)
 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -595,7 +595,13 @@ rollup leaves all leaf reads intact.
   lifecycle/expiration, access policy, inventory) dominate in practice —
   under colocation each would need per-object tagging or the
   out-of-contract full enumeration; under hash-first each is one prefix
-  rule. Within-product walk/terminal semantics revert to the proven
+  rule. Cost prediction for appending new shards to a product is likewise
+  greatly simplified (espg-noted in-session, 2026-07-20): the product root
+  scopes its own telemetry history — the D20 run records and sidecars all
+  sit under one prefix — so the pilot-first cost estimator's priors (the
+  #298 design) are exactly the product's own records: same template, same
+  per-observation cost profile, no cross-product filtering. Within-product
+  walk/terminal semantics revert to the proven
   single-product forms, and per-product artifacts keep bare names (one
   less naming surface for readers to get wrong). What hash-first gives
   up — a single spatial prefix spanning all products — serves no planned

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -3,8 +3,9 @@
 **Status**: draft. Tracks [#198](https://github.com/englacial/zagg/issues/198);
 temporal-partitioning amendments (D13–D15) ratified on
 [#237](https://github.com/englacial/zagg/issues/237); morton-only-storage
-amendment (D16, O10) ratified on
-[#262](https://github.com/englacial/zagg/issues/262).
+amendment ratified on
+[#262](https://github.com/englacial/zagg/issues/262) (D16; open item O10
+carved from it).
 
 > All design decisions (both made and open) are consolidated in the
 > [Decisions registry](#8-decisions-registry). Inline references use **D#** for

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -5,7 +5,12 @@ temporal-partitioning amendments (D13–D15) ratified on
 [#237](https://github.com/englacial/zagg/issues/237); morton-only-storage
 amendment ratified on
 [#262](https://github.com/englacial/zagg/issues/262) (D16; open item O10
-carved from it).
+carved from it); 2026-07 consolidation (D17–D22, O3 resolved, O11 opened)
+recording decisions settled on the
+[#251](https://github.com/englacial/zagg/issues/251)/[#236](https://github.com/englacial/zagg/issues/236)/[#209](https://github.com/englacial/zagg/issues/209)
+and [#296](https://github.com/englacial/zagg/issues/296)-family threads —
+per-entry provenance (thread-ratified vs in-session-recorded) is cited
+inline.
 
 > All design decisions (both made and open) are consolidated in the
 > [Decisions registry](#8-decisions-registry). Inline references use **D#** for
@@ -30,8 +35,9 @@ set of primitives answers all of them:
    this fine ICESat-2 observation, what GEDI observation contains it?"
    Because a morton decimal string prefix *is* the spatial ancestor, that
    join is **truncation** — arithmetic, not I/O.
-3. **xdggs assumes dense full-sphere coordinates.** The current `fullsphere`
-   layout materializes a coordinate entry for every cell of the global grid.
+3. **xdggs assumes dense full-sphere coordinates.** The legacy `fullsphere`
+   layout (deprecated, dense path removed in 0.x — D17) materialized a
+   coordinate entry for every cell of the global grid.
    For sparse-coverage data (a continent, a flight campaign) this is waste at
    best and intractable at global orders. The fix is a **domain declaration**:
    a coverage MOC conservatively declaring where data exists, letting the
@@ -51,12 +57,19 @@ what zagg consumes:
 
 ```
 {store_root}/
-  morton_hive.json               <- static manifest (§3); root-only exception
-  coverage.moc                   <- optional root MOC (§4, O9); root-only exception
-  {sign+base}/{d1}/{d2}/.../     <- one digit per level (D2)
-    {full_id}.zarr/              <- self-describing leaf (D3), vanilla zarr v3
-    {full_id}_{window}.zarr/     <- time-windowed leaf (D13); naming frozen on
-                                    the mortie spec page (morton-hive/2)
+  {hash}.morton_hive.json        <- per-product static manifest (§3, D19);
+                                    pre-D19 stores: a single morton_hive.json
+  {hash}.yaml                    <- template registry entry (D19)
+  coverage.moc                   <- optional root MOC (§4, O9)
+  <run records (parquet)>        <- run-level telemetry, one row/shard (D20)
+  {sign+base}/{d1}/{d2}/.../     <- one digit per level (D2; digit-chunking is
+                                    the manifest path_grouping param, D21)
+    {hash}.zarr/                 <- leaf, basename = template hash (D19;
+                                    pre-D19: {full_id}.zarr, D3); zarr v3,
+                                    dense arrays via ShardingCodec (D17)
+    {hash}_{window}.zarr/        <- time-windowed leaf (D13 grammar, D19 base)
+    {hash}.stats.json            <- per-shard stats sidecar, sibling (D20)
+    <sub-shardmap JSON>          <- leaf sub-map for sweep rollups (D22)
 ```
 
 - **Ids are morton decimal strings** (D1): sign + base digit (constant width,
@@ -64,10 +77,15 @@ what zagg consumes:
   `0`. String prefix = spatial ancestor at every level.
 - **One digit per path component** (D2), because shards live at mixed orders —
   across datasets *and* within a store (coarse shards in sparse regions) —
-  so every order must be a legal node.
+  so every order must be a legal node. D21 makes the digit-chunking a
+  declared manifest parameter (`path_grouping`, default `1` = this layout);
+  readers chunk the digit string per the manifest, never by assumption.
 - **Full morton id at the leaf** (D3): `.../1/2/3/-31123.zarr/` is
   self-describing without parsing its path, greppable in inventories,
-  unambiguous if moved.
+  unambiguous if moved. *Amended by D19*: leaf basenames become template
+  hashes — spatial identity lives in the path, product identity in the
+  basename; the greppable full id moves to the stamp attrs and the stats
+  sidecar's `shard_key` (D20).
 - **Time-windowed leaves** (D13, ratified on
   [#237](https://github.com/englacial/zagg/issues/237)): a store whose
   manifest declares a temporal window schedule (§3) partitions each shard's
@@ -86,13 +104,17 @@ what zagg consumes:
   debris rule (rationale on the #237 thread). Cross-window reads open W
   leaves and concatenate along time; paths stay arithmetic because the
   schedule lives in the manifest (D10 preserved). The no-partitioning
-  degenerate case (`schedule: none`) keeps the bare `{full_id}.zarr` name and
-  is byte-identical to the pre-D13 layout — a `morton-hive/1` store *is* a
-  `/2` store with `schedule: none`.
+  degenerate case (`schedule: none`) keeps the bare leaf name (pre-D19
+  `{full_id}.zarr`, byte-identical to the pre-D13 layout; post-D19
+  `{hash}.zarr` — the window grammar is unchanged either way) — a
+  `morton-hive/1` store *is* a `/2` store with `schedule: none`.
 - **Node invariant**: below the root, a node contains *only* digit children
-  (`[1-4]/`) and `*.zarr` objects. Nothing else, ever — the walker's child
-  classification depends on it. The root alone also carries the manifest and
-  MOC objects.
+  (`[1-4]/`), `*.zarr` objects, and the declared leaf-adjacent sidecars —
+  the per-shard stats record (D20) and the sub-shardmap JSON (D22) — with
+  nothing else, ever: the walker's child classification depends on the name
+  set being closed. The root alone also carries the manifest(s), the
+  template registry (`{hash}.yaml`, D19), MOC objects, and run-level
+  telemetry records (D20).
 - **Termination condition**: S3 has no empty directories (a prefix exists iff
   ≥1 object lies beneath it) and LIST is strongly consistent, so a
   delimiter-LIST returning no digit-shaped children is a definitive "nothing
@@ -136,8 +158,16 @@ again during a run. Contents:
   orders, the allowed set).
 - Split schedule (implicit under D2: one digit per level to `shard_order`;
   recorded explicitly for forward compatibility).
-- Pyramid declaration: which ancestor orders carry overview zarrs, and their
-  aggregation methods (populated/updated by the §7 sweep).
+- `path_grouping` (D21): how many morton digits each path component chunks.
+  Existing stores are retroactively `1`; new stores default `1`; changing the
+  default later is a parameter flip for new stores, never a schema break.
+- Rollup/pyramid declaration (D22 extends the original overview-only form):
+  which ancestor orders carry which derived artifact family — overview
+  zarrs, stats rollups, sub-shardmap rollups — declared **per artifact
+  family** (schedules may differ; display overviews as dense as rendering
+  warrants, metadata rollups sparser), populated/updated by the §7 sweep.
+  Tree shape (`path_grouping`) and rollup schedules are deliberately
+  decoupled.
 - **Temporal block** (D15, ratified on
   [#237](https://github.com/englacial/zagg/issues/237)): a store carrying this
   block declares `spec: "morton-hive/2"` (the version string of D6 covers these
@@ -151,9 +181,10 @@ again during a run. Contents:
   Generative schedules keep the manifest
   write-once and static as data accrues: appending a new year to a
   `yearly` store adds leaves the schedule already describes — no manifest
-  touch, and **no new manifests**: the store has exactly one
-  `morton_hive.json`, and each new windowed leaf brings only its own zarr
-  metadata + D4 stamp. The explicit-range-list form is the noted exception:
+  touch, and **no new manifests**: the store has exactly one manifest *per
+  product* (pre-D19: one `morton_hive.json` total; post-D19: one
+  `{hash}.morton_hive.json` per template hash), and each new windowed leaf
+  brings only its own zarr metadata + D4 stamp. The explicit-range-list form is the noted exception:
   appending a window outside the declared list re-templates the manifest (a
   rare, single-writer, template-time operation, not a worker-race write) —
   append-heavy stores should prefer generative schedules. (This exception is
@@ -300,9 +331,10 @@ millions of photons the walk is the robustness path, not the join path (D10).
 
 ## 6. Layer 4: the xarray/xdggs extension ("sparse DGGS")
 
-This is the layer that should eventually land upstream — in xdggs if the
-convention generalizes, or as its own xarray extension if not (O3). Broad
-scope:
+This layer ships as zagg's own standalone extension — **moczarr** (O3
+resolved: standalone-first, offered upstream; xdggs adoption of
+`MortonIndexDtype` ([#72](https://github.com/englacial/zagg/issues/72)) is a
+follow-on, not a gate). Broad scope:
 
 - **Domain = MOC.** A dataset declares its coverage as a MOC instead of
   materializing dense full-sphere coordinates. The accessor uses it to
@@ -330,6 +362,9 @@ Everything derived or stale-prone lives in a second pass, never at write time
 (D11) — overviews aggregate across worker-shard boundaries, so they *can't*
 be produced by shard workers anyway.
 
+The sweep owns four derived artifact families (D22; the original scope was
+the first two):
+
 - **Overview zarrs at ancestor nodes**, explicitly marked
   (`role: overview` + source order + aggregation method in attrs). Never
   inferred from position: a shallow zarr may equally be *coarse source* in a
@@ -337,13 +372,30 @@ be produced by shard workers anyway.
   (4 children per order).
 - **MOC (re)generation** — compose ancestor MOCs bottom-up from the leaf
   stamps (union, re-coarsen to budget) and refresh the root `coverage.moc`.
+- **Sub-shardmap rollups** (D22): each leaf prefix carries its shard's
+  sub-map as full ShardMap JSON; the sweep folds them up-tree via the
+  coarsen path (`ShardMap.reproject` — exact pure regroup, granule union
+  deduped by id; [#294](https://github.com/englacial/zagg/issues/294)).
+- **Stats/cost rollups** (D22): the per-shard stats sidecars (D20) fold
+  up-tree — the schema is associative by construction, so the rollup is the
+  same fold shape as the pyramid.
 - **Optional interop materialization**: if a use case ever demands a
   `zarr.open(store_root)`-able hierarchy or a one-GET consolidated index,
   the sweep generates it *as a derived artifact* here. Round one ships
   without it (D12).
 
+Every rollup is stamped with **generation info** (merged-leaf count + max
+leaf timestamp): after a leaf re-run, ancestors are *detectably* stale —
+staleness is detected, not prevented, and rollups are regenerated
+opportunistically (D9 semantics). The core test obligation is
+**rollup == direct**: the folded artifact at level N must equal direct
+computation at level N, for every family. Triggering is an end-of-run
+dispatcher hook plus a manual CLI; the sweep discovers work from the run
+record, not by listing.
+
 The sweep is idempotent and can fail or lag without corrupting anything: the
-write path (§2) is load-bearing; this phase is optimization.
+write path (§2) is load-bearing; this phase is optimization — deleting every
+rollup leaves all leaf reads intact.
 
 ## 8. Decisions registry
 
@@ -359,8 +411,14 @@ write path (§2) is load-bearing; this phase is optimization.
   Grouped-digit and two-level schedules are dead ends. Note the schedule is
   *logical only*: S3 partitioning is delimiter-blind, so slashes buy zero
   throughput ([#197](https://github.com/englacial/zagg/issues/197) is the
-  throughput fix).
+  throughput fix). *Amended by D21*: digit-chunking becomes the declared
+  `path_grouping` manifest parameter (default `1` = this rule); the
+  "grouped-digit schedules are dead ends" verdict is thereby softened to
+  "grouping is a parameter, never a schema fork."
 - **D3 — Full morton id at the leaf** (`{full_id}.zarr`), self-describing.
+  *Amended by D19*: basename becomes the template hash; spatial identity is
+  the path, product identity the basename, and the full id moves to stamp
+  attrs + the D20 sidecar's `shard_key`.
 - **D4 — Commit stamp via final root-attrs update.** Absence (LIST) is
   trustworthy; presence requires the stamp. Torn shards are debris,
   overwritable on retry. One small PUT; not consolidation.
@@ -377,9 +435,16 @@ write path (§2) is load-bearing; this phase is optimization.
   write access). Replaces consolidated metadata (disabled; measured
   +70 s/worker).
 - **D9 — MOC is a regenerable cache; the tree walk is ground truth.**
-- **D10 — Arithmetic-first reads; no LISTs in join loops.**
+- **D10 — Arithmetic-first reads; no LISTs in join loops.** *Strengthened
+  with D22 (espg-ratified in-session, recorded on
+  [#300](https://github.com/englacial/zagg/issues/300#issuecomment-5017464707)):
+  MOC-first is the reader contract — full recursive enumeration is
+  **out-of-contract** for readers, reserved for prefix-sharded audit
+  tooling. The §5 discovery walk remains the robustness/verification path,
+  never the read path.*
 - **D11 — Pyramids/overviews are a second-pass sweep**, `role: overview`
-  attrs, never inferred from tree position.
+  attrs, never inferred from tree position. *Scope extended by D22 (four
+  artifact families, generation stamps, per-family manifest schedules).*
 - **D12 — Plain manifest, not a zarr-native hierarchy, in round one.**
   Hierarchy metadata at nodes reintroduces the metadata-op storm
   ([#189](https://github.com/englacial/zagg/issues/189),
@@ -403,7 +468,9 @@ write path (§2) is load-bearing; this phase is optimization.
   `{full_id}_{window}.zarr`, underscore separator, split on the first `_`
   — grammar and boundary semantics recorded on the
   [mortie spec page](https://github.com/espg/mortie/issues/62#issuecomment-4986809092)
-  as part of `morton-hive/2`. Reserved (lean, not decided): §7
+  as part of `morton-hive/2`. (*D19 swaps the `{full_id}` base for
+  `{hash}`; the underscore grammar and window semantics are unchanged — the
+  spec-page update rides the D19 break.*) Reserved (lean, not decided): §7
   overview/pyramid zarrs inherit window naming (per-window overviews, with
   an optional all-time overview as a derived artifact).
 - **D14 — Coverage `encoding: "full"` fast path**
@@ -462,6 +529,112 @@ write path (§2) is load-bearing; this phase is optimization.
   separately ratified on the thread.) The order-29 discriminator
   metadata is O10.
 
+- **D17 — Hive+sharded is the HEALPix default; flat/fullsphere deprecated;
+  dense leaf arrays write through the ShardingCodec.**
+  (Phase-1 ratification recorded on
+  [#251](https://github.com/englacial/zagg/issues/251#issuecomment-4989697559);
+  landed via PR #257 (default flip + dense-layout removal), #233 (`sharded:
+  true` default), #241 (hive dense parity); leaf object model ratified
+  in-session, recorded on
+  [#236](https://github.com/englacial/zagg/issues/236#issuecomment-4986241727).)
+  Every HEALPix config — point aggregation and raster — targets hive; the
+  grid determines the layout (no `store_layout` knob survives, #238); rect
+  keeps its bounded flat store. Hive leaf dense arrays are one object per
+  array per leaf via the ShardingCodec (always-accumulate); `sharded: false`
+  remains a legitimate opt-out, and **raster leaves skip the sharding codec
+  by design** — the only raster/aggregation difference at the leaf
+  ([espg on PR #257](https://github.com/englacial/zagg/pull/257#issuecomment-5005249126)).
+  `grid.shard_order` (sub-shard object granularity) is removed
+  ([#238](https://github.com/englacial/zagg/issues/238#issuecomment-4986885796));
+  the manifest's `shard_order` (tree/dispatch order) is unrelated and stays.
+  Full flat-machinery removal remains gated on the O3 reader (the #251
+  phase-2 gate).
+- **D18 — Ragged output = sharded vlen-bytes** (espg-ratified in-session,
+  recorded on
+  [#209](https://github.com/englacial/zagg/issues/209#issuecomment-4940116927);
+  tracking [#210](https://github.com/englacial/zagg/issues/210)). Ragged
+  t-digest arrays store as `bytes` dtype + vlen-bytes codec under the
+  ShardingCodec — one object per shard, 2-GET single-cell reads — with
+  element interpretation as an attrs convention and a **golden-bytes framing
+  pin** byte-compatible with numcodecs `VLenArray`. The CSR-per-inner-chunk
+  fanout is deleted. A typed `vlen-array<float32>` ZDType is deferred behind
+  three gates (upstream zarr-extensions convergence, at-scale proof, a
+  second consumer); the framing pin guarantees any future migration is
+  metadata-only. This is the second noted soft-exception to "vanilla zarr
+  v3" leaves (after the §4 coverage sidecar): plain zarr readers see opaque
+  bytes, not garbage.
+- **D19 — Template-hash leaf naming: the hive tree is a multi-product
+  store** (settled across
+  [#296](https://github.com/englacial/zagg/issues/296#issuecomment-5014826849)
+  and [#299](https://github.com/englacial/zagg/issues/299); espg on-thread:
+  [naming + registry + per-product manifests](https://github.com/englacial/zagg/issues/299#issuecomment-5017263033);
+  breaking, pre-1.0, same window as the D16 writer flip). Leaf basename =
+  truncated sha256 (12 hex; collision domain is templates-within-one-store)
+  of the **canonicalized** agg template (parse YAML → sorted-key JSON →
+  hash; never raw bytes). Products colocate as siblings under one morton
+  prefix; discovery is a prefix listing. The template itself is written to
+  the store root as `{hash}.yaml` — a content-addressed registry designed so
+  a future external/community registry is a pure file-merge superset.
+  Manifests go per-product (`{hash}.morton_hive.json`; root listing is
+  product discovery). **Catalog identity lives in the sidecar, never the
+  name**: granule count + sha256 of sorted granule ids + zagg version;
+  dedup/`has_run` consults name *and* sidecar (a catalog-grown shard is
+  "stale", not "hit") — the template hash alone proves identity only for a
+  frozen catalog. Immutable-provenance naming
+  (`{hash}+{catalog-hash}.zarr`) is an opt-in for frozen-catalog archival
+  runs; default stays template-hash-only. The output content hash that
+  makes dedup *verifiable* is O11 (proposal). Old-layout stores must fail
+  loudly, never misread.
+- **D20 — Per-shard telemetry sidecar + run records** (espg on-thread:
+  [sibling placement + envelope ride](https://github.com/englacial/zagg/issues/297#issuecomment-5016910923),
+  [caller identity](https://github.com/englacial/zagg/issues/297#issuecomment-5016901381);
+  schema decisions recorded on
+  [#296](https://github.com/englacial/zagg/issues/296#issuecomment-5014826849)).
+  Each successful shard writes a versioned stats record as a **sibling**
+  object next to the leaf (not inside the `.zarr/`): timings
+  (read/index/aggregate/write/spill), counts, memory, cost (GB-s ×
+  price), catalog identity (D19), zagg version, and `invoked_by` (caller
+  identity resolved once per run by the dispatcher via STS and stamped
+  through the invoke payload — workers cannot see the caller). The schema
+  is **mergeable by construction** — only associative stats (counts, sums,
+  min/max, t-digests; never stored means) — so up-tree rollups are a pure
+  fold (D22). The record also rides the async result envelope; the
+  dispatcher writes a **run-level parquet at the store root** (one row per
+  shard, *including failure rows* sourced from the run report — sidecars
+  exist only on success; CloudWatch structured logs remain the failure
+  forensics channel). Sidecars omit account-identifying fields (request
+  ids, ARNs beyond the caller identity).
+- **D21 — `path_grouping` is a manifest parameter, not a layout**
+  (espg-ratified in-session, recorded on
+  [#300](https://github.com/englacial/zagg/issues/300#issuecomment-5017464707)).
+  The manifest declares how many morton digits each path component chunks;
+  existing stores are retroactively `1`; new stores default `1`; readers
+  chunk the digit string per the manifest. Rationale: hive paths are
+  *computed* (manifest + MOC → arithmetic paths → parallel GETs — zero
+  LISTs on every hot path), so grouping is walk ergonomics, not
+  performance; hard-adopting a grouped layout would have forked the path
+  dialect permanently for ~$1.60 and ~1.6 s per rare full walk. A future
+  default flip (e.g. to 3-order groups) is a parameter change, never a
+  schema break.
+- **D22 — One unified second-pass sweep owns all derived artifacts**
+  (espg on-thread:
+  [trigger + sub-map format + schedule discussion](https://github.com/englacial/zagg/issues/300#issuecomment-5017291722);
+  schedule decoupling ratified in-session, recorded on
+  [#300](https://github.com/englacial/zagg/issues/300#issuecomment-5017464707)).
+  Four families — overview zarrs, MOC regen, sub-shardmap rollups (full
+  ShardMap JSON at leaf prefixes, folded via the exact coarsen regroup,
+  [#294](https://github.com/englacial/zagg/issues/294)), stats rollups
+  (D20 fold) — in one idempotent pass with per-family, manifest-declared
+  order schedules (decoupled from `path_grouping`). Generation stamps
+  (merged-leaf count + max leaf timestamp) make staleness detectable, not
+  prevented; **rollup == direct** is the standing test obligation per
+  family; trigger is end-of-run hook + manual CLI; the sweep discovers work
+  from the run record, never by listing. Nothing is load-bearing: deleting
+  every rollup leaves leaf reads intact (D9 semantics). (The refine
+  direction of `ShardMap.reproject` and its no-region semantics are still
+  under review on PR #295 — the sweep depends only on the exact coarsen
+  direction.)
+
 ### 8.2 Open for review (input needed)
 
 - **O1 — MOC serialization format** for `coverage.moc`: JSON of nested-range
@@ -472,9 +645,14 @@ write path (§2) is load-bearing; this phase is optimization.
   `MAX_DEPTH = 18` constant, not a u64 limit; the coverage/MOC paths now
   reach the packed-u64 kernel ceiling (order 29), so cell-order MOCs at
   order 19 are representable today.
-- **O3 — Upstream target**: extend xdggs vs. standalone xarray extension.
-  Depends partly on xdggs's appetite for MortonIndexDtype (#72) and
-  non-dense coordinate models.
+- **O3 — Upstream target: RESOLVED — standalone-first (moczarr)**
+  ([espg-ratified, recorded on
+  #251](https://github.com/englacial/zagg/issues/251#issuecomment-4989697559)):
+  the sparse-DGGS reader ships as zagg's own standalone xarray extension
+  (espg/moczarr, published from our side and offered upstream); xdggs
+  adoption of MortonIndexDtype (#72) is a follow-on, not a 1.0 gate.
+  Near-drop-in `xr.open_zarr()`-grade ergonomics is a hard acceptance
+  criterion (it gates the #251 flat removal).
 - **O4 — Multi-dataset join API**: what does the cross-resolution join look
   like in xarray terms — alignment, an accessor method, a lazy index?
 - **O5 — Sentinel-2 encoding**: native ~10 m order, one order finer (6 m,
@@ -526,6 +704,21 @@ write path (§2) is load-bearing; this phase is optimization.
   documented point-id/area-word parse non-injectivity at order 29; field
   name, values, and placement to be frozen with the mortie spec page
   ([mortie#62](https://github.com/espg/mortie/issues/62)).
+- **O11 — logical content hash of outputs** (carved from D19; **proposal
+  awaiting espg sign-off** — espg asked for expanded context on
+  [#299](https://github.com/englacial/zagg/issues/299#issuecomment-5017263033),
+  expansion posted
+  [in reply](https://github.com/englacial/zagg/issues/299#issuecomment-5017334704)).
+  Proposal: per-array sha256 over *decoded* values (raw C-order bytes at the
+  declared dtype, after decompression — never stored object bytes, which
+  churn on codec/library upgrades), recorded in the D20 sidecar as
+  `{array_name: hash}` plus one combined hash. Exact bytes, no float
+  tolerance: any value change — including flagged code changes that pass
+  `np.isclose` (the PR #282 class) — flips the hash by design;
+  interpretation pairs the hash with the sidecar's recorded zagg version.
+  Motivation: outputs have been byte-identical between runs in practice, so
+  this turns D19's "probably already ran" dedup into a verifiable claim
+  without folding catalog identity into leaf names.
 
 ## 9. References
 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -538,8 +538,10 @@ rollup leaves all leaf reads intact.
   in-session, recorded on
   [#236](https://github.com/englacial/zagg/issues/236#issuecomment-4986241727).)
   Every HEALPix config — point aggregation and raster — targets hive; the
-  grid determines the layout (no `store_layout` knob survives, #238); rect
-  keeps its bounded flat store. Hive leaf dense arrays are one object per
+  grid keys the default layout (hive for HEALPix; PR #257 / #253), and an
+  explicit `store_layout: flat` survives only as a deprecated escape hatch
+  (emits a `DeprecationWarning`) until the O3-gated flat removal; rect keeps
+  its bounded flat store. Hive leaf dense arrays are one object per
   array per leaf via the ShardingCodec (always-accumulate); `sharded: false`
   remains a legitimate opt-out, and **raster leaves skip the sharding codec
   by design** — the only raster/aggregation difference at the leaf

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -5,7 +5,8 @@ temporal-partitioning amendments (D13–D15) ratified on
 [#237](https://github.com/englacial/zagg/issues/237); morton-only-storage
 amendment ratified on
 [#262](https://github.com/englacial/zagg/issues/262) (D16; open item O10
-carved from it); 2026-07 consolidation (D17–D24, O3 resolved, O11 opened)
+carved from it); 2026-07 consolidation (D17–D24, O3 resolved, O11–O13
+opened, §8.3 test-obligations index added)
 recording decisions settled on the
 [#251](https://github.com/englacial/zagg/issues/251)/[#236](https://github.com/englacial/zagg/issues/236)/[#209](https://github.com/englacial/zagg/issues/209)
 and [#296](https://github.com/englacial/zagg/issues/296)-family threads —
@@ -147,6 +148,17 @@ products by listing `{store_root}/` and reading each
 - **The write path needs zero metadata above the leaf** (D5). No zarr group
   objects at digit nodes, no shared mutable state, no create-group races
   across 2,000 workers.
+- **Concurrency contract** (a derived property, recorded 2026-07-20 —
+  assembled here so it exists in one place): concurrent runs against one
+  product are supported whenever they are **shard-disjoint** — they share
+  no objects (D4/D5), their run records are distinct by name
+  (timestamp + run id, D20), and the manifest precheck admits both
+  (frozen keys match by construction under D19). Same-(shard, window)
+  concurrency degrades to D4 semantics — last writer wins; the loser's
+  partial output is stamped-over or remains ignorable debris. Interior
+  rollups may go stale during any of this, which D22's generation stamps
+  make detectable, never silently wrong. Cross-product concurrency shares
+  nothing at all.
 
 Zarr-version note: implicit groups were a *draft*-v3 feature, dropped before
 finalization; v2 requires explicit `.zgroup` objects too. Neither models the
@@ -661,7 +673,15 @@ rollup leaves all leaf reads intact.
   the hash in metadata rather than prevented by unreadable paths. D7
   generalizes cleanly: "one store per dataset" becomes "one product tree
   per semantic core" under a shared root, with cross-product joins
-  unchanged.
+  unchanged. Three refinements (espg-confirmed in-session, 2026-07-20):
+  **the manifest `semantic_hash` is truth** — `aggregation.yaml` is a
+  derived convenience (D9 cache class, sweep-regenerable), so divergence
+  resolves to the hash; the hash is stored **full-length** with git-style
+  ergonomics (the full digest is what is compared; a short fingerprint —
+  12 hex — is the display/CLI shorthand); and product names are
+  **URL-safe by requirement** (they appear in gridlook deep-links and web
+  paths — proposed charset: lowercase alphanumerics plus `-`/`_`, frozen
+  with the name grammar on the mortie spec page).
 - **D20 — Per-shard telemetry sidecar + run records** (espg on-thread:
   [sibling placement + envelope ride](https://github.com/englacial/zagg/issues/297#issuecomment-5016910923),
   [caller identity](https://github.com/englacial/zagg/issues/297#issuecomment-5016901381);
@@ -719,7 +739,11 @@ rollup leaves all leaf reads intact.
   every rollup leaves leaf reads intact (D9 semantics). (The refine
   direction of `ShardMap.reproject` and its no-region semantics are still
   under review on PR #295 — the sweep depends only on the exact coarsen
-  direction.)
+  direction.) An optional fifth, audit-class family (espg-directed
+  in-session, 2026-07-20): **debris collection** — unstamped `.zarr/`
+  prefixes older than a declared horizon are deleted, prefix-sharded,
+  never load-bearing (D4 already makes debris ignorable; this stops it
+  accumulating as paid storage at fleet scale).
 - **D23 — Leaf basename = time window (`{window}.zarr`), `morton-hive/3`**
   (espg-proposed and ratified in-session, 2026-07-20; recorded here and on
   the PR #306 thread). Completes the axis separation D19 began: product =
@@ -785,7 +809,16 @@ rollup leaves all leaf reads intact.
   provenance attrs; the pyramid is the store's resolution axis, partially
   materialized. Reader support is gated on mortie#116 mixed-order morton
   (tracked as moczarr#8); the schema needs no bump — this is what the
-  coordinate system was built for.
+  coordinate system was built for. Open sub-point (deferred pending
+  discussion, espg leans recorded 2026-07-20): how a `none`
+  (non-composable) field behaves — the recorded lean is **per-field
+  exclusion from coarser materializations** (composable fields roll up;
+  non-composable fields exist only at native resolution — matching
+  #201's "which fields degrade" question) rather than min-semantics
+  pinning the whole product; and whether `none` fields are permitted at
+  all — lean: allowed, with a **loud warning** at template validation.
+  Per-field exclusion makes "resolution of a product" per-field, which
+  readers must handle; not ratified.
 
 ### 8.2 Open for review (input needed)
 
@@ -871,6 +904,58 @@ rollup leaves all leaf reads intact.
   Motivation: outputs have been byte-identical between runs in practice, so
   this turns D19's "probably already ran" dedup into a verifiable claim
   without folding catalog identity into leaf names.
+- **O12 — retention/expiration (proposal, espg-directed to record
+  2026-07-20)**: **product-level** retention is a *prefix* lifecycle rule
+  (one rule per `{name}/` — delete or transition a whole product); 
+  **window-level** retention within a product is the *tag* mechanism —
+  the expiration rule filters on an object tag (e.g. `ephemeral=true`)
+  and keep-alive is a retag (`PutObjectTagging`), never an access-refresh
+  or self-copy "touch" (plain S3 lifecycle cannot key on access; a
+  self-copy is a full write per object). Pin/unpin is therefore explicit
+  and cheap. Open: tag vocabulary, who tags at write time (worker vs
+  dispatcher), and whether pinned windows are recorded in the manifest or
+  only in tags.
+- **O13 — publication profile (shape espg-ratified in-session,
+  2026-07-20; details open)**: publishing a product to a public bucket is
+  a **prefix copy minus operator telemetry**, with the telemetry replaced
+  by a **simple roll-up summary** that preserves cost-estimation utility
+  (per-product totals; no `invoked_by` ARNs, no request ids, no per-run
+  operator detail). Defined once so publishing tooling never improvises.
+  Open: the summary's exact schema, its placement in the published copy
+  (product root), and whether sub-shardmap rollups publish as-is (they
+  carry granule ids — likely fine) or coarsen.
+
+### 8.3 Standing test obligations (what a conforming implementation proves)
+
+Consolidated index of the normative test claims scattered through the
+registry — CI coverage should be auditable against this list:
+
+- **Rollup == direct**, per derived-artifact family (D22): stats fold,
+  shardmap coarsen (the #294 exactness property), MOC union, overview
+  aggregation. Sweep idempotence (second run over an unchanged tree is a
+  no-op) and nothing-load-bearing (deleting every rollup leaves leaf
+  reads green).
+- **Merge-fold algebra** (D20): associativity/commutativity of the stats
+  record fold; merge-of-children == direct.
+- **Semantic-hash canonicalization** (D19): syntactic edits (whitespace,
+  key order, comments) never change the hash; packaging-knob edits
+  (orders, chunking, worker size, streaming mode) never change the hash;
+  any semantic edit does. Name-grammar validation (base-component
+  exclusion, URL-safe charset).
+- **Manifest guard** (§3): frozen-key match ⇒ idempotent accept, no
+  second PUT; mismatch ⇒ pre-dispatch refusal; `path_grouping` absent⇒1
+  normalization; allowed-set membership for `cell_order`/`shard_order`.
+- **D24 guards**: cross-cell-order write into an occupied (shard, window)
+  leaf refuses with the useful error; same-order rerun replaces (D4);
+  composability-class derivation from the aggregator merge-law flags.
+- **Naming dialects** (D23): `/3` round-trip (`{window}.zarr` ↔ sidecar
+  stem) with `/1`–`/2` grammars byte-unchanged; spec-string
+  discrimination.
+- **Golden byte pins**: the D18 vlen-bytes framing (numcodecs
+  `VLenArray`-compatible) and the O8 coverage-bitmap bit convention
+  (PR #208 vectors).
+- **Stamp/debris semantics** (D4): an unstamped leaf is invisible to
+  readers and safely overwritable; a stamped leaf is complete.
 
 ## 9. References
 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -675,7 +675,7 @@ rollup leaves all leaf reads intact.
   "hit"). Immutable-provenance naming (product root
   `{name}+{catalog-hash}/`) stays an opt-in for frozen-catalog archival
   runs. The output content hash that makes dedup *verifiable* is O11
-  (proposal; it complements the semantic hash — "intended identical" vs
+  (resolved — adopted; it complements the semantic hash — "intended identical" vs
   "actually byte-identical"). A community registry maps names → semantic
   cores + hashes; cross-deployment name collisions are disambiguated by
   the hash in metadata rather than prevented by unreadable paths. D7

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -56,21 +56,28 @@ contract: [mortie #48](https://github.com/espg/mortie/issues/48) discussion →
 what zagg consumes:
 
 ```
-{store_root}/
-  {hash}.morton_hive.json        <- per-product static manifest (§3, D19);
-                                    pre-D19 stores: a single morton_hive.json
-  {hash}.yaml                    <- template registry entry (D19)
-  coverage.moc                   <- optional root MOC (§4, O9)
-  <run records (parquet)>        <- run-level telemetry, one row/shard (D20)
-  {sign+base}/{d1}/{d2}/.../     <- one digit per level (D2; digit-chunking is
+{store_root}/                    <- multi-product form (D19): a directory of
+  {hash}.yaml                       stores + a content-addressed registry
+  {hash}/                        <- product root: each product subtree is a
+    morton_hive.json                COMPLETE morton-hive store — bare-named
+    coverage.moc                    manifest (§3) + optional root MOC (§4, O9)
+    <run records (parquet)>      <- run-level telemetry, one row/shard (D20)
+    {sign+base}/{d1}/{d2}/.../   <- one digit per level (D2; digit-chunking is
                                     the manifest path_grouping param, D21)
-    {hash}.zarr/                 <- leaf, basename = template hash (D19;
-                                    pre-D19: {full_id}.zarr, D3); zarr v3,
-                                    dense arrays via ShardingCodec (D17)
-    {hash}_{window}.zarr/        <- time-windowed leaf (D13 grammar, D19 base)
-    {hash}.stats.json            <- per-shard stats sidecar, sibling (D20)
-    <sub-shardmap JSON>          <- leaf sub-map for sweep rollups (D22)
+      {full_id}.zarr/            <- self-describing leaf (D3), zarr v3; dense
+                                    arrays via ShardingCodec (D17)
+      {full_id}_{window}.zarr/   <- time-windowed leaf (D13); naming frozen on
+                                    the mortie spec page (morton-hive/2)
+      stats.json                 <- per-shard stats sidecar, sibling (D20;
+                                    stats_{window}.json for windowed leaves)
+      <sub-shardmap JSON>        <- leaf sub-map for sweep rollups (D22)
 ```
+
+A bare single-product store (today's layout — `morton_hive.json` at the
+store root, no `{hash}/` level) remains fully valid: the D19 product root is
+*additive*, and a product subtree is byte-identical to a bare store. A
+reader distinguishes the two forms by what sits at the root (a manifest ⇒
+bare store; `{hash}.yaml` entries ⇒ product directory).
 
 - **Ids are morton decimal strings** (D1): sign + base digit (constant width,
   12 values `1..6`/`-1..-6`), then one digit per order, digits `1-4`, never
@@ -82,10 +89,9 @@ what zagg consumes:
   readers chunk the digit string per the manifest, never by assumption.
 - **Full morton id at the leaf** (D3): `.../1/2/3/-31123.zarr/` is
   self-describing without parsing its path, greppable in inventories,
-  unambiguous if moved. *Amended by D19*: leaf basenames become template
-  hashes — spatial identity lives in the path, product identity in the
-  basename; the greppable full id moves to the stamp attrs and the stats
-  sidecar's `shard_key` (D20).
+  unambiguous if moved. (Unchanged by D19 — product identity lives at the
+  product *root*, above the tree, so leaf naming and the within-product
+  walk semantics survive untouched.)
 - **Time-windowed leaves** (D13, ratified on
   [#237](https://github.com/englacial/zagg/issues/237)): a store whose
   manifest declares a temporal window schedule (§3) partitions each shard's
@@ -104,17 +110,17 @@ what zagg consumes:
   debris rule (rationale on the #237 thread). Cross-window reads open W
   leaves and concatenate along time; paths stay arithmetic because the
   schedule lives in the manifest (D10 preserved). The no-partitioning
-  degenerate case (`schedule: none`) keeps the bare leaf name (pre-D19
-  `{full_id}.zarr`, byte-identical to the pre-D13 layout; post-D19
-  `{hash}.zarr` — the window grammar is unchanged either way) — a
-  `morton-hive/1` store *is* a `/2` store with `schedule: none`.
-- **Node invariant**: below the root, a node contains *only* digit children
-  (`[1-4]/`), `*.zarr` objects, and the declared leaf-adjacent sidecars —
-  the per-shard stats record (D20) and the sub-shardmap JSON (D22) — with
-  nothing else, ever: the walker's child classification depends on the name
-  set being closed. The root alone also carries the manifest(s), the
-  template registry (`{hash}.yaml`, D19), MOC objects, and run-level
-  telemetry records (D20).
+  degenerate case (`schedule: none`) keeps the bare `{full_id}.zarr` name and
+  is byte-identical to the pre-D13 layout — a `morton-hive/1` store *is* a
+  `/2` store with `schedule: none`.
+- **Node invariant**: below a product root, a node contains *only* digit
+  children (`[1-4]/`), `*.zarr` objects, and the declared leaf-adjacent
+  sidecars — the per-shard stats record (D20) and the sub-shardmap JSON
+  (D22) — with nothing else, ever: the walker's child classification
+  depends on the name set being closed. The product root alone also carries
+  the manifest, MOC objects, and run-level telemetry records (D20); the
+  *store* root of a multi-product directory carries only `{hash}.yaml`
+  registry entries and `{hash}/` product roots (D19).
 - **Termination condition**: S3 has no empty directories (a prefix exists iff
   ≥1 object lies beneath it) and LIST is strongly consistent, so a
   delimiter-LIST returning no digit-shaped children is a definitive "nothing
@@ -181,10 +187,10 @@ again during a run. Contents:
   Generative schedules keep the manifest
   write-once and static as data accrues: appending a new year to a
   `yearly` store adds leaves the schedule already describes — no manifest
-  touch, and **no new manifests**: the store has exactly one manifest *per
-  product* (pre-D19: one `morton_hive.json` total; post-D19: one
-  `{hash}.morton_hive.json` per template hash), and each new windowed leaf
-  brings only its own zarr metadata + D4 stamp. The explicit-range-list form is the noted exception:
+  touch, and **no new manifests**: each product tree has exactly one
+  `morton_hive.json` (under D19 a multi-product store is a directory of
+  product trees, each with its own bare-named manifest), and each new
+  windowed leaf brings only its own zarr metadata + D4 stamp. The explicit-range-list form is the noted exception:
   appending a window outside the declared list re-templates the manifest (a
   rare, single-writer, template-time operation, not a worker-race write) —
   append-heavy stores should prefer generative schedules. (This exception is
@@ -416,9 +422,8 @@ rollup leaves all leaf reads intact.
   "grouped-digit schedules are dead ends" verdict is thereby softened to
   "grouping is a parameter, never a schema fork."
 - **D3 — Full morton id at the leaf** (`{full_id}.zarr`), self-describing.
-  *Amended by D19*: basename becomes the template hash; spatial identity is
-  the path, product identity the basename, and the full id moves to stamp
-  attrs + the D20 sidecar's `shard_key`.
+  (Unchanged by D19: product identity lives at the product root, above the
+  tree.)
 - **D4 — Commit stamp via final root-attrs update.** Absence (LIST) is
   trustworthy; presence requires the stamp. Torn shards are debris,
   overwritable on retry. One small PUT; not consolidation.
@@ -468,9 +473,8 @@ rollup leaves all leaf reads intact.
   `{full_id}_{window}.zarr`, underscore separator, split on the first `_`
   — grammar and boundary semantics recorded on the
   [mortie spec page](https://github.com/espg/mortie/issues/62#issuecomment-4986809092)
-  as part of `morton-hive/2`. (*D19 swaps the `{full_id}` base for
-  `{hash}`; the underscore grammar and window semantics are unchanged — the
-  spec-page update rides the D19 break.*) Reserved (lean, not decided): §7
+  as part of `morton-hive/2`. (Unchanged by D19 — leaf naming survives the
+  product-root design intact.) Reserved (lean, not decided): §7
   overview/pyramid zarrs inherit window naming (per-window overviews, with
   an optional all-time overview as a derived artifact).
 - **D14 — Coverage `encoding: "full"` fast path**
@@ -521,13 +525,11 @@ rollup leaves all leaf reads intact.
   on the fly to order 24 for Number-safe browser paths (NESTED ids are
   float64-exact only through order 24; genuinely-finer-than-24 data takes
   other measures — hub-side fabrication, aggregation). The writer flip
-  sequences as 0.x phases (emit knob default-on → default flip → removal),
-  bundled into the same break window as the
-  [#299](https://github.com/englacial/zagg/issues/299) leaf rename so
-  moczarr golden vectors regenerate once. (The #299 break-window bundling
-  is a sequencing implication recorded from in-session planning, not
-  separately ratified on the thread.) The order-29 discriminator
-  metadata is O10.
+  sequences as 0.x phases (emit knob default-on → default flip → removal).
+  (An earlier plan bundled the flip with a #299 leaf-basename rename;
+  D19's product-root revision made #299 additive, so this writer flip is
+  the one remaining breaking store change in this family.) The order-29
+  discriminator metadata is O10.
 
 - **D17 — Hive+sharded is the HEALPix default; flat/fullsphere deprecated;
   dense leaf arrays write through the ShardingCodec.**
@@ -567,28 +569,48 @@ rollup leaves all leaf reads intact.
   metadata-only. This is the second noted soft-exception to "vanilla zarr
   v3" leaves (after the §4 coverage sidecar): plain zarr readers see opaque
   bytes, not garbage.
-- **D19 — Template-hash leaf naming: the hive tree is a multi-product
-  store** (settled across
+- **D19 — Template-hash product roots: a multi-product store is a
+  directory of stores + a registry** (concept settled across
   [#296](https://github.com/englacial/zagg/issues/296#issuecomment-5014826849)
-  and [#299](https://github.com/englacial/zagg/issues/299); espg on-thread:
+  and [#299](https://github.com/englacial/zagg/issues/299) — espg
+  on-thread:
   [naming + registry + per-product manifests](https://github.com/englacial/zagg/issues/299#issuecomment-5017263033);
-  breaking, pre-1.0, same window as the D16 writer flip). Leaf basename =
-  truncated sha256 (12 hex; collision domain is templates-within-one-store)
-  of the **canonicalized** agg template (parse YAML → sorted-key JSON →
-  hash; never raw bytes). Products colocate as siblings under one morton
-  prefix; discovery is a prefix listing. The template itself is written to
-  the store root as `{hash}.yaml` — a content-addressed registry designed so
-  a future external/community registry is a pure file-merge superset.
-  Manifests go per-product (`{hash}.morton_hive.json`; root listing is
-  product discovery). **Catalog identity lives in the sidecar, never the
-  name**: granule count + sha256 of sorted granule ids + zagg version;
-  dedup/`has_run` consults name *and* sidecar (a catalog-grown shard is
-  "stale", not "hit") — the template hash alone proves identity only for a
-  frozen catalog. Immutable-provenance naming
-  (`{hash}+{catalog-hash}.zarr`) is an opt-in for frozen-catalog archival
+  **hash-first revision espg-ratified in-session 2026-07-20**, superseding
+  the earlier leaf-basename form recorded in this PR's phase 2 —
+  trade study on the PR #306 thread). Each product lives under its own
+  root prefix `{hash}/`, where hash = truncated sha256 (12 hex; collision
+  domain is products-within-one-store) of the **canonicalized** agg
+  template (parse YAML → sorted-key JSON → hash; never raw bytes). A
+  product subtree is a *complete, unmodified* morton-hive store —
+  bare-named manifest and MOC, `{full_id}.zarr` leaves (D3 and D13's
+  frozen grammar untouched) — so existing single-product stores are
+  already valid and the change is **additive, not breaking**; readers
+  distinguish the two root forms by content (manifest ⇒ bare store,
+  `{hash}.yaml` entries ⇒ product directory). The template itself is
+  written beside each product root as `{hash}.yaml` — a content-addressed
+  registry designed so a future external/community registry is a pure
+  file-merge superset; root listing is product discovery. Rationale for
+  hash-first over leaf-basename colocation: S3's only cheap scoping
+  primitive is the prefix, and product-scoped operations (delete,
+  lifecycle/expiration, access policy, inventory) dominate in practice —
+  under colocation each would need per-object tagging or the
+  out-of-contract full enumeration; under hash-first each is one prefix
+  rule. Within-product walk/terminal semantics revert to the proven
+  single-product forms, and per-product artifacts keep bare names (one
+  less naming surface for readers to get wrong). What hash-first gives
+  up — a single spatial prefix spanning all products — serves no planned
+  workload: cross-product reads are manifest + MOC + truncation
+  arithmetic (§5) and never depended on physical colocation. **Catalog
+  identity lives in the sidecar, never the name**: granule count + sha256
+  of sorted granule ids + zagg version; dedup/`has_run` consults the
+  computed path *and* sidecar (a catalog-grown shard is "stale", not
+  "hit") — the template hash alone proves identity only for a frozen
+  catalog. Immutable-provenance naming (product root
+  `{hash}+{catalog-hash}/`) is an opt-in for frozen-catalog archival
   runs; default stays template-hash-only. The output content hash that
-  makes dedup *verifiable* is O11 (proposal). Old-layout stores must fail
-  loudly, never misread.
+  makes dedup *verifiable* is O11 (proposal). D7 generalizes cleanly:
+  "one store per dataset" becomes "one product tree per template" under a
+  shared root, with cross-product joins unchanged.
 - **D20 — Per-shard telemetry sidecar + run records** (espg on-thread:
   [sibling placement + envelope ride](https://github.com/englacial/zagg/issues/297#issuecomment-5016910923),
   [caller identity](https://github.com/englacial/zagg/issues/297#issuecomment-5016901381);

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -456,7 +456,9 @@ write path (§2) is load-bearing; this phase is optimization.
   sequences as 0.x phases (emit knob default-on → default flip → removal),
   bundled into the same break window as the
   [#299](https://github.com/englacial/zagg/issues/299) leaf rename so
-  moczarr golden vectors regenerate once. The order-29 discriminator
+  moczarr golden vectors regenerate once. (The #299 break-window bundling
+  is a sequencing implication recorded from in-session planning, not
+  separately ratified on the thread.) The order-29 discriminator
   metadata is O10.
 
 ### 8.2 Open for review (input needed)

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -69,9 +69,10 @@ what zagg consumes:
                                     schedule: none (reserved token — lean).
                                     /1–/2 stores keep {full_id}.zarr and
                                     {full_id}_{window}.zarr (D3/D13)
-      {window}.stats.json        <- per-shard stats sidecar, sibling (D20,
-                                    naming aligned by D23; all.stats.json
-                                    for the degenerate case)
+      stats_{window}.json        <- per-shard stats sidecar, sibling; ratified
+                                    D20 naming (stats.json for schedule: none).
+                                    D23 lean, not ratified: {window}.stats.json
+                                    / all.stats.json (follow-up to #302)
       <sub-shardmap JSON>        <- leaf sub-map for sweep rollups (D22)
 ```
 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -976,7 +976,7 @@ rollup leaves all leaf reads intact.
   optional interop materialization can generate a consolidated,
   `open_datatree`-able hierarchy *as a derived cache* for non-moczarr
   consumers, while the MOC-first opener remains the truth path (the
-  derived-views principle, third instance). Phasing: (1) `open_hive` →
+  derived-views principle, fourth instance). Phasing: (1) `open_hive` →
   Dataset stays the primitive, unchanged; (2) `open_store()` →
   product-level DataTree after moczarr#11; (3) level nodes with
   #201/D24; (4) optional sweep-generated interop hierarchy.

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -268,10 +268,10 @@ the data itself). Tracks [#200](https://github.com/englacial/zagg/issues/200).
   shard's coverage is within one base cell *by construction* (a shard is a
   single subtree; its id alone is the trivial 1-member cover, so the box is
   what buys sub-shard resolution). Padded to exactly 4 slots for fixed width
-  (32 B raw; four decimal strings in attrs); pad-sentinel *lean* is null
-  (base-0 words / JSON `null`), with repetition-padding the viable
-  alternative since repeats are idempotent under MOC algebra — the choice
-  is frozen with the mortie-side spec (O8). Future *store-level* covers that cross base
+  (32 B raw; four decimal strings in attrs); the pad sentinel is null
+  (base-0 words / JSON `null`), decided with the mortie-side spec (O8);
+  repetition-padding would also have worked since repeats are idempotent
+  under MOC algebra, but null is the frozen choice. Future *store-level* covers that cross base
   cells generalize to **≤ 12 members** (the 12 base cells). Readers
   AOI-reject on the box without parsing anything larger.
 - **Tier 1 — the exact shard bitmap** *(as O8 resolved it — the originally

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -2,7 +2,9 @@
 
 **Status**: draft. Tracks [#198](https://github.com/englacial/zagg/issues/198);
 temporal-partitioning amendments (D13–D15) ratified on
-[#237](https://github.com/englacial/zagg/issues/237).
+[#237](https://github.com/englacial/zagg/issues/237); morton-only-storage
+amendment (D16, O10) ratified on
+[#262](https://github.com/englacial/zagg/issues/262).
 
 > All design decisions (both made and open) are consolidated in the
 > [Decisions registry](#8-decisions-registry). Inline references use **D#** for
@@ -305,11 +307,16 @@ scope:
   materializing dense full-sphere coordinates. The accessor uses it to
   truncate the notional global grid to where data exists — top-level MOC
   coverage/polygons drive what the extension exposes.
-- **Coordinates stay sparse.** The `morton` coordinate (packed u64 words,
-  `MortonIndexDtype` in memory — upstream ask tracked in
-  [#72](https://github.com/englacial/zagg/issues/72)) is the native cell
-  labeling; `cell_ids` (HEALPix NESTED) remains the interop encoding
-  (`cell_ids_encoding`, [#135](https://github.com/englacial/zagg/issues/135)).
+- **Coordinates stay sparse, and morton is the only stored coordinate**
+  (D16). The `morton` coordinate (packed u64 words, `MortonIndexDtype` in
+  memory — upstream ask tracked in
+  [#72](https://github.com/englacial/zagg/issues/72)) is the sole cell
+  labeling on disk. NESTED `cell_ids` remains the *interop* encoding but is
+  fabricated exactly, on demand (`mort2healpix` is vectorized arithmetic):
+  moczarr fabricates it Python-side, the gridlook-jupyter hub proxy at serve
+  time, a TS decode for browser-direct stores. The `cell_ids_encoding` knob
+  ([#135](https://github.com/englacial/zagg/issues/135)) retires with the
+  D16 writer flip.
 - **Dense views are fabricated lazily**, per-region, on demand — never stored.
 - **Multi-store alignment**: opening several stores (datasets) over one AOI
   yields aligned sparse views whose join semantics are the §5 truncation
@@ -419,6 +426,38 @@ write path (§2) is load-bearing; this phase is optimization.
   re-templates the manifest — append-heavy stores should prefer generative
   schedules. (That exception is an implication recorded from the ratified
   schedule set, not separately ratified on the thread.)
+- **D16 — Morton-only storage: NESTED is fabricated, never stored**
+  (espg-ratified in-session 2026-07-17, filed on
+  [#262](https://github.com/englacial/zagg/issues/262); both verification
+  checks — artools clean, gridlook requirement satisfiable by fabrication —
+  [confirmed on the thread](https://github.com/englacial/zagg/issues/262#issuecomment-5007833161)).
+  zagg stops writing the `cell_ids` (NESTED uint64) array to leaves;
+  `morton` is the only stored cell coordinate and the declared convention
+  coordinate. Rationale: (1) morton words carry order intrinsically, so
+  mixed-order arrays (D2 coarse shards, §7 pyramids) are first-class where
+  NESTED u64 needs side-metadata or zuniq/nuniq; (2) kills the
+  dual-encoding cost — one u64 array per leaf (8 B/cell, plus one array's
+  objects per leaf in the
+  [#236](https://github.com/englacial/zagg/issues/236)/[#240](https://github.com/englacial/zagg/issues/240)
+  object-count currency) and the NESTED↔morton double-encode maintenance
+  ([#72](https://github.com/englacial/zagg/issues/72)); (3) the reader
+  stack is ready — the moczarr fabrication layer was the named gate and is
+  merged (espg/moczarr PR #7), with `open_hive` + xdggs
+  `grid_name: "morton"` + MOC-backed lazy index. Third instance of the
+  derived-views principle (§6 dense views, D9 caches). Ratified
+  refinements: the dggs attrs use a **distinct grid `name: "morton"`** —
+  never `name: "healpix"` + `indexing_scheme: "morton"`, which scheme-blind
+  readers silently misread as NESTED (garbage renders); a distinct name
+  makes them hard-reject with a diagnostic, and matches moczarr's xdggs
+  registration. Unknown-resolution point encodings at order 29 are clipped
+  on the fly to order 24 for Number-safe browser paths (NESTED ids are
+  float64-exact only through order 24; genuinely-finer-than-24 data takes
+  other measures — hub-side fabrication, aggregation). The writer flip
+  sequences as 0.x phases (emit knob default-on → default flip → removal),
+  bundled into the same break window as the
+  [#299](https://github.com/englacial/zagg/issues/299) leaf rename so
+  moczarr golden vectors regenerate once. The order-29 discriminator
+  metadata is O10.
 
 ### 8.2 Open for review (input needed)
 
@@ -474,6 +513,16 @@ write path (§2) is load-bearing; this phase is optimization.
   true rejected elsewhere). The write is fail-open on both backends; the
   Lambda leg is one fire-and-forget `mode: "coverage"` Event invoke with the
   pre-serialized ranges envelope.
+- **O10 — order-29 resolution discriminator** (carved from D16): two
+  order-29 encodings exist — (a) genuinely order-29 resolution, and (b)
+  unknown resolution point-encoded at order 29, the default for any raw
+  lat/lon conversion and expected to be common. Readers need declared
+  metadata to tell them apart, because the D16 clip rule (29→24) applies
+  only to (b). Proposal: `resolution: "exact" | "point"` in the dggs attrs
+  block, defaulting to `"point"` for raw conversions. Intersects mortie's
+  documented point-id/area-word parse non-injectivity at order 29; field
+  name, values, and placement to be frozen with the mortie spec page
+  ([mortie#62](https://github.com/espg/mortie/issues/62)).
 
 ## 9. References
 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -6,7 +6,7 @@ temporal-partitioning amendments (D13–D15) ratified on
 amendment ratified on
 [#262](https://github.com/englacial/zagg/issues/262) (D16; open item O10
 carved from it); 2026-07 consolidation (D17–D24; O3/O11 resolved, O8
-constants blessed, O12–O13 opened, D23 tokens ratified, §8.3
+constants blessed, O12–O14 opened, D23 tokens ratified, §8.3
 test-obligations index added)
 recording decisions settled on the
 [#251](https://github.com/englacial/zagg/issues/251)/[#236](https://github.com/englacial/zagg/issues/236)/[#209](https://github.com/englacial/zagg/issues/209)
@@ -950,6 +950,36 @@ rollup leaves all leaf reads intact.
   Open: the summary's exact schema, its placement in the published copy
   (product root), and whether sub-shardmap rollups publish as-is (they
   carry granule ids — likely fine) or coarsen.
+
+- **O14 — reader tree model: product and resolution axes as DataTree**
+  (direction espg-ratified in-session 2026-07-20; API details open with
+  moczarr — espg/moczarr#1). The store's four hierarchical axes map to
+  xarray `DataTree` unevenly, and the mapping is now declared: the
+  **product axis** is a strong fit (`open_store()` → one child node per
+  `{name}/`, each node today's `open_hive` Dataset — heterogeneous
+  schemas are exactly the non-alignable-groups case DataTree exists for,
+  and D19's named roots make node names human-meaningful); the
+  **resolution axis** is a good fit once #201/D24 materialize (one node
+  per order, source + overviews distinguished by `role`, riding the
+  emerging multiscale-DataTree conventions) — with the honest caveat
+  that a D24-heterogeneous product has no complete Dataset at any single
+  order: the seamless order-k view is a *computed compose* (per the
+  composability classes), never a tree node, so the DataTree represents
+  what is *stored* and the single-resolution Dataset stays an
+  accessor-fabricated view; the **window axis** stays a concatenated
+  time dimension inside each node (windows-as-nodes would shatter the
+  dominant time-series read); the **spatial digit axis is never tree
+  nodes** — a node per morton digit recreates the D5/D12 metadata storm
+  client-side. The Rust-backed fast `open_datatree` path applies to
+  zarr-native hierarchies, which the hive tree deliberately is not
+  (D12) — it plugs in via D12's escape hatch instead: the sweep's
+  optional interop materialization can generate a consolidated,
+  `open_datatree`-able hierarchy *as a derived cache* for non-moczarr
+  consumers, while the MOC-first opener remains the truth path (the
+  derived-views principle, third instance). Phasing: (1) `open_hive` →
+  Dataset stays the primitive, unchanged; (2) `open_store()` →
+  product-level DataTree after moczarr#11; (3) level nodes with
+  #201/D24; (4) optional sweep-generated interop hierarchy.
 
 ### 8.3 Standing test obligations (what a conforming implementation proves)
 

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -767,7 +767,12 @@ rollup leaves all leaf reads intact.
   the decision: (1) **composability class** — `exact | approximate |
   none` — is declared in the semantic core, derived from the product's
   aggregator set; a `none` product pins its cell order (resolution *is*
-  identity there) and refuses mixed-order appends. (2) Per (shard,
+  identity there) and refuses mixed-order appends. The implementation
+  ships helper functions to derive the class from the product's
+  aggregator set (the existing mergeable-reducer merge-law flags) and to
+  enforce it — at template-validation time (the class is recorded into
+  the semantic core) and at append time (the mixed-order guard consults
+  it) (espg-directed in-session). (2) Per (shard,
   window) there is **one resolution at a time**: heterogeneity is
   regional, across shards. A same-cell-order rerun is D4 idempotent
   replacement; **writing a different cell order into an occupied leaf

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -430,7 +430,9 @@ rollup leaves all leaf reads intact.
   "grouping is a parameter, never a schema fork."
 - **D3 — Full morton id at the leaf** (`{full_id}.zarr`), self-describing.
   (Unchanged by D19: product identity lives at the product root, above the
-  tree.)
+  tree. *Superseded by D23 for `morton-hive/3` stores*: the basename becomes
+  the time window; the full id stays recoverable from the path and from the
+  stamp/sidecar `shard_key`.)
 - **D4 — Commit stamp via final root-attrs update.** Absence (LIST) is
   trustworthy; presence requires the stamp. Torn shards are debris,
   overwritable on retry. One small PUT; not consolidation.
@@ -591,8 +593,9 @@ rollup leaves all leaf reads intact.
   domain is products-within-one-store) of the **canonicalized** agg
   template (parse YAML → sorted-key JSON → hash; never raw bytes). A
   product subtree is a *complete, unmodified* morton-hive store —
-  bare-named manifest and MOC, `{full_id}.zarr` leaves (D3 and D13's
-  frozen grammar untouched) — so existing single-product stores are
+  bare-named manifest and MOC, `{full_id}.zarr` leaves under `/1`–`/2`
+  grammars (`{window}.zarr` under `/3` — D23; D3 and D13's grammar
+  untouched by D19) — so existing single-product stores are
   already valid and the change is **additive, not breaking**; readers
   distinguish the two root forms by content (manifest ⇒ bare store,
   `{hash}.yaml` entries ⇒ product directory). The template itself is


### PR DESCRIPTION
Closes #262
Closes #296

The consolidated spec amendment: records the espg-ratified morton-only-storage decision (#262) **plus every design decision settled over the last ten days** that the spec didn't yet reflect, swept from the #296-family, #251/#253, #236/#233/#241, #238, #209/#210, #294, and #300 threads. Every new entry cites its provenance inline — thread-ratified comments are linked directly; in-session ratifications are marked as recorded, per the same discipline the phase-1 review enforced on D16.

## Phases

- [x] Phase 1 — D16 (morton-only storage) + O10 (order-29 discriminator) + §6 rewrite; adversarial review run, both findings folded
- [x] Phase 2 — consolidation: D17–D22, O3 resolved, O11 opened; §1/§2/§3/§6/§7 amended to match
- [x] Phase 3 — **D19 revised to hash-first product roots** (espg-ratified 2026-07-20 after pushing on terminal-leaf semantics; [trade study on this thread](https://github.com/englacial/zagg/pull/306#issuecomment-5019696069)): `{store_root}/{hash}/` product roots, each subtree a complete unmodified morton-hive store — #299 becomes **additive, not breaking**; D3/D13 survive untouched; the singular-`coverage.moc` inconsistency in the phase-2 layout block is fixed; D16's break-window note updated (the writer flip is now the only breaking change in this family)
- [x] Phase 7 — **final rulings + reader model** (espg-ratified 2026-07-20; [record on this thread](https://github.com/englacial/zagg/pull/306#issuecomment-5025396393)): O8 constants blessed as-shipped (bit convention + range ordering contract, zstd level non-normative); **O11 → RESOLVED** (per-named-zarr-array sha256 over decoded values, at write, all arrays incl. coordinates); **D23 tokens ratified** (`all` + `{window}.stats.json` alignment — PR #307 shipped exactly these); **O14** opened (reader DataTree model: product + resolution axes yes, spatial axis never, interop hierarchy as D12 derived cache)
- [x] Phase 6 — **espg-directed spec-gap additions** ([record](https://github.com/englacial/zagg/pull/306#issuecomment-5025140978)): O12 retention proposal (prefix rules per product, tags per window), O13 publication profile (prefix copy minus operator telemetry, roll-up summary preserved), D22 debris-collection family, §2 concurrency contract (same-leaf concurrency out-of-contract after review fold), §8.3 standing-test-obligations index, D19 refinements (hash-is-truth, full-length + short-fingerprint display, URL-safe names), D24 `none`-handling leans (deferred)
- [x] Phase 5 — **D19 rev 2 + D24** (espg-ratified 2026-07-20 in-session; [record + analysis on this thread](https://github.com/englacial/zagg/pull/306#issuecomment-5024857031)): product roots become **named** (`{name}/`, hash demoted to metadata); the hash shrinks to the **semantic core** (aggregation block + data-source semantics + grid type/indexing — cell order, packaging, worker knobs, streaming mode all excluded) as a frozen manifest key with the canonical core at `{name}/aggregation.yaml`; **D24 resolution polymorphism** — cell order is a query/packaging axis (composes per aggregator merge laws; composability class `exact|approximate|none`; one resolution per (shard, window) with a **cross-order overwrite guard**; allowed-set frozen keys; gated on mortie#116/moczarr#8 for readers); D20 gains timestamp-first run-record names + `run_id`/`semantic_hash` in sidecars
- [x] Phase 4 — **D23: window-only leaf naming** (`{window}.zarr`, `morton-hive/3`; espg-ratified 2026-07-20 in-session; [trade study on this thread](https://github.com/englacial/zagg/pull/306#issuecomment-5019934798)): completes the product/space/time axis separation (product = root, space = path, time = basename); `all.zarr` token and `{window}.stats.json` sidecar alignment recorded as **leans, not ratified**; `/1`–`/2` grammars stay frozen for existing stores; D3/D13 carry supersession pointers; adversarial review's two findings folded (layout block keeps ratified sidecar names with the lean marked; D3/D19 version-scoped)

## What phase 2 adds

**New decisions (registry §8.1):**
- **D17** — hive+sharded is the HEALPix default; flat/fullsphere deprecated (dense path removed, PR #257); ShardingCodec one-object-per-array leaves; raster leaves unsharded by design; `grid.shard_order` removed (#238).
- **D18** — ragged output = sharded vlen-bytes with golden-bytes framing pin (#209); typed ZDType deferred behind the #210 gates.
- **D19** — **named product roots + semantic-core hash** (phase-5 revision; the name is the address, the hash is the integrity check): a multi-product store is a directory of complete morton-hive stores under human-readable `{name}/` roots; `semantic_hash` (output-defining subset only) is a frozen manifest key with the canonical core at `{name}/aggregation.yaml`; literal per-run templates archive with run records; catalog identity in the sidecar; immutable-provenance opt-in `{name}+{catalog-hash}/` (#296/#299; both trade studies + the phase-5 record on this thread).
- **D20** — per-shard stats sidecar (sibling object, associative-only schema, `invoked_by`, `run_id`, `semantic_hash`) + run-level parquet at the product root including failure rows, timestamp-first names (#297).
- **D24** — resolution polymorphism (phase 5): cell order excluded from product identity; per-aggregator composability class; one resolution per (shard, window) with a cross-order overwrite guard; manifest order fields become allowed sets.
- **D21** — `path_grouping` manifest parameter, default 1; grouping is ergonomics, never a schema fork (#300).
- **D22** — one unified sweep owns overview zarrs, MOC regen, sub-shardmap rollups (full ShardMap JSON), stats rollups; generation stamps; rollup == direct obligation; MOC-first reader contract strengthening D10 (#300).

**Registry updates:** O3 → RESOLVED (standalone moczarr, per the #251 ratification); O11 opened (logical content hash — the one item still awaiting espg sign-off); amendment pointers added at D2, D3, D10, D11, D13.

**Section edits:** §1 fullsphere reframed as legacy; §2 layout block, node invariant, and D2/D3/D13 bullets updated for hash naming, sidecars, and `path_grouping`; §3 gains `path_grouping` + per-artifact-family rollup schedules and the per-product manifest qualification; §6 reflects O3's resolution; §7 lists all four sweep artifact families with generation-stamp semantics.

All amendments are within-section — §ordering is unchanged, so `docs/hive_layout.md` and `docs/deployment/benchmark.md` cross-references stay valid.

## Closure map

Design-record issues close on this PR; implementation issues close on their own PRs — nothing floats:

- **Closes here**: #262 (morton-only design; implementation carved to #304/#305, attached as its sub-issues) and #296 (cost/provenance discussion; decisions recorded here, work carved to sub-issues #297–#301).
- **Close on their own PRs**: #297 → PR #302 (wired), #298 → PR #303 (wired); #299, #300, #301, #304, #305 → future implementation PRs.
- **Deliberately not closed here**: #251 (phases 2–3 pending), #201 (open pyramid questions), #210 (gated follow-up).

## Testing

Docs-only; codespell clean via the pre-commit hook. No code paths touched.

## Questions for review

- **Provenance caveat, stated plainly**: entries marked "in-session, recorded on <link>" trace to Claude-posted records of session ratifications under the espg account; the directly espg-typed thread approvals are the linked comments on #297 (two), #298, #299, #300, #301, #236, #238, #251, and PR #257. Merging this PR is the act that ratifies the *doc text*; if any recorded item doesn't match your intent, flag the entry.
- **O11 is a proposal, not a decision** — per-array sha256 over decoded values, exact-match, no float tolerance. It's written as open; sign-off belongs on #299/#305.
- **Flag from the sweep** (not incorporated, surfacing for a call): #276 item 5 notes PR #208's coverage-MOC contract constants (bitmap order vs literal order-19, zstd level 3, root-MOC range ordering) merged without explicit sign-off, and they sit beneath O8's "espg-ratified" text. If you bless them, O8 gets a one-line addendum; if not, they need a thread.
- D16/O10 numbering from phase 1 stands (registry ran D15/O9); phase 2 continues D17–D22/O11.
- `Closes #296`/`Closes #262` leave their open sub-issues attached under closed parents — detach the lines if you'd rather keep the umbrellas open until all children land.
