### PR TITLE
Morton convention: O10 resolution discriminator + self-declared UUID (issue #305)

### DIFF
--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -4,10 +4,13 @@
 temporal-partitioning amendments (D13–D15) ratified on
 [#237](https://github.com/englacial/zagg/issues/237); morton-only-storage
 amendment ratified on
-[#262](https://github.com/englacial/zagg/issues/262) (D16; open item O10
-carved from it); 2026-07 consolidation (D17–D24; O3/O11 resolved, O8
+[#262](https://github.com/englacial/zagg/issues/262) (D16; O10 carved from
+it, resolved via [#305](https://github.com/englacial/zagg/issues/305));
+2026-07 consolidation (D17–D24; O3/O10/O11 resolved, O8
 constants blessed, O12–O14 opened, D23 tokens ratified, §8.3
-test-obligations index added)
+test-obligations index added; normative grammars/constants relocated to the
+[mortie spec page](https://github.com/espg/mortie/blob/main/docs/specification.md)
+per the #305 acceptance criterion)
 recording decisions settled on the
 [#251](https://github.com/englacial/zagg/issues/251)/[#236](https://github.com/englacial/zagg/issues/236)/[#209](https://github.com/englacial/zagg/issues/209)
 and [#296](https://github.com/englacial/zagg/issues/296)-family threads —
@@ -54,7 +57,11 @@ artifacts.
 
 The layout convention is **owned by the mortie spec** (the frozen 1.x
 contract: [mortie #48](https://github.com/espg/mortie/issues/48) discussion →
-[mortie #62](https://github.com/espg/mortie/issues/62) spec page). Summary of
+[mortie #62](https://github.com/espg/mortie/issues/62) →
+[`docs/specification.md`](https://github.com/espg/mortie/blob/main/docs/specification.md),
+the normative page). Grammars and constants are normative **there only**;
+this registry records decisions and rationale and cites the page (the #305
+acceptance criterion — duplicated normative text drifts). Summary of
 what zagg consumes:
 
 ```
@@ -224,7 +231,9 @@ again during a run. Contents:
   `quarterly` grammar-reserved), and the append policy. Label grammar and
   boundary semantics (UTC calendar terms, half-open `[start, end)`,
   lexicographic = chronological) are frozen on the
-  [mortie spec page](https://github.com/espg/mortie/issues/62#issuecomment-4986809092).
+  [mortie spec page §6.3](https://github.com/espg/mortie/blob/main/docs/specification.md)
+  (consolidated there from the
+  [original #62 thread record](https://github.com/espg/mortie/issues/62#issuecomment-4986809092)).
   Generative schedules keep the manifest
   write-once and static as data accrues: appending a new year to a
   `yearly` store adds leaves the schedule already describes — no manifest
@@ -519,8 +528,10 @@ rollup leaves all leaf reads intact.
   per-year 88S runs, seasonal subsets, and append-as-acquired are all
   window leaves under the same convention. Leaf naming is **frozen**:
   `{full_id}_{window}.zarr`, underscore separator, split on the first `_`
-  — grammar and boundary semantics recorded on the
-  [mortie spec page](https://github.com/espg/mortie/issues/62#issuecomment-4986809092)
+  — grammar and boundary semantics normative on the
+  [mortie spec page §6.3](https://github.com/espg/mortie/blob/main/docs/specification.md)
+  (originally recorded on the
+  [#62 thread](https://github.com/espg/mortie/issues/62#issuecomment-4986809092))
   as part of `morton-hive/2`. (Unchanged by D19 — leaf naming survives the
   product-root design intact. *Naming revised by D23 for `morton-hive/3`*:
   the basename becomes the window alone; the `/2` grammar stays frozen for
@@ -579,7 +590,8 @@ rollup leaves all leaf reads intact.
   (An earlier plan bundled the flip with a #299 leaf-basename rename;
   D19's product-root revision made #299 additive, so this writer flip is
   the one remaining breaking store change in this family.) The order-29
-  discriminator metadata is O10.
+  discriminator metadata is O10 (resolved: `resolution: "exact" | "point"`,
+  clip rule `point`-only — see the O10 entry).
 
 - **D17 — Hive+sharded is the HEALPix default; flat/fullsphere deprecated;
   dense leaf arrays write through the ShardingCodec.**
@@ -688,8 +700,9 @@ rollup leaves all leaf reads intact.
   ergonomics (the full digest is what is compared; a short fingerprint —
   12 hex — is the display/CLI shorthand); and product names are
   **URL-safe by requirement** (they appear in gridlook deep-links and web
-  paths — proposed charset: lowercase alphanumerics plus `-`/`_`, frozen
-  with the name grammar on the mortie spec page).
+  paths — charset lowercase alphanumerics plus `-`/`_`, with the
+  base-component exclusion; the grammar is normative on the
+  [mortie spec page §6.5](https://github.com/espg/mortie/blob/main/docs/specification.md)).
 - **D20 — Per-shard telemetry sidecar + run records** (espg on-thread:
   [sibling placement + envelope ride](https://github.com/englacial/zagg/issues/297#issuecomment-5016910923),
   [caller identity](https://github.com/englacial/zagg/issues/297#issuecomment-5016901381);
@@ -765,8 +778,9 @@ rollup leaves all leaf reads intact.
   actually ask. Spec bump to `morton-hive/3` under D6 versioning: `/1`
   and `/2` stores remain valid forever under their frozen grammars;
   readers discriminate by the manifest `spec` string; the `/3` grammar is
-  to be re-frozen on the mortie spec page
-  ([mortie#62](https://github.com/espg/mortie/issues/62)). Costs accepted
+  frozen on the
+  [mortie spec page §6.4](https://github.com/espg/mortie/blob/main/docs/specification.md)
+  (mortie#62, drafted via espg/mortie PR #118). Costs accepted
   with the decision: the name==path self-check moves to the stamp attrs /
   D20 sidecar `shard_key` (an fsck pays one GET per leaf); D3's
   "unambiguous if moved" softens to "recoverable from attrs" — the moved
@@ -888,13 +902,15 @@ rollup leaves all leaf reads intact.
   Stamp attrs carry only the tier-0 box + the bitmap's order + pointer +
   byte sizes; pad sentinel is JSON null; the envelope gains an
   `encoding: "ranges" | "bitmap"` discriminator (later extended by D14 to add
-  a third value, `"full"`). Bit convention (frozen
-  with the mortie spec, golden-vector-pinned on PR #208): bit i = the i-th
+  a third value, `"full"`). Bit convention (normative on the
+  [mortie spec page §7](https://github.com/espg/mortie/blob/main/docs/specification.md),
+  golden-vector-pinned on PR #208): bit i = the i-th
   shard-subtree cell in ascending packed-word order (base-4 D1 digit tail,
   digits 1..4 → 0..3), MSB-first per byte. *Addendum (espg-blessed
   in-session, 2026-07-20 — closing the #276 item-5 flag)*: the PR #208
   contract constants stand as-shipped — the bitmap bit convention and the
-  root-MOC range ordering are **contract** (both golden-vector-pinned);
+  root-MOC range ordering are **contract** (both golden-vector-pinned;
+  spec page §7.2–§7.3);
   zstd level 3 is **non-normative** (any zstd level decodes identically;
   only "zstd stream" is contract).
 - **O9 — end-of-run root MOC default**: **RESOLVED — on** for hive stores
@@ -904,16 +920,36 @@ rollup leaves all leaf reads intact.
   true rejected elsewhere). The write is fail-open on both backends; the
   Lambda leg is one fire-and-forget `mode: "coverage"` Event invoke with the
   pre-serialized ranges envelope.
-- **O10 — order-29 resolution discriminator** (carved from D16): two
-  order-29 encodings exist — (a) genuinely order-29 resolution, and (b)
-  unknown resolution point-encoded at order 29, the default for any raw
-  lat/lon conversion and expected to be common. Readers need declared
-  metadata to tell them apart, because the D16 clip rule (29→24) applies
-  only to (b). Proposal: `resolution: "exact" | "point"` in the dggs attrs
-  block, defaulting to `"point"` for raw conversions. Intersects mortie's
-  documented point-id/area-word parse non-injectivity at order 29; field
-  name, values, and placement to be frozen with the mortie spec page
-  ([mortie#62](https://github.com/espg/mortie/issues/62)).
+- **O10 — order-29 resolution discriminator: RESOLVED — `resolution:
+  "exact" | "point"` in the dggs attrs block** (espg-ratified in-session,
+  2026-07-21; carved from D16; ruling recorded on
+  [#305](https://github.com/englacial/zagg/issues/305#issuecomment-5025784723)).
+  Two order-29 encodings exist — (a) genuinely order-29 resolution, and
+  (b) unknown resolution point-encoded at order 29, the default for any
+  raw lat/lon conversion — and readers need declared metadata to tell
+  them apart, because the D16 clip rule (29→24) applies only to (b).
+  Ruling: emission is **per data kind and the writer always knows
+  which** — grid-derived cell coordinates are `exact` **by construction**
+  (all zagg aggregation outputs); location-derived id fields (order-29
+  ids from raw lat/lon — the temporal event path, future HHDC) are
+  `point`. There is **no heuristic default**: the issue-body's "default
+  `point` for raw conversions" was refined away — a writer either
+  produces grid cells (`exact`) or converts raw coordinates (`point`),
+  never guesses. The clip rule keys only on the declared field.
+  Intersects mortie's documented point-id/area-word parse non-injectivity
+  at order 29; field name, values, placement, and the clip rule's
+  point-only scope are frozen normatively on the
+  [mortie spec page §4–§5](https://github.com/espg/mortie/blob/main/docs/specification.md)
+  (mortie#62, drafted via espg/mortie PR #118). Implementation:
+  `RESOLUTION_EXACT`/`RESOLUTION_POINT` in `zagg.grids.morton` (the
+  importable seam for future `point` writers) and the `resolution` field
+  in `HealpixGrid._dggs_attrs`. The companion identity ruling (same
+  session): morton-declared stores carry a **self-declared convention
+  UUID** — minted once, permanent, normative value on the mortie spec
+  page §5 (`MORTON_CONVENTION` in `zagg.grids.morton`) — while the
+  upstream dggs-registry ask
+  ([#72](https://github.com/englacial/zagg/issues/72) ask 3) proceeds in
+  parallel; the conventions attrs are a list, so both entries coexist.
 - **O11 — logical content hash of outputs: RESOLVED — adopted as
   proposed** (espg-ratified in-session, 2026-07-20; carved from D19,
   discussion trail on

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -27,7 +27,7 @@ from zagg.grids.base import (
     vector_array_spec,
     vlen_dtype_warning_suppressed,
 )
-from zagg.grids.morton import morton_decimal, to_morton_array
+from zagg.grids.morton import RESOLUTION_EXACT, morton_decimal, to_morton_array
 
 HEALPIX_BASE_CELLS: int = 12
 # Reference order at which ``assign`` resolves points before ``cells_of`` /
@@ -675,6 +675,14 @@ class HealpixGrid:
                 # cell. "morton" is outside the DGGS convention's standard schemes;
                 # the flag is a test/prototype capability.
                 "indexing_scheme": self.cell_ids_encoding,
+                # O10 resolution discriminator (issue #305, espg-ratified):
+                # grid-derived cell coordinates are "exact" by construction —
+                # every id is a true cell at its encoded order. "point"
+                # (RESOLUTION_POINT) is reserved for location-derived id
+                # fields (raw lat/lon cast to order 29 — the temporal event
+                # path), which the 29->24 clip rule on the mortie spec page
+                # applies to; no zagg aggregation output ever emits it.
+                "resolution": RESOLUTION_EXACT,
                 "spatial_dimension": "cells",
                 "ellipsoid": {
                     "name": "WGS84",

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -33,6 +33,31 @@ import numpy as np
 MORTON_EXTENSION_NAME = "mortie.morton_index"
 _EXTENSION_NAME_KEY = "ARROW:extension:name"
 
+#: Self-declared ``zarr_conventions`` entry for morton-declared stores
+#: (issue #305, D16). The UUID is minted once and PERMANENT — readers key on
+#: it; never regenerate it. The spec/schema URLs point at the mortie
+#: specification page (``docs/specification.md`` — the normative home of the
+#: convention; zagg's design doc only cites it). ``zarr_conventions`` is a
+#: LIST: a future upstream dggs-registry entry (issue #72 ask 3) coexists
+#: alongside this one rather than replacing it.
+MORTON_CONVENTION = {
+    "schema_url": "https://github.com/espg/mortie/blob/main/docs/specification.md#dggs-attrs",
+    "spec_url": "https://github.com/espg/mortie/blob/main/docs/specification.md",
+    "uuid": "3e22156d-ea9e-4e01-95fe-e3809a4b41e7",
+    "name": "morton-dggs",
+    "description": "Packed-u64 morton (HEALPix) DGGS convention",
+}
+
+#: O10 resolution discriminator (espg-ratified, issue #305): ``exact`` — ids
+#: are true cells at their encoded order; grid-derived cell coordinates are
+#: exact BY CONSTRUCTION, so every zagg aggregation output emits it.
+RESOLUTION_EXACT = "exact"
+#: ``point`` — locations cast to order 29 with no area claim (raw lat/lon
+#: conversions: the temporal event path, future HHDC id fields). The mortie
+#: spec page's 29->24 clip rule applies to ``point`` ONLY. Emission is per
+#: data kind and the writer always knows which; no heuristic fallback.
+RESOLUTION_POINT = "point"
+
 
 def is_morton_array(values) -> bool:
     """True if ``values`` is a mortie ``MortonIndexArray``."""
@@ -203,7 +228,10 @@ def is_morton_arrow(col) -> bool:
 
 
 __all__ = [
+    "MORTON_CONVENTION",
     "MORTON_EXTENSION_NAME",
+    "RESOLUTION_EXACT",
+    "RESOLUTION_POINT",
     "is_morton_array",
     "is_morton_arrow",
     "morton_box",

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1028,6 +1028,32 @@ class TestCellIdsEncoding:
         assert self._grid("nested")._dggs_attrs()["dggs"]["indexing_scheme"] == "nested"
         assert self._grid("morton")._dggs_attrs()["dggs"]["indexing_scheme"] == "morton"
 
+    def test_dggs_attrs_declare_resolution_exact(self):
+        # O10 discriminator (issue #305): grid-derived cell coordinates are
+        # "exact" by construction, under every encoding — "point" is reserved
+        # for location-derived id paths that don't exist in zagg outputs.
+        from zagg.grids.morton import RESOLUTION_EXACT
+
+        for enc in (None, "nested", "morton"):
+            assert self._grid(enc)._dggs_attrs()["dggs"]["resolution"] == RESOLUTION_EXACT
+
+    def test_morton_convention_constants_pinned(self):
+        # The self-declared convention identity (issue #305): the UUID is
+        # minted once and PERMANENT — this pin makes an accidental regeneration
+        # a test failure, not a silent identity change.
+        from zagg.grids.morton import MORTON_CONVENTION, RESOLUTION_EXACT, RESOLUTION_POINT
+
+        assert MORTON_CONVENTION["uuid"] == "3e22156d-ea9e-4e01-95fe-e3809a4b41e7"
+        assert MORTON_CONVENTION["name"] == "morton-dggs"
+        # Same entry shape as the zarr_conventions list already emitted by
+        # _dggs_attrs, so the PR-2 attrs flip can append it verbatim.
+        emitted = self._grid()._dggs_attrs()["zarr_conventions"][0]
+        assert set(MORTON_CONVENTION) == set(emitted)
+        # The normative home is the mortie spec page, not the design doc.
+        assert "espg/mortie" in MORTON_CONVENTION["spec_url"]
+        assert MORTON_CONVENTION["spec_url"].endswith("docs/specification.md")
+        assert (RESOLUTION_EXACT, RESOLUTION_POINT) == ("exact", "point")
+
     def test_spatial_signature_unchanged_by_encoding(self):
         # The encoding changes coordinate VALUES, not the spatial layout, so
         # shard maps stay reusable across the flag (#89).

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1037,6 +1037,21 @@ class TestCellIdsEncoding:
         for enc in (None, "nested", "morton"):
             assert self._grid(enc)._dggs_attrs()["dggs"]["resolution"] == RESOLUTION_EXACT
 
+    def test_dggs_attrs_reach_written_store(self):
+        # Round-trip past the return-value assertions above: the dggs block
+        # (incl. `resolution`) must survive spec()->emit_template->to_zarr and
+        # be readable off the WRITTEN group's attrs — that store path is what
+        # #305 readers key on.
+        from zagg.grids.morton import RESOLUTION_EXACT
+
+        g = self._grid()
+        store = MemoryStore()
+        g.emit_template(store)
+        attrs = open_group(store, path="8", mode="r").attrs
+        assert attrs["dggs"]["resolution"] == RESOLUTION_EXACT
+        assert isinstance(attrs["zarr_conventions"], list)
+        assert len(attrs["zarr_conventions"]) >= 1
+
     def test_morton_convention_constants_pinned(self):
         # The self-declared convention identity (issue #305): the UUID is
         # minted once and PERMANENT — this pin makes an accidental regeneration


### PR DESCRIPTION
Closes #305. Implements the spec half of #262 (D16): morton as a real, declared convention, per the espg-ratified rulings recorded on the issue thread ([O10 ruling record](https://github.com/englacial/zagg/issues/305#issuecomment-5025784723), [acceptance criterion](https://github.com/englacial/zagg/issues/305#issuecomment-5025141183)).

## What this does

1. **mortie spec page (cross-repo)** — [espg/mortie PR #118](https://github.com/espg/mortie/pull/118) (mortie#62) drafts `docs/specification.md`, the normative v1.0 conventions page: bit layout, resolution/Δ table (drift-pinned against `order2res`), decimal grammar + order-29 point/area parse non-injectivity, the `resolution: "exact" | "point"` discriminator and the 29→24 clip rule (`point`-only), the dggs convention block (`name: "morton"`, `coordinate: "morton"`, self-declared UUID), the morton-hive `/1`–`/3` grammars (windowed leaves, the ratified `all` token, `/3` sidecar names, product-name grammar with base-component exclusion), and the coverage-bitmap/root-MOC contracts (zstd level non-normative). espg sign-off on that page is decision 3 of this issue.
2. **zagg conventions surface** (`src/zagg/grids/morton.py`, `src/zagg/grids/healpix.py`):
   - `MORTON_CONVENTION` — the self-declared `zarr_conventions` entry with the **permanent** UUID `3e22156d-ea9e-4e01-95fe-e3809a4b41e7` (minted once; pinned by test so accidental regeneration fails loudly), name `morton-dggs`, spec/schema URLs pointing at the mortie page. The upstream dggs-registry ask (#72 ask 3) proceeds in parallel; `zarr_conventions` is a list so both entries later coexist.
   - `RESOLUTION_EXACT` / `RESOLUTION_POINT` — the O10 discriminator constants, importable where the temporal/point paths will need `point` later (the seam; no speculative point-writer implementation).
   - `HealpixGrid._dggs_attrs` now emits `resolution: "exact"` in the `dggs` block — grid-derived cell coordinates are exact **by construction**, under every `cell_ids_encoding`.
   - The attrs **flip** to `name: "morton"` / `coordinate: "morton"` + the convention entry is deliberately NOT here — that is #304's phase 1 (the writer-flip PR, based on this branch).
3. **Design-doc update** (`docs/design/sparse_coverage.md`): O10 marked RESOLVED with the ruling + permalink; normative grammar/constant references throughout (§2, §3, D13, D16, D19, D23, O8) now cite the mortie spec page as the normative home — completing the acceptance criterion that zero normative constants live only in the design doc.

## Phases

- [x] Phase 1 — conventions constants + `resolution` attrs wiring + tests (`src/zagg/grids/morton.py`, `src/zagg/grids/healpix.py`, `tests/test_grids.py`)
- [x] Phase 2 — design-doc update (O10 RESOLVED, normative citations to the mortie page)
- [x] Cross-repo — mortie spec page draft: espg/mortie PR #118 (tracked there; espg sign-off = decision 3)

## Testing

- New tests in `tests/test_grids.py` (`TestCellIdsEncoding`): `resolution: "exact"` emitted under every encoding; `MORTON_CONVENTION` UUID/name/URL pinned; entry shape matches the emitted `zarr_conventions` entries so #304 can append it verbatim.
- `ruff check` / `ruff format --check` clean on touched files; full `pytest` run locally (results noted below).
- Pre-existing, unrelated: `ruff check src tests` on main currently flags `N818` in `src/zagg/registry.py` (`UnknownCapability`) — not touched here, flagged per §4.

## Questions for review

1. Convention entry `name: "morton-dggs"` and description "Packed-u64 morton (HEALPix) DGGS convention" — naming taste check (the UUID, not the name, is the identity key).
2. The `resolution` field is emitted for **nested**-encoded stores too (the dggs block is present either way, and NESTED grid cells are equally exact-by-construction). Confirm that's wanted vs morton-declared stores only.
