### PR TITLE
D23 sidecar naming seam + temporal cost-block status (refs #297/#298)

### DIFF
--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -364,14 +364,34 @@ def write_run_parquet(
 # ---------------------------------------------------------------------------
 
 
-def sidecar_key(leaf_name: str) -> str:
-    """Sidecar object name for a leaf zarr basename.
+#: Manifest ``spec`` string selecting the D23 window-only naming grammar.
+#: ``/1``/``/2`` (and an absent spec) keep the frozen legacy sidecar names.
+SPEC_V3 = "morton-hive/3"
 
-    Bare leaves get :data:`SIDECAR_NAME`; windowed leaves (issue #246) get
+
+def sidecar_key(leaf_name: str, spec: str | None = None) -> str:
+    """Sidecar object name for a leaf zarr basename, keyed by store spec.
+
+    Legacy (``spec`` absent / ``morton-hive/1`` / ``/2``): bare leaves get
+    :data:`SIDECAR_NAME`; windowed leaves (issue #246) get
     ``stats_{window}.json`` — a hive node directory holds every window's leaf
     of its one shard, so a bare ``stats.json`` would self-clobber across
-    windows. Mirrors the ``{full_id}_{window}.zarr`` leaf naming.
+    windows. Mirrors the ``{full_id}_{window}.zarr`` leaf naming. Frozen: what
+    every current writer emits, unchanged.
+
+    ``morton-hive/3`` (:data:`SPEC_V3`, D23 — window-only leaf naming, no
+    writer yet): the sidecar is the leaf stem + ``.stats.json`` —
+    ``{window}.stats.json``, and ``all.stats.json`` for the ``schedule:
+    none`` :data:`~zagg.windows.SCHEDULE_NONE_TOKEN` leaf. Derived from the
+    leaf basename itself, so the token has ONE source
+    (:func:`zagg.windows.leaf_name_v3`) and the issue #299 writer flip is a
+    spec switch here, not a rename.
     """
+    if spec == SPEC_V3:
+        stem = leaf_name.removesuffix(".zarr")
+        if not stem or stem == leaf_name:
+            raise ValueError(f"{leaf_name!r} is not a leaf zarr name")
+        return f"{stem}.stats.json"
     from zagg.windows import split_leaf_name
 
     _full_id, window = split_leaf_name(leaf_name)
@@ -381,13 +401,13 @@ def sidecar_key(leaf_name: str) -> str:
     return f"{stem}_{window}.{ext}"
 
 
-def sidecar_path(leaf_path: str) -> str:
+def sidecar_path(leaf_path: str, spec: str | None = None) -> str:
     """Absolute path of a leaf's stats sidecar (sibling of the ``.zarr``)."""
     prefix, _, name = leaf_path.rstrip("/").rpartition("/")
-    return f"{prefix}/{sidecar_key(name)}"
+    return f"{prefix}/{sidecar_key(name, spec)}"
 
 
-def write_sidecar(leaf_path: str, record: dict, **store_kwargs) -> None:
+def write_sidecar(leaf_path: str, record: dict, spec: str | None = None, **store_kwargs) -> None:
     """PUT ``record`` as the leaf's stats sidecar (success path only, #297)."""
     import obstore
 
@@ -395,11 +415,13 @@ def write_sidecar(leaf_path: str, record: dict, **store_kwargs) -> None:
 
     prefix, _, name = leaf_path.rstrip("/").rpartition("/")
     obstore.put(
-        open_object_store(prefix, **store_kwargs), sidecar_key(name), json.dumps(record).encode()
+        open_object_store(prefix, **store_kwargs),
+        sidecar_key(name, spec),
+        json.dumps(record).encode(),
     )
 
 
-def read_sidecar(leaf_path: str, **store_kwargs) -> dict | None:
+def read_sidecar(leaf_path: str, spec: str | None = None, **store_kwargs) -> dict | None:
     """The leaf's stats sidecar record, or ``None`` when absent."""
     import obstore
     from obstore.exceptions import NotFoundError
@@ -408,7 +430,9 @@ def read_sidecar(leaf_path: str, **store_kwargs) -> dict | None:
 
     prefix, _, name = leaf_path.rstrip("/").rpartition("/")
     try:
-        data = obstore.get(open_object_store(prefix, **store_kwargs), sidecar_key(name)).bytes()
+        data = obstore.get(
+            open_object_store(prefix, **store_kwargs), sidecar_key(name, spec)
+        ).bytes()
     except (FileNotFoundError, NotFoundError):
         return None
     return json.loads(bytes(data))

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -368,6 +368,10 @@ def write_run_parquet(
 #: ``/1``/``/2`` (and an absent spec) keep the frozen legacy sidecar names.
 SPEC_V3 = "morton-hive/3"
 
+#: Specs that key the frozen legacy sidecar names (bare / ``stats_{window}.json``).
+#: An absent spec (``None``) is a ``morton-hive/1`` store by definition.
+_LEGACY_SPECS = (None, "morton-hive/1", "morton-hive/2")
+
 
 def sidecar_key(leaf_name: str, spec: str | None = None) -> str:
     """Sidecar object name for a leaf zarr basename, keyed by store spec.
@@ -386,12 +390,22 @@ def sidecar_key(leaf_name: str, spec: str | None = None) -> str:
     leaf basename itself, so the token has ONE source
     (:func:`zagg.windows.leaf_name_v3`) and the issue #299 writer flip is a
     spec switch here, not a rename.
+
+    An unrecognized spec RAISES rather than silently defaulting to the legacy
+    grammar: a versioned naming bump must be a loud, deliberate change here, or
+    a writer/reader spec mismatch would key the wrong sidecar name and read as
+    absent instead of failing.
     """
     if spec == SPEC_V3:
         stem = leaf_name.removesuffix(".zarr")
         if not stem or stem == leaf_name:
             raise ValueError(f"{leaf_name!r} is not a leaf zarr name")
         return f"{stem}.stats.json"
+    if spec not in _LEGACY_SPECS:
+        raise ValueError(
+            f"unknown store spec {spec!r} (one of {_LEGACY_SPECS} for legacy names "
+            f"or {SPEC_V3!r} for D23 window-only naming)"
+        )
     from zagg.windows import split_leaf_name
 
     _full_id, window = split_leaf_name(leaf_name)

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -397,9 +397,16 @@ def sidecar_key(leaf_name: str, spec: str | None = None) -> str:
     absent instead of failing.
     """
     if spec == SPEC_V3:
+        from zagg.windows import validate_label
+
         stem = leaf_name.removesuffix(".zarr")
         if not stem or stem == leaf_name:
             raise ValueError(f"{leaf_name!r} is not a leaf zarr name")
+        # Match the legacy branch's strictness: a malformed stem (embedded
+        # ``/`` path escape, forbidden ``_``) must raise, not pass through as a
+        # malformed key. The ``all`` schedule-none token satisfies the explicit
+        # grammar, so it keeps passing.
+        validate_label(stem)
         return f"{stem}.stats.json"
     if spec not in _LEGACY_SPECS:
         raise ValueError(

--- a/src/zagg/windows.py
+++ b/src/zagg/windows.py
@@ -221,6 +221,29 @@ def windows_intersecting(
         label = window_label(hi, schedule)
 
 
+#: The ``schedule: none`` leaf token under D23 window-only naming
+#: (``morton-hive/3``): the degenerate no-schedule leaf is ``all.zarr`` and
+#: its sidecar ``all.stats.json``. LEAN, not ratified (recorded with D23 in
+#: docs/design/sparse_coverage.md §8.1): kept a single constant so
+#: ratifying a different token is a one-line change.
+SCHEDULE_NONE_TOKEN = "all"
+
+
+def leaf_name_v3(window: str | None) -> str:
+    """The ``morton-hive/3`` leaf basename: the time window alone (D23).
+
+    Space lives in the digit path, time in the basename — the morton id no
+    longer repeats in the leaf name. ``None`` (``schedule: none``) is the
+    reserved :data:`SCHEDULE_NONE_TOKEN` leaf. No ``/3`` writer exists yet
+    (issue #299 flips the writers to this seam); ``/1``/``/2`` stores keep
+    :func:`leaf_name`'s frozen grammar forever (D6 versioning).
+    """
+    if window is None:
+        return f"{SCHEDULE_NONE_TOKEN}.zarr"
+    validate_label(window)
+    return f"{window}.zarr"
+
+
 def leaf_name(full_id: str, window: str | None = None) -> str:
     """The leaf zarr basename: ``{full_id}_{window}.zarr``, or bare (D13).
 

--- a/src/zagg/windows.py
+++ b/src/zagg/windows.py
@@ -240,6 +240,12 @@ def leaf_name_v3(window: str | None) -> str:
     """
     if window is None:
         return f"{SCHEDULE_NONE_TOKEN}.zarr"
+    if window == SCHEDULE_NONE_TOKEN:
+        raise ValueError(
+            f"window label {window!r} is the reserved schedule:none token "
+            f"(SCHEDULE_NONE_TOKEN, D23) — the explicit grammar admits it, but it "
+            f"would alias the no-schedule leaf; declare a different explicit label"
+        )
     validate_label(window)
     return f"{window}.zarr"
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -4,6 +4,7 @@ import pytest
 
 from zagg.telemetry import (
     SCHEMA_VERSION,
+    SPEC_V3,
     build_record,
     failure_record,
     flatten_record,
@@ -299,6 +300,35 @@ class TestSidecarIO:
         # Sibling object, never inside the leaf prefix.
         assert (tmp_path / "-4" / "2" / "stats.json").exists()
         assert not (tmp_path / "-4" / "2" / "-42.zarr").exists()
+
+    def test_v3_spec_keys_off_leaf_stem(self):
+        # D23 window-only naming (morton-hive/3): sidecar = leaf stem +
+        # .stats.json, derived from the leaf basename so the schedule-none
+        # token has one source (windows.leaf_name_v3). Legacy specs above are
+        # frozen — every current writer emits them unchanged.
+        from zagg.windows import SCHEDULE_NONE_TOKEN, leaf_name_v3
+
+        assert sidecar_key(leaf_name_v3("2019"), SPEC_V3) == "2019.stats.json"
+        assert leaf_name_v3(None) == f"{SCHEDULE_NONE_TOKEN}.zarr"
+        assert sidecar_key(leaf_name_v3(None), SPEC_V3) == f"{SCHEDULE_NONE_TOKEN}.stats.json"
+        # The /1 and /2 specs (and an absent spec) keep the legacy names.
+        assert sidecar_key("-4211322.zarr", "morton-hive/2") == "stats.json"
+        assert sidecar_key("-4211322_2019.zarr", "morton-hive/1") == "stats_2019.json"
+        with pytest.raises(ValueError, match="not a leaf zarr name"):
+            sidecar_key("2019", SPEC_V3)
+        with pytest.raises(ValueError, match="not a leaf zarr name"):
+            sidecar_key(".zarr", SPEC_V3)
+
+    def test_v3_write_read_roundtrip(self, tmp_path):
+        from zagg.windows import leaf_name_v3
+
+        leaf = str(tmp_path / "-4" / "2" / leaf_name_v3("2019"))
+        rec = _record()
+        write_sidecar(leaf, rec, spec=SPEC_V3)
+        assert read_sidecar(leaf, spec=SPEC_V3) == rec
+        assert (tmp_path / "-4" / "2" / "2019.stats.json").exists()
+        # The legacy reader does not see it (different name — spec selects).
+        assert read_sidecar(leaf) is None
 
     def test_read_absent_returns_none(self, tmp_path):
         (tmp_path / "-4").mkdir()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -319,6 +319,17 @@ class TestSidecarIO:
         with pytest.raises(ValueError, match="not a leaf zarr name"):
             sidecar_key(".zarr", SPEC_V3)
 
+    def test_unknown_spec_raises(self):
+        # An unrecognized spec must not silently fall back to the legacy names:
+        # a future morton-hive/4 or a typo would key the wrong sidecar and read
+        # as absent instead of failing. /1 and /2 (and absent) stay legacy.
+        with pytest.raises(ValueError, match="unknown store spec"):
+            sidecar_key("-4211322.zarr", "morton-hive/4")
+        with pytest.raises(ValueError, match="unknown store spec"):
+            sidecar_key("-4211322.zarr", "Morton-Hive/3")
+        assert sidecar_key("-4211322.zarr", "morton-hive/1") == "stats.json"
+        assert sidecar_key("-4211322_2019.zarr", "morton-hive/2") == "stats_2019.json"
+
     def test_v3_write_read_roundtrip(self, tmp_path):
         from zagg.windows import leaf_name_v3
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -330,6 +330,22 @@ class TestSidecarIO:
         assert sidecar_key("-4211322.zarr", "morton-hive/1") == "stats.json"
         assert sidecar_key("-4211322_2019.zarr", "morton-hive/2") == "stats_2019.json"
 
+    def test_v3_malformed_stem_raises(self):
+        # The v3 branch must be as strict as legacy: a stem that fails the label
+        # grammar (embedded ``/`` path escape, forbidden ``_``) raises rather
+        # than yielding a malformed sidecar key.
+        with pytest.raises(ValueError, match="grammar"):
+            sidecar_key("a/b.zarr", SPEC_V3)
+        with pytest.raises(ValueError, match="grammar"):
+            sidecar_key("foo_bar.zarr", SPEC_V3)
+        # The schedule-none token still satisfies the explicit grammar.
+        from zagg.windows import SCHEDULE_NONE_TOKEN
+
+        assert (
+            sidecar_key(f"{SCHEDULE_NONE_TOKEN}.zarr", SPEC_V3)
+            == f"{SCHEDULE_NONE_TOKEN}.stats.json"
+        )
+
     def test_v3_write_read_roundtrip(self, tmp_path):
         from zagg.windows import leaf_name_v3
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -163,6 +163,26 @@ class TestLeafNameSplit:
             w.leaf_name("-31123", "melt_2019")
 
 
+# ── leaf_name_v3 (D23 window-only naming) ────────────────────────────────────
+
+
+class TestLeafNameV3:
+    def test_window_and_none(self):
+        assert w.leaf_name_v3("2019") == "2019.zarr"
+        assert w.leaf_name_v3(None) == f"{w.SCHEDULE_NONE_TOKEN}.zarr"
+
+    def test_explicit_label_equal_to_reserved_token_raises(self):
+        # The explicit grammar admits "all", but leaf_name_v3(None) already
+        # owns that leaf — an explicit label equal to the token must raise
+        # rather than alias the no-schedule leaf (D23 reservation).
+        with pytest.raises(ValueError, match="reserved schedule:none token"):
+            w.leaf_name_v3(w.SCHEDULE_NONE_TOKEN)
+
+    def test_rejects_bad_window(self):
+        with pytest.raises(ValueError, match="grammar"):
+            w.leaf_name_v3("melt_2019")
+
+
 # ── windows_intersecting ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Refs #297, Refs #298. Design record: D23 in `docs/design/sparse_coverage.md` on PR #306's branch (espg-proposed and ratified in-session, 2026-07-20).

Two small follow-ups to the merged PR #302, directed on the PR threads:

## 1. D23 sidecar-naming seam (`{window}.stats.json`)

D23 makes `morton-hive/3` leaf basenames the time window alone (`{window}.zarr`; `all.zarr` reserved for `schedule: none`), and aligns the stats sidecar to `{window}.stats.json` / `all.stats.json`.

**Choice: (a) — a spec-keyed seam, no change to what current writers emit.** No `/3` writer exists yet, so renaming today's `/2` output would fork the frozen `/1`–`/2` grammar for nothing. Instead:

- `zagg.windows.leaf_name_v3(window)` — the `/3` leaf-basename seam (`{window}.zarr`, `all.zarr` for `None`) the issue #299 writer flips to; `leaf_name` stays the frozen `/1`–`/2` grammar.
- `zagg.windows.SCHEDULE_NONE_TOKEN = "all"` — **the `all` token is a recorded LEAN, not ratified** (see D23 §8.1 "leans recorded"); it is a single constant, so ratifying a different token is a one-line change ("token pending ratification, one-constant change").
- `zagg.telemetry.sidecar_key(leaf_name, spec)` (+ `sidecar_path`/`write_sidecar`/`read_sidecar` pass-through): `spec == "morton-hive/3"` derives the sidecar from the leaf stem (`{window}.stats.json`, `all.stats.json`) — the token flows from the leaf name itself, one source; any other/absent spec keeps the frozen legacy names (`stats.json` / `stats_{window}.json`) byte-identically. The #299 flip is a spec switch at the writer call sites, not a rename.

## 2. Temporal cost-block status (verification, no code)

Verified against `main` (post PR #303 merge): the temporal dispatch path **already carries the full cost block** — `_run_lambda_events` computes the pre-invoke `max_cost_usd` ceiling and stamps `summary["cost"] = {max_cost_usd, estimated_cost_usd, actual_cost_usd}` with the billed-duration actual rollup, exactly like the spatial (and now raster) paths. The fold commit "note temporal path out of scope for estimator (issue #298)" concerns only the Phase-3 **estimator stub** (`estimated_cost_usd` stays `None` on temporal because there is no shardmap to estimate from — documented in `estimate_cost_usd`'s docstring); `max` and `actual` are real values there. Nothing to add; recording the status here per the directive.

## Phases

- [x] Phase 1 — the D23 naming seam (`windows.leaf_name_v3` + `SCHEDULE_NONE_TOKEN`, spec-keyed `telemetry.sidecar_key` and sidecar I/O pass-through) with tests pinning the `/3` mapping, the frozen legacy mapping, and the token's single-source derivation
- [x] Temporal cost-block verification (document-only, above)

## Testing

`tests/test_telemetry.py`: `/3` mapping (`2019.zarr` → `2019.stats.json`; `leaf_name_v3(None)` → `all.zarr` → `all.stats.json`), legacy specs and absent-spec unchanged, malformed leaf names raise, `/3` write/read round-trip on a local store (and the legacy reader not seeing the `/3` name — spec selects). Full suite green locally; the two pre-existing environment-only items noted on PR #302 are unchanged.

## Questions for review

1. **`all` token**: implemented as the single `SCHEDULE_NONE_TOKEN` constant per the recorded lean — flip the constant if ratification picks another spelling (`none`, `full`, …).
2. **Seam shape**: `sidecar_key` takes the manifest `spec` string rather than a bool, so future spec bumps route through the same switch. If you'd rather the `/3` naming ride `zagg.windows` entirely (sidecar name computed next to `leaf_name_v3`), easy to move before #299 builds on it.
