### PR TITLE
Unified second-pass rollup sweep: stats + MOC + sub-shardmap families, hook + CLI (issue #300)

### DIFF
--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -276,18 +276,26 @@ def store_object_counts(
             if key in (hive.MANIFEST_NAME, hive.ROOT_COVERAGE_NAME) or _is_run_parquet(key):
                 metadata += 1
                 continue
-            # Sweep rollups (issue #300): `{family}.rollup.json` at any digit
-            # node — second-pass D9 caches with their own bucket, never
-            # write-path objects (and never inside a leaf prefix, so the #215
-            # per-shard guard is untouched).
-            if key.endswith(".rollup.json"):
-                rollups += 1
-                continue
+            # Leaf-prefix membership FIRST (issue #300 review): an object that
+            # lands INSIDE a leaf `.zarr/` prefix is that shard's data object —
+            # rollup-named or not — so it counts into ``per_shard`` and trips
+            # the exact #215 per-shard guard. Only keys OUTSIDE every leaf
+            # prefix are eligible for the rollup / sibling buckets below.
             for prefix, label in leaf_of.items():
                 if key.startswith(prefix):
                     per_shard[label] = per_shard.get(label, 0) + 1
                     break
             else:
+                # Sweep rollups (issue #300): `{family}.rollup.json` at a digit
+                # node — second-pass D9 caches with their own bucket, never
+                # write-path objects. Legit rollups sit at `{node}/` (siblings
+                # of the leaf `.zarr/`), so classifying them here — after the
+                # leaf-membership check has failed — leaves the per-shard guard
+                # untouched while a MISPLACED in-leaf rollup falls to the
+                # attribution above and trips #215 instead of vanishing.
+                if key.endswith(".rollup.json"):
+                    rollups += 1
+                    continue
                 node, _, name = key.rpartition("/")
                 is_sibling = any(
                     name == f"{stem}.json"

--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -148,10 +148,14 @@ def expected_object_counts(
         # Leaf fixed objects: leaf root zarr.json + group zarr.json + one
         # zarr.json per array, plus the in-leaf coverage.moc sidecar (written
         # for any populated leaf when the leaf has depth, i.e. child_order >
-        # parent_order), plus the stats.json sidecar SIBLING to the leaf
-        # (issue #297 — one per successful shard, in the leaf's node dir).
+        # parent_order), plus TWO node-dir siblings per successful shard: the
+        # stats.json sidecar (issue #297) and the shardmap.json leaf sub-map
+        # (issue #300 — same success gate; on the Lambda path it may be
+        # legitimately absent for a unit whose submap event block was dropped
+        # over the async payload cap, which then surfaces here as a mismatch
+        # worth seeing rather than a modeled window).
         sidecar = 1 if grid.child_order > grid.parent_order else 0
-        lo = hi = 3 + len(members) + sidecar
+        lo = hi = 4 + len(members) + sidecar
         for m in members:
             blocks = m["blocks_per_shard"]
             hi += blocks
@@ -225,6 +229,7 @@ def store_object_counts(
     per_shard: dict[str, int] = {}
     other: list[str] = []
     metadata = 0
+    rollups = 0
 
     if store_layout == "flat":
         _require_fullsphere(grid)
@@ -259,9 +264,10 @@ def store_object_counts(
             hive.shard_leaf_path("", int(k)).lstrip("/") + "/": grid.shard_label(int(k))
             for k in shard_keys
         }
-        # The per-shard stats sidecar (issue #297) is a SIBLING of the leaf
-        # .zarr — ``{node}/stats.json`` (``stats_{window}.json`` windowed) —
-        # so attribute it to the node's shard rather than pooling it in
+        # The per-shard stats sidecar (issue #297) and the leaf sub-map
+        # (issue #300) are SIBLINGS of the leaf .zarr — ``{node}/stats.json``
+        # and ``{node}/shardmap.json`` (``_{window}`` suffixed when windowed)
+        # — so attribute them to the node's shard rather than pooling them in
         # ``other``.
         stats_of = {
             prefix.rstrip("/").rsplit("/", 1)[0] + "/": label for prefix, label in leaf_of.items()
@@ -270,16 +276,25 @@ def store_object_counts(
             if key in (hive.MANIFEST_NAME, hive.ROOT_COVERAGE_NAME) or _is_run_parquet(key):
                 metadata += 1
                 continue
+            # Sweep rollups (issue #300): `{family}.rollup.json` at any digit
+            # node — second-pass D9 caches with their own bucket, never
+            # write-path objects (and never inside a leaf prefix, so the #215
+            # per-shard guard is untouched).
+            if key.endswith(".rollup.json"):
+                rollups += 1
+                continue
             for prefix, label in leaf_of.items():
                 if key.startswith(prefix):
                     per_shard[label] = per_shard.get(label, 0) + 1
                     break
             else:
                 node, _, name = key.rpartition("/")
-                is_stats = name == "stats.json" or (
-                    name.startswith("stats_") and name.endswith(".json")
+                is_sibling = any(
+                    name == f"{stem}.json"
+                    or (name.startswith(f"{stem}_") and name.endswith(".json"))
+                    for stem in ("stats", "shardmap")
                 )
-                if is_stats and node + "/" in stats_of:
+                if is_sibling and node + "/" in stats_of:
                     per_shard[stats_of[node + "/"]] = per_shard.get(stats_of[node + "/"], 0) + 1
                 else:
                     other.append(key)
@@ -290,6 +305,7 @@ def store_object_counts(
         "objects_total": len(keys),
         "objects_metadata": metadata,
         "objects_per_shard": per_shard,
+        "objects_rollups": rollups,
         "objects_other": len(other),
         "other_keys": other[:20],
     }
@@ -346,7 +362,13 @@ def object_count_mismatch(measured: dict, expected: dict) -> str | None:
     know every object the run writes.
     """
     problems = []
-    total = measured["objects_total"]
+    # Sweep rollups (issue #300) are second-pass D9 caches, not write-path
+    # objects: the end-of-run sweep may or may not have landed them by
+    # measurement time (fire-and-forget on Lambda), so they are tallied in
+    # their own bucket and excluded from the write-path total this model
+    # audits (the #215 bypass guard below is untouched — rollups never live
+    # inside a leaf prefix).
+    total = measured["objects_total"] - measured.get("objects_rollups", 0)
     meta = measured["objects_metadata"]
     meta_lo, meta_hi = expected["metadata_min"], expected["metadata"]
     if not (meta_lo <= meta <= meta_hi):

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -1171,6 +1171,7 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
                 granule_ids=raster_granule_ids(event["granules"]),
                 invoked_by=event.get("invoked_by"),
                 run_id=event.get("run_id"),
+                window=(event.get("window") or {}).get("label"),
                 lambda_config=lambda_env(),
             )
             body["stats"] = record
@@ -1613,6 +1614,7 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             granule_ids=event.get("granule_urls"),
             invoked_by=event.get("invoked_by"),
             run_id=event.get("run_id"),
+            window=(event.get("window") or {}).get("label"),
             lambda_config=lambda_env(),
         )
         metadata["stats"] = record

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -1257,18 +1257,24 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
                 submap = event.get("submap")
                 if submap:
                     try:
-                        from zagg.sweep import write_leaf_submap
+                        from zagg.sweep import submap_emittable, write_leaf_submap
 
                         window = event.get("window")
-                        write_leaf_submap(
-                            event["store_path"],
-                            shard_key,
-                            event["granules"],
-                            grid_signature=submap["grid_signature"],
-                            metadata=submap.get("metadata"),
-                            window=window["label"] if window else None,
-                            store_kwargs=_output_store_kwargs(event),
-                        )
+                        if submap_emittable(submap["grid_signature"], event["granules"]):
+                            write_leaf_submap(
+                                event["store_path"],
+                                shard_key,
+                                event["granules"],
+                                grid_signature=submap["grid_signature"],
+                                metadata=submap.get("metadata"),
+                                window=window["label"] if window else None,
+                                store_kwargs=_output_store_kwargs(event),
+                            )
+                        else:
+                            logger.debug(
+                                f"leaf sub-map skipped for shard {shard_key}: non-HEALPix "
+                                f"grid or id-less entries (unmergeable, issue #300)"
+                            )
                     except Exception as e:
                         logger.warning(f"leaf sub-map write failed (fail-open, issue #300): {e}")
             return {"statusCode": 200, "body": json.dumps(body)}
@@ -1698,18 +1704,25 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             submap = event.get("submap")
             if submap:
                 try:
-                    from zagg.sweep import write_leaf_submap
+                    from zagg.sweep import submap_emittable, write_leaf_submap
 
                     window = event.get("window")
-                    write_leaf_submap(
-                        store_path,
-                        int(shard_key),
-                        submap.get("granules") or [],
-                        grid_signature=submap["grid_signature"],
-                        metadata=submap.get("metadata"),
-                        window=window["label"] if window else None,
-                        store_kwargs=_output_store_kwargs(event),
-                    )
+                    granules = submap.get("granules") or []
+                    if submap_emittable(submap["grid_signature"], granules):
+                        write_leaf_submap(
+                            store_path,
+                            int(shard_key),
+                            granules,
+                            grid_signature=submap["grid_signature"],
+                            metadata=submap.get("metadata"),
+                            window=window["label"] if window else None,
+                            store_kwargs=_output_store_kwargs(event),
+                        )
+                    else:
+                        logger.debug(
+                            f"leaf sub-map skipped for shard {shard_key}: non-HEALPix grid "
+                            f"or id-less entries (unmergeable, issue #300)"
+                        )
                 except Exception as e:
                     logger.warning(f"leaf sub-map write failed (fail-open, issue #300): {e}")
 

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -120,6 +120,20 @@ echoes the deployed zagg version; the handler also runs the READ-ONLY
 zagg.hive.validate_manifest against any existing root so an incompatible rerun
 refuses up front (D2).
 
+Sweep mode (unified rollup sweep, issue #300 — the D8 worker-invoke transport
+for the D22 second pass; fire-and-forget Event invoke from the dispatcher at
+end of run, like coverage mode; also invocable ad hoc):
+{
+    "mode": "sweep",
+    "store_path": str,
+    "leaves": [[shard_key, window-or-null], ...] (optional) -- the run's
+        completed leaves, inline when they fit the async payload budget,
+    "discover": bool (optional) -- re-derive the work set from the store's
+        run-record parquets instead (zagg.sweep.discover_leaves; sent when
+        the leaves list would overflow the 256 KB Event cap),
+    "output_credentials": dict (optional, same shape as process mode),
+}
+
 Extract mode (chunk-boundary geometry extraction, issue #148 — one parquet per
 granule under an S3 prefix; a batch of granules per invocation for the fan-out):
 {
@@ -501,6 +515,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     creates the zarr template; ``mode="finalize"`` consolidates metadata;
     ``mode="ping"`` is the hive pre-fan-out preflight (issue #252);
     ``mode="coverage"`` writes the store-root ``coverage.moc`` (issue #200);
+    ``mode="sweep"`` folds the D22 rollup families worker-side (issue #300);
     ``mode="extract"`` extracts chunk-boundary geometry parquets (issue #148);
     ``mode="process_event"`` runs the temporal/event worker (issue #12).
     """
@@ -519,6 +534,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         return _handle_ping(event)
     if mode == "coverage":
         return _handle_coverage(event)
+    if mode == "sweep":
+        return _handle_sweep(event)
     # Extract mode returns directly: the result_url mirror below is for the
     # per-unit fan-out handlers (spatial process, temporal process_event) only.
     if mode == "extract":
@@ -905,6 +922,50 @@ def _handle_coverage(event: Dict[str, Any]) -> Dict[str, Any]:
     except Exception as e:
         logger.exception(e)
         return {"statusCode": 500, "body": json.dumps({"error": str(e), "mode": "coverage"})}
+
+
+def _handle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Run the unified rollup sweep worker-side (issue #300, D8 transport).
+
+    Posted fire-and-forget (``InvocationType="Event"``) by the Lambda-path
+    dispatcher at end of run — the D8 orchestrator-no-write rule means the
+    dispatcher cannot PUT rollups itself, so the worker role folds them,
+    exactly like the root ``coverage.moc``. The work set rides inline as
+    ``leaves`` (``[[shard_key, window], ...]``) when it fits the async
+    budget; ``discover: true`` has the worker re-derive it from the store's
+    run records (the D22 discovery path). Nobody reads this response on the
+    Event invoke; errors log and fail open — every rollup is a regenerable
+    cache (D9) and ``python -m zagg.sweep`` is the manual backstop.
+    """
+    from zagg.sweep import discover_leaves, run_sweep
+
+    logger.info(f"Sweep mode: folding rollups at {event.get('store_path')}")
+    try:
+        store_kwargs = _output_store_kwargs(event)
+        if event.get("leaves") is not None:
+            leaves = [(int(key), window) for key, window in event["leaves"]]
+        else:
+            leaves = discover_leaves(event["store_path"], store_kwargs=store_kwargs)
+        if not leaves:
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"ok": True, "mode": "sweep", "n_leaves": 0}),
+            }
+        summary = run_sweep(event["store_path"], leaves, store_kwargs=store_kwargs)
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                {
+                    "ok": True,
+                    "mode": "sweep",
+                    "n_leaves": summary["n_leaves"],
+                    "families": summary["families"],
+                }
+            ),
+        }
+    except Exception as e:
+        logger.exception(e)
+        return {"statusCode": 500, "body": json.dumps({"error": str(e), "mode": "sweep"})}
 
 
 def _json_scalar(v: Any) -> Any:

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -40,6 +40,16 @@ Event payload (default / process mode):
         record so leaf sidecars join back to the run-level stats parquet
         (whose object name carries the same id). Absent -> the stats record
         carries null.
+    "submap": dict (optional, issue #300, hive only) -- {"grid_signature",
+        "metadata", "granules"} leaf sub-map fields: on success the worker
+        writes the unit's full ShardMap JSON sub-map (D22) sibling to the
+        stats sidecar via zagg.sweep.write_leaf_submap. The dispatcher
+        threads the {id, s3, https} granule entries here because the event's
+        bare granule_urls can't reconstruct them; size-gated dispatcher-side
+        (dropped when it would push an async event over the 256 KB cap).
+        Absent -> no write (old dispatchers keep working). The raster
+        process_raster mode carries the same block minus "granules" (its
+        events already ship the entries).
     "result_url": str (optional, issue #151) -- where to ALSO write this
         invocation's response envelope as JSON (e.g.
         "s3://bucket/out.zarr.status/<run_id>/<shard_label>.json", where the
@@ -1177,6 +1187,28 @@ def _handle_process_raster(event: Dict[str, Any]) -> Dict[str, Any]:
                     write_sidecar(leaf, record, **_output_store_kwargs(event))
                 except Exception as e:
                     logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
+                # Leaf sub-map (issue #300, D22): full ShardMap JSON next to
+                # the stats sidecar. Raster events already carry the unit's
+                # ShardMap entries in ``granules``; the ``submap`` block adds
+                # the catalog identity a worker cannot derive. Absent block
+                # (old dispatcher) -> no write, fail-open like the sidecar.
+                submap = event.get("submap")
+                if submap:
+                    try:
+                        from zagg.sweep import write_leaf_submap
+
+                        window = event.get("window")
+                        write_leaf_submap(
+                            event["store_path"],
+                            shard_key,
+                            event["granules"],
+                            grid_signature=submap["grid_signature"],
+                            metadata=submap.get("metadata"),
+                            window=window["label"] if window else None,
+                            store_kwargs=_output_store_kwargs(event),
+                        )
+                    except Exception as e:
+                        logger.warning(f"leaf sub-map write failed (fail-open, issue #300): {e}")
             return {"statusCode": 200, "body": json.dumps(body)}
 
         time_index = {k: int(v) for k, v in event["time_index"].items()}
@@ -1595,6 +1627,28 @@ def _handle_process(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 write_sidecar(leaf, record, **_output_store_kwargs(event))
             except Exception as e:
                 logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
+            # Leaf sub-map (issue #300, D22): full ShardMap JSON next to the
+            # stats sidecar. The event's bare granule_urls can't reconstruct
+            # the ShardMap entries, so the dispatcher threads them (plus the
+            # catalog identity) in the size-gated ``submap`` block; absent
+            # (old dispatcher, or dropped for the async cap) -> no write.
+            submap = event.get("submap")
+            if submap:
+                try:
+                    from zagg.sweep import write_leaf_submap
+
+                    window = event.get("window")
+                    write_leaf_submap(
+                        store_path,
+                        int(shard_key),
+                        submap.get("granules") or [],
+                        grid_signature=submap["grid_signature"],
+                        metadata=submap.get("metadata"),
+                        window=window["label"] if window else None,
+                        store_kwargs=_output_store_kwargs(event),
+                    )
+                except Exception as e:
+                    logger.warning(f"leaf sub-map write failed (fail-open, issue #300): {e}")
 
         # Log structured result
         logger.info(

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -742,6 +742,17 @@ def _validate_store_layout_keys(config: PipelineConfig) -> None:
                 "coverage.moc lives at the hive store root; flat stores have no "
                 "hive root to bootstrap from)"
             )
+    # End-of-run rollup sweep trigger (issue #300), same posture as
+    # coverage_moc: boolean when present, default ON for hive (get_sweep
+    # resolves it), explicit true on a non-hive store is a config mistake.
+    sweep = config.output.get("sweep")
+    if sweep is not None and not isinstance(sweep, bool):
+        raise ValueError(f"output.sweep must be a boolean (got {sweep!r})")
+    if sweep and get_store_layout(config) != "hive":
+        raise ValueError(
+            "output.sweep requires output.store_layout: hive (the rollup sweep "
+            "folds hive-tree leaf artifacts; flat stores have no digit tree)"
+        )
 
 
 def _validate_windowing(config: PipelineConfig) -> None:
@@ -2127,6 +2138,24 @@ def get_coverage_moc(config: PipelineConfig) -> bool:
     like ``store_layout``.
     """
     flag = config.output.get("coverage_moc")
+    if flag is None:
+        return get_store_layout(config) == "hive"
+    return bool(flag)
+
+
+def get_sweep(config: PipelineConfig) -> bool:
+    """Whether the end-of-run rollup sweep trigger is on (issue #300).
+
+    Default ON for hive-layout stores (the D22 sweep folds hive-tree leaf
+    artifacts into interior rollups; every artifact is a fail-open regenerable
+    cache, D9); ``output.sweep: false`` opts out. Non-hive configs default
+    off, and an explicit ``true`` there is rejected by ``validate_config``,
+    mirroring ``coverage_moc``. A present-but-null key falls back to the
+    default. The trigger transport is backend-shaped (D8): the local
+    dispatchers run the sweep in-process; the Lambda dispatchers post a
+    fire-and-forget ``mode="sweep"`` worker Event invoke.
+    """
+    flag = config.output.get("sweep")
     if flag is None:
         return get_store_layout(config) == "hive"
     return bool(flag)

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -939,6 +939,7 @@ class RasterStrategy:
                 metadata=meta,
                 granule_ids=raster_granule_ids(granules),
                 run_id=run_id,
+                window=window["label"] if window else None,
             )
             meta["stats"] = record
             if store_layout == "hive" and meta.get("leaf_written"):
@@ -2571,6 +2572,7 @@ def _run_local(
                 metadata=meta,
                 granule_ids=_resolve_urls(records, driver),
                 run_id=run_id,
+                window=window["label"] if window else None,
             )
             meta["stats"] = record
             if store_layout == "hive" and not meta.get("error"):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -957,17 +957,24 @@ class RasterStrategy:
                 # entries as full ShardMap JSON, sibling to the stats sidecar
                 # (same in-process rationale as the aggregation local path).
                 try:
-                    from zagg.sweep import write_leaf_submap
+                    from zagg.sweep import submap_emittable, write_leaf_submap
 
-                    write_leaf_submap(
-                        store_path,
-                        int(shard_key),
-                        granules,
-                        grid_signature=catalog_data["grid_signature"],
-                        metadata=catalog_data.get("metadata"),
-                        window=window["label"] if window else None,
-                        store_kwargs=store_kwargs,
-                    )
+                    sig = catalog_data["grid_signature"]
+                    if submap_emittable(sig, granules):
+                        write_leaf_submap(
+                            store_path,
+                            int(shard_key),
+                            granules,
+                            grid_signature=sig,
+                            metadata=catalog_data.get("metadata"),
+                            window=window["label"] if window else None,
+                            store_kwargs=store_kwargs,
+                        )
+                    else:
+                        logger.debug(
+                            f"leaf sub-map skipped for shard {shard_key}: non-HEALPix grid "
+                            f"or id-less entries (unmergeable, issue #300)"
+                        )
                 except Exception as e:
                     logger.warning(f"leaf sub-map write failed (fail-open, issue #300): {e}")
             return meta, stage_stats, write_s
@@ -2623,17 +2630,24 @@ def _run_local(
                 # (the Lambda path threads them via the event's submap block).
                 # Fail-open, like the sidecar.
                 try:
-                    from zagg.sweep import write_leaf_submap
+                    from zagg.sweep import submap_emittable, write_leaf_submap
 
-                    write_leaf_submap(
-                        store_path,
-                        int(shard_key),
-                        records,
-                        grid_signature=catalog_data["grid_signature"],
-                        metadata=catalog_data.get("metadata"),
-                        window=window["label"] if window else None,
-                        store_kwargs=store_kwargs,
-                    )
+                    sig = catalog_data["grid_signature"]
+                    if submap_emittable(sig, records):
+                        write_leaf_submap(
+                            store_path,
+                            int(shard_key),
+                            records,
+                            grid_signature=sig,
+                            metadata=catalog_data.get("metadata"),
+                            window=window["label"] if window else None,
+                            store_kwargs=store_kwargs,
+                        )
+                    else:
+                        logger.debug(
+                            f"leaf sub-map skipped for shard {shard_key}: non-HEALPix grid "
+                            f"or id-less entries (unmergeable, issue #300)"
+                        )
                 except Exception as e:
                     logger.warning(f"leaf sub-map write failed (fail-open, issue #300): {e}")
             return {"shard_key": shard_key, "ok": True, "meta": meta}

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -808,6 +808,10 @@ class RasterStrategy:
                 output_endpoint_url=resolved_endpoint,
                 store_layout=store_layout,
                 dataset={"short_name": md.get("short_name"), "version": md.get("version")},
+                catalog_signature={
+                    "grid_signature": catalog_data.get("grid_signature"),
+                    "metadata": catalog_data.get("metadata"),
+                },
                 profile=profile,
                 invocation=invocation,
                 on_progress=on_progress,
@@ -947,6 +951,23 @@ class RasterStrategy:
                     write_sidecar(leaf, record, **store_kwargs)
                 except Exception as e:
                     logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
+                # Leaf sub-map (issue #300, D22): the unit's raster ShardMap
+                # entries as full ShardMap JSON, sibling to the stats sidecar
+                # (same in-process rationale as the aggregation local path).
+                try:
+                    from zagg.sweep import write_leaf_submap
+
+                    write_leaf_submap(
+                        store_path,
+                        int(shard_key),
+                        granules,
+                        grid_signature=catalog_data["grid_signature"],
+                        metadata=catalog_data.get("metadata"),
+                        window=window["label"] if window else None,
+                        store_kwargs=store_kwargs,
+                    )
+                except Exception as e:
+                    logger.warning(f"leaf sub-map write failed (fail-open, issue #300): {e}")
             return meta, stage_stats, write_s
 
         stage_max: dict = {}
@@ -1075,6 +1096,7 @@ class RasterStrategy:
         output_endpoint_url,
         store_layout="flat",
         dataset=None,
+        catalog_signature=None,
         profile=False,
         invocation="async",
         on_progress=None,
@@ -1252,6 +1274,12 @@ class RasterStrategy:
                 # byte-identical to pre-#247 runs.
                 if window is not None:
                     ev["window"] = window
+                # Leaf sub-map fields (issue #300, D22): raster events already
+                # carry the unit's full ShardMap entries in ``granules``, so
+                # only the catalog identity rides here; the worker writes the
+                # full ShardMap JSON sub-map next to the leaf on success.
+                if catalog_signature is not None:
+                    ev["submap"] = catalog_signature
             else:
                 keys = {e.get("time_key") or e.get("datetime") for e in granules if e.get("assets")}
                 ev["time_index"] = {k: time_index[k] for k in keys}
@@ -2555,6 +2583,25 @@ def _run_local(
                     write_sidecar(leaf, record, **store_kwargs)
                 except Exception as e:
                     logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
+                # Leaf sub-map (issue #300, D22): the unit's ShardMap entries as
+                # full ShardMap JSON, sibling to the stats sidecar. The local
+                # "worker" is in-process, so the catalog fields are in scope
+                # (the Lambda path threads them via the event's submap block).
+                # Fail-open, like the sidecar.
+                try:
+                    from zagg.sweep import write_leaf_submap
+
+                    write_leaf_submap(
+                        store_path,
+                        int(shard_key),
+                        records,
+                        grid_signature=catalog_data["grid_signature"],
+                        metadata=catalog_data.get("metadata"),
+                        window=window["label"] if window else None,
+                        store_kwargs=store_kwargs,
+                    )
+                except Exception as e:
+                    logger.warning(f"leaf sub-map write failed (fail-open, issue #300): {e}")
             return {"shard_key": shard_key, "ok": True, "meta": meta}
         except Exception as e:
             return {"shard_key": shard_key, "ok": False, "error": e}
@@ -2911,6 +2958,16 @@ def _run_lambda(
         granule_urls = _resolve_urls(records, "s3")
         ds = _clamped_data_source(config.data_source, len(granule_urls))
         cell_config_dict = {**config_dict, "data_source": ds} if ds is not None else config_dict
+        # Leaf sub-map fields (issue #300, D22): the worker writes the full
+        # ShardMap JSON sub-map at the leaf prefix on success, but the event's
+        # bare granule_urls can't reconstruct the {id, s3, https} entries — so
+        # the unit's entries + the catalog identity ride a dedicated block
+        # (size-gated in _invoke_lambda_cell; dropped, never fatal).
+        submap = {
+            "grid_signature": catalog_data["grid_signature"],
+            "metadata": catalog_data.get("metadata"),
+            "granules": records,
+        }
         return _invoke_lambda_cell(
             state["lambda_client"],
             grid.block_index(int(shard_key)),
@@ -2930,6 +2987,7 @@ def _run_lambda(
             label=label,
             invoked_by=invoked_by,
             run_id=run_id,
+            submap=submap,
             **extra,
         )
 
@@ -4400,6 +4458,7 @@ def _invoke_lambda_cell(
     label=None,
     invoked_by=None,
     run_id=None,
+    submap=None,
 ):
     """Invoke Lambda for a single cell with retry logic.
 
@@ -4425,6 +4484,12 @@ def _invoke_lambda_cell(
     connection sits idle while the shard runs, so long shards survive NAT idle
     timeouts (GitHub-hosted runners sever synchronous invokes at ~4 min). When
     ``None`` (legacy sync path) the invoke is byte-identical to before.
+    ``submap`` (issue #300) forwards the unit's leaf sub-map fields
+    (``grid_signature``/``metadata``/``granules`` — the ShardMap entries the
+    worker cannot derive from bare urls) so the worker writes the D22 full
+    ShardMap JSON sub-map next to the leaf; size-gated below (dropped, never
+    fatal, when it would push an async event over the 256 KB cap) and omitted
+    (``None``) the event stays byte-identical.
     """
     wall_start = time.time()
 
@@ -4484,6 +4549,20 @@ def _invoke_lambda_cell(
     # rather than letting every attempt fail on Lambda's raw
     # RequestEntityTooLargeException (issue #151).
     payload = json.dumps(event)
+    # Leaf sub-map block (issue #300): attached only when it FITS — a unit
+    # whose granule entries would push an async event over the cap keeps its
+    # pre-#300 payload (the sub-map is a regenerable D9 artifact; the manual
+    # sweep CLI is the backstop), so the cap gate below can never start
+    # rejecting a run that dispatched fine before.
+    if submap is not None:
+        with_submap = json.dumps({**event, "submap": submap})
+        if invocation_type != "Event" or len(with_submap) <= _ASYNC_PAYLOAD_CAP_BYTES:
+            payload = with_submap
+        else:
+            logger.debug(
+                f"cell {label or shard_key}: dropping submap block ({len(with_submap):,} "
+                f"bytes over the async budget); leaf sub-map deferred to the sweep CLI"
+            )
     if invocation_type == "Event" and len(payload) > _ASYNC_PAYLOAD_CAP_BYTES:
         raise ValueError(
             f"cell {label or shard_key} event payload is {len(payload):,} bytes, over the "

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -44,6 +44,7 @@ from zagg.config import (
     get_pipeline_type,
     get_store_layout,
     get_store_path,
+    get_sweep,
     get_windowing,
 )
 from zagg.dispatch import (
@@ -1046,6 +1047,18 @@ class RasterStrategy:
         run_stats_path = _write_run_stats(
             store_path, rows, run_id=run_id, store_kwargs=store_kwargs
         )
+        # End-of-run rollup sweep (issue #300): in-process on the local
+        # backend (this process is the worker — see _run_local's note; D8
+        # constrains only the Lambda paths). Only units that wrote a leaf
+        # contribute work; fail-open inside sweep_after_run (D9).
+        if store_layout == "hive" and get_sweep(config):
+            from zagg.sweep import leaves_from_stats_records, sweep_after_run
+
+            leaves = leaves_from_stats_records(
+                [m.get("stats") for m in ok_metas if m.get("leaf_written")]
+            )
+            if leaves:
+                sweep_after_run(store_path, leaves, store_kwargs=store_kwargs)
         # Per-shard isolation lets one bad shard be counted and skipped, but a
         # run where EVERY shard raised (e.g. a config band whose ``asset`` is
         # absent from every granule) would otherwise return a success-shaped,
@@ -1437,6 +1450,25 @@ class RasterStrategy:
             run_id=run_id,
             store_kwargs=_output_store_kwargs(output_creds_event, region),
         )
+        # End-of-run rollup sweep (issue #300): D8 worker-invoke transport,
+        # mirroring the aggregation lambda path — one fire-and-forget
+        # mode="sweep" Event invoke, fail-open (D9; the CLI backstops).
+        if store_layout == "hive" and get_sweep(config):
+            try:
+                from zagg.sweep import leaves_from_stats_records
+
+                leaves = leaves_from_stats_records([b.get("stats") for _k, b in ok_units])
+                if leaves:
+                    _invoke_lambda_sweep(
+                        client,
+                        function_name,
+                        store_path,
+                        leaves,
+                        output_creds_event=output_creds_event,
+                    )
+                    logger.info(f"Dispatched rollup sweep ({len(leaves)} leaves, fire-and-forget)")
+            except Exception as e:
+                logger.warning(f"rollup sweep dispatch failed (fail-open, D9): {e}")
         if cells and errors == len(cells):
             raise RuntimeError(f"all {errors} raster shard(s) failed; last error: {last_error}")
         # Worker telemetry rollup (issue #250): billed durations and peak RSS,
@@ -2723,6 +2755,17 @@ def _run_local(
         for key, exc in stats_failures
     ]
     _write_run_stats(store_path, rows, run_id=run_id, store_kwargs=store_kwargs, summary=summary)
+    # End-of-run rollup sweep (issue #300): the LOCAL dispatcher runs it
+    # in-process — this process is also the worker and already PUTs every
+    # leaf with these credentials, so the D8 orchestrator-no-write rule
+    # (which sends the Lambda paths through a mode="sweep" worker invoke)
+    # doesn't constrain it. Fail-open inside sweep_after_run (D9).
+    if store_layout == "hive" and get_sweep(config):
+        from zagg.sweep import leaves_from_stats_records, sweep_after_run
+
+        leaves = leaves_from_stats_records([m.get("stats") for m in report.results])
+        if leaves:
+            sweep_after_run(store_path, leaves, store_kwargs=store_kwargs)
     logger.info(
         f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"
     )
@@ -3353,6 +3396,34 @@ def _run_lambda(
         store_kwargs=_output_store_kwargs(output_creds_event, region),
         summary=summary,
     )
+    # End-of-run rollup sweep (issue #300): the Lambda dispatcher never PUTs
+    # (D8 standing rule), so the sweep rides ONE fire-and-forget mode="sweep"
+    # worker Event invoke — async, retries-0, fail-open (D9: rollups are
+    # caches; `python -m zagg.sweep` is the regeneration backstop). Leaves
+    # come from the envelope stats records; a stale deployed worker's
+    # record-less envelope simply contributes no leaf.
+    if get_store_layout(config) == "hive" and get_sweep(config):
+        try:
+            from zagg.sweep import leaves_from_stats_records
+
+            leaves = leaves_from_stats_records(
+                [
+                    (r.get("body") or {}).get("stats")
+                    for r in report.results
+                    if r.get("status_code") == 200 and not r.get("error")
+                ]
+            )
+            if leaves:
+                _invoke_lambda_sweep(
+                    state["lambda_client"],
+                    function_name,
+                    store_path,
+                    leaves,
+                    output_creds_event=output_creds_event,
+                )
+                logger.info(f"Dispatched rollup sweep ({len(leaves)} leaves, fire-and-forget)")
+        except Exception as e:
+            logger.warning(f"rollup sweep dispatch failed (fail-open, D9): {e}")
     logger.info(
         f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"
     )
@@ -4428,6 +4499,34 @@ def _invoke_lambda_coverage(
     event = {"mode": "coverage", "store_path": store_path, "coverage": envelope}
     if output_creds_event is not None:
         event["output_credentials"] = output_creds_event
+    lambda_client.invoke(
+        FunctionName=function_name,
+        InvocationType="Event",
+        Payload=json.dumps(event),
+    )
+
+
+def _invoke_lambda_sweep(lambda_client, function_name, store_path, leaves, output_creds_event=None):
+    """Fire-and-forget end-of-run rollup sweep invoke (issue #300, D8).
+
+    ``InvocationType="Event"`` (async, retries-0 semantics, nothing blocks on
+    it and no response is read) — the Lambda-path dispatcher never PUTs to
+    the store (the D8 standing rule), so the sweep runs worker-side exactly
+    like the root ``coverage.moc``'s ``mode="coverage"`` leg. The run's
+    ``(shard_key, window)`` leaves ride inline when they fit the async
+    budget; an oversized set falls back to ``discover: true`` — the worker
+    re-derives the work set from the store's run records (the D22 discovery
+    path; this run's parquet is written before this invoke fires). Failure is
+    harmless by design: rollups are regenerable caches (D9) and the manual
+    CLI (``python -m zagg.sweep``) is the regeneration backstop.
+    """
+    event: dict = {"mode": "sweep", "store_path": store_path}
+    if output_creds_event is not None:
+        event["output_credentials"] = output_creds_event
+    event["leaves"] = [[int(key), window] for key, window in leaves]
+    if len(json.dumps(event)) > _ASYNC_PAYLOAD_CAP_BYTES:
+        del event["leaves"]
+        event["discover"] = True
     lambda_client.invoke(
         FunctionName=function_name,
         InvocationType="Event",

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -3,8 +3,9 @@
 One idempotent bottom-up pass over a hive store's digit tree that folds leaf
 artifacts into interior-node rollups, per registered **artifact family**
 (D22): stats sidecars (the :func:`zagg.telemetry.merge` fold), MOC regen,
-sub-shardmap rollups (stubbed on PR #295), overview zarrs (reserved for
-issue #201), and optional debris collection (stubbed). Everything the sweep
+sub-shardmap rollups (leaf ShardMap JSON folded via the #294 exact coarsen
+regroup), overview zarrs (reserved for issue #201), and optional debris
+collection (stubbed). Everything the sweep
 writes is a **regenerable cache, never truth** (D9): deleting every rollup
 leaves all leaf reads intact, and the leaf sidecars/stamps remain the durable
 ground truth.
@@ -49,8 +50,8 @@ logger = logging.getLogger(__name__)
 #: Envelope version of every rollup object this module writes.
 SWEEP_SPEC = "zagg-sweep/1"
 
-#: Families swept when the caller does not choose (D22 phases 1-2).
-DEFAULT_FAMILIES = ("stats", "moc")
+#: Families swept when the caller does not choose (D22 phases 1-3).
+DEFAULT_FAMILIES = ("stats", "moc", "submap")
 
 
 class SweepFamily:
@@ -83,8 +84,13 @@ class SweepFamily:
         """
         raise NotImplementedError
 
-    def merge(self, payloads: list) -> dict:
-        """Fold payloads into one (associative — rollup == direct, §8.3)."""
+    def merge(self, payloads: list, *, node, order) -> dict:
+        """Fold payloads into one (associative — rollup == direct, §8.3).
+
+        ``node``/``order`` name the target rollup node (decimal prefix and its
+        morton order) for families whose fold is order-aware (the sub-shardmap
+        reproject); order-free families ignore them.
+        """
         raise NotImplementedError
 
     def finish(self, store_root, tops, shard_order, store_kwargs) -> dict:
@@ -114,7 +120,7 @@ class StatsFamily(SweepFamily):
             return None
         return record, record.get("timestamp")
 
-    def merge(self, payloads: list) -> dict:
+    def merge(self, payloads: list, *, node, order) -> dict:
         from zagg.telemetry import merge
 
         return merge(payloads)
@@ -154,7 +160,7 @@ class MocFamily(SweepFamily):
         payload = _moc_payload([morton_word(decimal)], stamp.get("time_range"))
         return payload, stamp.get("written_at")
 
-    def merge(self, payloads: list) -> dict:
+    def merge(self, payloads: list, *, node, order) -> dict:
         import numpy as np
 
         from zagg.hive import root_coverage_words
@@ -232,15 +238,172 @@ def _moc_payload(words, time_range) -> dict:
     return payload
 
 
+#: Leaf sub-map object name (bare leaves); windowed and ``/3`` leaves derive
+#: their names through :func:`submap_key`, single-sourced on the stats-sidecar
+#: naming seam.
+SUBMAP_NAME = "shardmap.json"
+
+
+def submap_key(leaf_name: str, spec: str | None = None) -> str:
+    """Sub-map object name for a leaf zarr basename, keyed by store spec.
+
+    Single-sourced on the PR #307 sidecar-naming seam
+    (:func:`zagg.telemetry.sidecar_key`) with the ``shardmap`` stem swapped in:
+    legacy stores get ``shardmap.json`` / ``shardmap_{window}.json``,
+    ``morton-hive/3`` stores get ``{window}.shardmap.json`` — so the issue
+    #299 writer flip renames both sidecars through one seam. Raises on an
+    unknown spec, exactly as the seam does.
+    """
+    from zagg.telemetry import sidecar_key
+
+    key = sidecar_key(leaf_name, spec)
+    if key.endswith(".stats.json"):  # D23 /3 grammar: {stem}.stats.json
+        return key.removesuffix(".stats.json") + ".shardmap.json"
+    return "shardmap" + key.removeprefix("stats")  # legacy: stats[_{window}].json
+
+
+def write_leaf_submap(
+    store_root: str,
+    shard_key,
+    granules,
+    *,
+    grid_signature: dict,
+    metadata: dict | None = None,
+    window: str | None = None,
+    spec: str | None = None,
+    store_kwargs: dict | None = None,
+) -> None:
+    """PUT one leaf's sub-map — full ShardMap JSON (D22, ratified) — at its prefix.
+
+    The payload is a one-shard :class:`~zagg.catalog.shardmap.ShardMap` in the
+    standard JSON schema (``metadata``/``grid_signature``/``shard_keys``/
+    ``granules``) plus a top-level ``written_at`` staleness stamp — extra keys
+    are ignored by ``ShardMap.from_json``, so the object stays loadable as-is.
+    ``granules`` are the unit's ShardMap entries, copied verbatim (windowed
+    units carry their window's subset, so the shard-node fold's window union
+    reassembles the shard). ``metadata`` is the run catalog's, with the
+    whole-catalog counts and build fields rewritten to describe this sub-map
+    (the same fields ``reproject`` strips from derived maps). Written by the
+    worker on success, sibling to the stats sidecar — call sites fail open.
+    """
+    import obstore
+
+    from zagg.hive import _utcnow, shard_leaf_path
+    from zagg.store import open_object_store
+
+    entries = [dict(g) for g in granules]
+    meta = dict(metadata or {})
+    for stale in ("aoi_mask", "build_wall_s", "reproject"):
+        meta.pop(stale, None)
+    meta.update(total_shards=1, total_granules=len(entries), total_pairs=len(entries))
+    payload = {
+        "metadata": meta,
+        "grid_signature": dict(grid_signature),
+        "shard_keys": [int(shard_key)],
+        "granules": [entries],
+        "written_at": _utcnow(),
+    }
+    leaf = shard_leaf_path(store_root, int(shard_key), window=window)
+    prefix, _, name = leaf.rstrip("/").rpartition("/")
+    obstore.put(
+        open_object_store(prefix, **(store_kwargs or {})),
+        submap_key(name, spec),
+        json.dumps(payload, indent=1).encode(),
+    )
+
+
 class SubmapFamily(SweepFamily):
-    """Sub-shardmap rollups (D22) — registered, NOT implemented yet."""
+    """Sub-shardmap rollups (D22): leaf ShardMap JSON folded via ``reproject``.
+
+    Leaf artifact: the full-ShardMap-JSON sub-map the worker writes next to
+    the leaf (:func:`write_leaf_submap`). Shard-node fold: the windows' entry
+    lists union, deduplicated by granule ``id`` (a granule spanning two
+    windows counts once). Interior fold: children sub-maps concatenate and
+    coarsen to the node's order via :meth:`ShardMap.reproject` — the #294
+    exact pure regroup (granule union deduped by id), now over stored
+    artifacts — so the rollup at order N equals a direct reproject of the
+    leaf-level map to N (§8.3). Every rollup's ``payload`` is a plain
+    ShardMap JSON dict (the sweep envelope wraps it, as for every family).
+    """
 
     name = "submap"
-    available = False
-    reason = (
-        "sub-shardmap rollups fold leaf ShardMap JSON up-tree via the exact "
-        "coarsen regroup (ShardMap.reproject), still under review on PR #295"
-    )
+
+    def read_leaf(self, store_root, decimal, window, spec, store_kwargs):
+        import obstore
+        from obstore.exceptions import NotFoundError
+
+        from zagg.grids.morton import morton_word
+        from zagg.hive import shard_leaf_path
+        from zagg.store import open_object_store
+
+        leaf = shard_leaf_path(store_root, morton_word(decimal), window=window)
+        prefix, _, name = leaf.rstrip("/").rpartition("/")
+        try:
+            data = obstore.get(
+                open_object_store(prefix, **store_kwargs), submap_key(name, spec)
+            ).bytes()
+        except (FileNotFoundError, NotFoundError):
+            return None
+        sub = json.loads(bytes(data))
+        ok = isinstance(sub, dict) and all(
+            k in sub for k in ("grid_signature", "shard_keys", "granules")
+        )
+        if not ok:
+            # Loud, not absent: a present-but-malformed sub-map means a broken
+            # writer; the engine catches per leaf and counts it failed.
+            raise ValueError(f"malformed leaf sub-map next to {leaf}")
+        timestamp = sub.pop("written_at", None)
+        return sub, timestamp
+
+    def merge(self, payloads: list, *, node, order) -> dict:
+        from zagg.catalog.shardmap import ShardMap
+
+        # Same-key union first (several windows of one shard), deduplicated by
+        # granule id — the same rule reproject's coarsen applies across shards.
+        buckets: dict[int, dict] = {}
+        for p in payloads:
+            for key, entries in zip(p["shard_keys"], p["granules"]):
+                bucket = buckets.setdefault(int(key), {})
+                for entry in entries:
+                    bucket[entry["id"]] = dict(entry)
+        keys = sorted(buckets)
+        granules = [list(buckets[k].values()) for k in keys]
+        signature = dict(payloads[0]["grid_signature"])
+        meta = dict(payloads[0].get("metadata") or {})
+        meta.pop("reproject", None)  # never inherit a child fold's stamp
+        meta["total_granules"] = len({e["id"] for g in granules for e in g})
+        folded = ShardMap(signature, keys, granules, meta)
+        if int(signature["parent_order"]) == int(order):
+            # Shard-node fold: already at the node's order — a window union,
+            # not a reprojection; keep counts honest without a noop stamp.
+            meta.update(total_shards=len(keys), total_pairs=sum(len(g) for g in granules))
+        else:
+            folded = folded.reproject(_ReprojectTarget(signature, order))
+        return {
+            "metadata": folded.metadata,
+            "grid_signature": folded.grid_signature,
+            "shard_keys": [int(k) for k in folded.shard_keys],
+            "granules": folded.granules,
+        }
+
+
+class _ReprojectTarget:
+    """Minimal coarsen-target shim for :meth:`ShardMap.reproject`.
+
+    ``reproject`` consumes exactly ``parent_order``/``child_order`` and
+    ``spatial_signature()``. The sweep has no run config to build a full
+    :class:`~zagg.grids.healpix.HealpixGrid` from, and the target signature IS
+    the source's with the shard order swapped — reproject changes only the
+    dispatch order, never the leaf DGGS resolution.
+    """
+
+    def __init__(self, signature: dict, parent_order: int):
+        self._signature = {**signature, "parent_order": int(parent_order)}
+        self.parent_order = int(parent_order)
+        self.child_order = int(signature["child_order"])
+
+    def spatial_signature(self) -> dict:
+        return dict(self._signature)
 
 
 class OverviewFamily(SweepFamily):
@@ -408,7 +571,7 @@ def _rollup_shard_node(
         counts["empty"] += 1
         return None
     generation = _generation(len(parts), [ts for _w, _p, ts in parts])
-    payload = _merged(fam, [p for _w, p, _ts in parts], decimal, counts)
+    payload = _merged(fam, [p for _w, p, _ts in parts], decimal, shard_order, counts)
     if payload is None:
         return None
     if (
@@ -464,7 +627,7 @@ def _rollup_interior(store, fam, node, computed, counts) -> dict | None:
         [a["generation"].get("max_leaf_timestamp") for a in children],
     )
     existing = _read_rollup(store, fam, node)
-    payload = _merged(fam, [a["payload"] for a in children], node, counts)
+    payload = _merged(fam, [a["payload"] for a in children], node, _decimal_order(node), counts)
     if payload is None:
         return None
     if (
@@ -487,10 +650,10 @@ def _rollup_interior(store, fam, node, computed, counts) -> dict | None:
     return envelope
 
 
-def _merged(fam, payloads, node, counts) -> dict | None:
+def _merged(fam, payloads, node, order, counts) -> dict | None:
     """The family fold, fail-open per node: unmergeable -> logged + skipped."""
     try:
-        return fam.merge(payloads)
+        return fam.merge(payloads, node=node, order=order)
     except Exception as e:
         logger.warning(f"sweep[{fam.name}]: merge failed at node {node}; skipping ({e})")
         counts["failed"] += 1

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -440,6 +440,14 @@ class SubmapFamily(SweepFamily):
             # not a reprojection; keep counts honest without a noop stamp.
             meta.update(total_shards=len(keys), total_pairs=sum(len(g) for g in granules))
         else:
+            # Interior fold: coarsen the children to this node's order. The
+            # resulting metadata["reproject"]["source_parent_order"] records the
+            # immediately-lower fold level (payloads[0]'s parent_order, one order
+            # below this node) — the LAST hop, not the leaf/shard origin order.
+            # Coarsen is transitive, so the folded data equals a direct reproject
+            # of the leaf-level map straight to this order (§8.3,
+            # test_rollup_equals_direct_reproject); the stamp naming the last hop
+            # is by design, not a data discrepancy.
             folded = folded.reproject(_ReprojectTarget(signature, order))
         return {
             "metadata": folded.metadata,

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -851,9 +851,12 @@ def discover_leaves(store_root: str, *, store_kwargs: dict | None = None) -> lis
     ``stats_*.parquet`` run records (both the timestamp-first D20 names and
     the older ``stats_{run_id}_{ts}`` form); their success rows give the work
     set — discovery is from run records, never a tree enumeration. Windowed
-    leaves resolve through the records' ``window`` column; rows from
-    pre-column records on a windowed store fall back to one delimiter LIST of
-    that shard's node (bounded by the run-record shard set). Rows whose
+    leaves resolve through the records' ``window`` column; every shard that
+    contributed a pre-column (window-less) row on a windowed store falls back
+    to one delimiter LIST of that shard's node — regardless of whether some
+    other record already named one of its windows, since the LIST + set dedup
+    is idempotent and a mixed-deployment store can hold a window only the
+    sidecar knows about (bounded by the run-record shard set). Rows whose
     ``shard_key`` came back float-typed (pre-fix parquets mixing keys with
     failure-row nulls) are skipped past 2^53 with a warning — those keys are
     inexact by construction; :func:`zagg.telemetry.write_run_parquet` now
@@ -922,10 +925,13 @@ def discover_leaves(store_root: str, *, store_kwargs: dict | None = None) -> lis
                 refs.add((key, None))
     # Pre-``window``-column records on a windowed store: the row can't name
     # its leaf, so resolve each shard's windows with ONE delimiter LIST of its
-    # node — scoped by the run-record shard set, never a tree walk.
+    # node — scoped by the run-record shard set, never a tree walk. Every
+    # pre-column shard is LISTed even if another record already named one of
+    # its windows: the LIST + set dedup is idempotent, and on a mixed
+    # deployment the sidecar can hold a window no post-column record names.
     from zagg.grids.morton import morton_decimal
 
-    for key in sorted(fallback_keys - {k for k, _w in refs}):
+    for key in sorted(fallback_keys):
         node_listing = obstore.list_with_delimiter(store, _node_rel(morton_decimal(key)) + "/")
         for obj in node_listing["objects"]:
             window = _sidecar_window(obj["path"].rsplit("/", 1)[-1], spec)

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -20,8 +20,16 @@ Every rollup is stamped with **generation info** — merged-leaf count + max
 leaf timestamp (D22) — making staleness *detectable, not prevented*: a leaf
 re-run bumps its artifact timestamp past every earlier stamp, so ancestors'
 stored generations no longer match and the next sweep rewrites exactly that
-chain (skip-if-current elsewhere keeps the pass idempotent: a second sweep
-over an unchanged tree PUTs nothing).
+chain. Skip-if-current is a **two-part test**: the generation stamp is the
+fast path (a matching count + max timestamp), backstopped by a
+**payload-equality** check for same-second rewrites. Both timestamp sources
+resolve to whole seconds (``timespec="seconds"``), so a leaf re-run within one
+wall-clock second carries an unchanged stamp; every node therefore recomputes
+its merged payload BEFORE the skip decision and PUTs whenever the stored
+payload differs, so a same-second content change still rewrites the whole
+chain (shard nodes re-read their leaf sidecars each pass; interior nodes fold
+the freshly computed child payloads, so the rewrite cascades up). A second
+sweep over an unchanged tree recomputes but PUTs nothing.
 
 Rollup objects are JSON sidecars at digit nodes, named ``{family}.rollup.json``
 — deliberately DISTINCT from the leaf sidecar names (``stats.json`` /
@@ -285,8 +293,10 @@ def run_sweep(store_root: str, leaves, *, families=None, store_kwargs: dict | No
     unsupported this round, matching ``refresh_root_coverage``).
 
     Idempotent: a rollup whose stored generation (merged-leaf count + max
-    leaf timestamp) matches the freshly computed one is left untouched, so a
-    second pass over an unchanged tree writes nothing. Returns a summary with
+    leaf timestamp) AND stored payload both match the freshly computed ones is
+    left untouched, so a second pass over an unchanged tree writes nothing; the
+    payload compare is the same-second backstop the generation stamp cannot see
+    (module docstring). Returns a summary with
     per-family ``written`` / ``current`` (skip-if-current) / ``empty`` (no
     artifact found) / ``failed`` (unmergeable, logged) counts.
     """
@@ -398,12 +408,16 @@ def _rollup_shard_node(
         counts["empty"] += 1
         return None
     generation = _generation(len(parts), [ts for _w, _p, ts in parts])
-    if existing is not None and existing.get("generation") == generation:
-        counts["current"] += 1
-        return existing
     payload = _merged(fam, [p for _w, p, _ts in parts], decimal, counts)
     if payload is None:
         return None
+    if (
+        existing is not None
+        and existing.get("generation") == generation
+        and existing.get("payload") == payload
+    ):
+        counts["current"] += 1
+        return existing
     envelope = {
         "spec": SWEEP_SPEC,
         "family": fam.name,
@@ -443,12 +457,16 @@ def _rollup_interior(store, fam, node, computed, counts) -> dict | None:
         [a["generation"].get("max_leaf_timestamp") for a in children],
     )
     existing = _read_rollup(store, fam, node)
-    if existing is not None and existing.get("generation") == generation:
-        counts["current"] += 1
-        return existing
     payload = _merged(fam, [a["payload"] for a in children], node, counts)
     if payload is None:
         return None
+    if (
+        existing is not None
+        and existing.get("generation") == generation
+        and existing.get("payload") == payload
+    ):
+        counts["current"] += 1
+        return existing
     envelope = {
         "spec": SWEEP_SPEC,
         "family": fam.name,

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -439,6 +439,13 @@ def _rollup_interior(store, fam, node, computed, counts) -> dict | None:
     is probed on the store (<= 4 GETs, no LIST) so prior runs' siblings keep
     contributing. Generation is the children's sum/max — fold-of-folds equals
     the direct leaf fold because every family's merge is associative (§8.3).
+
+    The store is append-only at the leaf level (leaf deletion/GC is the
+    registered debris family, deliberately stubbed), so a child that emptied
+    this pass returns ``None`` from its shard rollup and this fallback picks up
+    its prior on-store rollup — an emptied/vanished leaf keeps contributing to
+    its parent until a deletion-aware family exists. Under append-only + D9
+    (rollups are regenerable caches) that is intended, not stale-serving.
     """
     from zagg.hive import _decimal_order
 

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -312,6 +312,24 @@ def write_leaf_submap(
     )
 
 
+def submap_emittable(grid_signature: dict | None, granules) -> bool:
+    """Whether a unit's leaf sub-map can be folded by :class:`SubmapFamily`.
+
+    The sub-shardmap fold is HEALPix-morton only — ``reproject`` coarsens by
+    ``parent_order``/``child_order`` and the merge keys entries by granule
+    ``id``. A rectilinear raster signature (grid ``type != "healpix"``, no
+    ``parent_order``/``child_order``) or id-less granule entries would fold to
+    a ``failed`` node the sweep can never consume, so the emission sites (issue
+    #300) check this and skip the write instead of persisting an unmergeable
+    payload. ``store_layout: hive`` is HEALPix-only by validation, so the
+    realistic skip is id-less raster entries under a rectilinear signature.
+    """
+    sig = grid_signature or {}
+    if sig.get("type") != "healpix" or "parent_order" not in sig or "child_order" not in sig:
+        return False
+    return all("id" in g for g in granules)
+
+
 class SubmapFamily(SweepFamily):
     """Sub-shardmap rollups (D22): leaf ShardMap JSON folded via ``reproject``.
 

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -399,6 +399,19 @@ class SubmapFamily(SweepFamily):
         return sub, timestamp
 
     def merge(self, payloads: list, *, node, order) -> dict:
+        """Fold child sub-maps into this node's rollup (§8.3).
+
+        Identity metadata (``collection``/``short_name``/``version``/
+        ``footprint``) is inherited from the first child payload
+        (``payloads[0]``); only ``total_granules`` is recomputed. The
+        one-store-per-product invariant (D7/D19: one product tree per semantic
+        core, one catalog family) makes those fields uniform across a node's
+        children by construction, so the first child is representative. A store
+        that accreted leaves from more than one catalog under one root would
+        need identity reconciliation this fold does not attempt (the rollup
+        would advertise one arbitrary child's identity). ``grid_signature`` is
+        safe regardless — all children of a node share ``child_order``.
+        """
         from zagg.catalog.shardmap import ShardMap
 
         # Same-key union first (several windows of one shard), deduplicated by

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -53,6 +53,21 @@ SWEEP_SPEC = "zagg-sweep/1"
 #: Families swept when the caller does not choose (D22 phases 1-3).
 DEFAULT_FAMILIES = ("stats", "moc", "submap")
 
+#: Grid types already warned about as unsupported leaf sub-maps (once-ish, so a
+#: raster sweep does not warn-spam per shard). Never security-load-bearing.
+_warned_unsupported_submap: set[str | None] = set()
+
+
+def _warn_unsupported_submap(grid_type: str | None) -> None:
+    """Warn once per grid type that a non-HEALPix leaf sub-map was skipped."""
+    if grid_type in _warned_unsupported_submap:
+        return
+    _warned_unsupported_submap.add(grid_type)
+    logger.warning(
+        f"sweep[submap]: skipping non-HEALPix leaf sub-map (grid type {grid_type!r}); "
+        f"the sub-shardmap fold is HEALPix-only (issue #300)"
+    )
+
 
 class SweepFamily:
     """One derived-artifact family (D22): how leaves read and payloads fold.
@@ -367,9 +382,19 @@ class SubmapFamily(SweepFamily):
             k in sub for k in ("grid_signature", "shard_keys", "granules")
         )
         if not ok:
-            # Loud, not absent: a present-but-malformed sub-map means a broken
-            # writer; the engine catches per leaf and counts it failed.
+            # Corrupt (missing required keys): a present-but-malformed sub-map
+            # means a broken writer; the engine catches per leaf and counts it
+            # failed — the loud, not-absent signal.
             raise ValueError(f"malformed leaf sub-map next to {leaf}")
+        sig = sub["grid_signature"] or {}
+        if sig.get("type") != "healpix" or "parent_order" not in sig or "child_order" not in sig:
+            # Unsupported (not corrupt): the sub-shardmap fold is HEALPix-only
+            # (reproject coarsens by parent/child order). A non-HEALPix leaf —
+            # e.g. a rectilinear raster sub-map slipped past the emission guard
+            # (submap_emittable) — is a SKIP, not a broken writer: return None so
+            # the engine counts it "empty", never "failed" (data-corruption).
+            _warn_unsupported_submap(sig.get("type"))
+            return None
         timestamp = sub.pop("written_at", None)
         return sub, timestamp
 
@@ -383,6 +408,12 @@ class SubmapFamily(SweepFamily):
             for key, entries in zip(p["shard_keys"], p["granules"]):
                 bucket = buckets.setdefault(int(key), {})
                 for entry in entries:
+                    # read_leaf already filters non-HEALPix/id-less leaves to the
+                    # "empty" skip path, so an id-less entry reaching the fold is a
+                    # genuinely broken artifact — name the field cleanly ("failed"),
+                    # never a bare KeyError.
+                    if "id" not in entry:
+                        raise ValueError("leaf sub-map granule entry missing required 'id' field")
                     bucket[entry["id"]] = dict(entry)
         keys = sorted(buckets)
         granules = [list(buckets[k].values()) for k in keys]

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 #: Envelope version of every rollup object this module writes.
 SWEEP_SPEC = "zagg-sweep/1"
 
-#: Families swept when the caller does not choose (phase 1: stats only).
-DEFAULT_FAMILIES = ("stats",)
+#: Families swept when the caller does not choose (D22 phases 1-2).
+DEFAULT_FAMILIES = ("stats", "moc")
 
 
 class SweepFamily:
@@ -65,11 +65,13 @@ class SweepFamily:
         """The family's per-node rollup object name."""
         return f"{self.name}.rollup.json"
 
-    def read_leaf(self, store_root, decimal, window, store_kwargs):
+    def read_leaf(self, store_root, decimal, window, spec, store_kwargs):
         """One leaf's ``(payload, timestamp)`` contribution, or ``None``.
 
         ``None`` means the leaf carries no artifact for this family (e.g. a
         fail-open sidecar PUT that never landed) — it is skipped, not fatal.
+        ``spec`` is the manifest's store spec string, threaded so spec-keyed
+        sidecar naming (the PR #307 D23 seam) resolves per store.
         """
         raise NotImplementedError
 
@@ -93,13 +95,13 @@ class StatsFamily(SweepFamily):
 
     name = "stats"
 
-    def read_leaf(self, store_root, decimal, window, store_kwargs):
+    def read_leaf(self, store_root, decimal, window, spec, store_kwargs):
         from zagg.grids.morton import morton_word
         from zagg.hive import shard_leaf_path
         from zagg.telemetry import read_sidecar
 
         leaf = shard_leaf_path(store_root, morton_word(decimal), window=window)
-        record = read_sidecar(leaf, **store_kwargs)
+        record = read_sidecar(leaf, spec, **store_kwargs)
         if record is None:
             return None
         return record, record.get("timestamp")
@@ -108,6 +110,118 @@ class StatsFamily(SweepFamily):
         from zagg.telemetry import merge
 
         return merge(payloads)
+
+
+class MocFamily(SweepFamily):
+    """MOC regen (D8/D9): committed-leaf coverage folded up-tree + root refresh.
+
+    A leaf contributes iff its D4 commit stamp is present (unstamped debris is
+    invisible, exactly as the walk treats it); the staleness timestamp is the
+    stamp's ``written_at``. Payloads are shard-order ranges bodies (the root
+    ``coverage.moc``'s O1 encoding, minus its carrier fields) plus the D15
+    time union, so the fold is a word union and the base-node artifacts
+    compose directly into the store root. :meth:`finish` refreshes the root
+    ``coverage.moc`` from those base folds via the GET-union-PUT writer —
+    the sweep is the REGENERATOR; the runner's end-of-run fail-open write
+    stays the fast path (O7/D9) — skipping the PUT when the existing root
+    already covers the folded words and time range (sweep idempotence). The
+    O8 in-leaf bitmap contract is untouched: this family reads only the
+    stamp envelope, never the cell-order bitmap sidecar.
+    """
+
+    name = "moc"
+
+    def read_leaf(self, store_root, decimal, window, spec, store_kwargs):
+        # ``spec`` is unused here: leaf PATHS are the frozen /1-/2 grammar
+        # (shard_leaf_path); the D23 /3 leaf naming has no writer yet, and
+        # adopting it is the issue #299 flip, which lands in shard_leaf_path.
+        from zagg.grids.morton import morton_word
+        from zagg.hive import read_commit, shard_leaf_path
+        from zagg.store import open_store
+
+        leaf = shard_leaf_path(store_root, morton_word(decimal), window=window)
+        stamp = read_commit(open_store(leaf, **store_kwargs))
+        if stamp is None:
+            return None  # absent leaf or unstamped debris (D4)
+        payload = _moc_payload([morton_word(decimal)], stamp.get("time_range"))
+        return payload, stamp.get("written_at")
+
+    def merge(self, payloads: list) -> dict:
+        import numpy as np
+
+        from zagg.hive import root_coverage_words
+        from zagg.windows import union_time_range
+
+        words = np.unique(np.concatenate([root_coverage_words(p) for p in payloads]))
+        return _moc_payload(words, union_time_range(*(p.get("time_range") for p in payloads)))
+
+    def finish(self, store_root, tops, shard_order, store_kwargs) -> dict:
+        """Refresh the store-root ``coverage.moc`` from the base-node folds.
+
+        Unions with the existing root object (the sweep may cover only the
+        dirty subtrees — untouched bases must keep their listing), via the
+        same :func:`zagg.hive.write_root_coverage` transport the runner uses.
+        No PUT when the existing root already lists every folded word and
+        covers the folded time range, so an unchanged tree re-sweep is a
+        no-op here too.
+        """
+        import numpy as np
+
+        from zagg.hive import (
+            build_root_coverage,
+            read_root_coverage,
+            root_coverage_words,
+            write_root_coverage,
+        )
+        from zagg.windows import union_time_range
+
+        if not tops:
+            return {"root_moc_written": False}
+        words = np.unique(np.concatenate([root_coverage_words(t["payload"]) for t in tops]))
+        time_range = union_time_range(*(t["payload"].get("time_range") for t in tops))
+        try:
+            existing = read_root_coverage(store_root, **store_kwargs)
+        except ValueError:
+            existing = None  # unparsable root -> regenerate (D9)
+        if isinstance(existing, dict):
+            try:
+                covered = bool(np.isin(words, root_coverage_words(existing)).all())
+                covered = covered and (
+                    union_time_range(existing.get("time_range"), time_range)
+                    == existing.get("time_range")
+                )
+                if covered:
+                    return {"root_moc_written": False}
+            except (KeyError, TypeError, ValueError):
+                pass  # malformed cache cannot vouch for coverage -> rewrite
+        write_root_coverage(
+            store_root,
+            build_root_coverage(words, shard_order, source="sweep", time_range=time_range),
+            **store_kwargs,
+        )
+        return {"root_moc_written": True}
+
+
+def _moc_payload(words, time_range) -> dict:
+    """A rollup's shard-order ranges body (deterministic — no carrier fields).
+
+    Reuses :func:`zagg.hive.build_root_coverage` for the O1 range encoding and
+    drops ``source``/``generated_at`` (they would defeat skip-if-current
+    byte stability) and ``spec`` (the rollup rides the ``zagg-sweep/1``
+    envelope; the root object written by :meth:`MocFamily.finish` carries the
+    full ``morton-moc/1`` carrier as usual). ``time_range`` is normalized
+    through the D15 union so leaf and merged payloads compare equal.
+    """
+    from zagg.grids.morton import morton_decimal
+    from zagg.hive import _decimal_order, build_root_coverage
+    from zagg.windows import union_time_range
+
+    order = _decimal_order(morton_decimal(int(words[0])))
+    envelope = build_root_coverage(words, order, time_range=union_time_range(time_range))
+    payload = {"encoding": "ranges", "order": envelope["order"], "ranges": envelope["ranges"]}
+    if "time_range" in envelope:
+        payload["time_range"] = envelope["time_range"]
+    return payload
 
 
 class SubmapFamily(SweepFamily):
@@ -146,7 +260,7 @@ class DebrisFamily(SweepFamily):
 #: Family registry (D22's plug-in point): name -> class. Unavailable entries
 #: are visible slots that :func:`get_family` refuses with their ``reason``.
 FAMILIES: dict[str, type[SweepFamily]] = {
-    cls.name: cls for cls in (StatsFamily, SubmapFamily, OverviewFamily, DebrisFamily)
+    cls.name: cls for cls in (StatsFamily, MocFamily, SubmapFamily, OverviewFamily, DebrisFamily)
 }
 
 
@@ -196,7 +310,7 @@ def run_sweep(store_root: str, leaves, *, families=None, store_kwargs: dict | No
     }
     for fam in fams:
         summary["families"][fam.name] = _sweep_family(
-            store_root, store, fam, by_shard, shard_order, store_kwargs
+            store_root, store, fam, by_shard, shard_order, manifest.get("spec"), store_kwargs
         )
     return summary
 
@@ -222,13 +336,21 @@ def _normalize_leaves(leaves, shard_order: int):
     return by_shard, skipped
 
 
-def _sweep_family(store_root, store, fam, by_shard, shard_order, store_kwargs) -> dict:
+def _sweep_family(store_root, store, fam, by_shard, shard_order, spec, store_kwargs) -> dict:
     """Bottom-up fold of one family over the dirty ancestor paths."""
     counts = {"written": 0, "current": 0, "empty": 0, "failed": 0}
     computed: dict[str, dict | None] = {}
     for decimal in sorted(by_shard):
         computed[decimal] = _rollup_shard_node(
-            store_root, store, fam, decimal, by_shard[decimal], shard_order, store_kwargs, counts
+            store_root,
+            store,
+            fam,
+            decimal,
+            by_shard[decimal],
+            shard_order,
+            spec,
+            store_kwargs,
+            counts,
         )
     frontier = [d for d in sorted(by_shard) if computed[d] is not None]
     for _order in range(shard_order - 1, -1, -1):
@@ -247,7 +369,7 @@ def _sweep_family(store_root, store, fam, by_shard, shard_order, store_kwargs) -
 
 
 def _rollup_shard_node(
-    store_root, store, fam, decimal, windows, shard_order, store_kwargs, counts
+    store_root, store, fam, decimal, windows, shard_order, spec, store_kwargs, counts
 ) -> dict | None:
     """Fold one shard node's window-leaf artifacts into its rollup.
 
@@ -262,7 +384,7 @@ def _rollup_shard_node(
     parts = []
     for window in sorted(known, key=lambda w: (w is not None, w or "")):
         try:
-            got = fam.read_leaf(store_root, decimal, window, store_kwargs)
+            got = fam.read_leaf(store_root, decimal, window, spec, store_kwargs)
         except Exception as e:
             logger.warning(
                 f"sweep[{fam.name}]: leaf read failed at {decimal} window {window!r}; "

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -725,3 +725,174 @@ def _put_rollup(store, fam, decimal: str, envelope: dict) -> None:
     import obstore
 
     obstore.put(store, _rollup_key(fam, decimal), json.dumps(envelope, indent=1).encode())
+
+
+# ---------------------------------------------------------------------------
+# Trigger surfaces (issue #300 phases 4-5): run-record discovery + manual CLI.
+# ---------------------------------------------------------------------------
+
+
+def discover_leaves(store_root: str, *, store_kwargs: dict | None = None) -> list:
+    """Leaf refs from the run-record parquets at the product root (D22).
+
+    One shallow delimiter LIST of the product root finds the
+    ``stats_*.parquet`` run records (both the timestamp-first D20 names and
+    the older ``stats_{run_id}_{ts}`` form); their success rows give the work
+    set — discovery is from run records, never a tree enumeration. Windowed
+    leaves resolve through the records' ``window`` column; rows from
+    pre-column records on a windowed store fall back to one delimiter LIST of
+    that shard's node (bounded by the run-record shard set). Rows whose
+    ``shard_key`` came back float-typed (pre-fix parquets mixing keys with
+    failure-row nulls) are skipped past 2^53 with a warning — those keys are
+    inexact by construction; :func:`zagg.telemetry.write_run_parquet` now
+    writes the column nullable-UInt64 so new records round-trip exactly.
+    Returns sorted, deduplicated ``(shard_key, window)`` pairs.
+    """
+    import re
+    import tempfile
+
+    import obstore
+
+    from zagg.hive import MANIFEST_NAME, read_manifest
+    from zagg.store import open_object_store
+
+    store_kwargs = dict(store_kwargs or {})
+    manifest = read_manifest(store_root, **store_kwargs)
+    if manifest is None:
+        raise ValueError(f"no {MANIFEST_NAME} at {store_root} — not a hive store root")
+    spec = manifest.get("spec")
+    windowed = manifest.get("temporal") is not None
+    store = open_object_store(store_root, **store_kwargs)
+    listing = obstore.list_with_delimiter(store)
+    names = sorted(
+        o["path"].rsplit("/", 1)[-1]
+        for o in listing["objects"]
+        if re.fullmatch(r"stats_.+\.parquet", o["path"].rsplit("/", 1)[-1])
+    )
+    refs: set = set()
+    fallback_keys: set[int] = set()
+    warned_float = False
+    for name in names:
+        import pandas as pd
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet") as tmp:
+            tmp.write(bytes(obstore.get(store, name).bytes()))
+            tmp.flush()
+            try:
+                df = pd.read_parquet(tmp.name, engine="fastparquet")
+            except Exception as e:
+                logger.warning(f"sweep discovery: unreadable run record {name}; skipping ({e})")
+                continue
+        if "shard_key" not in df.columns:
+            logger.warning(f"sweep discovery: run record {name} has no shard_key; skipping")
+            continue
+        ok = df[df["shard_key"].notna() & df.get("success", True)]
+        has_window = "window" in df.columns
+        for _idx, row in ok.iterrows():
+            key = row["shard_key"]
+            if isinstance(key, float):
+                if key != int(key) or key >= 2**53:
+                    if not warned_float:
+                        warned_float = True
+                        logger.warning(
+                            f"sweep discovery: {name} stores shard_key as float64 (a "
+                            f"pre-fix run record); keys past 2^53 are inexact and are "
+                            f"skipped — re-run those shards or sweep them by hand"
+                        )
+                    continue
+            key = int(key)
+            if has_window:
+                window = row["window"]
+                refs.add((key, None if window is None or pd.isna(window) else str(window)))
+            elif windowed:
+                fallback_keys.add(key)  # pre-column record: resolve below
+            else:
+                refs.add((key, None))
+    # Pre-``window``-column records on a windowed store: the row can't name
+    # its leaf, so resolve each shard's windows with ONE delimiter LIST of its
+    # node — scoped by the run-record shard set, never a tree walk.
+    from zagg.grids.morton import morton_decimal
+
+    for key in sorted(fallback_keys - {k for k, _w in refs}):
+        node_listing = obstore.list_with_delimiter(store, _node_rel(morton_decimal(key)) + "/")
+        for obj in node_listing["objects"]:
+            window = _sidecar_window(obj["path"].rsplit("/", 1)[-1], spec)
+            if window is not _NO_SIDECAR:
+                refs.add((key, window))
+    return sorted(refs, key=lambda r: (r[0], r[1] is not None, r[1] or ""))
+
+
+#: Sentinel: "this object is not a stats sidecar" (``None`` means unwindowed).
+_NO_SIDECAR = object()
+
+
+def _sidecar_window(name: str, spec: str | None):
+    """The window label a stats-sidecar object name encodes, else the sentinel."""
+    from zagg.telemetry import SIDECAR_NAME, SPEC_V3
+    from zagg.windows import validate_label
+
+    try:
+        if spec == SPEC_V3:
+            if not name.endswith(".stats.json"):
+                return _NO_SIDECAR
+            stem = name.removesuffix(".stats.json")
+            validate_label(stem)
+            return stem
+        if name == SIDECAR_NAME:
+            return None
+        stem, ext = SIDECAR_NAME.rsplit(".", 1)
+        if name.startswith(f"{stem}_") and name.endswith(f".{ext}"):
+            window = name[len(stem) + 1 : -(len(ext) + 1)]
+            validate_label(window)
+            return window
+    except ValueError:
+        return _NO_SIDECAR
+    return _NO_SIDECAR
+
+
+def main(argv=None) -> int:
+    """Manual CLI: ``python -m zagg.sweep <store_root>`` (issue #300, D22)."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="zagg unified rollup sweep: fold leaf artifacts into interior-node "
+        "rollups (issue #300). Work is discovered from the store's run records."
+    )
+    parser.add_argument("store_root", help="Hive store root (local path or s3://bucket/prefix)")
+    parser.add_argument(
+        "--families",
+        default=None,
+        help=f"Comma-separated families (default: {','.join(DEFAULT_FAMILIES)}; "
+        f"registered: {', '.join(sorted(FAMILIES))})",
+    )
+    parser.add_argument("--region", default="us-west-2", help="AWS region (default: us-west-2)")
+    parser.add_argument(
+        "--output-creds",
+        default=None,
+        metavar="PATH",
+        help="Path to a JSON credentials file for the store (same format as python -m zagg)",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    store_kwargs: dict = {"region": args.region}
+    if args.output_creds:
+        from zagg.runner import normalize_output_credentials
+
+        with open(args.output_creds) as f:
+            credentials = normalize_output_credentials(json.load(f))
+        store_kwargs["credentials"] = credentials
+        store_kwargs["endpoint_url"] = credentials.get("endpointUrl")
+    families = [f.strip() for f in args.families.split(",")] if args.families else None
+    leaves = discover_leaves(args.store_root, store_kwargs=store_kwargs)
+    if not leaves:
+        print("No completed leaves found in the store's run records; nothing to sweep.")
+        return 0
+    summary = run_sweep(args.store_root, leaves, families=families, store_kwargs=store_kwargs)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -1,0 +1,417 @@
+"""Unified second-pass rollup sweep (issue #300, design §7 / D22).
+
+One idempotent bottom-up pass over a hive store's digit tree that folds leaf
+artifacts into interior-node rollups, per registered **artifact family**
+(D22): stats sidecars (the :func:`zagg.telemetry.merge` fold), MOC regen,
+sub-shardmap rollups (stubbed on PR #295), overview zarrs (reserved for
+issue #201), and optional debris collection (stubbed). Everything the sweep
+writes is a **regenerable cache, never truth** (D9): deleting every rollup
+leaves all leaf reads intact, and the leaf sidecars/stamps remain the durable
+ground truth.
+
+Discovery is from **run records, never a recursive LIST** (D22): callers pass
+the leaves a run touched — ``(shard_key, window)`` pairs from the dispatcher's
+run report (the end-of-run hook) or from the run-level stats parquets at the
+store root (the manual CLI). The walk visits only the ancestor paths of those
+leaves; untouched siblings contribute through their existing stored rollups
+(read, never recomputed), so incremental runs accumulate exactly.
+
+Every rollup is stamped with **generation info** — merged-leaf count + max
+leaf timestamp (D22) — making staleness *detectable, not prevented*: a leaf
+re-run bumps its artifact timestamp past every earlier stamp, so ancestors'
+stored generations no longer match and the next sweep rewrites exactly that
+chain (skip-if-current elsewhere keeps the pass idempotent: a second sweep
+over an unchanged tree PUTs nothing).
+
+Rollup objects are JSON sidecars at digit nodes, named ``{family}.rollup.json``
+— deliberately DISTINCT from the leaf sidecar names (``stats.json`` /
+``coverage.moc``): under D24 mixed-order stores a node can be leaf and
+interior at once, so sharing the leaf names would self-clobber; distinct names
+also keep the walker's closed name set unambiguous (they list as objects,
+never as digit-shaped prefixes, so the §5 discovery walk is unaffected).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Envelope version of every rollup object this module writes.
+SWEEP_SPEC = "zagg-sweep/1"
+
+#: Families swept when the caller does not choose (phase 1: stats only).
+DEFAULT_FAMILIES = ("stats",)
+
+
+class SweepFamily:
+    """One derived-artifact family (D22): how leaves read and payloads fold.
+
+    Subclasses implement :meth:`read_leaf` (one leaf's contribution + its
+    staleness timestamp) and :meth:`merge` (the associative payload fold);
+    :meth:`finish` is an optional post-walk hook fed the top-level (base-node)
+    artifacts — the seam the MOC family uses to refresh the store-root
+    ``coverage.moc``. Families registered with ``available = False`` are
+    visible slots that :func:`get_family` refuses with their ``reason``.
+    """
+
+    name = ""
+    available = True
+    reason = ""
+
+    @property
+    def rollup_name(self) -> str:
+        """The family's per-node rollup object name."""
+        return f"{self.name}.rollup.json"
+
+    def read_leaf(self, store_root, decimal, window, store_kwargs):
+        """One leaf's ``(payload, timestamp)`` contribution, or ``None``.
+
+        ``None`` means the leaf carries no artifact for this family (e.g. a
+        fail-open sidecar PUT that never landed) — it is skipped, not fatal.
+        """
+        raise NotImplementedError
+
+    def merge(self, payloads: list) -> dict:
+        """Fold payloads into one (associative — rollup == direct, §8.3)."""
+        raise NotImplementedError
+
+    def finish(self, store_root, tops, shard_order, store_kwargs) -> dict:
+        """Post-walk hook over the base-node artifacts; extra summary keys."""
+        return {}
+
+
+class StatsFamily(SweepFamily):
+    """Stats/cost rollups (D20 fold): leaf ``stats.json`` sidecars up-tree.
+
+    The payload is a stats record as :func:`zagg.telemetry.merge` produces —
+    mergeable by construction (counts/sums/min-max, never stored means), so
+    interior payloads re-merge exactly and the rollup at any node equals the
+    direct fold of every leaf record beneath it.
+    """
+
+    name = "stats"
+
+    def read_leaf(self, store_root, decimal, window, store_kwargs):
+        from zagg.grids.morton import morton_word
+        from zagg.hive import shard_leaf_path
+        from zagg.telemetry import read_sidecar
+
+        leaf = shard_leaf_path(store_root, morton_word(decimal), window=window)
+        record = read_sidecar(leaf, **store_kwargs)
+        if record is None:
+            return None
+        return record, record.get("timestamp")
+
+    def merge(self, payloads: list) -> dict:
+        from zagg.telemetry import merge
+
+        return merge(payloads)
+
+
+class SubmapFamily(SweepFamily):
+    """Sub-shardmap rollups (D22) — registered, NOT implemented yet."""
+
+    name = "submap"
+    available = False
+    reason = (
+        "sub-shardmap rollups fold leaf ShardMap JSON up-tree via the exact "
+        "coarsen regroup (ShardMap.reproject), still under review on PR #295"
+    )
+
+
+class OverviewFamily(SweepFamily):
+    """Overview zarrs (D11/D22) — the reserved issue #201 slot."""
+
+    name = "overview"
+    available = False
+    reason = (
+        "overview zarr aggregation is issue #201's follow-on PR; this slot "
+        "reserves the family registration (D22)"
+    )
+
+
+class DebrisFamily(SweepFamily):
+    """Debris collection (D22 optional audit-class fifth family) — stub."""
+
+    name = "debris"
+    available = False
+    reason = (
+        "debris collection (deleting unstamped .zarr/ prefixes past a "
+        "declared horizon, D22's optional fifth family) is not implemented"
+    )
+
+
+#: Family registry (D22's plug-in point): name -> class. Unavailable entries
+#: are visible slots that :func:`get_family` refuses with their ``reason``.
+FAMILIES: dict[str, type[SweepFamily]] = {
+    cls.name: cls for cls in (StatsFamily, SubmapFamily, OverviewFamily, DebrisFamily)
+}
+
+
+def get_family(name: str) -> SweepFamily:
+    """Instantiate a registered family; loud on unknown or stubbed names."""
+    cls = FAMILIES.get(name)
+    if cls is None:
+        raise ValueError(f"unknown sweep family {name!r}; registered: {sorted(FAMILIES)}")
+    if not cls.available:
+        raise NotImplementedError(f"sweep family {name!r} is registered but stubbed: {cls.reason}")
+    return cls()
+
+
+def run_sweep(store_root: str, leaves, *, families=None, store_kwargs: dict | None = None) -> dict:
+    """One sweep pass: fold leaf artifacts up-tree for each family (D22).
+
+    ``leaves`` is the run-record-derived work set — an iterable of
+    ``(shard_key, window)`` pairs (or bare shard keys, meaning unwindowed):
+    the leaves whose ancestors may be stale. The walk visits ONLY those
+    ancestor paths; siblings contribute via their stored rollups. Leaves at a
+    non-manifest order are skipped with a warning (mixed-order stores are
+    unsupported this round, matching ``refresh_root_coverage``).
+
+    Idempotent: a rollup whose stored generation (merged-leaf count + max
+    leaf timestamp) matches the freshly computed one is left untouched, so a
+    second pass over an unchanged tree writes nothing. Returns a summary with
+    per-family ``written`` / ``current`` (skip-if-current) / ``empty`` (no
+    artifact found) / ``failed`` (unmergeable, logged) counts.
+    """
+    from zagg.hive import MANIFEST_NAME, read_manifest
+    from zagg.store import open_object_store
+
+    store_kwargs = dict(store_kwargs or {})
+    manifest = read_manifest(store_root, **store_kwargs)
+    if manifest is None:
+        raise ValueError(f"no {MANIFEST_NAME} at {store_root} — not a hive store root")
+    shard_order = int(manifest["shard_order"])
+    fams = [get_family(n) for n in (DEFAULT_FAMILIES if families is None else families)]
+    by_shard, skipped = _normalize_leaves(leaves, shard_order)
+    store = open_object_store(store_root, **store_kwargs)
+    summary: dict = {
+        "store_root": store_root,
+        "shard_order": shard_order,
+        "n_leaves": sum(len(w) for w in by_shard.values()),
+        "skipped_leaves": skipped,
+        "families": {},
+    }
+    for fam in fams:
+        summary["families"][fam.name] = _sweep_family(
+            store_root, store, fam, by_shard, shard_order, store_kwargs
+        )
+    return summary
+
+
+def _normalize_leaves(leaves, shard_order: int):
+    """``{shard_decimal: {window, ...}}`` from run-record leaf refs."""
+    from zagg.grids.morton import morton_decimal
+    from zagg.hive import _decimal_order
+
+    by_shard: dict[str, set] = {}
+    skipped: list[str] = []
+    for ref in leaves:
+        key, window = ref if isinstance(ref, (tuple, list)) else (ref, None)
+        decimal = morton_decimal(int(key))
+        if _decimal_order(decimal) != shard_order:
+            logger.warning(
+                f"sweep: skipping leaf {decimal} at order {_decimal_order(decimal)} under a "
+                f"shard_order-{shard_order} manifest (mixed-order stores are unsupported)"
+            )
+            skipped.append(decimal)
+            continue
+        by_shard.setdefault(decimal, set()).add(None if window is None else str(window))
+    return by_shard, skipped
+
+
+def _sweep_family(store_root, store, fam, by_shard, shard_order, store_kwargs) -> dict:
+    """Bottom-up fold of one family over the dirty ancestor paths."""
+    counts = {"written": 0, "current": 0, "empty": 0, "failed": 0}
+    computed: dict[str, dict | None] = {}
+    for decimal in sorted(by_shard):
+        computed[decimal] = _rollup_shard_node(
+            store_root, store, fam, decimal, by_shard[decimal], shard_order, store_kwargs, counts
+        )
+    frontier = [d for d in sorted(by_shard) if computed[d] is not None]
+    for _order in range(shard_order - 1, -1, -1):
+        parents = sorted({a for d in frontier if (a := _ancestor(d)) is not None})
+        frontier = []
+        for node in parents:
+            computed[node] = _rollup_interior(store, fam, node, computed, counts)
+            if computed[node] is not None:
+                frontier.append(node)
+        if not frontier:
+            break
+    tops = [computed[d] for d in frontier]
+    result = dict(counts)
+    result.update(fam.finish(store_root, tops, shard_order, store_kwargs))
+    return result
+
+
+def _rollup_shard_node(
+    store_root, store, fam, decimal, windows, shard_order, store_kwargs, counts
+) -> dict | None:
+    """Fold one shard node's window-leaf artifacts into its rollup.
+
+    The window set is the union of the run's dirty windows and the windows the
+    existing rollup already merged (recorded in its ``windows`` key), so an
+    append run that touches one window never drops its siblings.
+    """
+    existing = _read_rollup(store, fam, decimal)
+    known = set(windows)
+    if existing is not None:
+        known |= {None if w is None else str(w) for w in existing.get("windows") or []}
+    parts = []
+    for window in sorted(known, key=lambda w: (w is not None, w or "")):
+        try:
+            got = fam.read_leaf(store_root, decimal, window, store_kwargs)
+        except Exception as e:
+            logger.warning(
+                f"sweep[{fam.name}]: leaf read failed at {decimal} window {window!r}; "
+                f"skipping that leaf ({e})"
+            )
+            counts["failed"] += 1
+            got = None
+        if got is not None:
+            parts.append((window, *got))
+    if not parts:
+        counts["empty"] += 1
+        return None
+    generation = _generation(len(parts), [ts for _w, _p, ts in parts])
+    if existing is not None and existing.get("generation") == generation:
+        counts["current"] += 1
+        return existing
+    payload = _merged(fam, [p for _w, p, _ts in parts], decimal, counts)
+    if payload is None:
+        return None
+    envelope = {
+        "spec": SWEEP_SPEC,
+        "family": fam.name,
+        "node": decimal,
+        "order": shard_order,
+        "generation": generation,
+        "windows": [w for w, _p, _ts in parts],
+        "payload": payload,
+    }
+    _put_rollup(store, fam, decimal, envelope)
+    counts["written"] += 1
+    return envelope
+
+
+def _rollup_interior(store, fam, node, computed, counts) -> dict | None:
+    """Fold a digit node's four candidate children rollups into its own.
+
+    A child freshly computed this pass is used in memory; any other candidate
+    is probed on the store (<= 4 GETs, no LIST) so prior runs' siblings keep
+    contributing. Generation is the children's sum/max — fold-of-folds equals
+    the direct leaf fold because every family's merge is associative (§8.3).
+    """
+    from zagg.hive import _decimal_order
+
+    children = []
+    for digit in "1234":
+        art = computed.get(node + digit)
+        if art is None:
+            art = _read_rollup(store, fam, node + digit)
+        if art is not None:
+            children.append(art)
+    if not children:
+        counts["empty"] += 1
+        return None
+    generation = _generation(
+        sum(int(a["generation"]["n_leaves"]) for a in children),
+        [a["generation"].get("max_leaf_timestamp") for a in children],
+    )
+    existing = _read_rollup(store, fam, node)
+    if existing is not None and existing.get("generation") == generation:
+        counts["current"] += 1
+        return existing
+    payload = _merged(fam, [a["payload"] for a in children], node, counts)
+    if payload is None:
+        return None
+    envelope = {
+        "spec": SWEEP_SPEC,
+        "family": fam.name,
+        "node": node,
+        "order": _decimal_order(node),
+        "generation": generation,
+        "payload": payload,
+    }
+    _put_rollup(store, fam, node, envelope)
+    counts["written"] += 1
+    return envelope
+
+
+def _merged(fam, payloads, node, counts) -> dict | None:
+    """The family fold, fail-open per node: unmergeable -> logged + skipped."""
+    try:
+        return fam.merge(payloads)
+    except Exception as e:
+        logger.warning(f"sweep[{fam.name}]: merge failed at node {node}; skipping ({e})")
+        counts["failed"] += 1
+        return None
+
+
+def _generation(n_leaves: int, timestamps) -> dict:
+    """The D22 generation stamp: merged-leaf count + max leaf timestamp."""
+    stamps = [t for t in timestamps if t is not None]
+    return {"n_leaves": int(n_leaves), "max_leaf_timestamp": max(stamps) if stamps else None}
+
+
+def _ancestor(decimal: str) -> str | None:
+    """The parent prefix of a node decimal (``None`` at a base component)."""
+    from zagg.hive import _decimal_base
+
+    return None if decimal == _decimal_base(decimal) else decimal[:-1]
+
+
+def _node_rel(decimal: str) -> str:
+    """A node decimal's relative digit path (``-311`` -> ``-3/1/1``)."""
+    from zagg.hive import _decimal_base
+
+    base = _decimal_base(decimal)
+    return "/".join([base, *decimal[len(base) :]])
+
+
+def _rollup_key(fam, decimal: str) -> str:
+    return f"{_node_rel(decimal)}/{fam.rollup_name}"
+
+
+def _read_rollup(store, fam, decimal: str) -> dict | None:
+    """A node's stored rollup envelope, or ``None`` — strict, cache posture.
+
+    Missing, unparsable, wrong-spec/family, or stamp-less objects all read as
+    absent (debug-logged): a corrupt rollup is a regenerable cache (D9) and is
+    simply rebuilt, never half-trusted.
+    """
+    import obstore
+    from obstore.exceptions import NotFoundError
+
+    try:
+        data = obstore.get(store, _rollup_key(fam, decimal)).bytes()
+    except (FileNotFoundError, NotFoundError):
+        return None
+    try:
+        envelope = json.loads(bytes(data))
+    except ValueError:
+        envelope = None
+    generation = envelope.get("generation") if isinstance(envelope, dict) else None
+    usable = (
+        isinstance(envelope, dict)
+        and envelope.get("spec") == SWEEP_SPEC
+        and envelope.get("family") == fam.name
+        and isinstance(generation, dict)
+        and isinstance(generation.get("n_leaves"), int)
+        and "payload" in envelope
+    )
+    if not usable:
+        logger.debug(
+            f"sweep[{fam.name}]: unusable rollup at node {decimal}; ignoring "
+            f"(regenerable cache, D9)"
+        )
+        return None
+    return envelope
+
+
+def _put_rollup(store, fam, decimal: str, envelope: dict) -> None:
+    import obstore
+
+    obstore.put(store, _rollup_key(fam, decimal), json.dumps(envelope, indent=1).encode())

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -728,8 +728,50 @@ def _put_rollup(store, fam, decimal: str, envelope: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Trigger surfaces (issue #300 phases 4-5): run-record discovery + manual CLI.
+# Trigger surfaces (issue #300 phases 4-5): run-record discovery, the manual
+# CLI, and the end-of-run hook wrapper.
 # ---------------------------------------------------------------------------
+
+
+def sweep_after_run(
+    store_root: str, leaves, *, families=None, store_kwargs: dict | None = None
+) -> dict | None:
+    """End-of-run hook: fail-open wrapper around :func:`run_sweep` (D22).
+
+    Off the critical path by contract: any failure — missing manifest, no
+    store write access, a family blowing up — logs one warning and returns
+    ``None``; the run result is untouched. Rollups are regenerable caches
+    (D9), so a skipped sweep costs one later CLI pass, never a wrong answer.
+    Called in-process by the LOCAL dispatchers only (they are the workers and
+    hold the user's store credentials); the Lambda dispatchers never PUT (the
+    D8 standing rule) and post a fire-and-forget ``mode="sweep"`` worker
+    Event invoke instead, whose handler calls :func:`run_sweep` directly.
+    """
+    try:
+        summary = run_sweep(store_root, leaves, families=families, store_kwargs=store_kwargs)
+        logger.info(f"Post-run sweep: {summary['families']}")
+        return summary
+    except Exception as e:
+        logger.warning(f"post-run sweep failed (fail-open, D9/D22 — rollups are caches): {e}")
+        return None
+
+
+def leaves_from_stats_records(records) -> list:
+    """``(shard_key, window)`` work-set pairs from per-shard stats records.
+
+    The dispatcher-side bridge from a run report to the sweep: every
+    successful unit's record (envelope- or meta-ridden) names its leaf via
+    ``shard_key`` + the issue #300 ``window`` field. Records without a window
+    key (older workers) map to the unwindowed leaf name — on a windowed store
+    that read simply misses (fail-open; the CLI backstops). Failure and
+    ``None`` records are skipped; pairs are deduplicated and sorted.
+    """
+    refs = {
+        (int(r["shard_key"]), r.get("window"))
+        for r in records
+        if r and r.get("success") and r.get("shard_key") is not None
+    }
+    return sorted(refs, key=lambda p: (p[0], p[1] is not None, p[1] or ""))
 
 
 def discover_leaves(store_root: str, *, store_kwargs: dict | None = None) -> list:

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -58,6 +58,7 @@ _SUM_OR_NONE_KEYS = (
 )
 _MAX_OR_NONE_KEYS = ("max_memory_mb", "container_hwm_mb")
 _EQ_OR_NONE_KEYS = (
+    "window",
     "shard_key",
     "run_id",
     "semantic_hash",
@@ -116,6 +117,7 @@ def build_record(
     granule_ids: Iterable[str] | None = None,
     invoked_by: dict | None = None,
     run_id: str | None = None,
+    window: str | None = None,
     lambda_config: dict | None = None,
 ) -> dict:
     """Build one shard's stats record from the worker's ``metadata`` dict.
@@ -129,6 +131,11 @@ def build_record(
     ``run_id`` is threaded the same way (dispatcher-generated, stamped through
     the invoke payload, copied verbatim) so a leaf sidecar joins back to its
     run-level parquet.
+    ``window`` (issue #300) is the unit's time-window label (``None``
+    unwindowed) — recorded so run records name the exact leaf a row describes
+    (the sweep's run-record discovery computes sidecar names from it) and
+    merged equal-or-``None`` like the other identity fields, so a cross-window
+    rollup reads ``None``.
     ``lambda_config`` is :func:`lambda_env` on Lambda, ``None`` locally;
     when present it prices ``gb_seconds`` / ``est_cost_usd`` from
     ``duration_s`` (the billed-duration approximation the dispatcher's cost
@@ -162,6 +169,7 @@ def build_record(
     return {
         "schema_version": SCHEMA_VERSION,
         "shard_key": int(shard_key),
+        "window": str(window) if window is not None else None,
         "run_id": run_id,
         # The semantic-core hash (D19 rev 2, docs/design/sparse_coverage.md):
         # hashes the config's semantic core, NOT the whole template. Nullable
@@ -279,6 +287,7 @@ def failure_record(*, shard_key=None, error, duration_s=None, run_id=None) -> di
 _ROW_SCALARS = (
     "schema_version",
     "shard_key",
+    "window",
     "run_id",
     "semantic_hash",
     "zagg_version",
@@ -366,6 +375,18 @@ def write_run_parquet(
         raise ValueError("write_run_parquet requires at least one row")
     key = run_parquet_key(run_id)
     df = pd.DataFrame(rows)
+    # Packed morton shard keys exceed 2^53 (and int64 for high base cells), so
+    # the DataFrame's float64 inference on a column that mixes ints with
+    # failure-row ``None``s silently corrupts them (issue #300 — the sweep's
+    # run-record discovery needs exact keys back). Rebuild the column as
+    # nullable UInt64 straight from the row values, bypassing the float
+    # intermediate; key spaces it cannot hold (a negative key) fall through
+    # untouched.
+    if "shard_key" in df.columns:
+        try:
+            df["shard_key"] = pd.array([r.get("shard_key") for r in rows], dtype="UInt64")
+        except (TypeError, ValueError, OverflowError):
+            pass
     with tempfile.TemporaryDirectory() as tmp:
         local = os.path.join(tmp, key)
         df.to_parquet(local, engine="fastparquet", index=False, object_encoding="utf8")

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2051,9 +2051,10 @@ def test_hive_config_expected_counts_root_moc_optional():
     # The committed hive arm's model: per-shard DATA is exact (11 objects/leaf,
     # the sharded-write-bypass tripwire), but the store-root coverage.moc is a
     # fail-open, regenerable D9 cache (runner.write_root_coverage) that may be
-    # present OR absent -- so store-root metadata is a [1, 3] window (the
-    # morton_hive.json manifest always; +coverage.moc and the run stats parquet
-    # when they land) and the total is [14, 16]. A real bypass still fails on
+    # present OR absent -- so store-root metadata is a [1, 4] window (the
+    # morton_hive.json manifest always; +coverage.moc, the run stats parquet,
+    # and aggregation.yaml when they land) and the total is [12, 15]. A real
+    # bypass still fails on
     # the exact per-shard count.
     import bench_objects
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2048,12 +2048,13 @@ def test_run_target_threads_store_layout():
 
 
 def test_hive_config_expected_counts_root_moc_optional():
-    # The committed hive arm's model: per-shard DATA is exact (11 objects/leaf,
+    # The committed hive arm's model: per-shard DATA is exact (13 objects/leaf,
     # the sharded-write-bypass tripwire), but the store-root coverage.moc is a
     # fail-open, regenerable D9 cache (runner.write_root_coverage) that may be
-    # present OR absent -- so store-root metadata is a [1, 2] window (the
-    # morton_hive.json manifest always; +coverage.moc when it lands) and the
-    # total is [12, 13]. A real bypass still fails on the exact per-shard count.
+    # present OR absent -- so store-root metadata is a [1, 3] window (the
+    # morton_hive.json manifest always; +coverage.moc and the run stats parquet
+    # when they land) and the total is [14, 16]. A real bypass still fails on
+    # the exact per-shard count.
     import bench_objects
 
     from zagg.config import get_coverage_moc, get_store_layout, load_config
@@ -2067,16 +2068,16 @@ def test_hive_config_expected_counts_root_moc_optional():
     )
     # 4 arrays (cell_ids/morton/count/h_tdigest): leaf root+group zarr.json (2)
     # + 4 array zarr.json + 4 sharded data objects + coverage sidecar +
-    # stats.json sibling (issue #297) = 12.
+    # stats.json AND shardmap.json siblings (issues #297/#300) = 13.
     # Store root: morton_hive.json (always) + coverage.moc (optional) + the
     # run stats parquet (optional, issue #297) -> [1, 3].
     assert exp == {
         "metadata": 3,
         "metadata_min": 1,
-        "per_shard_min": 12,
-        "per_shard_max": 12,
-        "total_min": 13,
-        "total_max": 15,
+        "per_shard_min": 13,
+        "per_shard_max": 13,
+        "total_min": 14,
+        "total_max": 16,
         "exact": True,
     }
 

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -319,6 +319,35 @@ def test_hive_store_matches_model(tmp_path, monkeypatch):
     assert any(k.startswith(leaf) for k in bench_objects.list_store_keys(root))
 
 
+def test_hive_misplaced_rollup_counts_into_shard(monkeypatch):
+    # A `.rollup.json` name is a second-pass sweep cache ONLY when it sits
+    # outside every leaf `.zarr/` prefix (issue #300 review). A legit rollup at
+    # the digit node lands in ``objects_rollups``; a hand-planted
+    # `{leaf}.zarr/stats.rollup.json` is a write-path bypass and must surface
+    # as one of that shard's data objects (tripping the exact #215 guard), not
+    # vanish into the bucket.
+    from zagg import hive
+
+    grid = from_config(_cfg())
+    word = int(morton_word(_KEY_A))
+    label = grid.shard_label(word)
+    leaf = hive.shard_leaf_path("", word).lstrip("/")  # {node}.zarr
+    node = leaf.rsplit("/", 1)[0]  # the digit node dir (rollup lives here)
+    keys = [
+        f"{leaf}/count/c/0",  # normal in-leaf data object -> this shard
+        f"{node}/stats.rollup.json",  # legit sibling rollup -> rollup bucket
+        f"{leaf}/stats.rollup.json",  # MISPLACED in-leaf rollup -> this shard
+    ]
+    monkeypatch.setattr(bench_objects, "list_store_keys", lambda *a, **k: keys)
+    measured = bench_objects.store_object_counts(
+        "unused", grid=grid, shard_keys=[word], store_layout="hive"
+    )
+    assert measured["objects_rollups"] == 1  # only the sibling rollup
+    assert measured["objects_per_shard"] == {label: 2}  # data + misplaced rollup
+    assert measured["objects_other"] == 0
+    assert not any(k.endswith("stats.rollup.json") for k in measured["other_keys"])
+
+
 # --- mismatch helper (pure) --------------------------------------------------
 
 

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -309,7 +309,10 @@ def test_hive_store_matches_model(tmp_path, monkeypatch):
     assert measured["objects_metadata"] == expected["metadata"] == 3
     assert measured["objects_other"] == 0
     assert list(measured["objects_per_shard"]) == [_KEY_A]
-    assert measured["objects_total"] == expected["total_max"]
+    # The end-of-run sweep (issue #300) lands its rollups in their own bucket
+    # (second-pass D9 caches); the write-path total excludes them.
+    assert measured["objects_rollups"] > 0
+    assert measured["objects_total"] - measured["objects_rollups"] == expected["total_max"]
     assert bench_objects.object_count_mismatch(measured, expected) is None
     # Attribution really is the leaf prefix.
     leaf = hive.shard_leaf_path("", word).lstrip("/")
@@ -557,8 +560,11 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     # (issue #297); store root = manifest + MOC + the run stats parquet.
     n_arrays = len(grid.shard_spec().members)
     assert expected["exact"] is True
-    assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 1
+    # ... + the stats.json AND shardmap.json siblings (issues #297/#300).
+    assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 2
     assert expected["metadata"] == 3
-    assert measured["objects_total"] == expected["total_max"]
+    # Sweep rollups (issue #300) ride their own bucket, outside the
+    # write-path total this model audits.
+    assert measured["objects_total"] - measured["objects_rollups"] == expected["total_max"]
     assert measured["objects_other"] == 0
     assert bench_objects.object_count_mismatch(measured, expected) is None

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -719,6 +719,40 @@ class TestDiscoverLeaves:
         refs = discover_leaves(str(tmp_path))
         assert refs == [(morton_word("-311"), "2019"), (morton_word("-311"), "2020")]
 
+    def test_mixed_deployment_pre_and_post_column_records_union(self, tmp_path):
+        # Mixed deployment: one post-#300 record names window "2019" for a
+        # shard, and a pre-column record touches the SAME shard whose node also
+        # holds window "2020"'s sidecar. The fallback node LIST must fire even
+        # though "2019" already named the shard — the subtraction that skipped
+        # already-seen keys dropped "2020". LIST + set dedup is idempotent.
+        import pandas as pd
+
+        from zagg.sweep import discover_leaves
+
+        _write_manifest(tmp_path)
+        manifest = json.loads((tmp_path / MANIFEST_NAME).read_text())
+        manifest["spec"] = "morton-hive/2"
+        manifest["temporal"] = {"schedule": "yearly", "time_field": "t"}
+        (tmp_path / MANIFEST_NAME).write_text(json.dumps(manifest))
+        # Post-column record: names window "2019" for shard -311.
+        _run_record(tmp_path, [_row("-311", window="2019")], run_id="new1")
+        # Pre-column record for the same shard: no window column at all.
+        row = _row("-311", window="2020")
+        row.pop("window")
+        df = pd.DataFrame([row])
+        df["shard_key"] = pd.array([morton_word("-311")], dtype="UInt64")
+        df.to_parquet(
+            tmp_path / "stats_20260101T000000Z_old3.parquet",
+            engine="fastparquet",
+            index=False,
+            object_encoding="utf8",
+        )
+        # The node holds BOTH windows' sidecars; only "2020" needs the fallback.
+        _put_leaf(tmp_path, "-311", window="2019")
+        _put_leaf(tmp_path, "-311", window="2020")
+        refs = discover_leaves(str(tmp_path))
+        assert refs == [(morton_word("-311"), "2019"), (morton_word("-311"), "2020")]
+
     def test_inexact_float_keys_skipped_with_warning(self, tmp_path, caplog):
         import pandas as pd
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,0 +1,219 @@
+"""Unified rollup sweep (issue #300): engine + stats family (§8.3 obligations).
+
+Covers the standing D22 test claims on local stores: rollup == direct (stats
+fold), sweep idempotence (second pass over an unchanged tree writes nothing),
+leaf re-runs making ancestors detectably stale, incremental accumulation
+(window and sibling union), and nothing-load-bearing (deleting every rollup
+leaves leaf reads intact).
+"""
+
+import json
+
+import obstore
+import pytest
+
+from zagg import sweep as sweep_mod
+from zagg.grids.morton import morton_word
+from zagg.hive import MANIFEST_NAME, shard_leaf_path
+from zagg.store import open_object_store
+from zagg.sweep import SWEEP_SPEC, get_family, run_sweep
+from zagg.telemetry import build_record, merge, read_sidecar, write_sidecar
+
+SHARD_ORDER = 2
+
+
+def _write_manifest(root, shard_order=SHARD_ORDER):
+    manifest = {
+        "spec": "morton-hive/1",
+        "dataset": {"short_name": "TEST", "version": "1"},
+        "cell_order": shard_order + 2,
+        "shard_order": shard_order,
+        "split_schedule": [1] * shard_order,
+        "pyramid": {"orders": [], "aggregation": {}},
+        "generated_at": "2026-01-01T00:00:00+00:00",
+    }
+    obstore.put(open_object_store(str(root)), MANIFEST_NAME, json.dumps(manifest).encode())
+
+
+def _record(decimal, *, n_obs=10, duration_s=0.5, timestamp=None):
+    # Exact binary floats so fold order can never perturb equality asserts.
+    rec = build_record(
+        shard_key=morton_word(decimal),
+        metadata={
+            "total_obs": n_obs,
+            "cells_with_data": 2,
+            "duration_s": duration_s,
+            "phase_timings": {"read": 0.25, "write": 0.5},
+        },
+        granule_ids=[f"g-{decimal}"],
+    )
+    if timestamp is not None:
+        rec["timestamp"] = timestamp
+    return rec
+
+
+def _put_leaf(root, decimal, *, window=None, **kwargs):
+    leaf = shard_leaf_path(str(root), morton_word(decimal), window=window)
+    rec = _record(decimal, **kwargs)
+    write_sidecar(leaf, rec)
+    return rec
+
+
+def _rollup(root, decimal, family="stats"):
+    from zagg.sweep import _node_rel
+
+    path = root / _node_rel(decimal) / f"{family}.rollup.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())
+
+
+def _leaf_refs(*decimals, window=None):
+    return [(morton_word(d), window) for d in decimals]
+
+
+class TestStatsRollupEqualsDirect:
+    def test_interior_and_base_match_direct_fold(self, tmp_path):
+        _write_manifest(tmp_path)
+        recs = {d: _put_leaf(tmp_path, d) for d in ("-311", "-312", "-321")}
+        summary = run_sweep(str(tmp_path), _leaf_refs("-311", "-312", "-321"))
+        # Nodes: -311, -312, -321 (shard), -31, -32 (order 1), -3 (base).
+        assert summary["families"]["stats"]["written"] == 6
+        assert _rollup(tmp_path, "-31")["payload"] == merge([recs["-311"], recs["-312"]])
+        direct = merge([recs["-311"], recs["-312"], recs["-321"]])
+        base = _rollup(tmp_path, "-3")
+        assert base["payload"] == direct
+        assert base["generation"] == {
+            "n_leaves": 3,
+            "max_leaf_timestamp": direct["timestamp"],
+        }
+        assert base["spec"] == SWEEP_SPEC and base["order"] == 0 and base["node"] == "-3"
+
+    def test_windowed_leaves_fold_at_the_shard_node(self, tmp_path):
+        _write_manifest(tmp_path)
+        a = _put_leaf(tmp_path, "-311", window="2019")
+        b = _put_leaf(tmp_path, "-311", window="2020")
+        run_sweep(str(tmp_path), [(morton_word("-311"), "2019"), (morton_word("-311"), "2020")])
+        node = _rollup(tmp_path, "-311")
+        assert node["payload"] == merge([a, b])
+        assert node["windows"] == ["2019", "2020"]
+        assert node["generation"]["n_leaves"] == 2
+
+
+class TestIdempotenceAndStaleness:
+    def test_second_pass_over_unchanged_tree_writes_nothing(self, tmp_path):
+        _write_manifest(tmp_path)
+        for d in ("-311", "-321"):
+            _put_leaf(tmp_path, d)
+        refs = _leaf_refs("-311", "-321")
+        first = run_sweep(str(tmp_path), refs)["families"]["stats"]
+        assert first["written"] == 5 and first["current"] == 0
+        before = _rollup(tmp_path, "-3")
+        second = run_sweep(str(tmp_path), refs)["families"]["stats"]
+        assert second["written"] == 0
+        assert second["current"] == 5
+        assert _rollup(tmp_path, "-3") == before  # byte-stable, not just skipped
+
+    def test_leaf_rerun_makes_ancestors_detectably_stale(self, tmp_path):
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311", timestamp="2026-01-01T00:00:00+00:00")
+        _put_leaf(tmp_path, "-321", timestamp="2026-01-02T00:00:00+00:00")
+        run_sweep(str(tmp_path), _leaf_refs("-311", "-321"))
+        stale_gen = _rollup(tmp_path, "-3")["generation"]
+        # Re-run of one leaf: a rewritten sidecar always carries a LATER
+        # timestamp than every earlier record, so ancestor stamps mismatch.
+        _put_leaf(tmp_path, "-311", n_obs=99, timestamp="2026-01-03T00:00:00+00:00")
+        result = run_sweep(str(tmp_path), _leaf_refs("-311"))["families"]["stats"]
+        assert result["written"] == 3  # -311, -31, -3: exactly the stale chain
+        fresh = _rollup(tmp_path, "-3")
+        assert fresh["generation"] != stale_gen
+        assert fresh["generation"]["max_leaf_timestamp"] == "2026-01-03T00:00:00+00:00"
+        assert fresh["payload"]["n_obs"] == 99 + 10
+
+    def test_incremental_append_unions_windows_and_siblings(self, tmp_path):
+        _write_manifest(tmp_path)
+        a = _put_leaf(tmp_path, "-311", window="2019")
+        run_sweep(str(tmp_path), [(morton_word("-311"), "2019")])
+        # A later run touches ONLY a new window and a new sibling shard; the
+        # sweep is given only those leaves (run-record discovery) yet the
+        # rollups keep the earlier contributions.
+        b = _put_leaf(tmp_path, "-311", window="2020")
+        c = _put_leaf(tmp_path, "-312")
+        run_sweep(str(tmp_path), [(morton_word("-311"), "2020"), (morton_word("-312"), None)])
+        assert _rollup(tmp_path, "-311")["payload"] == merge([a, b])
+        assert _rollup(tmp_path, "-31")["generation"]["n_leaves"] == 3
+        assert _rollup(tmp_path, "-31")["payload"] == merge([merge([a, b]), c])
+
+    def test_corrupt_rollup_is_rebuilt(self, tmp_path):
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        run_sweep(str(tmp_path), _leaf_refs("-311"))
+        from zagg.sweep import _node_rel
+
+        victim = tmp_path / _node_rel("-31") / "stats.rollup.json"
+        victim.write_text("{not json")
+        result = run_sweep(str(tmp_path), _leaf_refs("-311"))["families"]["stats"]
+        # The corrupt node is rewritten; its parent's stamp still matches.
+        assert result["written"] == 1 and result["current"] == 2
+        assert _rollup(tmp_path, "-31")["spec"] == SWEEP_SPEC
+
+
+class TestNothingLoadBearing:
+    def test_deleting_every_rollup_leaves_leaf_reads_green(self, tmp_path):
+        _write_manifest(tmp_path)
+        recs = {d: _put_leaf(tmp_path, d) for d in ("-311", "-312")}
+        run_sweep(str(tmp_path), _leaf_refs("-311", "-312"))
+        removed = [p for p in tmp_path.rglob("*.rollup.json")]
+        assert removed
+        for p in removed:
+            p.unlink()
+        # Leaf sidecars (the truth) read back untouched...
+        for d, rec in recs.items():
+            leaf = shard_leaf_path(str(tmp_path), morton_word(d))
+            assert read_sidecar(leaf) == rec
+        # ...and one sweep regenerates identical payloads from them.
+        run_sweep(str(tmp_path), _leaf_refs("-311", "-312"))
+        assert _rollup(tmp_path, "-3")["payload"] == merge(list(recs.values()))
+
+
+class TestWorkSetEdges:
+    def test_missing_sidecar_leaf_is_skipped_not_fatal(self, tmp_path):
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        result = run_sweep(str(tmp_path), _leaf_refs("-311", "-312"))["families"]["stats"]
+        assert result["empty"] == 1  # -312 contributed nothing
+        assert _rollup(tmp_path, "-31")["generation"]["n_leaves"] == 1
+        assert _rollup(tmp_path, "-312") is None
+
+    def test_foreign_order_leaf_ref_is_skipped_with_warning(self, tmp_path, caplog):
+        _write_manifest(tmp_path)
+        summary = run_sweep(str(tmp_path), [(morton_word("-3111"), None)])
+        assert summary["skipped_leaves"] == ["-3111"]
+        assert summary["n_leaves"] == 0
+        assert "mixed-order" in caplog.text
+
+    def test_no_manifest_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="not a hive store root"):
+            run_sweep(str(tmp_path), [])
+
+
+class TestFamilyRegistry:
+    def test_unknown_family_raises(self):
+        with pytest.raises(ValueError, match="unknown sweep family"):
+            get_family("nope")
+
+    @pytest.mark.parametrize(
+        ("name", "marker"),
+        [("submap", "PR #295"), ("overview", "issue #201"), ("debris", "not implemented")],
+    )
+    def test_stub_families_refuse_with_pointer(self, name, marker):
+        assert name in sweep_mod.FAMILIES  # registered slot stays visible
+        with pytest.raises(NotImplementedError, match="stubbed"):
+            get_family(name)
+        try:
+            get_family(name)
+        except NotImplementedError as e:
+            assert marker in str(e)
+
+    def test_stats_is_a_default_family(self):
+        assert "stats" in sweep_mod.DEFAULT_FAMILIES

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -577,3 +577,130 @@ class TestFamilyRegistry:
 
     def test_default_families_are_the_implemented_set(self):
         assert sweep_mod.DEFAULT_FAMILIES == ("stats", "moc", "submap")
+
+
+def _run_record(root, rows, run_id="r1"):
+    from zagg.telemetry import write_run_parquet
+
+    write_run_parquet(str(root), rows, run_id=run_id)
+
+
+def _row(decimal, *, window=None, success=True):
+    from zagg.telemetry import build_record, failure_record, flatten_record
+
+    if success:
+        rec = build_record(
+            shard_key=morton_word(decimal),
+            metadata={"total_obs": 1, "duration_s": 1.0},
+            window=window,
+        )
+    else:
+        rec = failure_record(shard_key=morton_word(decimal), error="boom")
+    return flatten_record(rec)
+
+
+class TestDiscoverLeaves:
+    def test_column_first_discovery(self, tmp_path):
+        from zagg.sweep import discover_leaves
+
+        _write_manifest(tmp_path)
+        _run_record(
+            tmp_path,
+            [
+                _row("-311"),
+                _row("-312"),
+                _row("-321", success=False),  # failure rows never become work
+            ],
+        )
+        refs = discover_leaves(str(tmp_path))
+        assert refs == [(morton_word("-311"), None), (morton_word("-312"), None)]
+
+    def test_windowed_column_names_the_leaf(self, tmp_path):
+        from zagg.sweep import discover_leaves
+
+        _write_manifest(tmp_path)
+        # Windowed store: the manifest carries a temporal block.
+        manifest = json.loads((tmp_path / MANIFEST_NAME).read_text())
+        manifest["spec"] = "morton-hive/2"
+        manifest["temporal"] = {"schedule": "yearly", "time_field": "t"}
+        (tmp_path / MANIFEST_NAME).write_text(json.dumps(manifest))
+        _run_record(
+            tmp_path, [_row("-311", window="2019"), _row("-311", window="2020")], run_id="r2"
+        )
+        refs = discover_leaves(str(tmp_path))
+        assert refs == [(morton_word("-311"), "2019"), (morton_word("-311"), "2020")]
+
+    def test_pre_column_windowed_rows_fall_back_to_node_list(self, tmp_path):
+        import pandas as pd
+
+        from zagg.sweep import discover_leaves
+
+        _write_manifest(tmp_path)
+        manifest = json.loads((tmp_path / MANIFEST_NAME).read_text())
+        manifest["spec"] = "morton-hive/2"
+        manifest["temporal"] = {"schedule": "yearly", "time_field": "t"}
+        (tmp_path / MANIFEST_NAME).write_text(json.dumps(manifest))
+        # A pre-#300 run record: no window column at all. Its shard's windows
+        # resolve from the node's sidecar names (one bounded delimiter LIST).
+        row = _row("-311", window="2019")
+        row.pop("window")
+        df = pd.DataFrame([row])
+        df["shard_key"] = pd.array([morton_word("-311")], dtype="UInt64")
+        df.to_parquet(
+            tmp_path / "stats_20260101T000000Z_old1.parquet",
+            engine="fastparquet",
+            index=False,
+            object_encoding="utf8",
+        )
+        _put_leaf(tmp_path, "-311", window="2019")
+        _put_leaf(tmp_path, "-311", window="2020")
+        refs = discover_leaves(str(tmp_path))
+        assert refs == [(morton_word("-311"), "2019"), (morton_word("-311"), "2020")]
+
+    def test_inexact_float_keys_skipped_with_warning(self, tmp_path, caplog):
+        import pandas as pd
+
+        from zagg.sweep import discover_leaves
+
+        _write_manifest(tmp_path)
+        # A pre-fix parquet whose key column collapsed to float64: packed
+        # words are inexact there and must be skipped, not silently mangled.
+        row = _row("-311")
+        df = pd.DataFrame([row])
+        df["shard_key"] = df["shard_key"].astype("float64")
+        df.to_parquet(
+            tmp_path / "stats_20260101T000000Z_old2.parquet",
+            engine="fastparquet",
+            index=False,
+            object_encoding="utf8",
+        )
+        refs = discover_leaves(str(tmp_path))
+        assert refs == []
+        assert "inexact" in caplog.text
+
+    def test_no_manifest_raises(self, tmp_path):
+        from zagg.sweep import discover_leaves
+
+        with pytest.raises(ValueError, match="not a hive store root"):
+            discover_leaves(str(tmp_path))
+
+
+class TestSweepCli:
+    def test_end_to_end_discovers_and_folds(self, tmp_path, capsys):
+        from zagg.sweep import main
+
+        _write_manifest(tmp_path)
+        rec_a = _put_leaf(tmp_path, "-311")
+        rec_b = _put_leaf(tmp_path, "-312")
+        _run_record(tmp_path, [_row("-311"), _row("-312")])
+        assert main([str(tmp_path), "--families", "stats"]) == 0
+        summary = json.loads(capsys.readouterr().out)
+        assert summary["families"]["stats"]["written"] == 4  # -311, -312, -31, -3
+        assert _rollup(tmp_path, "-3")["payload"] == merge([rec_a, rec_b])
+
+    def test_empty_store_is_a_noop(self, tmp_path, capsys):
+        from zagg.sweep import main
+
+        _write_manifest(tmp_path)
+        assert main([str(tmp_path)]) == 0
+        assert "nothing to sweep" in capsys.readouterr().out

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -231,6 +231,25 @@ class TestWorkSetEdges:
         with pytest.raises(ValueError, match="not a hive store root"):
             run_sweep(str(tmp_path), [])
 
+    def test_empty_work_set_writes_nothing(self, tmp_path):
+        # A run that touched nothing (or a caller that filtered every leaf out)
+        # on a manifest-bearing store: the frontier walk breaks immediately and
+        # MocFamily.finish(tops=[]) reports no root MOC. No object is written.
+        from zagg.hive import read_root_coverage
+
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        _stamp_leaf(tmp_path, "-311")
+        summary = run_sweep(str(tmp_path), [])
+        assert summary["n_leaves"] == 0
+        for fam in ("stats", "moc"):
+            counts = summary["families"][fam]
+            assert counts["written"] == 0 and counts["current"] == 0
+            assert counts["empty"] == 0 and counts["failed"] == 0
+        assert summary["families"]["moc"]["root_moc_written"] is False
+        assert not list(tmp_path.rglob("*.rollup.json"))
+        assert read_root_coverage(str(tmp_path)) is None
+
 
 def _stamp_leaf(root, decimal, *, window=None, time_range=None):
     """A minimal committed leaf: root zarr group + D4 commit stamp."""

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -704,3 +704,178 @@ class TestSweepCli:
         _write_manifest(tmp_path)
         assert main([str(tmp_path)]) == 0
         assert "nothing to sweep" in capsys.readouterr().out
+
+
+class TestSweepConfig:
+    """output.sweep (issue #300): default on for hive, boolean, hive-only —
+    mirroring coverage_moc's posture."""
+
+    def _cfg(self, **output):
+        from zagg.config import default_config
+
+        cfg = default_config("atl06")
+        cfg.output.update(output)
+        return cfg
+
+    def test_default_on_for_hive(self):
+        from zagg.config import get_sweep, validate_config
+
+        cfg = self._cfg(store_layout="hive")
+        assert get_sweep(cfg) is True
+        validate_config(cfg)
+
+    def test_explicit_off(self):
+        from zagg.config import get_sweep
+
+        assert get_sweep(self._cfg(store_layout="hive", sweep=False)) is False
+
+    def test_null_falls_back_to_default(self):
+        from zagg.config import get_sweep
+
+        assert get_sweep(self._cfg(store_layout="hive", sweep=None)) is True
+
+    def test_default_off_for_flat(self):
+        from zagg.config import get_sweep
+
+        assert get_sweep(self._cfg(store_layout="flat", coverage_moc=False)) is False
+
+    def test_explicit_true_on_flat_rejected(self):
+        from zagg.config import validate_config
+
+        with pytest.raises(ValueError, match="output.sweep requires"):
+            validate_config(self._cfg(store_layout="flat", coverage_moc=False, sweep=True))
+
+    def test_non_bool_rejected(self):
+        from zagg.config import validate_config
+
+        with pytest.raises(ValueError, match="output.sweep must be a boolean"):
+            validate_config(self._cfg(store_layout="hive", sweep="yes"))
+
+
+class TestSweepHook:
+    def test_sweep_after_run_is_fail_open(self, monkeypatch, caplog):
+        from zagg import sweep as sm
+
+        def boom(*a, **k):
+            raise RuntimeError("kaput")
+
+        monkeypatch.setattr(sm, "run_sweep", boom)
+        assert sm.sweep_after_run("/nowhere", [(1, None)]) is None
+        assert "fail-open" in caplog.text
+
+    def test_leaves_from_stats_records(self):
+        from zagg.sweep import leaves_from_stats_records
+
+        records = [
+            {"shard_key": 7, "window": None, "success": True},
+            {"shard_key": 7, "window": "2019", "success": True},
+            {"shard_key": 7, "window": "2019", "success": True},  # dup collapses
+            {"shard_key": 8, "success": True},  # pre-#300 record: no window key
+            {"shard_key": 9, "window": None, "success": False},  # failures skipped
+            {"shard_key": None, "success": True},  # keyless skipped
+            None,  # record-less envelope skipped
+        ]
+        assert leaves_from_stats_records(records) == [(7, None), (7, "2019"), (8, None)]
+
+    def test_local_run_folds_rollups(self, monkeypatch, tmp_path):
+        # End-to-end through the local backend (fake hive write): the
+        # in-process hook folds the stats family up the ancestor chain.
+        from zagg import hive, runner
+        from zagg.config import default_config
+        from zagg.runner import agg
+
+        cfg = default_config("atl06")
+        cfg.output["store_layout"] = "hive"
+        shard = morton_word("-5112333")
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "a"})
+
+        def fake_hive_write(shard_key, granule_urls, grid, s3_creds, store_root, config, **kw):
+            return {"shard_key": int(shard_key), "error": None, "total_obs": 1}
+
+        monkeypatch.setattr(hive, "process_and_write_hive", fake_hive_write)
+        catalog = {
+            "metadata": {"short_name": "ATL06", "version": "007"},
+            "grid_signature": {
+                "type": "healpix",
+                "indexing_scheme": "nested",
+                "parent_order": 6,
+                "child_order": 12,
+                "layout": "fullsphere",
+            },
+            "shard_keys": [int(shard)],
+            "granules": [[_entry("g1")]],
+        }
+        path = tmp_path / "catalog.json"
+        path.write_text(json.dumps(catalog))
+        root = str(tmp_path / "out")
+        agg(cfg, catalog=str(path), store=root, backend="local")
+        # The stats rollup chain reaches the base node (order 0)...
+        base = _rollup(Path(root), "-5")
+        assert base is not None and base["payload"]["n_shards"] == 1
+        # ...and the submap family folded the worker-emitted leaf sub-map.
+        sub = _rollup(Path(root), "-5", family="submap")
+        assert sub is not None
+        assert [g["id"] for g in sub["payload"]["granules"][0]] == ["g1"]
+
+    def test_local_run_sweep_off_writes_no_rollups(self, monkeypatch, tmp_path):
+        from zagg import hive, runner
+        from zagg.config import default_config
+        from zagg.runner import agg
+
+        cfg = default_config("atl06")
+        cfg.output["store_layout"] = "hive"
+        cfg.output["sweep"] = False
+        shard = morton_word("-5112333")
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "a"})
+        monkeypatch.setattr(
+            hive,
+            "process_and_write_hive",
+            lambda shard_key, *a, **k: {"shard_key": int(shard_key), "error": None, "total_obs": 1},
+        )
+        catalog = {
+            "metadata": {"short_name": "ATL06", "version": "007"},
+            "grid_signature": {
+                "type": "healpix",
+                "indexing_scheme": "nested",
+                "parent_order": 6,
+                "child_order": 12,
+                "layout": "fullsphere",
+            },
+            "shard_keys": [int(shard)],
+            "granules": [[_entry("g1")]],
+        }
+        path = tmp_path / "catalog.json"
+        path.write_text(json.dumps(catalog))
+        root = str(tmp_path / "out")
+        agg(cfg, catalog=str(path), store=root, backend="local")
+        assert not list(Path(root).rglob("*.rollup.json"))
+
+
+class TestInvokeLambdaSweep:
+    def _client(self):
+        from unittest.mock import MagicMock
+
+        return MagicMock()
+
+    def test_inline_leaves_event(self):
+        from zagg.runner import _invoke_lambda_sweep
+
+        client = self._client()
+        _invoke_lambda_sweep(client, "fn", "s3://b/store", [(7, None), (8, "2019")])
+        kwargs = client.invoke.call_args.kwargs
+        assert kwargs["InvocationType"] == "Event"
+        event = json.loads(kwargs["Payload"])
+        assert event["mode"] == "sweep"
+        assert event["leaves"] == [[7, None], [8, "2019"]]
+        assert "discover" not in event
+
+    def test_oversized_leaves_fall_back_to_discovery(self):
+        from zagg.runner import _ASYNC_PAYLOAD_CAP_BYTES, _invoke_lambda_sweep
+
+        client = self._client()
+        # Packed-word-sized keys (~20 digits each) comfortably overflow the budget.
+        n = _ASYNC_PAYLOAD_CAP_BYTES // 16
+        _invoke_lambda_sweep(client, "fn", "s3://b/store", [(10**19 + i, "2019") for i in range(n)])
+        event = json.loads(client.invoke.call_args.kwargs["Payload"])
+        assert "leaves" not in event
+        assert event["discover"] is True

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -494,6 +494,27 @@ class TestSubmapRollup:
         assert result["families"]["submap"]["failed"] == 1
         assert result["families"]["submap"]["written"] == 0
 
+    def test_submap_emittable_gates_unmergeable_units(self):
+        from zagg.sweep import submap_emittable
+
+        # A HEALPix signature with id-bearing entries is the only emittable case.
+        assert submap_emittable(SUBMAP_SIG, [_entry("gA"), _entry("gB")])
+        # Rectilinear raster signature (no parent_order/child_order) -> skip: the
+        # sub-shardmap fold is HEALPix-morton only (reproject is HEALPix-only).
+        rect_sig = {
+            "type": "rectilinear",
+            "crs": "EPSG:4326",
+            "affine": [1.0, 0.0, 0.0, 0.0, -1.0, 0.0],
+            "shape": [10, 10],
+            "chunk_shape": [5, 5],
+        }
+        raster_entries = [{"s3": "s3://b/t0", "datetime": "2025-01-01T00:00:00Z"}]
+        assert not submap_emittable(rect_sig, raster_entries)
+        # HEALPix signature but id-less entries (raster ShardMap falls back to
+        # datetime, telemetry.py) -> also skip, never a KeyError in the fold.
+        assert not submap_emittable(SUBMAP_SIG, raster_entries)
+        assert not submap_emittable(None, [_entry("gA")])
+
 
 class TestLocalRunnerEmitsSubmap:
     """The local backend's in-process worker writes the leaf sub-map on

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -8,6 +8,7 @@ leaves leaf reads intact).
 """
 
 import json
+from datetime import datetime, timezone
 
 import obstore
 import pytest
@@ -114,7 +115,10 @@ class TestIdempotenceAndStaleness:
         assert second["current"] == 5
         assert _rollup(tmp_path, "-3") == before  # byte-stable, not just skipped
 
-    def test_leaf_rerun_makes_ancestors_detectably_stale(self, tmp_path):
+    def test_leaf_rerun_day_apart_bumps_generation_stamp(self, tmp_path):
+        # Fast path: distinct timestamps make the generation stamp itself move,
+        # so staleness is caught by the (n_leaves, max_leaf_timestamp) compare
+        # alone. Timestamps are hand-injected here to force the day-apart gap.
         _write_manifest(tmp_path)
         _put_leaf(tmp_path, "-311", timestamp="2026-01-01T00:00:00+00:00")
         _put_leaf(tmp_path, "-321", timestamp="2026-01-02T00:00:00+00:00")
@@ -128,6 +132,37 @@ class TestIdempotenceAndStaleness:
         fresh = _rollup(tmp_path, "-3")
         assert fresh["generation"] != stale_gen
         assert fresh["generation"]["max_leaf_timestamp"] == "2026-01-03T00:00:00+00:00"
+        assert fresh["payload"]["n_obs"] == 99 + 10
+
+    def test_leaf_rerun_same_second_rewrites_via_payload_compare(self, tmp_path, monkeypatch):
+        # Backstop path: the production timestamp comes from build_record, which
+        # stamps timespec="seconds" — so a real back-to-back re-run carries the
+        # SAME (n_leaves, max_leaf_timestamp) and the generation stamp is blind
+        # to it. Freeze the wall clock to force that same-second collision (no
+        # hand-injected timestamp=; build_record still stamps the record), then
+        # assert the payload-equality backstop rewrites the whole chain anyway.
+        _write_manifest(tmp_path)
+        frozen = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        class _FrozenClock:
+            @staticmethod
+            def now(tz=None):
+                return frozen
+
+        monkeypatch.setattr("zagg.telemetry.datetime", _FrozenClock)
+        _put_leaf(tmp_path, "-311")  # real build_record auto-stamp
+        _put_leaf(tmp_path, "-321")
+        run_sweep(str(tmp_path), _leaf_refs("-311", "-321"))
+        stale = _rollup(tmp_path, "-3")
+        # Same wall-clock second, different content: re-run -311 with new obs.
+        _put_leaf(tmp_path, "-311", n_obs=99)
+        result = run_sweep(str(tmp_path), _leaf_refs("-311"))["families"]["stats"]
+        assert result["written"] == 3  # -311, -31, -3: the full stale chain
+        fresh = _rollup(tmp_path, "-3")
+        # The generation stamp is IDENTICAL (same second, unchanged leaf count),
+        # so only the payload compare could have caught the change.
+        assert fresh["generation"] == stale["generation"]
+        assert fresh["payload"] != stale["payload"]
         assert fresh["payload"]["n_obs"] == 99 + 10
 
     def test_incremental_append_unions_windows_and_siblings(self, tmp_path):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -9,6 +9,7 @@ leaves leaf reads intact).
 
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 import obstore
 import pytest
@@ -357,14 +358,203 @@ class TestMocRollup:
             [other, morton_word("-311")]
         )
 
-    def test_default_families_cover_stats_and_moc(self, tmp_path):
+    def test_default_families_cover_all_implemented(self, tmp_path):
         _write_manifest(tmp_path)
         _put_leaf(tmp_path, "-311")
         _stamp_leaf(tmp_path, "-311")
         summary = run_sweep(str(tmp_path), _leaf_refs("-311"))
-        assert set(summary["families"]) == {"stats", "moc"}
+        assert set(summary["families"]) == {"stats", "moc", "submap"}
         assert _rollup(tmp_path, "-3", family="stats") is not None
         assert _rollup(tmp_path, "-3", family="moc") is not None
+        # No leaf sub-map was written -> the submap family finds nothing and
+        # stays empty without failing the pass.
+        assert summary["families"]["submap"]["empty"] >= 1
+        assert _rollup(tmp_path, "-3", family="submap") is None
+
+
+SUBMAP_SIG = {
+    "type": "healpix",
+    "indexing_scheme": "nested",
+    "parent_order": SHARD_ORDER,
+    "child_order": SHARD_ORDER + 2,
+    "layout": "flat",
+}
+
+
+def _entry(gid):
+    return {"id": gid, "s3": f"s3://bucket/{gid}", "https": f"https://host/{gid}"}
+
+
+def _emit_submap(root, decimal, gids, window=None):
+    from zagg.sweep import write_leaf_submap
+
+    write_leaf_submap(
+        str(root),
+        morton_word(decimal),
+        [_entry(g) for g in gids],
+        grid_signature=SUBMAP_SIG,
+        metadata={"collection": "TEST_001"},
+        window=window,
+    )
+
+
+class TestSubmapNaming:
+    def test_legacy_and_v3_names(self):
+        from zagg.sweep import submap_key
+
+        assert submap_key("-311.zarr") == "shardmap.json"
+        assert submap_key("-311_2019.zarr") == "shardmap_2019.json"
+        assert submap_key("2019.zarr", spec="morton-hive/3") == "2019.shardmap.json"
+
+    def test_unknown_spec_raises(self):
+        from zagg.sweep import submap_key
+
+        with pytest.raises(ValueError, match="unknown store spec"):
+            submap_key("-311.zarr", spec="morton-hive/9")
+
+
+class TestSubmapRollup:
+    def test_leaf_submap_is_loadable_shardmap_json(self, tmp_path):
+        from zagg.catalog.shardmap import ShardMap
+        from zagg.sweep import _node_rel
+
+        _write_manifest(tmp_path)
+        _emit_submap(tmp_path, "-311", ["gA", "gB"])
+        path = tmp_path / _node_rel("-311") / "shardmap.json"
+        sm = ShardMap.from_json(str(path))
+        assert sm.shard_keys == [morton_word("-311")]
+        assert [g["id"] for g in sm.granules[0]] == ["gA", "gB"]
+        assert sm.metadata["total_shards"] == 1 and sm.metadata["total_granules"] == 2
+        assert json.loads(path.read_text())["written_at"]  # staleness stamp rides the file
+
+    def test_rollup_equals_direct_reproject(self, tmp_path):
+        from zagg.catalog.shardmap import ShardMap
+        from zagg.sweep import _ReprojectTarget
+
+        _write_manifest(tmp_path)
+        per_shard = {"-311": ["gA", "gB"], "-312": ["gB"], "-321": ["gC"]}
+        for dec, gids in per_shard.items():
+            _emit_submap(tmp_path, dec, gids)
+        result = run_sweep(str(tmp_path), _leaf_refs(*per_shard), families=("submap",))
+        assert result["families"]["submap"]["written"] == 6
+        # -31 folds two shards; a granule shared across them (gB) counts once
+        # (the #294 dedup rule), and the rollup grid signature carries the
+        # node's order.
+        r31 = _rollup(tmp_path, "-31", family="submap")["payload"]
+        assert r31["shard_keys"] == [morton_word("-31")]
+        assert sorted(e["id"] for e in r31["granules"][0]) == ["gA", "gB"]
+        assert r31["grid_signature"]["parent_order"] == 1
+        assert r31["metadata"]["reproject"]["method"] == "coarsen"
+        # Rollup == direct (§8.3): the base rollup equals the run-level
+        # ShardMap reprojected straight to order 0 by the production coarsen.
+        direct = ShardMap(
+            dict(SUBMAP_SIG),
+            [morton_word(d) for d in sorted(per_shard)],
+            [[_entry(g) for g in per_shard[d]] for d in sorted(per_shard)],
+            {"collection": "TEST_001"},
+        ).reproject(_ReprojectTarget(SUBMAP_SIG, 0))
+        r3 = _rollup(tmp_path, "-3", family="submap")["payload"]
+        assert r3["shard_keys"] == [int(k) for k in direct.shard_keys]
+        assert {e["id"] for e in r3["granules"][0]} == {e["id"] for e in direct.granules[0]}
+
+    def test_window_union_dedups_by_id(self, tmp_path):
+        _write_manifest(tmp_path)
+        _emit_submap(tmp_path, "-311", ["gA", "gB"], window="2019")
+        _emit_submap(tmp_path, "-311", ["gB", "gC"], window="2020")
+        word = morton_word("-311")
+        run_sweep(str(tmp_path), [(word, "2019"), (word, "2020")], families=("submap",))
+        node = _rollup(tmp_path, "-311", family="submap")
+        assert node["generation"]["n_leaves"] == 2
+        assert node["payload"]["shard_keys"] == [word]
+        assert sorted(e["id"] for e in node["payload"]["granules"][0]) == ["gA", "gB", "gC"]
+        # Same-order union, not a reprojection: no fold stamp at the shard node.
+        assert "reproject" not in node["payload"]["metadata"]
+
+    def test_idempotent_and_incremental(self, tmp_path):
+        _write_manifest(tmp_path)
+        _emit_submap(tmp_path, "-311", ["gA"])
+        run_sweep(str(tmp_path), _leaf_refs("-311"), families=("submap",))
+        second = run_sweep(str(tmp_path), _leaf_refs("-311"), families=("submap",))
+        assert second["families"]["submap"]["written"] == 0
+        # A later run adds a sibling shard; sweeping ONLY it keeps -311's
+        # contribution via the stored sibling rollup.
+        _emit_submap(tmp_path, "-312", ["gB"])
+        run_sweep(str(tmp_path), _leaf_refs("-312"), families=("submap",))
+        r31 = _rollup(tmp_path, "-31", family="submap")["payload"]
+        assert sorted(e["id"] for e in r31["granules"][0]) == ["gA", "gB"]
+
+    def test_malformed_submap_counts_failed(self, tmp_path):
+        from zagg.sweep import _node_rel
+
+        _write_manifest(tmp_path)
+        node = tmp_path / _node_rel("-311")
+        node.mkdir(parents=True)
+        (node / "shardmap.json").write_text(json.dumps({"shard_keys": [1]}))  # missing keys
+        result = run_sweep(str(tmp_path), _leaf_refs("-311"), families=("submap",))
+        assert result["families"]["submap"]["failed"] == 1
+        assert result["families"]["submap"]["written"] == 0
+
+
+class TestLocalRunnerEmitsSubmap:
+    """The local backend's in-process worker writes the leaf sub-map on
+    success (issue #300) — sibling to the stats sidecar, fail-open."""
+
+    SHARD = "-5112333"  # order 6, matching default_config's parent_order
+
+    def _agg(self, monkeypatch, tmp_path, *, meta_error=None):
+        from zagg import hive, runner
+        from zagg.config import default_config
+        from zagg.runner import agg
+
+        cfg = default_config("atl06")
+        cfg.output["store_layout"] = "hive"
+        shard = morton_word(self.SHARD)
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: {"accessKeyId": "a"})
+
+        def fake_hive_write(shard_key, granule_urls, grid, s3_creds, store_root, config, **kw):
+            return {"shard_key": int(shard_key), "error": meta_error, "total_obs": 1}
+
+        monkeypatch.setattr(hive, "process_and_write_hive", fake_hive_write)
+        catalog = {
+            "metadata": {"short_name": "ATL06", "version": "007"},
+            "grid_signature": {
+                "type": "healpix",
+                "indexing_scheme": "nested",
+                "parent_order": int(cfg.output["grid"]["parent_order"]),
+                "child_order": int(cfg.output["grid"]["child_order"]),
+                "layout": cfg.output["grid"].get("layout", "fullsphere"),
+            },
+            "shard_keys": [int(shard)],
+            "granules": [[_entry("g1")]],
+        }
+        path = tmp_path / "catalog.json"
+        path.write_text(json.dumps(catalog))
+        root = str(tmp_path / "out")
+        agg(cfg, catalog=str(path), store=root, backend="local")
+        return root, shard, catalog
+
+    def test_success_writes_leaf_submap(self, monkeypatch, tmp_path):
+        from zagg.catalog.shardmap import ShardMap
+        from zagg.sweep import submap_key
+
+        root, shard, catalog = self._agg(monkeypatch, tmp_path)
+        from zagg.hive import shard_leaf_path
+
+        leaf = shard_leaf_path(root, shard)
+        prefix, _, name = leaf.rpartition("/")
+        sub = ShardMap.from_json(f"{prefix}/{submap_key(name)}")
+        assert sub.shard_keys == [shard]
+        assert [g["id"] for g in sub.granules[0]] == ["g1"]
+        assert sub.grid_signature == catalog["grid_signature"]
+
+    def test_failed_shard_writes_none(self, monkeypatch, tmp_path):
+        from zagg.hive import shard_leaf_path
+        from zagg.sweep import submap_key
+
+        root, shard, _catalog = self._agg(monkeypatch, tmp_path, meta_error="boom")
+        leaf = shard_leaf_path(root, shard)
+        prefix, _, name = leaf.rpartition("/")
+        assert not Path(f"{prefix}/{submap_key(name)}").exists()
 
 
 class TestFamilyRegistry:
@@ -374,7 +564,7 @@ class TestFamilyRegistry:
 
     @pytest.mark.parametrize(
         ("name", "marker"),
-        [("submap", "PR #295"), ("overview", "issue #201"), ("debris", "not implemented")],
+        [("overview", "issue #201"), ("debris", "not implemented")],
     )
     def test_stub_families_refuse_with_pointer(self, name, marker):
         assert name in sweep_mod.FAMILIES  # registered slot stays visible
@@ -385,5 +575,5 @@ class TestFamilyRegistry:
         except NotImplementedError as e:
             assert marker in str(e)
 
-    def test_stats_is_a_default_family(self):
-        assert "stats" in sweep_mod.DEFAULT_FAMILIES
+    def test_default_families_are_the_implemented_set(self):
+        assert sweep_mod.DEFAULT_FAMILIES == ("stats", "moc", "submap")

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -197,6 +197,122 @@ class TestWorkSetEdges:
             run_sweep(str(tmp_path), [])
 
 
+def _stamp_leaf(root, decimal, *, window=None, time_range=None):
+    """A minimal committed leaf: root zarr group + D4 commit stamp."""
+    import zarr
+
+    from zagg.hive import stamp_commit
+    from zagg.store import open_store
+
+    leaf = shard_leaf_path(str(root), morton_word(decimal), window=window)
+    store = open_store(leaf)
+    zarr.open_group(store, mode="w", zarr_format=3)
+    stamp_commit(store, cells_with_data=1, granule_count=1, window=window, time_range=time_range)
+
+
+def _payload_words(payload):
+    from zagg.hive import root_coverage_words
+
+    return sorted(int(w) for w in root_coverage_words(payload))
+
+
+class TestMocRollup:
+    def test_union_equals_direct_walk(self, tmp_path):
+        _write_manifest(tmp_path)
+        decimals = ("-311", "-312", "-321")
+        for d in decimals:
+            _stamp_leaf(tmp_path, d)
+        result = run_sweep(str(tmp_path), _leaf_refs(*decimals), families=("moc",))
+        moc = result["families"]["moc"]
+        assert moc["written"] == 6 and moc["root_moc_written"] is True
+        base = _rollup(tmp_path, "-3", family="moc")
+        assert _payload_words(base["payload"]) == sorted(morton_word(d) for d in decimals)
+        assert _payload_words(_rollup(tmp_path, "-31", family="moc")["payload"]) == sorted(
+            morton_word(d) for d in ("-311", "-312")
+        )
+        # The refreshed root coverage.moc lists exactly the committed shards.
+        from zagg.hive import read_root_coverage
+
+        root_moc = read_root_coverage(str(tmp_path))
+        assert root_moc["source"] == "sweep" and root_moc["order"] == SHARD_ORDER
+        assert _payload_words(root_moc) == sorted(morton_word(d) for d in decimals)
+
+    def test_unstamped_debris_is_invisible(self, tmp_path):
+        import zarr
+
+        from zagg.store import open_store
+
+        _write_manifest(tmp_path)
+        _stamp_leaf(tmp_path, "-311")
+        # A torn worker's leaf: prefix exists, no commit stamp (D4).
+        debris = shard_leaf_path(str(tmp_path), morton_word("-312"))
+        zarr.open_group(open_store(debris), mode="w", zarr_format=3)
+        result = run_sweep(str(tmp_path), _leaf_refs("-311", "-312"), families=("moc",))
+        assert result["families"]["moc"]["empty"] == 1
+        assert _payload_words(_rollup(tmp_path, "-31", family="moc")["payload"]) == [
+            morton_word("-311")
+        ]
+
+    def test_windowed_stamps_union_time_range(self, tmp_path):
+        _write_manifest(tmp_path)
+        _stamp_leaf(
+            tmp_path,
+            "-311",
+            window="2019",
+            time_range=["2019-02-01T00:00:00+00:00", "2019-11-01T00:00:00+00:00"],
+        )
+        _stamp_leaf(
+            tmp_path,
+            "-311",
+            window="2020",
+            time_range=["2020-01-01T00:00:00+00:00", "2020-06-01T00:00:00+00:00"],
+        )
+        word = morton_word("-311")
+        run_sweep(str(tmp_path), [(word, "2019"), (word, "2020")], families=("moc",))
+        node = _rollup(tmp_path, "-311", family="moc")
+        # Two stamped windows of one shard: one covered word, unioned extent.
+        assert node["generation"]["n_leaves"] == 2
+        assert _payload_words(node["payload"]) == [word]
+        assert node["payload"]["time_range"] == [
+            "2019-02-01T00:00:00+00:00",
+            "2020-06-01T00:00:00+00:00",
+        ]
+
+    def test_second_pass_writes_nothing_including_root(self, tmp_path):
+        _write_manifest(tmp_path)
+        for d in ("-311", "-321"):
+            _stamp_leaf(tmp_path, d)
+        refs = _leaf_refs("-311", "-321")
+        first = run_sweep(str(tmp_path), refs, families=("moc",))["families"]["moc"]
+        assert first["written"] == 5 and first["root_moc_written"] is True
+        second = run_sweep(str(tmp_path), refs, families=("moc",))["families"]["moc"]
+        assert second["written"] == 0 and second["current"] == 5
+        assert second["root_moc_written"] is False
+
+    def test_root_union_keeps_untouched_bases(self, tmp_path):
+        from zagg.hive import build_root_coverage, read_root_coverage, write_root_coverage
+
+        _write_manifest(tmp_path)
+        # A prior run's root MOC lists a shard under ANOTHER base that this
+        # sweep never visits; the refresh must union, not replace (D9).
+        other = morton_word("411")
+        write_root_coverage(str(tmp_path), build_root_coverage([other], SHARD_ORDER))
+        _stamp_leaf(tmp_path, "-311")
+        run_sweep(str(tmp_path), _leaf_refs("-311"), families=("moc",))
+        assert _payload_words(read_root_coverage(str(tmp_path))) == sorted(
+            [other, morton_word("-311")]
+        )
+
+    def test_default_families_cover_stats_and_moc(self, tmp_path):
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        _stamp_leaf(tmp_path, "-311")
+        summary = run_sweep(str(tmp_path), _leaf_refs("-311"))
+        assert set(summary["families"]) == {"stats", "moc"}
+        assert _rollup(tmp_path, "-3", family="stats") is not None
+        assert _rollup(tmp_path, "-3", family="moc") is not None
+
+
 class TestFamilyRegistry:
     def test_unknown_family_raises(self):
         with pytest.raises(ValueError, match="unknown sweep family"):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -427,6 +427,24 @@ class TestSubmapRollup:
         assert sm.metadata["total_shards"] == 1 and sm.metadata["total_granules"] == 2
         assert json.loads(path.read_text())["written_at"]  # staleness stamp rides the file
 
+    def test_reproject_shim_matches_real_grid_signature(self):
+        # Pin the coarsen-target shim to the real grid it stands in for: at the
+        # coarsened order N, _ReprojectTarget(SUBMAP_SIG, N).spatial_signature()
+        # must equal a genuine HealpixGrid's — otherwise the rollup oracle below
+        # would only prove the fold agrees with itself. The signatures match on
+        # every key except ``layout``: SUBMAP_SIG carries the store-layout token
+        # ("flat"), while a live grid reports its DGGS layout ("fullsphere");
+        # reproject only swaps the dispatch order, never the DGGS resolution.
+        from zagg.grids.healpix import HealpixGrid
+        from zagg.sweep import _ReprojectTarget
+
+        for order in (0, 1, SHARD_ORDER):
+            shim = _ReprojectTarget(SUBMAP_SIG, order).spatial_signature()
+            real = HealpixGrid(order, SUBMAP_SIG["child_order"]).spatial_signature()
+            assert {k: v for k, v in shim.items() if k != "layout"} == {
+                k: v for k, v in real.items() if k != "layout"
+            }
+
     def test_rollup_equals_direct_reproject(self, tmp_path):
         from zagg.catalog.shardmap import ShardMap
         from zagg.sweep import _ReprojectTarget

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -515,6 +515,29 @@ class TestSubmapRollup:
         assert not submap_emittable(SUBMAP_SIG, raster_entries)
         assert not submap_emittable(None, [_entry("gA")])
 
+    def test_unsupported_signature_counts_empty_not_failed(self, tmp_path):
+        # A well-formed-but-unsupported leaf sub-map (all required keys, but a
+        # rectilinear grid_signature the HEALPix-only fold cannot coarsen) is a
+        # SKIP, not corruption: read_leaf returns None -> "empty", never "failed".
+        from zagg.sweep import _node_rel
+
+        _write_manifest(tmp_path)
+        node = tmp_path / _node_rel("-311")
+        node.mkdir(parents=True)
+        (node / "shardmap.json").write_text(
+            json.dumps(
+                {
+                    "grid_signature": {"type": "rectilinear", "shape": [10, 10]},
+                    "shard_keys": [morton_word("-311")],
+                    "granules": [[{"s3": "s3://b/t0", "datetime": "2025-01-01T00:00:00Z"}]],
+                }
+            )
+        )
+        result = run_sweep(str(tmp_path), _leaf_refs("-311"), families=("submap",))
+        assert result["families"]["submap"]["empty"] == 1
+        assert result["families"]["submap"]["failed"] == 0
+        assert result["families"]["submap"]["written"] == 0
+
 
 class TestLocalRunnerEmitsSubmap:
     """The local backend's in-process worker writes the leaf sub-map on

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -801,6 +801,31 @@ class TestSweepCli:
         assert main([str(tmp_path)]) == 0
         assert "nothing to sweep" in capsys.readouterr().out
 
+    def test_end_to_end_windowed_discovery_folds_both_windows(self, tmp_path):
+        # The at-scale seam: a windowed run record threads through
+        # discover_leaves into a real run_sweep, and the discovered
+        # ``(key, window)`` pairs name the leaves the fold reads — exercising
+        # the discovery-side sidecar-name grammar against the fold-side reader.
+        from zagg.sweep import discover_leaves
+
+        _write_manifest(tmp_path)
+        manifest = json.loads((tmp_path / MANIFEST_NAME).read_text())
+        manifest["spec"] = "morton-hive/2"
+        manifest["temporal"] = {"schedule": "yearly", "time_field": "t"}
+        (tmp_path / MANIFEST_NAME).write_text(json.dumps(manifest))
+        # Real windowed leaf sidecars for two windows of one shard...
+        a = _put_leaf(tmp_path, "-311", window="2019")
+        b = _put_leaf(tmp_path, "-311", window="2020")
+        # ...and a real run record carrying the window column.
+        _run_record(tmp_path, [_row("-311", window="2019"), _row("-311", window="2020")])
+        refs = discover_leaves(str(tmp_path))
+        assert refs == [(morton_word("-311"), "2019"), (morton_word("-311"), "2020")]
+        run_sweep(str(tmp_path), refs, families=("stats",))
+        node = _rollup(tmp_path, "-311")
+        assert node["generation"]["n_leaves"] == 2
+        assert node["windows"] == ["2019", "2020"]
+        assert node["payload"] == merge([a, b])
+
 
 class TestSweepConfig:
     """output.sweep (issue #300): default on for hive, boolean, hive-only —

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -459,3 +459,49 @@ class TestRunParquet:
     def test_empty_rows_raise(self, tmp_path):
         with pytest.raises(ValueError, match="at least one"):
             write_run_parquet(str(tmp_path), [], run_id="x")
+
+
+class TestWindowColumn:
+    """The per-shard record's ``window`` label (issue #300): threaded like
+    run_id, merged equal-or-None, flattened to a run-parquet column."""
+
+    def _windowed(self, window, **kwargs):
+        return build_record(
+            shard_key=5,
+            metadata={"total_obs": 1, "duration_s": 1.0},
+            window=window,
+            **kwargs,
+        )
+
+    def test_recorded_and_defaults_none(self):
+        assert self._windowed("2019")["window"] == "2019"
+        assert _record(5)["window"] is None
+
+    def test_merge_equal_keeps_mismatch_collapses(self):
+        a, b = self._windowed("2019"), self._windowed("2019")
+        assert merge([a, b])["window"] == "2019"
+        assert merge([a, self._windowed("2020")])["window"] is None  # cross-window rollup
+
+    def test_flattened_to_row(self):
+        row = flatten_record(self._windowed("2019"))
+        assert row["window"] == "2019"
+
+
+class TestRunParquetShardKeyExactness:
+    """Packed morton words round-trip the run parquet exactly (issue #300):
+    the sweep's run-record discovery recomputes leaf paths from these keys, so
+    float64 inference (from failure-row nulls) would corrupt them silently."""
+
+    def test_uint64_with_null_round_trips(self, tmp_path):
+        import pandas as pd
+
+        word = 10376293541461622786  # morton_word("-311"): > 2^63, float64-inexact
+        rows = [
+            flatten_record(_record(word)),
+            flatten_record(failure_record(shard_key=None, error="boom")),
+        ]
+        path = write_run_parquet(str(tmp_path / "store"), rows, run_id="ff01")
+        df = pd.read_parquet(path, engine="fastparquet")
+        assert str(df["shard_key"].dtype) == "UInt64"
+        assert int(df["shard_key"].dropna().iloc[0]) == word  # exact, not 2^53-rounded
+        assert df["shard_key"].isna().sum() == 1  # the failure row keeps its null


### PR DESCRIPTION
Closes #300

## What

Implements the D22 **unified second-pass rollup sweep** (`src/zagg/sweep.py`): one idempotent bottom-up pass over a hive store's digit tree that folds leaf artifacts into interior-node rollups, per registered artifact family, per the design record (`docs/design/sparse_coverage.md` §7 / D22 / D20 / D9) and the decisions on the issue thread ([trigger + full-ShardMap-JSON sub-maps](https://github.com/englacial/zagg/issues/300#issuecomment-5017291722), [schedule decoupling](https://github.com/englacial/zagg/issues/300#issuecomment-5017464707)).

Core mechanics (all families share the engine):

- **Discovery from run records, never a recursive LIST** (D22): callers pass the leaves a run touched — `(shard_key, window)` pairs from the dispatcher's run report (end-of-run hook) or from the run-level stats parquets at the product root (manual CLI). The walk visits only those leaves' ancestor paths; untouched siblings contribute through their existing stored rollups (≤ 4 candidate GETs per node, no LIST), so incremental runs accumulate exactly.
- **Generation stamps** (D22): every rollup records `{n_leaves, max_leaf_timestamp}`. A leaf re-run carries a later timestamp than every earlier record, so ancestor stamps stop matching — staleness is *detectable, not prevented* — and the next sweep rewrites exactly the stale chain. Skip-if-current is a two-part test: the generation stamp, backstopped by payload equality (covers same-second rewrites — both timestamp sources are whole-second). A second pass over an unchanged tree PUTs nothing.
- **Nothing load-bearing** (D9): rollups are regenerable caches. No existing read path consults them; deleting every rollup leaves all leaf reads (and the whole pre-existing test suite) green.
- Rollup objects are JSON sidecars at digit nodes named `{family}.rollup.json` — deliberately distinct from the leaf sidecar names (`stats.json` / `coverage.moc`): under D24 mixed-order stores a node can be leaf and interior at once, so sharing leaf names would self-clobber; the names list as objects, never digit-shaped prefixes, so the §5 discovery walk is unaffected.
- Shard-node rollups record the `windows` they merged, so an append run touching one window never drops its committed siblings (the union is re-read from leaf sidecars — truth — never re-derived from a prior rollup).
- The manifest's `spec` string is threaded into leaf-sidecar naming, so the PR #307 D23 seam resolves per store (legacy names today; the `/3` flip is issue #299's writer change). The sub-map sidecar name derives from the same seam (`shardmap.json` / `shardmap_{window}.json` / `{window}.shardmap.json`).

## Phases

- [x] **Phase 1 — sweep skeleton + stats rollup family.** Engine (bottom-up walk, generation stamps, skip-if-current), family registry, stats rollups via the existing `zagg.telemetry.merge` fold (D20 — associative by construction, so fold-of-folds == direct).
- [x] **Phase 2 — MOC regen family.** Committed-leaf coverage (D4 stamps — debris invisible) folded into interior MOC rollups in the same walk; the sweep is now a regenerator of the store-root `coverage.moc` via the same GET-union-PUT writer the runner uses (the runner's end-of-run fail-open write stays the fast path, per O7/D9), with a skip-when-covered gate. The O8 in-leaf bitmap contract is untouched (only the stamp envelope is read).
- [x] **Phase 3 — sub-shardmap rollup family, end-to-end.** Leaf sub-maps are **full ShardMap JSON** (the ratified format), written **by the worker on success** next to the stats sidecar — the local backends in-process, the Lambda workers from a new size-gated `submap` event block (`grid_signature` + catalog `metadata` + the `{id, s3, https}` granule entries the event's bare `granule_urls` can't reconstruct; raster events already carry entries, so their block is identity-only). The block is dropped (never fatal) when it would push an async event over the 256 KB cap — the sub-map is a D9 regenerable artifact and the sweep CLI is the backstop. Old deployments ignore the unknown key; old dispatchers send no block — both fail open. The fold: window union deduped by granule id at the shard node, then `ShardMap.reproject`'s exact coarsen regroup (merged in PR #295) level by level — rollup at order N == direct reproject at N (§8.3), verified against the production `reproject` as oracle. (Phase 1 had registered this family as a stub while #295 was open; this phase replaces it.)
- [x] **Phase 4 — window column + run-record discovery + manual CLI.** `window` joins the per-shard record and run parquet (threaded like `run_id`, per the ruling on the thread); run-parquet `shard_key` becomes a nullable UInt64 so packed morton words round-trip exactly (today the failure-row NaN coerces the column to float64, corrupting keys above 2^53 — found while building discovery); `python -m zagg.sweep` discovers leaves column-first from the run records, with a bounded per-shard-node LIST fallback for pre-column records only.
- [x] **Phase 5 — trigger wiring (D8-compliant).** Local backends: end-of-run in-process hook (fail-open, off the critical path) — the local "dispatcher" is also the worker and writes with the user's own credentials, so the D8 IAM rationale doesn't apply (stated here for veto). Lambda backends: **the dispatcher never PUTs** (D8 standing rule) — the hook is a fire-and-forget **`mode: "sweep"` worker Event invoke** (async, retries-0, fail-open, manual CLI as the D9 regeneration backstop), following the root-MOC `mode: "coverage"` pattern and coordinated with PR #315's `mode: "stats"` transport (size-gated inline leaves, discovery fallback).

**Registered but stubbed** (visible slots; `get_family` refuses with a pointer):
- `overview` — overview zarrs are issue #201's separate follow-on PR; only the D22 registration slot is reserved here.
- `debris` — the optional audit-class fifth family (D22), not implemented.

**Benchmark object model** (`.github/scripts/bench_objects.py`, the issue #240 tripwire): the model now counts the leaf sub-map as the second node-dir sibling, and sweep rollups get their own `objects_rollups` bucket — second-pass D9 caches, excluded from the write-path total the model audits (the #215 per-shard bypass guard is untouched: rollups never live inside a leaf prefix). This is the Python model module the unit tests import, not workflow/deploy config; it was updated the same way for the #297 sidecar.

**Sweep-invoke reliability vs #313's fire-verify-refire** (stated per the ruling): the `mode:"stats"` transport verifies-and-refires because a dropped invoke silently loses the run record. The `mode:"sweep"` invoke stays **plain fire-and-forget, retries-0, no refire** — a dropped invoke costs rollup *staleness only* (D9: every rollup is a regenerable cache; leaf truth is untouched), the next run's hook re-folds the same ancestor chains, and `python -m zagg.sweep` is the explicit backstop. Post-#313 ordering caveat documented at the dispatch site: the stats and sweep Event invokes race, so the oversized-work-set `discover: true` fallback may miss the racing run's records — same fail-open class.

**Post-#314 (morton-only writer flip)**: no interaction by construction — the sweep families read commit stamps, stats sidecars, and sub-map JSON, none of which carry `cell_ids`; the merged benchmark model tests (3-array leaves) and the full suite pass on the merged tip.

**Merged with post-branch main** (no rebase — the branch history is append-only per repo rules): the #299 semantic-hash stack and #305 landed mid-review, so `origin/main` is merged in with a merge commit. Reconciliations: `build_record` threads BOTH `window` (this PR) and `semantic_hash` (#299); the local sub-map emission now passes the manifest `spec` through the same #307 naming seam main's sidecar writes adopted; the benchmark hive model carries main's metadata ceiling (manifest + optional MOC + run parquet + `aggregation.yaml`) alongside this PR's per-shard sub-map sibling and rollup bucket.

## How tested

`tests/test_sweep.py`, keyed to the §8.3 standing obligations:

- **Rollup == direct**, per family: stats rollups equal `telemetry.merge` over the exact leaf record set; MOC rollup words at every level equal the direct union of committed shard words (root `coverage.moc` refreshed, `source: "sweep"`); sub-map rollups equal the run-level ShardMap reprojected directly to the rollup order by the production coarsen (shared granules dedup once).
- **Idempotence**: second pass over an unchanged tree has `written == 0`, byte-identical rollups, no root-MOC PUT.
- **Staleness**: a leaf re-run makes exactly its ancestor chain rewrite — both the timestamp fast path and the same-second payload-equality backstop are covered.
- **Incremental accumulation**: sweeping only a new window / sibling shard keeps earlier contributions; the root-MOC refresh unions with bases the sweep never visited.
- **Nothing load-bearing**: deleting every `*.rollup.json` leaves leaf sidecar reads intact and a re-sweep regenerates identical payloads.
- **Worker emission**: the local backend writes the leaf sub-map on success and none on failure (fake-hive-write integration, the `test_coverage_root` pattern); handler emission is additive (`submap` event block absent in the existing harness events, which stay green).
- Edge cases: missing sidecar/sub-map skipped, malformed sub-map counts `failed` (loud, not absent), unstamped debris invisible to the MOC family, foreign-order refs skipped with a warning, corrupt rollup rebuilt, windowed stamps union their D15 time ranges, empty work set is a no-op, no-manifest refusal, stub-family refusals, sub-map naming across legacy//3 grammars.

Local per push: `ruff check` / `ruff format --check` clean; `pytest` full suite green, with two local-environment-only exceptions flagged rather than fixed (§4): `test_lambda_build::test_function_build_succeeds` fails on this machine because the build env's pip cannot resolve `zarr>=3.1.5` (the PR's own CI `build / build-arm64` + `build-x86_64` checks pass), and `registry.py:64`'s pre-existing `N818` (outside the PR lint bot's `--select=E,F,W,I`).

## Questions for review

1. **Local-hook interpretation of D8** (phase 5): stated above — on the local backends the orchestrator process *is* the worker (it already PUTs every leaf), so the in-process hook doesn't cross the D8 boundary. Veto if the sweep should be invoke-shaped there too.
2. **Sub-map payload cap fallback**: units whose `submap` block would overflow the async event cap ship without it (logged at debug); their leaf sub-maps appear only once something re-emits them — a `--catalog` backfill flag on the sweep CLI is the natural home but is not in this PR; say the word if it should be. The dense-polar-shard case (#148-scale granule lists) is the realistic trigger.
3. **PR #315 interplay** (phase 5): the `mode: "sweep"` invoke will mirror its size-gated transport; whichever PR lands second carries a trivial rebase in `runner.py`'s post-run block.
4. **Rollup schedule**: dense every-order this round; sparse per-family manifest-declared schedules are issue #201 Phase C (confirmed on the thread), and the engine's level walk is compatible.
