### PR TITLE
Morton-only writer flip: stop writing cell_ids (issue #304)

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -92,8 +92,9 @@ Target coverage: ~1,300 cells covering Antarctic grounded ice drainage basins (e
 │                                                      │             │
 │ Shape:  12 × 4^child_order  (786,432 cells at O12)   │             │
 │ Chunks: 4^(child - parent)  (4,096 cells at O12-O6)  │             │
-│ Arrays: cell_ids, morton, count, h_min, h_max,       │             │
+│ Arrays: morton, count, h_min, h_max,                 │             │
 │         h_mean, h_sigma, h_variance, h_q25-75        │             │
+│ (cell_ids only under emit_cell_ids — issue #304)     │             │
 │                                                      │             │
 │ Written to: s3://bucket/prefix/12/                   │             │
 └──────────────────────────┬───────────────────────────┘             │
@@ -155,8 +156,8 @@ Target coverage: ~1,300 cells covering Antarctic grounded ice drainage basins (e
 │ │  │  └───────────────────────────────────────────────┘   │
 │ │  │       │                                              │
 │ │  │       ▼                                              │
-│ │  │  mort2healpix(children) → cell_ids                   │
-│ │  │  Assemble output DataFrame (11 columns × 4,096 rows) │
+│ │  │  Assemble output DataFrame (morton + data vars;      │
+│ │  │  NESTED cell_ids derived at read — issue #304)       │
 │ │  └──────────────────────────┬───────────────────────────┘
 │ │                             │
 │ │                             ▼
@@ -183,8 +184,7 @@ Target coverage: ~1,300 cells covering Antarctic grounded ice drainage basins (e
 │ Output Zarr store:                                   │
 │   s3://bucket/prefix/                                │
 │   └── 12/                                            │
-│       ├── cell_ids   (uint64, fill=0)                │
-│       ├── morton     (int64,  fill=0)                │
+│       ├── morton     (uint64, fill=0)                │
 │       ├── count      (int32,  fill=0)                │
 │       ├── h_min      (float32, fill=NaN)             │
 │       ├── h_max      (float32, fill=NaN)             │

--- a/docs/design/generalized_grids.md
+++ b/docs/design/generalized_grids.md
@@ -292,7 +292,7 @@ The generalization is straightforward: each `OutputGrid` implementation owns its
 
 | Grid | Array shape | Chunk shape | Coord arrays | Metadata conformance |
 |---|---|---|---|---|
-| HealpixGrid | `(12 · 4^child_order,)` | `4^(child − shard)` | `cell_ids` (uint64), `morton` (int64) | **xdggs** (unchanged) |
+| HealpixGrid | `(12 · 4^child_order,)` | `4^(child − shard)` | `morton` (uint64); `cell_ids` (uint64) hatch-only (issue #304) | **xdggs** (unchanged) |
 | H3Grid | `(n_cells_at_resolution,)` | `≈ 7^Δ` padded | `h3_index` (uint64) | **xdggs** (H3 variant) |
 | S2Grid | `(n_cells_at_resolution,)` | `≈ 4^Δ` | `s2_cell_id` (uint64) | **xdggs** (S2 variant) |
 | RectilinearGrid | `(height, width)` 2D | user-specified, typically `(256, 256)` | `x`, `y` + `crs` attr | **CF + GeoZarr** |

--- a/docs/design/schema.md
+++ b/docs/design/schema.md
@@ -67,8 +67,8 @@ Everything else --- the Zarr template, `calculate_cell_statistics`, and `process
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `cell_ids` | uint64 | HEALPix cell ID at child order |
-| `morton` | int64 | Morton index at child order |
+| `morton` | uint64 | Morton index at child order (default coordinate) |
+| `cell_ids` | uint64 | HEALPix NESTED cell ID at child order (hatch-only, issue #304) |
 | `count` | int32 | Number of observations |
 | `h_mean` | float32 | Inverse-variance weighted mean elevation |
 | `h_sigma` | float32 | Uncertainty of weighted mean |

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -4,10 +4,13 @@
 temporal-partitioning amendments (D13–D15) ratified on
 [#237](https://github.com/englacial/zagg/issues/237); morton-only-storage
 amendment ratified on
-[#262](https://github.com/englacial/zagg/issues/262) (D16; open item O10
-carved from it); 2026-07 consolidation (D17–D24; O3/O11 resolved, O8
+[#262](https://github.com/englacial/zagg/issues/262) (D16; O10 carved from
+it, resolved via [#305](https://github.com/englacial/zagg/issues/305));
+2026-07 consolidation (D17–D24; O3/O10/O11 resolved, O8
 constants blessed, O12–O14 opened, D23 tokens ratified, §8.3
-test-obligations index added)
+test-obligations index added; normative grammars/constants relocated to the
+[mortie spec page](https://github.com/espg/mortie/blob/main/docs/specification.md)
+per the #305 acceptance criterion)
 recording decisions settled on the
 [#251](https://github.com/englacial/zagg/issues/251)/[#236](https://github.com/englacial/zagg/issues/236)/[#209](https://github.com/englacial/zagg/issues/209)
 and [#296](https://github.com/englacial/zagg/issues/296)-family threads —
@@ -54,7 +57,11 @@ artifacts.
 
 The layout convention is **owned by the mortie spec** (the frozen 1.x
 contract: [mortie #48](https://github.com/espg/mortie/issues/48) discussion →
-[mortie #62](https://github.com/espg/mortie/issues/62) spec page). Summary of
+[mortie #62](https://github.com/espg/mortie/issues/62) →
+[`docs/specification.md`](https://github.com/espg/mortie/blob/main/docs/specification.md),
+the normative page). Grammars and constants are normative **there only**;
+this registry records decisions and rationale and cites the page (the #305
+acceptance criterion — duplicated normative text drifts). Summary of
 what zagg consumes:
 
 ```
@@ -224,7 +231,9 @@ again during a run. Contents:
   `quarterly` grammar-reserved), and the append policy. Label grammar and
   boundary semantics (UTC calendar terms, half-open `[start, end)`,
   lexicographic = chronological) are frozen on the
-  [mortie spec page](https://github.com/espg/mortie/issues/62#issuecomment-4986809092).
+  [mortie spec page §6.3](https://github.com/espg/mortie/blob/main/docs/specification.md)
+  (consolidated there from the
+  [original #62 thread record](https://github.com/espg/mortie/issues/62#issuecomment-4986809092)).
   Generative schedules keep the manifest
   write-once and static as data accrues: appending a new year to a
   `yearly` store adds leaves the schedule already describes — no manifest
@@ -519,8 +528,10 @@ rollup leaves all leaf reads intact.
   per-year 88S runs, seasonal subsets, and append-as-acquired are all
   window leaves under the same convention. Leaf naming is **frozen**:
   `{full_id}_{window}.zarr`, underscore separator, split on the first `_`
-  — grammar and boundary semantics recorded on the
-  [mortie spec page](https://github.com/espg/mortie/issues/62#issuecomment-4986809092)
+  — grammar and boundary semantics normative on the
+  [mortie spec page §6.3](https://github.com/espg/mortie/blob/main/docs/specification.md)
+  (originally recorded on the
+  [#62 thread](https://github.com/espg/mortie/issues/62#issuecomment-4986809092))
   as part of `morton-hive/2`. (Unchanged by D19 — leaf naming survives the
   product-root design intact. *Naming revised by D23 for `morton-hive/3`*:
   the basename becomes the window alone; the `/2` grammar stays frozen for
@@ -579,7 +590,8 @@ rollup leaves all leaf reads intact.
   (An earlier plan bundled the flip with a #299 leaf-basename rename;
   D19's product-root revision made #299 additive, so this writer flip is
   the one remaining breaking store change in this family.) The order-29
-  discriminator metadata is O10.
+  discriminator metadata is O10 (resolved: `resolution: "exact" | "point"`,
+  clip rule `point`-only — see the O10 entry).
 
 - **D17 — Hive+sharded is the HEALPix default; flat/fullsphere deprecated;
   dense leaf arrays write through the ShardingCodec.**
@@ -688,8 +700,9 @@ rollup leaves all leaf reads intact.
   ergonomics (the full digest is what is compared; a short fingerprint —
   12 hex — is the display/CLI shorthand); and product names are
   **URL-safe by requirement** (they appear in gridlook deep-links and web
-  paths — proposed charset: lowercase alphanumerics plus `-`/`_`, frozen
-  with the name grammar on the mortie spec page).
+  paths — charset lowercase alphanumerics plus `-`/`_`, with the
+  base-component exclusion; the grammar is normative on the
+  [mortie spec page §6.5](https://github.com/espg/mortie/blob/main/docs/specification.md)).
 - **D20 — Per-shard telemetry sidecar + run records** (espg on-thread:
   [sibling placement + envelope ride](https://github.com/englacial/zagg/issues/297#issuecomment-5016910923),
   [caller identity](https://github.com/englacial/zagg/issues/297#issuecomment-5016901381);
@@ -765,8 +778,9 @@ rollup leaves all leaf reads intact.
   actually ask. Spec bump to `morton-hive/3` under D6 versioning: `/1`
   and `/2` stores remain valid forever under their frozen grammars;
   readers discriminate by the manifest `spec` string; the `/3` grammar is
-  to be re-frozen on the mortie spec page
-  ([mortie#62](https://github.com/espg/mortie/issues/62)). Costs accepted
+  frozen on the
+  [mortie spec page §6.4](https://github.com/espg/mortie/blob/main/docs/specification.md)
+  (mortie#62, drafted via espg/mortie PR #118). Costs accepted
   with the decision: the name==path self-check moves to the stamp attrs /
   D20 sidecar `shard_key` (an fsck pays one GET per leaf); D3's
   "unambiguous if moved" softens to "recoverable from attrs" — the moved
@@ -888,13 +902,15 @@ rollup leaves all leaf reads intact.
   Stamp attrs carry only the tier-0 box + the bitmap's order + pointer +
   byte sizes; pad sentinel is JSON null; the envelope gains an
   `encoding: "ranges" | "bitmap"` discriminator (later extended by D14 to add
-  a third value, `"full"`). Bit convention (frozen
-  with the mortie spec, golden-vector-pinned on PR #208): bit i = the i-th
+  a third value, `"full"`). Bit convention (normative on the
+  [mortie spec page §7](https://github.com/espg/mortie/blob/main/docs/specification.md),
+  golden-vector-pinned on PR #208): bit i = the i-th
   shard-subtree cell in ascending packed-word order (base-4 D1 digit tail,
   digits 1..4 → 0..3), MSB-first per byte. *Addendum (espg-blessed
   in-session, 2026-07-20 — closing the #276 item-5 flag)*: the PR #208
   contract constants stand as-shipped — the bitmap bit convention and the
-  root-MOC range ordering are **contract** (both golden-vector-pinned);
+  root-MOC range ordering are **contract** (both golden-vector-pinned;
+  spec page §7.2–§7.3);
   zstd level 3 is **non-normative** (any zstd level decodes identically;
   only "zstd stream" is contract).
 - **O9 — end-of-run root MOC default**: **RESOLVED — on** for hive stores
@@ -904,16 +920,36 @@ rollup leaves all leaf reads intact.
   true rejected elsewhere). The write is fail-open on both backends; the
   Lambda leg is one fire-and-forget `mode: "coverage"` Event invoke with the
   pre-serialized ranges envelope.
-- **O10 — order-29 resolution discriminator** (carved from D16): two
-  order-29 encodings exist — (a) genuinely order-29 resolution, and (b)
-  unknown resolution point-encoded at order 29, the default for any raw
-  lat/lon conversion and expected to be common. Readers need declared
-  metadata to tell them apart, because the D16 clip rule (29→24) applies
-  only to (b). Proposal: `resolution: "exact" | "point"` in the dggs attrs
-  block, defaulting to `"point"` for raw conversions. Intersects mortie's
-  documented point-id/area-word parse non-injectivity at order 29; field
-  name, values, and placement to be frozen with the mortie spec page
-  ([mortie#62](https://github.com/espg/mortie/issues/62)).
+- **O10 — order-29 resolution discriminator: RESOLVED — `resolution:
+  "exact" | "point"` in the dggs attrs block** (espg-ratified in-session,
+  2026-07-21; carved from D16; ruling recorded on
+  [#305](https://github.com/englacial/zagg/issues/305#issuecomment-5025784723)).
+  Two order-29 encodings exist — (a) genuinely order-29 resolution, and
+  (b) unknown resolution point-encoded at order 29, the default for any
+  raw lat/lon conversion — and readers need declared metadata to tell
+  them apart, because the D16 clip rule (29→24) applies only to (b).
+  Ruling: emission is **per data kind and the writer always knows
+  which** — grid-derived cell coordinates are `exact` **by construction**
+  (all zagg aggregation outputs); location-derived id fields (order-29
+  ids from raw lat/lon — the temporal event path, future HHDC) are
+  `point`. There is **no heuristic default**: the issue-body's "default
+  `point` for raw conversions" was refined away — a writer either
+  produces grid cells (`exact`) or converts raw coordinates (`point`),
+  never guesses. The clip rule keys only on the declared field.
+  Intersects mortie's documented point-id/area-word parse non-injectivity
+  at order 29; field name, values, placement, and the clip rule's
+  point-only scope are frozen normatively on the
+  [mortie spec page §4–§5](https://github.com/espg/mortie/blob/main/docs/specification.md)
+  (mortie#62, drafted via espg/mortie PR #118). Implementation:
+  `RESOLUTION_EXACT`/`RESOLUTION_POINT` in `zagg.grids.morton` (the
+  importable seam for future `point` writers) and the `resolution` field
+  in `HealpixGrid._dggs_attrs`. The companion identity ruling (same
+  session): morton-declared stores carry a **self-declared convention
+  UUID** — minted once, permanent, normative value on the mortie spec
+  page §5 (`MORTON_CONVENTION` in `zagg.grids.morton`) — while the
+  upstream dggs-registry ask
+  ([#72](https://github.com/englacial/zagg/issues/72) ask 3) proceeds in
+  parallel; the conventions attrs are a list, so both entries coexist.
 - **O11 — logical content hash of outputs: RESOLVED — adopted as
   proposed** (espg-ratified in-session, 2026-07-20; carved from D19,
   discussion trail on

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -590,8 +590,9 @@ rollup leaves all leaf reads intact.
   (An earlier plan bundled the flip with a #299 leaf-basename rename;
   D19's product-root revision made #299 additive, so this writer flip is
   the one remaining breaking store change in this family.) The order-29
-  discriminator metadata is O10 (resolved: `resolution: "exact" | "point"`,
-  clip rule `point`-only — see the O10 entry).
+  discriminator metadata is O10 (final ruling: kind is encoding-carried,
+  no metadata field; the clip is a viewer-side transient cast — see the
+  O10 entry).
 
 - **D17 — Hive+sharded is the HEALPix default; flat/fullsphere deprecated;
   dense leaf arrays write through the ShardingCodec.**
@@ -920,36 +921,28 @@ rollup leaves all leaf reads intact.
   true rejected elsewhere). The write is fail-open on both backends; the
   Lambda leg is one fire-and-forget `mode: "coverage"` Event invoke with the
   pre-serialized ranges envelope.
-- **O10 — order-29 resolution discriminator: RESOLVED — `resolution:
-  "exact" | "point"` in the dggs attrs block** (espg-ratified in-session,
-  2026-07-21; carved from D16; ruling recorded on
-  [#305](https://github.com/englacial/zagg/issues/305#issuecomment-5025784723)).
-  Two order-29 encodings exist — (a) genuinely order-29 resolution, and
-  (b) unknown resolution point-encoded at order 29, the default for any
-  raw lat/lon conversion — and readers need declared metadata to tell
-  them apart, because the D16 clip rule (29→24) applies only to (b).
-  Ruling: emission is **per data kind and the writer always knows
-  which** — grid-derived cell coordinates are `exact` **by construction**
-  (all zagg aggregation outputs); location-derived id fields (order-29
-  ids from raw lat/lon — the temporal event path, future HHDC) are
-  `point`. There is **no heuristic default**: the issue-body's "default
-  `point` for raw conversions" was refined away — a writer either
-  produces grid cells (`exact`) or converts raw coordinates (`point`),
-  never guesses. The clip rule keys only on the declared field.
-  *Addendum (espg-proposed on the mortie PR #118 review, 2026-07-21)*: a
-  third value **`mixed`** — order-29 ids are points, ids at any other
-  order are exact (per-id recovery via the reserved order 29); the 29→24
-  clip rule is inapplicable to `mixed` arrays, and genuinely-exact
-  order-29 cells are unrepresentable under it (declare `exact`).
-  Intersects mortie's documented point-id/area-word parse non-injectivity
-  at order 29; field name, values, placement, and the clip rule's
-  point-only scope are frozen normatively on the
-  [mortie spec page §4–§5](https://github.com/espg/mortie/blob/main/docs/specification.md)
-  (mortie#62, drafted via espg/mortie PR #118). Implementation:
-  `RESOLUTION_EXACT`/`RESOLUTION_POINT` in `zagg.grids.morton` (the
-  importable seam for future `point` writers) and the `resolution` field
-  in `HealpixGrid._dggs_attrs`. The companion identity ruling (same
-  session): morton-declared stores carry a **self-declared convention
+- **O10 — order-29 kind: RESOLVED by encoding-carried convention**
+  (espg-ratified 2026-07-21 on the mortie PR #118 review — the FINAL
+  ruling, superseding this entry's earlier declaration-based forms:
+  `resolution: "exact" | "point"`, recorded on
+  [#305](https://github.com/englacial/zagg/issues/305#issuecomment-5025784723),
+  and the interim three-value `mixed` addendum). **Point-ness is carried
+  by the encoding itself, never by store or array metadata**: mortie's
+  area words and point ids are distinct encodings — area words are exact
+  cells at EVERY order including 29 (nothing unrepresentable); point ids
+  are points, full stop. There is **no metadata field**; readers key on
+  the packed word's suffix region. The 29→24 clip is **not spec
+  semantics** — it is a viewer-side *transient cast* (a gridlook/JS
+  float64-safety measure at the display layer; other viewers or future
+  runtimes may not need it), and membership of a point in a coarser cell
+  is likewise the ordinary transient truncation. The one remaining
+  ambiguity — the order-29 decimal string, which denotes both kinds — is
+  resolved by the normative parse tie-break **pinned on the
+  [mortie spec page §4](https://github.com/espg/mortie/blob/main/docs/specification.md)**
+  (a parsed string always yields the AREA word; golden-pinned at the bit
+  level in mortie's `test_spec_page.py`). zagg emits no kind field and
+  carries no kind constants. The companion identity ruling stands
+  unchanged: morton-declared stores carry a **self-declared convention
   UUID** — minted once, permanent, normative value on the mortie spec
   page §5 (`MORTON_CONVENTION` in `zagg.grids.morton`) — while the
   upstream dggs-registry ask

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -936,6 +936,11 @@ rollup leaves all leaf reads intact.
   `point` for raw conversions" was refined away — a writer either
   produces grid cells (`exact`) or converts raw coordinates (`point`),
   never guesses. The clip rule keys only on the declared field.
+  *Addendum (espg-proposed on the mortie PR #118 review, 2026-07-21)*: a
+  third value **`mixed`** — order-29 ids are points, ids at any other
+  order are exact (per-id recovery via the reserved order 29); the 29→24
+  clip rule is inapplicable to `mixed` arrays, and genuinely-exact
+  order-29 cells are unrepresentable under it (declare `exact`).
   Intersects mortie's documented point-id/area-word parse non-injectivity
   at order 29; field name, values, placement, and the clip rule's
   point-only scope are frozen normatively on the

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -354,7 +354,9 @@ refresh builds it.
 Raster (pull-NN) pipelines write the same tree with **windowed `(time, cells)`
 leaves**: one vanilla zarr v3 leaf per **(shard, window)** unit at
 `shard_leaf_path(root, shard, window=label)`, each carrying leaf-local `time`
-(int64 microseconds, CF attrs) and `cell_ids` coords plus one
+(int64 microseconds, CF attrs) and `morton` (packed u64 words) as the sole cell
+coordinate — `cell_ids` (NESTED) rides only the `emit_cell_ids` transition hatch
+(issue #304) — plus one
 `(T_leaf, cells_per_shard)` array per configured band, chunked
 `(1, cells_per_chunk)`. The leaf's time axis is the unit's **own acquisition
 groups** — known at dispatch from the catalog, so both dispatchers produce

--- a/docs/morton_arrow.md
+++ b/docs/morton_arrow.md
@@ -36,12 +36,19 @@ PyCapsule surface speak the Arrow C Data Interface directly (pyarrow stays in
 the off-Lambda `catalog` extra). Arrow nulls map to mortie's all-zero empty
 sentinel word in both directions, so missing values round-trip.
 
-## `cell_ids` encoding
+## `cell_ids`: morton-only storage (D16)
 
-`cell_ids` stays the standardized **NESTED HEALPix** id (`uint64`) by default.
-For test and prototyping flows, `output.grid.cell_ids_encoding: morton` emits
-the packed morton words as `cell_ids` instead (HEALPix grids only; the store's
-`dggs.indexing_scheme` attribute records the active encoding):
+Since the issue #304 flip, **`morton` is the only stored cell coordinate**:
+the packed `uint64` words carry the cell identity (and its order,
+intrinsically), the store's `dggs` attrs declare grid `name: "morton"` +
+`coordinate: "morton"`, and NESTED HEALPix ids are **derived at read** (the
+moczarr fabrication layer). The issue #135 `cell_ids_encoding` knob is
+retired — a config still carrying it fails validation with a migration
+pointer.
+
+For transition stores (browser-direct demos until the gridlook morton decode
+lands), the escape hatch keeps writing the legacy NESTED array *in addition
+to* `morton`:
 
 ```yaml
 output:
@@ -49,17 +56,16 @@ output:
     type: healpix
     parent_order: 6
     child_order: 12
-    cell_ids_encoding: morton   # default: nested
+    emit_cell_ids: true   # default: false — morton only
 ```
 
-The default (key absent or `nested`) is byte-identical to a pre-flag run.
-
-Note the grid's `spatial_signature()` (recorded in ShardMap manifests) stays
-`nested` regardless of the flag — deliberately, so shard maps remain reusable
-across encodings: the flag changes coordinate *values*, not the spatial layout.
-Only the store's `dggs.indexing_scheme` attribute tracks the active encoding.
-(The pre-existing `output.grid.indexing_scheme` config key is descriptive only
-and must stay `nested`; `cell_ids_encoding` is the knob.)
+A hatch store's declared coordinate stays `morton`; `cell_ids` is an extra
+legacy member. The grid's `spatial_signature()` (recorded in ShardMap
+manifests) is unchanged by the hatch — deliberately, so shard maps remain
+reusable — while the full `signature()` records `emit_cell_ids` (the hatch
+changes the leaf schema, so mixed states never co-aggregate). (The
+pre-existing `output.grid.indexing_scheme` config key is descriptive only and
+must stay `nested`.)
 
 ## Shardmap parquet manifests
 

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -294,26 +294,23 @@ def validate_config(config: PipelineConfig) -> None:
                 f"output.grid.layout must be 'fullsphere' (got {layout!r}; "
                 "the deprecated 'dense' layout was removed — issue #88)"
             )
-        # Optional cell_ids encoding (issue #135): "nested" (default, the DGGS
-        # standard) or "morton" (emit the packed morton words as cell_ids — a
-        # test/prototype capability). HEALPix-only: rectilinear grids have no
-        # cell_ids coordinate, so the knob would silently do nothing there.
-        encoding = grid.get("cell_ids_encoding")
-        if encoding is not None:
-            if encoding not in ("nested", "morton"):
-                raise ValueError(
-                    f"output.grid.cell_ids_encoding must be 'nested' or 'morton' (got {encoding!r})"
-                )
-            if grid["type"] != "healpix":
-                raise ValueError(
-                    "output.grid.cell_ids_encoding only applies to healpix grids "
-                    f"(grid type is {grid['type']!r})"
-                )
-        # Transition escape hatch (issue #304 phase 2): emit the legacy
+        # The issue #135 knob is retired (issue #304 phase 3, D16 — #135
+        # inverts): morton is the stored cell coordinate and NESTED ids are
+        # DERIVED at read (moczarr fabrication). A config still carrying the
+        # key gets a pointed error, never a silent ignore.
+        if grid.get("cell_ids_encoding") is not None:
+            raise ValueError(
+                "output.grid.cell_ids_encoding was retired (issue #304): morton is "
+                "the stored cell coordinate and NESTED ids are derived at read; "
+                "to keep writing the legacy NESTED cell_ids array for transition "
+                "stores set output.grid.emit_cell_ids: true"
+            )
+        # Transition escape hatch (issue #304 phase 2): emit the legacy NESTED
         # cell_ids array ALONGSIDE the morton coordinate. Default off — morton
         # is the only stored cell coordinate (D16); the hatch exists for
         # transition stores (browser-direct demos) until the gridlook morton
-        # path lands. HEALPix-only for the same reason as cell_ids_encoding.
+        # path lands. HEALPix-only: rectilinear grids have no cell_ids
+        # coordinate, so the flag would silently do nothing there.
         emit = grid.get("emit_cell_ids")
         if emit is not None:
             if not isinstance(emit, bool):
@@ -324,15 +321,14 @@ def validate_config(config: PipelineConfig) -> None:
                     f"(grid type is {grid['type']!r})"
                 )
         # The legacy output.grid.indexing_scheme key is descriptive only (the
-        # shipped configs carry "nested"); it does NOT select the cell_ids
-        # encoding. Reject any other value so a user reaching for it lands on the
-        # real knob instead of a silently-NESTED store.
+        # shipped configs carry "nested"); it never selected an encoding.
+        # Reject any other value so a user reaching for it fails loudly.
         legacy_scheme = grid.get("indexing_scheme")
         if legacy_scheme is not None and legacy_scheme != "nested":
             raise ValueError(
                 f"output.grid.indexing_scheme is descriptive and must be 'nested' "
-                f"(got {legacy_scheme!r}); to emit morton words as cell_ids set "
-                f"output.grid.cell_ids_encoding: morton"
+                f"(got {legacy_scheme!r}); the store's declared coordinate is morton "
+                f"(D16 — issue #304)"
             )
 
     # Validate the optional per-cell carrier (issue #132). Mirrors the worker's
@@ -2059,29 +2055,6 @@ def get_sharded(config: PipelineConfig, default: bool = False) -> bool:
     not cost the ~K-fold object blow-up).
     """
     return bool(config.output.get("grid", {}).get("sharded", default))
-
-
-def get_cell_ids_encoding(config: PipelineConfig) -> str:
-    """Return the HEALPix ``cell_ids`` coordinate encoding (issue #135).
-
-    ``"nested"`` (default) stores the standardized NESTED HEALPix cell IDs.
-    ``"morton"`` stores the packed morton words instead — the same ``uint64``
-    words the ``morton`` coordinate carries — opening test/prototype flows that
-    index by morton directly. Default behavior (key absent, explicit ``null``,
-    or ``"nested"``) is byte-identical to a pre-flag run.
-
-    Parameters
-    ----------
-    config : PipelineConfig
-
-    Returns
-    -------
-    str
-        ``"nested"`` (default) or ``"morton"``.
-    """
-    # A present-but-null key (YAML ``cell_ids_encoding:``) must fall back to the
-    # default too — the same treatment ``from_config`` gives a null ``layout``.
-    return config.output.get("grid", {}).get("cell_ids_encoding") or "nested"
 
 
 def get_emit_cell_ids(config: PipelineConfig) -> bool:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -309,6 +309,20 @@ def validate_config(config: PipelineConfig) -> None:
                     "output.grid.cell_ids_encoding only applies to healpix grids "
                     f"(grid type is {grid['type']!r})"
                 )
+        # Transition escape hatch (issue #304 phase 2): emit the legacy
+        # cell_ids array ALONGSIDE the morton coordinate. Default off — morton
+        # is the only stored cell coordinate (D16); the hatch exists for
+        # transition stores (browser-direct demos) until the gridlook morton
+        # path lands. HEALPix-only for the same reason as cell_ids_encoding.
+        emit = grid.get("emit_cell_ids")
+        if emit is not None:
+            if not isinstance(emit, bool):
+                raise ValueError(f"output.grid.emit_cell_ids must be a boolean (got {emit!r})")
+            if emit and grid["type"] != "healpix":
+                raise ValueError(
+                    "output.grid.emit_cell_ids only applies to healpix grids "
+                    f"(grid type is {grid['type']!r})"
+                )
         # The legacy output.grid.indexing_scheme key is descriptive only (the
         # shipped configs carry "nested"); it does NOT select the cell_ids
         # encoding. Reject any other value so a user reaching for it lands on the
@@ -2068,6 +2082,19 @@ def get_cell_ids_encoding(config: PipelineConfig) -> str:
     # A present-but-null key (YAML ``cell_ids_encoding:``) must fall back to the
     # default too — the same treatment ``from_config`` gives a null ``layout``.
     return config.output.get("grid", {}).get("cell_ids_encoding") or "nested"
+
+
+def get_emit_cell_ids(config: PipelineConfig) -> bool:
+    """Whether to keep writing the legacy ``cell_ids`` array (issue #304).
+
+    Default ``False`` (the D16 flip): ``morton`` is the only stored cell
+    coordinate; NESTED ids are derived at read (moczarr fabrication). ``True``
+    is the transition escape hatch — the ``cell_ids`` array is written in
+    ADDITION to ``morton`` (values per ``cell_ids_encoding``) so legacy
+    browser-direct consumers keep working until the gridlook morton decode
+    lands; the dggs attrs are unaffected by the hatch.
+    """
+    return bool(config.output.get("grid", {}).get("emit_cell_ids", False))
 
 
 def get_store_path(config: PipelineConfig) -> str | None:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -2063,7 +2063,7 @@ def get_emit_cell_ids(config: PipelineConfig) -> bool:
     Default ``False`` (the D16 flip): ``morton`` is the only stored cell
     coordinate; NESTED ids are derived at read (moczarr fabrication). ``True``
     is the transition escape hatch — the ``cell_ids`` array is written in
-    ADDITION to ``morton`` (values per ``cell_ids_encoding``) so legacy
+    ADDITION to ``morton`` (holding the NESTED encode) so legacy
     browser-direct consumers keep working until the gridlook morton decode
     lands; the dggs attrs are unaffected by the hatch.
     """

--- a/src/zagg/configs/atl03_gain_bias_healpix.yaml
+++ b/src/zagg/configs/atl03_gain_bias_healpix.yaml
@@ -69,9 +69,6 @@ data_source:
 
 aggregation:
   coordinates:
-    cell_ids:
-      dtype: uint64
-      fill_value: 0
     morton:
       dtype: uint64
       fill_value: 0

--- a/src/zagg/configs/atl03_tdigest_healpix.yaml
+++ b/src/zagg/configs/atl03_tdigest_healpix.yaml
@@ -56,9 +56,6 @@ data_source:
 
 aggregation:
   coordinates:
-    cell_ids:
-      dtype: uint64
-      fill_value: 0
     morton:
       dtype: uint64
       fill_value: 0

--- a/src/zagg/configs/atl03_tdigest_located_healpix.yaml
+++ b/src/zagg/configs/atl03_tdigest_located_healpix.yaml
@@ -47,9 +47,6 @@ data_source:
 
 aggregation:
   coordinates:
-    cell_ids:
-      dtype: uint64
-      fill_value: 0
     morton:
       dtype: uint64
       fill_value: 0

--- a/src/zagg/configs/atl06.yaml
+++ b/src/zagg/configs/atl06.yaml
@@ -19,9 +19,6 @@ aggregation:
   # A nullable/sparse source should set "pandas" (see atl06_nullable.yaml).
   handoff: arrow
   coordinates:
-    cell_ids:
-      dtype: uint64
-      fill_value: 0
     morton:
       dtype: uint64
       fill_value: 0

--- a/src/zagg/configs/atl06_nullable.yaml
+++ b/src/zagg/configs/atl06_nullable.yaml
@@ -22,9 +22,6 @@ aggregation:
   # Nullable source -> pandas carrier (arrow's null_cols guard would raise).
   handoff: pandas
   coordinates:
-    cell_ids:
-      dtype: uint64
-      fill_value: 0
     morton:
       dtype: uint64
       fill_value: 0

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -14,7 +14,6 @@ from zagg.config import (
     default_config,
     get_agg_fields,
     get_aoi_mask,
-    get_cell_ids_encoding,
     get_emit_cell_ids,
     get_output_signature,
     output_field_signature,
@@ -121,20 +120,6 @@ class HealpixGrid:
         self.sharded = bool(sharded)
         self.layout = layout
         self.config = config or default_config("atl06")
-        # cell_ids coordinate encoding (issue #135): "nested" (default, the DGGS
-        # standard) or "morton" (emit the packed morton words as cell_ids — a
-        # test/prototype capability). Default is byte-identical to a pre-flag run.
-        # Re-validated here (not only in validate_config) because both coords_of
-        # (which interprets this string for the hatch's cell_ids VALUES) and
-        # _dggs_attrs (which keys the morton-declared block on it) consume it: an
-        # unvalidated third value would write NESTED values while declaring a
-        # different block — a mis-decode for consumers.
-        self.cell_ids_encoding = get_cell_ids_encoding(self.config)
-        if self.cell_ids_encoding not in ("nested", "morton"):
-            raise ValueError(
-                f"Unknown cell_ids_encoding: {self.cell_ids_encoding!r} "
-                "(expected 'nested' or 'morton')"
-            )
         # D16 default flip (issue #304 phase 2): the legacy cell_ids array is
         # written only under the explicit transition hatch; morton is the one
         # stored cell coordinate. Both the template member (_group_spec) and
@@ -416,8 +401,8 @@ class HealpixGrid:
         it is stored as ``uint64`` on disk via :mod:`zagg.grids.morton` and is
         the ONLY cell coordinate written by default (D16, issue #304). The
         ``output.grid.emit_cell_ids: true`` transition hatch adds the legacy
-        ``cell_ids`` array — NESTED ``uint64``, or the packed morton words under
-        ``cell_ids_encoding: morton`` (issue #135).
+        NESTED ``uint64`` ``cell_ids`` array (the issue #135 encoding knob was
+        retired in issue #304 phase 3 — morton stored, NESTED derived).
         """
         return self.coords_of(self.children(shard_key))
 
@@ -432,10 +417,7 @@ class HealpixGrid:
         children = np.asarray(children)
         coords: dict = {"morton": to_morton_array(children)}
         if self.emit_cell_ids:
-            if self.cell_ids_encoding == "morton":
-                coords["cell_ids"] = np.asarray(children, dtype=np.uint64)
-            else:
-                coords["cell_ids"] = self.encode_cell_ids(children)
+            coords["cell_ids"] = self.encode_cell_ids(children)
         return coords
 
     # ── identity / nesting ───────────────────────────────────────────────
@@ -460,18 +442,16 @@ class HealpixGrid:
         """Canonical fingerprint of the grid's defining parameters.
 
         The full fingerprint: the spatial layout (:meth:`spatial_signature`)
-        plus the Option-B output-field set and the ``cell_ids_encoding``
-        (issue #135 — mixed encodings must never co-aggregate; ``nests_with``
-        keys on both). The shard-map reuse guard keys on the spatial part
-        only (#89).
+        plus the Option-B output-field set and the ``emit_cell_ids`` hatch
+        state (issue #304 — the hatch changes the leaf schema, so mixed
+        states must never co-aggregate; ``nests_with`` keys on both). The
+        shard-map reuse guard keys on the spatial part only (#89). (The
+        issue #135 ``cell_ids_encoding`` field was retired in issue #304
+        phase 3.)
         """
         return {
             **self.spatial_signature(),
             "output_fields": output_field_signature(self.config),
-            "cell_ids_encoding": self.cell_ids_encoding,
-            # The transition hatch (issue #304 phase 2) changes the leaf
-            # schema (an extra cell_ids array), so it is part of the full
-            # fingerprint — mixed hatch states must never co-aggregate.
             "emit_cell_ids": self.emit_cell_ids,
         }
 
@@ -481,18 +461,13 @@ class HealpixGrid:
         Any two HEALPix grids nest (the nested hierarchy subdivides 4-for-1 at
         every order), provided they declare the same Option-B output-field set
         (issue #29) — co-aggregated grids must produce the same scalar/vector
-        schema — and the same ``cell_ids_encoding`` (issue #135): NESTED ids
-        and morton words are different id spaces, so a consumer joining
-        co-aggregated products on ``cell_ids`` would silently mismatch.
-        Cross-family (e.g. rectilinear) never nests.
+        schema — and the same ``emit_cell_ids`` hatch state (issue #304): one
+        store carrying an extra cell_ids array while the other does not is a
+        schema mismatch. Cross-family (e.g. rectilinear) never nests.
         """
         if not isinstance(other, HealpixGrid):
             return False
-        if self.cell_ids_encoding != other.cell_ids_encoding:
-            return False
         if self.emit_cell_ids != other.emit_cell_ids:
-            # The hatch changes the leaf schema (issue #304 phase 2): one
-            # store carries a cell_ids array, the other does not.
             return False
         return output_field_signature(self.config) == output_field_signature(other.config)
 
@@ -714,28 +689,20 @@ class HealpixGrid:
             },
             "compression": "none",
         }
-        if self.cell_ids_encoding == "morton":
-            # D16 / issue #304 phase 1: a morton-declared store uses the
-            # DISTINCT grid name "morton" with the typed `morton` coordinate —
-            # never name: "healpix" + indexing_scheme: "morton", which a
-            # scheme-blind reader silently misreads as NESTED (garbage
-            # renders); an unknown grid name makes it hard-reject with a
-            # diagnostic instead, and matches moczarr's xdggs registration.
-            # The self-declared convention entry (issue #305; permanent UUID)
-            # rides the zarr_conventions LIST alongside the generic dggs
-            # entry, so a future upstream registry entry can coexist too.
-            return {
-                "zarr_conventions": [dggs_entry, dict(MORTON_CONVENTION)],
-                "dggs": {"name": "morton", **common, "coordinate": "morton"},
-            }
+        # D16 / issue #304 phase 3: every HEALPix aggregation store is
+        # morton-declared — the DISTINCT grid name "morton" with the typed
+        # `morton` coordinate. Never name: "healpix" + indexing_scheme:
+        # "morton", which a scheme-blind reader silently misreads as NESTED
+        # (garbage renders); an unknown grid name makes it hard-reject with a
+        # diagnostic instead, and matches moczarr's xdggs registration. The
+        # self-declared convention entry (issue #305; permanent UUID) rides
+        # the zarr_conventions LIST alongside the generic dggs entry, so a
+        # future upstream registry entry can coexist too. A hatch store
+        # (emit_cell_ids) carries the legacy NESTED array as an EXTRA member;
+        # the declared coordinate stays morton.
         return {
-            "zarr_conventions": [dggs_entry],
-            "dggs": {
-                "name": "healpix",
-                "indexing_scheme": "nested",
-                **common,
-                "coordinate": "cell_ids",
-            },
+            "zarr_conventions": [dggs_entry, dict(MORTON_CONVENTION)],
+            "dggs": {"name": "morton", **common, "coordinate": "morton"},
         }
 
 

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -27,7 +27,12 @@ from zagg.grids.base import (
     vector_array_spec,
     vlen_dtype_warning_suppressed,
 )
-from zagg.grids.morton import RESOLUTION_EXACT, morton_decimal, to_morton_array
+from zagg.grids.morton import (
+    MORTON_CONVENTION,
+    RESOLUTION_EXACT,
+    morton_decimal,
+    to_morton_array,
+)
 
 HEALPIX_BASE_CELLS: int = 12
 # Reference order at which ``assign`` resolves points before ``cells_of`` /
@@ -656,41 +661,52 @@ class HealpixGrid:
         return GroupSpec(members=members, attributes=self._dggs_attrs())
 
     def _dggs_attrs(self) -> dict:
+        dggs_entry = {
+            "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
+            "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
+            "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
+            "name": "dggs",
+            "description": "Discrete Global Grid Systems convention for zarr",
+        }
+        common = {
+            "refinement_level": self.child_order,
+            # O10 resolution discriminator (issue #305, espg-ratified):
+            # grid-derived cell coordinates are "exact" by construction —
+            # every id is a true cell at its encoded order. "point"
+            # (RESOLUTION_POINT) is reserved for location-derived id
+            # fields (raw lat/lon cast to order 29 — the temporal event
+            # path), which the 29->24 clip rule on the mortie spec page
+            # applies to; no zagg aggregation output ever emits it.
+            "resolution": RESOLUTION_EXACT,
+            "spatial_dimension": "cells",
+            "ellipsoid": {
+                "name": "WGS84",
+                "semimajor_axis": 6378137.0,
+                "inverse_flattening": 298.257223563,
+            },
+            "compression": "none",
+        }
+        if self.cell_ids_encoding == "morton":
+            # D16 / issue #304 phase 1: a morton-declared store uses the
+            # DISTINCT grid name "morton" with the typed `morton` coordinate —
+            # never name: "healpix" + indexing_scheme: "morton", which a
+            # scheme-blind reader silently misreads as NESTED (garbage
+            # renders); an unknown grid name makes it hard-reject with a
+            # diagnostic instead, and matches moczarr's xdggs registration.
+            # The self-declared convention entry (issue #305; permanent UUID)
+            # rides the zarr_conventions LIST alongside the generic dggs
+            # entry, so a future upstream registry entry can coexist too.
+            return {
+                "zarr_conventions": [dggs_entry, dict(MORTON_CONVENTION)],
+                "dggs": {"name": "morton", **common, "coordinate": "morton"},
+            }
         return {
-            "zarr_conventions": [
-                {
-                    "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
-                    "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
-                    "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
-                    "name": "dggs",
-                    "description": "Discrete Global Grid Systems convention for zarr",
-                }
-            ],
+            "zarr_conventions": [dggs_entry],
             "dggs": {
                 "name": "healpix",
-                "refinement_level": self.child_order,
-                # cell_ids_encoding: morton (issue #135) stores packed morton words
-                # as cell_ids, so the recorded scheme must not claim "nested" — a
-                # consumer decoding morton words as NESTED ids would mis-place every
-                # cell. "morton" is outside the DGGS convention's standard schemes;
-                # the flag is a test/prototype capability.
-                "indexing_scheme": self.cell_ids_encoding,
-                # O10 resolution discriminator (issue #305, espg-ratified):
-                # grid-derived cell coordinates are "exact" by construction —
-                # every id is a true cell at its encoded order. "point"
-                # (RESOLUTION_POINT) is reserved for location-derived id
-                # fields (raw lat/lon cast to order 29 — the temporal event
-                # path), which the 29->24 clip rule on the mortie spec page
-                # applies to; no zagg aggregation output ever emits it.
-                "resolution": RESOLUTION_EXACT,
-                "spatial_dimension": "cells",
-                "ellipsoid": {
-                    "name": "WGS84",
-                    "semimajor_axis": 6378137.0,
-                    "inverse_flattening": 298.257223563,
-                },
+                "indexing_scheme": "nested",
+                **common,
                 "coordinate": "cell_ids",
-                "compression": "none",
             },
         }
 

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -15,6 +15,7 @@ from zagg.config import (
     get_agg_fields,
     get_aoi_mask,
     get_cell_ids_encoding,
+    get_emit_cell_ids,
     get_output_signature,
     output_field_signature,
 )
@@ -133,6 +134,12 @@ class HealpixGrid:
                 f"Unknown cell_ids_encoding: {self.cell_ids_encoding!r} "
                 "(expected 'nested' or 'morton')"
             )
+        # D16 default flip (issue #304 phase 2): the legacy cell_ids array is
+        # written only under the explicit transition hatch; morton is the one
+        # stored cell coordinate. Both the template member (_group_spec) and
+        # the coords column (coords_of) key off this single flag so template
+        # and writes can never disagree.
+        self.emit_cell_ids = get_emit_cell_ids(self.config)
 
     @property
     def n_shards(self) -> int:
@@ -402,13 +409,14 @@ class HealpixGrid:
         return cell_ids
 
     def chunk_coords(self, shard_key) -> dict:
-        """Per-cell coord columns for HEALPix: ``morton`` and ``cell_ids``.
+        """Per-cell coord columns for HEALPix: ``morton`` (plus legacy ``cell_ids``).
 
         ``morton`` is a mortie ``MortonIndexArray`` (the typed coordinate; #71);
-        it is stored as ``uint64`` on disk via :mod:`zagg.grids.morton`. ``cell_ids``
-        is NESTED ``uint64`` (the DGGS coordinate) by default; the
-        ``output.grid.cell_ids_encoding: morton`` flag (issue #135) emits the
-        packed morton words instead.
+        it is stored as ``uint64`` on disk via :mod:`zagg.grids.morton` and is
+        the ONLY cell coordinate written by default (D16, issue #304). The
+        ``output.grid.emit_cell_ids: true`` transition hatch adds the legacy
+        ``cell_ids`` array — NESTED ``uint64``, or the packed morton words under
+        ``cell_ids_encoding: morton`` (issue #135).
         """
         return self.coords_of(self.children(shard_key))
 
@@ -421,14 +429,13 @@ class HealpixGrid:
         ``chunk_coords`` is just ``coords_of(children(shard_key))``.
         """
         children = np.asarray(children)
-        if self.cell_ids_encoding == "morton":
-            cell_ids = np.asarray(children, dtype=np.uint64)
-        else:
-            cell_ids = self.encode_cell_ids(children)
-        return {
-            "morton": to_morton_array(children),
-            "cell_ids": cell_ids,
-        }
+        coords: dict = {"morton": to_morton_array(children)}
+        if self.emit_cell_ids:
+            if self.cell_ids_encoding == "morton":
+                coords["cell_ids"] = np.asarray(children, dtype=np.uint64)
+            else:
+                coords["cell_ids"] = self.encode_cell_ids(children)
+        return coords
 
     # ── identity / nesting ───────────────────────────────────────────────
 
@@ -461,6 +468,10 @@ class HealpixGrid:
             **self.spatial_signature(),
             "output_fields": output_field_signature(self.config),
             "cell_ids_encoding": self.cell_ids_encoding,
+            # The transition hatch (issue #304 phase 2) changes the leaf
+            # schema (an extra cell_ids array), so it is part of the full
+            # fingerprint — mixed hatch states must never co-aggregate.
+            "emit_cell_ids": self.emit_cell_ids,
         }
 
     def nests_with(self, other) -> bool:
@@ -477,6 +488,10 @@ class HealpixGrid:
         if not isinstance(other, HealpixGrid):
             return False
         if self.cell_ids_encoding != other.cell_ids_encoding:
+            return False
+        if self.emit_cell_ids != other.emit_cell_ids:
+            # The hatch changes the leaf schema (issue #304 phase 2): one
+            # store carries a cell_ids array, the other does not.
             return False
         return output_field_signature(self.config) == output_field_signature(other.config)
 
@@ -571,9 +586,21 @@ class HealpixGrid:
 
         members = {}
         for name, meta in self.config.aggregation.get("coordinates", {}).items():
+            # D16 default flip (issue #304 phase 2): a declared cell_ids
+            # coordinate is honored only under the emit_cell_ids transition
+            # hatch — otherwise the member is skipped so the template never
+            # carries an array the writer will not fill. Keyed off the same
+            # flag as coords_of, so template and writes cannot disagree.
+            if name == "cell_ids" and not self.emit_cell_ids:
+                continue
             dtype = meta.get("dtype", "float32")
             fill = meta.get("fill_value", "NaN")
             members[name] = _shard(base.with_data_type(dtype).with_fill_value(fill))
+        if self.emit_cell_ids and "cell_ids" not in members:
+            # The hatch must not depend on the config still DECLARING the
+            # legacy coordinate (phase 3 removes the shipped declarations):
+            # synthesize the standard uint64/fill-0 member.
+            members["cell_ids"] = _shard(base.with_data_type("uint64").with_fill_value(0))
         # Optional strict-AOI cell mask (issue #101): a bool array aligned to the
         # cell grid, emitted only when ``output.aoi_mask`` is on so off-runs stay
         # byte-identical. fill_value False — cells never written (out-of-AOI shards,

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -27,7 +27,7 @@ from zagg.grids.base import (
     vector_array_spec,
     vlen_dtype_warning_suppressed,
 )
-from zagg.grids.morton import morton_decimal, to_morton_array
+from zagg.grids.morton import RESOLUTION_EXACT, morton_decimal, to_morton_array
 
 HEALPIX_BASE_CELLS: int = 12
 # Reference order at which ``assign`` resolves points before ``cells_of`` /
@@ -675,6 +675,14 @@ class HealpixGrid:
                 # cell. "morton" is outside the DGGS convention's standard schemes;
                 # the flag is a test/prototype capability.
                 "indexing_scheme": self.cell_ids_encoding,
+                # O10 resolution discriminator (issue #305, espg-ratified):
+                # grid-derived cell coordinates are "exact" by construction —
+                # every id is a true cell at its encoded order. "point"
+                # (RESOLUTION_POINT) is reserved for location-derived id
+                # fields (raw lat/lon cast to order 29 — the temporal event
+                # path), which the 29->24 clip rule on the mortie spec page
+                # applies to; no zagg aggregation output ever emits it.
+                "resolution": RESOLUTION_EXACT,
                 "spatial_dimension": "cells",
                 "ellipsoid": {
                     "name": "WGS84",

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -27,12 +27,7 @@ from zagg.grids.base import (
     vector_array_spec,
     vlen_dtype_warning_suppressed,
 )
-from zagg.grids.morton import (
-    MORTON_CONVENTION,
-    RESOLUTION_EXACT,
-    morton_decimal,
-    to_morton_array,
-)
+from zagg.grids.morton import MORTON_CONVENTION, morton_decimal, to_morton_array
 
 HEALPIX_BASE_CELLS: int = 12
 # Reference order at which ``assign`` resolves points before ``cells_of`` /
@@ -673,14 +668,11 @@ class HealpixGrid:
         }
         common = {
             "refinement_level": self.child_order,
-            # O10 resolution discriminator (issue #305, espg-ratified):
-            # grid-derived cell coordinates are "exact" by construction —
-            # every id is a true cell at its encoded order. "point"
-            # (RESOLUTION_POINT) is reserved for location-derived id
-            # fields (raw lat/lon cast to order 29 — the temporal event
-            # path), which the 29->24 clip rule on the mortie spec page
-            # applies to; no zagg aggregation output ever emits it.
-            "resolution": RESOLUTION_EXACT,
+            # No kind/resolution field (O10 final ruling, espg 2026-07-21):
+            # point-vs-area kind is carried by the packed-word ENCODING
+            # itself (mortie spec page §4 — area words are exact cells at
+            # every order; point ids are points), so readers never consult
+            # a declaration and the attrs block carries none.
             "spatial_dimension": "cells",
             "ellipsoid": {
                 "name": "WGS84",

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -125,9 +125,10 @@ class HealpixGrid:
         # standard) or "morton" (emit the packed morton words as cell_ids — a
         # test/prototype capability). Default is byte-identical to a pre-flag run.
         # Re-validated here (not only in validate_config) because both coords_of
-        # (the cell_ids values) and _dggs_attrs (the recorded indexing_scheme)
-        # interpret this string: an unvalidated third value would write NESTED
-        # values while recording a different scheme — a mis-decode for consumers.
+        # (which interprets this string for the hatch's cell_ids VALUES) and
+        # _dggs_attrs (which keys the morton-declared block on it) consume it: an
+        # unvalidated third value would write NESTED values while declaring a
+        # different block — a mis-decode for consumers.
         self.cell_ids_encoding = get_cell_ids_encoding(self.config)
         if self.cell_ids_encoding not in ("nested", "morton"):
             raise ValueError(

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -33,6 +33,31 @@ import numpy as np
 MORTON_EXTENSION_NAME = "mortie.morton_index"
 _EXTENSION_NAME_KEY = "ARROW:extension:name"
 
+#: Self-declared ``zarr_conventions`` entry for morton-declared stores
+#: (issue #305, D16). The UUID is minted once and PERMANENT — readers key on
+#: it; never regenerate it. The spec/schema URLs point at the mortie
+#: specification page (``docs/specification.md`` — the normative home of the
+#: convention; zagg's design doc only cites it). ``zarr_conventions`` is a
+#: LIST: a future upstream dggs-registry entry (issue #72 ask 3) coexists
+#: alongside this one rather than replacing it.
+MORTON_CONVENTION = {
+    "schema_url": "https://github.com/espg/mortie/blob/main/docs/specification.md#dggs-attrs",
+    "spec_url": "https://github.com/espg/mortie/blob/main/docs/specification.md",
+    "uuid": "3e22156d-ea9e-4e01-95fe-e3809a4b41e7",
+    "name": "morton-dggs",
+    "description": "Packed-u64 morton (HEALPix) DGGS convention",
+}
+
+#: O10 resolution discriminator (espg-ratified, issue #305): ``exact`` — ids
+#: are true cells at their encoded order; grid-derived cell coordinates are
+#: exact BY CONSTRUCTION, so every zagg aggregation output emits it.
+RESOLUTION_EXACT = "exact"
+#: ``point`` — locations cast to order 29 with no area claim (raw lat/lon
+#: conversions: the temporal event path, future HHDC id fields). The mortie
+#: spec page's 29->24 clip rule applies to ``point`` ONLY. Emission is per
+#: data kind and the writer always knows which; no heuristic fallback.
+RESOLUTION_POINT = "point"
+
 
 def is_morton_array(values) -> bool:
     """True if ``values`` is a mortie ``MortonIndexArray``."""
@@ -203,7 +228,10 @@ def is_morton_arrow(col) -> bool:
 
 
 __all__ = [
+    "MORTON_CONVENTION",
     "MORTON_EXTENSION_NAME",
+    "RESOLUTION_EXACT",
+    "RESOLUTION_POINT",
     "is_morton_array",
     "is_morton_arrow",
     "morton_box",

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -59,6 +59,16 @@ RESOLUTION_EXACT = "exact"
 #: spec page's 29->24 clip rule applies to ``point`` ONLY. Emission is per
 #: data kind and the writer always knows which; no heuristic fallback.
 RESOLUTION_POINT = "point"
+#: ``mixed`` (espg-proposed on the mortie PR #118 review, 2026-07-21):
+#: order-29 ids are points (unknown resolution), ids at any other order are
+#: exact — per-id recovery via the RESERVED order 29. The 29->24 clip rule is
+#: INAPPLICABLE to mixed arrays (clipping destroys the in-band signal;
+#: Number-safe paths use the other D16 measures), and genuinely-exact
+#: order-29 cells are unrepresentable under it (declare ``exact``). Accepted
+#: as a declared value; no zagg writer emits it today (aggregation outputs
+#: are ``exact`` — the HHDC exact-cells-plus-raw-locations direction is the
+#: intended consumer).
+RESOLUTION_MIXED = "mixed"
 
 
 def is_morton_array(values) -> bool:
@@ -233,6 +243,7 @@ __all__ = [
     "MORTON_CONVENTION",
     "MORTON_EXTENSION_NAME",
     "RESOLUTION_EXACT",
+    "RESOLUTION_MIXED",
     "RESOLUTION_POINT",
     "is_morton_array",
     "is_morton_arrow",

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -13,8 +13,8 @@ reconstructed as a ``MortonIndexArray`` on read.
 This is the contained #71 migration: only the ``morton`` coordinate adopts the
 type — and since the D16 flip (issue #304) it is the only stored cell
 coordinate by default (the legacy NESTED ``cell_ids`` array survives behind
-the ``output.grid.emit_cell_ids: true`` transition hatch, with values per the
-issue-#135 ``cell_ids_encoding`` knob). The internal leaf/cell/shard morton
+the ``output.grid.emit_cell_ids: true`` transition hatch; the issue-#135
+``cell_ids_encoding`` knob is retired). The internal leaf/cell/shard morton
 arithmetic (``cells_of`` / ``shards_of`` / ``children``) stays on plain
 ``uint64`` ndarrays.
 

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -11,10 +11,12 @@ dtypes, and the extension metadata lives at the interchange layer only — and
 reconstructed as a ``MortonIndexArray`` on read.
 
 This is the contained #71 migration: only the ``morton`` coordinate adopts the
-type. ``cell_ids`` stays NESTED ``uint64`` by default (the DGGS coordinate;
-``output.grid.cell_ids_encoding: morton`` optionally emits the morton words
-instead — issue #135), and the internal leaf/cell/shard morton arithmetic
-(``cells_of`` / ``shards_of`` / ``children``) stays on plain ``uint64`` ndarrays.
+type — and since the D16 flip (issue #304) it is the only stored cell
+coordinate by default (the legacy NESTED ``cell_ids`` array survives behind
+the ``output.grid.emit_cell_ids: true`` transition hatch, with values per the
+issue-#135 ``cell_ids_encoding`` knob). The internal leaf/cell/shard morton
+arithmetic (``cells_of`` / ``shards_of`` / ``children``) stays on plain
+``uint64`` ndarrays.
 
 Storing the raw ``uint64`` words (rather than a reinterpreted ``int64``) is what
 removes the sign hazard: the packed word's prefix is ``base+1``, so base cells

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -50,26 +50,6 @@ MORTON_CONVENTION = {
     "description": "Packed-u64 morton (HEALPix) DGGS convention",
 }
 
-#: O10 resolution discriminator (espg-ratified, issue #305): ``exact`` — ids
-#: are true cells at their encoded order; grid-derived cell coordinates are
-#: exact BY CONSTRUCTION, so every zagg aggregation output emits it.
-RESOLUTION_EXACT = "exact"
-#: ``point`` — locations cast to order 29 with no area claim (raw lat/lon
-#: conversions: the temporal event path, future HHDC id fields). The mortie
-#: spec page's 29->24 clip rule applies to ``point`` ONLY. Emission is per
-#: data kind and the writer always knows which; no heuristic fallback.
-RESOLUTION_POINT = "point"
-#: ``mixed`` (espg-proposed on the mortie PR #118 review, 2026-07-21):
-#: order-29 ids are points (unknown resolution), ids at any other order are
-#: exact — per-id recovery via the RESERVED order 29. The 29->24 clip rule is
-#: INAPPLICABLE to mixed arrays (clipping destroys the in-band signal;
-#: Number-safe paths use the other D16 measures), and genuinely-exact
-#: order-29 cells are unrepresentable under it (declare ``exact``). Accepted
-#: as a declared value; no zagg writer emits it today (aggregation outputs
-#: are ``exact`` — the HHDC exact-cells-plus-raw-locations direction is the
-#: intended consumer).
-RESOLUTION_MIXED = "mixed"
-
 
 def is_morton_array(values) -> bool:
     """True if ``values`` is a mortie ``MortonIndexArray``."""
@@ -242,9 +222,6 @@ def is_morton_arrow(col) -> bool:
 __all__ = [
     "MORTON_CONVENTION",
     "MORTON_EXTENSION_NAME",
-    "RESOLUTION_EXACT",
-    "RESOLUTION_MIXED",
-    "RESOLUTION_POINT",
     "is_morton_array",
     "is_morton_arrow",
     "morton_box",

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -870,17 +870,26 @@ def _check_raster_grid(grid) -> None:
 
 
 def _raster_members(grid, config, n_time: int, n_cells: int) -> dict:
-    """The ``time``/``cell_ids``/band ArraySpec members for one raster store."""
+    """The ``time``/``morton``/band ArraySpec members for one raster store.
+
+    ``morton`` (packed u64 words) is the sole stored cell coordinate — the
+    D16 flip applies to the raster path too (espg-ruled on the PR #314
+    review: one default cell coordinate everywhere). The legacy NESTED
+    ``cell_ids`` array rides only the same ``emit_cell_ids`` transition
+    hatch as the spatial path — never a separate schedule.
+    """
     from zagg.config import get_raster_bands
 
     members = {
         "time": _raster_array_spec(
             (n_time,), (max(n_time, 1),), ("time",), "int64", 0, dict(_TIME_ATTRS)
         ),
-        "cell_ids": _raster_array_spec(
-            (n_cells,), (grid.cells_per_chunk,), ("cells",), "uint64", 0
-        ),
+        "morton": _raster_array_spec((n_cells,), (grid.cells_per_chunk,), ("cells",), "uint64", 0),
     }
+    if grid.emit_cell_ids:
+        members["cell_ids"] = _raster_array_spec(
+            (n_cells,), (grid.cells_per_chunk,), ("cells",), "uint64", 0
+        )
     for name, meta in get_raster_bands(config).items():
         members[name] = _raster_array_spec(
             (n_time, n_cells),
@@ -898,14 +907,19 @@ def raster_group_spec(grid, config, n_time: int):
 
     Per band: shape ``(n_time, n_pixels)``, chunks ``(1, cells_per_chunk)`` —
     one storage object per (timestep, chunk), so per-date rewrites are exact.
-    Plus ``time`` (int64 microseconds, CF attrs) and ``cell_ids`` (uint64,
-    written per shard by :func:`write_raster_coords`).
+    Plus ``time`` (int64 microseconds, CF attrs) and ``morton`` (packed u64
+    words, written per shard by :func:`write_raster_coords`). The group
+    carries the same morton-declared dggs attrs block as the spatial path
+    (issues #304/#305): one reader contract for every store.
     """
     from pydantic_zarr.experimental.v3 import GroupSpec
 
     _check_raster_grid(grid)
     n_pixels = int(np.prod(grid.array_shape))
-    return GroupSpec(members=_raster_members(grid, config, n_time, n_pixels), attributes={})
+    return GroupSpec(
+        members=_raster_members(grid, config, n_time, n_pixels),
+        attributes=grid._dggs_attrs(),
+    )
 
 
 def emit_raster_template(store, grid, config, times_us: np.ndarray, *, overwrite: bool = False):
@@ -942,7 +956,7 @@ def raster_leaf_spec(grid, config, n_time: int):
     """GroupSpec for ONE shard's hive leaf zarr (issue #247, D3/D13).
 
     The raster analog of ``HealpixGrid.shard_spec``: the same member set as
-    :func:`raster_group_spec` — ``time``/``cell_ids`` plus one ``(time,
+    :func:`raster_group_spec` — ``time``/``morton`` plus one ``(time,
     cells)`` array per band, same dtypes/fills/chunking — with the cells axis
     sized to a single shard (``cells_per_shard``) and the time axis to the
     LEAF's own acquisitions (``n_time`` = the groups intersecting this shard
@@ -954,7 +968,11 @@ def raster_leaf_spec(grid, config, n_time: int):
 
     _check_raster_grid(grid)
     inner = GroupSpec(
-        members=_raster_members(grid, config, n_time, grid.cells_per_shard), attributes={}
+        members=_raster_members(grid, config, n_time, grid.cells_per_shard),
+        # The same morton-declared dggs attrs as the spatial leaf (issue
+        # #304 — one reader contract), on the inner group like
+        # HealpixGrid._group_spec.
+        attributes=grid._dggs_attrs(),
     )
     return GroupSpec(members={grid.group_path: inner}, attributes={})
 
@@ -962,12 +980,13 @@ def raster_leaf_spec(grid, config, n_time: int):
 def emit_raster_leaf_template(
     store, grid, config, shard_key: int, times_us: np.ndarray, *, overwrite: bool = False
 ):
-    """Write one leaf's template plus its ``time`` and ``cell_ids`` coords.
+    """Write one leaf's template plus its ``time`` and ``morton`` coords.
 
     Unlike the flat path (template at fan-out time, coords per shard after
     the slabs), a leaf's coordinates are fully known at template time — the
-    time axis is the leaf's own acquisition groups and ``cell_ids`` is the
-    shard's children — so both are written here, once. Called lazily on the
+    time axis is the leaf's own acquisition groups and ``morton`` is the
+    shard's children (packed words; the legacy ``cell_ids`` only under the
+    ``emit_cell_ids`` hatch) — so both are written here, once. Called lazily on the
     first slab (mirroring ``process_and_write_hive``'s lazy ``_leaf``) with
     ``overwrite=True`` so a no-data shard never creates the ``.zarr/`` prefix
     and a retry replaces debris wholesale (D4).
@@ -976,15 +995,18 @@ def emit_raster_leaf_template(
     from zarr import open_array
 
     spec = raster_leaf_spec(grid, config, int(len(times_us)))
-    cell_ids = grid.encode_cell_ids(grid.children(int(shard_key)))
+    children = np.asarray(grid.children(int(shard_key)), dtype=np.uint64)
     with zarr_config.set({"async.concurrency": 128}):
         spec.to_zarr(store, "", overwrite=overwrite)
         arr = open_array(store, path=f"{grid.group_path}/time", zarr_format=3, consolidated=False)
         arr[:] = np.asarray(times_us, dtype=np.int64)
-        arr = open_array(
-            store, path=f"{grid.group_path}/cell_ids", zarr_format=3, consolidated=False
-        )
-        arr[:] = np.asarray(cell_ids, dtype=np.uint64)
+        arr = open_array(store, path=f"{grid.group_path}/morton", zarr_format=3, consolidated=False)
+        arr[:] = children
+        if grid.emit_cell_ids:
+            arr = open_array(
+                store, path=f"{grid.group_path}/cell_ids", zarr_format=3, consolidated=False
+            )
+            arr[:] = np.asarray(grid.encode_cell_ids(children), dtype=np.uint64)
     return store
 
 
@@ -1038,17 +1060,25 @@ def write_raster_slab(store, grid, shard_key: int, t_idx: int, slab: dict):
 
 
 def write_raster_coords(store, grid, shard_key: int):
-    """Write the shard's ``cell_ids`` coordinate block (once per shard)."""
+    """Write the shard's ``morton`` coordinate block (once per shard).
+
+    Packed u64 words — the sole stored cell coordinate (D16, issue #304);
+    the legacy NESTED ``cell_ids`` block rides only the ``emit_cell_ids``
+    transition hatch, exactly like the spatial path.
+    """
     from zarr import config as zarr_config
     from zarr import open_array
 
     start, stop = _shard_cell_range(grid, shard_key)
-    cell_ids = grid.encode_cell_ids(grid.children(int(shard_key)))
+    children = np.asarray(grid.children(int(shard_key)), dtype=np.uint64)
     with zarr_config.set({"async.concurrency": 128}):
-        arr = open_array(
-            store, path=f"{grid.group_path}/cell_ids", zarr_format=3, consolidated=False
-        )
-        arr[start:stop] = np.asarray(cell_ids, dtype=np.uint64)
+        arr = open_array(store, path=f"{grid.group_path}/morton", zarr_format=3, consolidated=False)
+        arr[start:stop] = children
+        if grid.emit_cell_ids:
+            arr = open_array(
+                store, path=f"{grid.group_path}/cell_ids", zarr_format=3, consolidated=False
+            )
+            arr[start:stop] = np.asarray(grid.encode_cell_ids(children), dtype=np.uint64)
     return store
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def zarr_store():
 @pytest.fixture
 def mock_dataframe_factory():
     """Factory to create mock DataFrames matching process_morton_cell output."""
-    from mortie import generate_morton_children, geo2mort, mort2healpix
+    from mortie import generate_morton_children, geo2mort
 
     data_vars = get_data_vars(default_config())
 
@@ -25,16 +25,31 @@ def mock_dataframe_factory():
         parent_morton = geo2mort(lat, lon, order=parent_order)
 
         children = generate_morton_children(parent_morton[0], child_order)
-        cell_ids, _ = mort2healpix(children)
         n = len(children)
 
-        df = pd.DataFrame({"morton": children, "cell_ids": cell_ids}).assign(
+        # D16 flip (issue #304): worker carriers hold morton only — the legacy
+        # cell_ids column is no longer produced by default. Tests that index
+        # fullsphere arrays by NESTED position derive it via nested_ids().
+        df = pd.DataFrame({"morton": children}).assign(
             **{var: np.random.randn(n).astype(np.float32) for var in data_vars if var != "count"}
         )
         df = df.assign(count=np.random.randn(n).astype(np.int32))
         return df
 
     return _create
+
+
+def nested_ids(df):
+    """NESTED uint64 ids for a carrier's ``morton`` column (test indexing).
+
+    The D16 flip (issue #304) removed the legacy ``cell_ids`` column from
+    worker carriers; fullsphere tests still index arrays by NESTED position,
+    so this derives it from the morton words — the same read-side fabrication
+    moczarr performs.
+    """
+    from mortie import mort2healpix
+
+    return mort2healpix(np.asarray(df["morton"], dtype=np.uint64))[0]
 
 
 def point_words(n, seed, lat0=45.0, lon0=45.0, spread=1e-4):

--- a/tests/test_aoi_mask.py
+++ b/tests/test_aoi_mask.py
@@ -7,6 +7,7 @@ Phase 2 covers the rectilinear shapely cell-center ``contains`` path.
 
 import numpy as np
 import pytest
+from conftest import nested_ids
 
 from zagg.grids import HealpixGrid
 from zagg.grids.aoi import (
@@ -496,11 +497,11 @@ class TestEndToEndWrite:
             aoi_mask=mask,
         )
         n_children = 4 ** (child_order - parent_order)
-        chunk_idx = (int(df["cell_ids"].min()) // n_children,)
+        chunk_idx = (int(nested_ids(df).min()) // n_children,)
         write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=chunk_idx)
 
         group = open_group(store=store, mode="r", path=str(child_order))
-        lo, hi = int(df["cell_ids"].min()), int(df["cell_ids"].max())
+        lo, hi = int(nested_ids(df).min()), int(nested_ids(df).max())
         actual = group["aoi_mask"][lo : hi + 1]
         assert actual.dtype == np.bool_
         np.testing.assert_array_equal(actual, mask)
@@ -521,7 +522,7 @@ class TestEndToEndWrite:
             grid.emit_template(store)
             df = mock_dataframe_factory(-78.5, -132.0, parent_order, child_order)
             n_children = 4 ** (child_order - parent_order)
-            chunk_idx = (int(df["cell_ids"].min()) // n_children,)
+            chunk_idx = (int(nested_ids(df).min()) // n_children,)
             write_dataframe_to_zarr(df, store, grid=grid, chunk_idx=chunk_idx)
             return store
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2048,7 +2048,7 @@ def test_run_target_threads_store_layout():
 
 
 def test_hive_config_expected_counts_root_moc_optional():
-    # The committed hive arm's model: per-shard DATA is exact (11 objects/leaf,
+    # The committed hive arm's model: per-shard DATA is exact (per-leaf count,
     # the sharded-write-bypass tripwire), but the store-root coverage.moc is a
     # fail-open, regenerable D9 cache (runner.write_root_coverage) that may be
     # present OR absent -- so store-root metadata is a [1, 2] window (the
@@ -2065,18 +2065,19 @@ def test_hive_config_expected_counts_root_moc_optional():
     exp = bench_objects.expected_object_counts(
         grid, n_shards=1, store_layout="hive", coverage_moc=True
     )
-    # 4 arrays (cell_ids/morton/count/h_tdigest): leaf root+group zarr.json (2)
-    # + 4 array zarr.json + 4 sharded data objects + coverage sidecar +
-    # stats.json sibling (issue #297) = 12.
+    # 3 arrays (morton/count/h_tdigest — no legacy cell_ids since the D16
+    # flip, issue #304): leaf root+group zarr.json (2) + 3 array zarr.json +
+    # 3 sharded data objects + coverage sidecar + stats.json sibling
+    # (issue #297) = 10.
     # Store root: morton_hive.json (always) + coverage.moc (optional) + the
     # run stats parquet (optional, issue #297) -> [1, 3].
     assert exp == {
         "metadata": 3,
         "metadata_min": 1,
-        "per_shard_min": 12,
-        "per_shard_max": 12,
-        "total_min": 13,
-        "total_max": 15,
+        "per_shard_min": 10,
+        "per_shard_max": 10,
+        "total_min": 11,
+        "total_max": 13,
         "exact": True,
     }
 

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -46,7 +46,6 @@ def _cfg(sharded=True):
         data_source={"groups": ["g"]},
         aggregation={
             "coordinates": {
-                "cell_ids": {"dtype": "uint64", "fill_value": 0},
                 "morton": {"dtype": "uint64", "fill_value": 0},
             },
             "variables": {
@@ -102,18 +101,19 @@ def _write_flat_shard(grid, store, word, *, sharded):
 
 
 def test_expected_counts_live_matrix_config():
-    # The live-matrix config (flat, sharded, K=256): root + group + 4 array
-    # zarr.json objects, then exactly one object per array per shard.
+    # The live-matrix config (flat, sharded, K=256): root + group + 3 array
+    # zarr.json objects (morton/count/h_tdigest — the legacy cell_ids array is
+    # gone since the D16 flip, issue #304), then one object per array per shard.
     config = load_config(str(BENCH / "configs" / "atl03_tdigest_healpix_o9.yaml"))
     exp = bench_objects.expected_object_counts(from_config(config), n_shards=1)
     # metadata ceiling adds the optional run-level stats parquet (issue #297).
     assert exp == {
-        "metadata": 7,
-        "metadata_min": 6,
-        "per_shard_min": 4,
-        "per_shard_max": 4,
-        "total_min": 10,
-        "total_max": 11,
+        "metadata": 6,
+        "metadata_min": 5,
+        "per_shard_min": 3,
+        "per_shard_max": 3,
+        "total_min": 8,
+        "total_max": 9,
         "exact": True,
     }
 
@@ -123,10 +123,10 @@ def test_expected_counts_aoimask_config_adds_one_array():
     # sharded object per shard.
     config = load_config(str(BENCH / "configs" / "atl03_tdigest_healpix_o9_aoimask.yaml"))
     exp = bench_objects.expected_object_counts(from_config(config), n_shards=4)
-    assert exp["metadata"] == 8
-    assert exp["per_shard_min"] == exp["per_shard_max"] == 5
+    assert exp["metadata"] == 7
+    assert exp["per_shard_min"] == exp["per_shard_max"] == 4
     assert exp["exact"] is True
-    assert exp["total_max"] == 8 + 4 * 5
+    assert exp["total_max"] == 7 + 4 * 4
 
 
 def test_expected_counts_unsharded_is_bounded_not_exact():
@@ -134,10 +134,10 @@ def test_expected_counts_unsharded_is_bounded_not_exact():
     # chunks are omitted), ragged 0..K -- a bounded, non-exact expectation.
     exp = bench_objects.expected_object_counts(_grid(sharded=False), n_shards=1)
     k = 16
-    assert exp["metadata"] == 7
+    assert exp["metadata"] == 6
     assert exp["exact"] is False
-    assert exp["per_shard_min"] == 3  # one populated chunk x 3 dense arrays
-    assert exp["per_shard_max"] == 4 * k
+    assert exp["per_shard_min"] == 2  # one populated chunk x 2 dense arrays
+    assert exp["per_shard_max"] == 3 * k
 
 
 def test_expected_counts_unknown_layout_raises():
@@ -164,10 +164,10 @@ def test_flat_sharded_store_matches_model(tmp_path):
     assert expected["exact"] is True
     # Direct writes (no runner) -> no run parquet, so the floor of the
     # issue-#297-widened metadata window is what lands.
-    assert measured["objects_total"] == expected["total_min"] == 6 + 2 * 4
-    assert measured["objects_metadata"] == expected["metadata_min"] == 6
+    assert measured["objects_total"] == expected["total_min"] == 5 + 2 * 3
+    assert measured["objects_metadata"] == expected["metadata_min"] == 5
     assert measured["objects_other"] == 0
-    assert measured["objects_per_shard"] == {_KEY_A: 4, _KEY_B: 4}
+    assert measured["objects_per_shard"] == {_KEY_A: 3, _KEY_B: 3}
     assert bench_objects.object_count_mismatch(measured, expected) is None
 
 
@@ -190,10 +190,10 @@ def test_flat_sharded_bypass_is_detected(tmp_path):
     assert "total objects" in mismatch
 
     # Against its OWN (unsharded, bounded) model the same store is in range:
-    # all 16 chunks populated -> 16 objects x 4 arrays, attributed to the shard.
+    # all 16 chunks populated -> 16 objects x 3 arrays, attributed to the shard.
     measured_own = bench_objects.store_object_counts(root, grid=grid_flat, shard_keys=[word])
     expected_own = bench_objects.expected_object_counts(grid_flat, n_shards=1)
-    assert measured_own["objects_per_shard"] == {_KEY_A: 64}
+    assert measured_own["objects_per_shard"] == {_KEY_A: 48}
     assert measured_own["objects_other"] == 0
     assert bench_objects.object_count_mismatch(measured_own, expected_own) is None
 
@@ -251,7 +251,7 @@ def test_hive_store_matches_model(tmp_path, monkeypatch):
 
     def carrier(shard_key):
         coords = grid.chunk_coords(shard_key)
-        n = len(coords["cell_ids"])
+        n = len(coords["morton"])
         agg_fields = get_agg_fields(cfg)
         df = pd.DataFrame(
             {
@@ -383,9 +383,9 @@ def test_measure_objects_end_to_end(tmp_path):
     cfg.output["store_layout"] = "flat"  # a flat-store measurement (issue #253 defaults hive)
     payload = run_benchmark._measure_objects(cfg, grid, root, word, region="us-west-2")
     assert payload == {
-        "objects_total": 10,  # 6 metadata + 4 shard objects
-        "objects_expected": 11,  # ceiling includes the optional run parquet (#297)
-        "objects_per_shard": {_KEY_A: 4},
+        "objects_total": 8,  # 5 metadata + 3 shard objects
+        "objects_expected": 9,  # ceiling includes the optional run parquet (#297)
+        "objects_per_shard": {_KEY_A: 3},
         "objects_mismatch": None,
     }
 
@@ -409,8 +409,8 @@ def test_measure_objects_flags_bypass(tmp_path):
         cfg, _grid(sharded=True), root, word, region="us-west-2"
     )
     assert payload["objects_mismatch"] is not None
-    assert payload["objects_total"] == 6 + 64  # metadata + 16 chunks x 4 arrays
-    assert payload["objects_expected"] == 11  # ceiling includes the run parquet (#297)
+    assert payload["objects_total"] == 5 + 48  # metadata + 16 chunks x 3 arrays
+    assert payload["objects_expected"] == 9  # ceiling includes the run parquet (#297)
 
 
 # --- review folds (PR #242) ---------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1117,8 +1117,10 @@ class TestAccessors:
         assert fields["h_q50"]["params"]["q"] == 0.50
 
     def test_get_coords(self, atl06_config):
+        # The shipped configs declare morton only (issue #304 phase 3 — the
+        # legacy cell_ids declaration was removed with the D16 flip).
         coords = get_coords(atl06_config)
-        assert "cell_ids" in coords
+        assert "cell_ids" not in coords
         assert "morton" in coords
 
     def test_get_data_vars(self, atl06_config):
@@ -1414,8 +1416,8 @@ class TestOutputGridValidation:
             validate_config(cfg)
 
 
-def _cfg_with_cell_ids_encoding(encoding=None, grid_type="healpix") -> PipelineConfig:
-    """Minimal valid config; sets output.grid.cell_ids_encoding only when given."""
+def _cfg_with_grid_knobs(grid_type="healpix", **grid_extra) -> PipelineConfig:
+    """Minimal valid config; extra output.grid keys applied when given."""
     grid: dict = {"type": grid_type, "parent_order": 6, "child_order": 12}
     if grid_type == "rectilinear":
         grid = {
@@ -1424,8 +1426,7 @@ def _cfg_with_cell_ids_encoding(encoding=None, grid_type="healpix") -> PipelineC
             "resolution": 100,
             "bounds": [0, 0, 1000, 1000],
         }
-    if encoding is not None:
-        grid["cell_ids_encoding"] = encoding
+    grid.update(grid_extra)
     return PipelineConfig(
         data_source={
             "reader": "h5coro",
@@ -1438,59 +1439,54 @@ def _cfg_with_cell_ids_encoding(encoding=None, grid_type="healpix") -> PipelineC
     )
 
 
-class TestCellIdsEncoding:
-    """Issue #135: optional output.grid.cell_ids_encoding — "nested" (default,
-    the DGGS standard) or "morton" (emit packed morton words as cell_ids)."""
+class TestCellIdsKnobs:
+    """Issue #304 phase 3: the issue #135 ``cell_ids_encoding`` knob is
+    retired (morton stored, NESTED derived); ``emit_cell_ids`` is the one
+    remaining transition hatch."""
 
-    def test_default_is_nested(self):
-        from zagg.config import get_cell_ids_encoding
+    def test_retired_knob_gets_pointed_error(self):
+        # Any value — including the formerly-valid ones — errors with the
+        # migration pointer, never a silent ignore.
+        for value in ("nested", "morton", "bogus"):
+            with pytest.raises(ValueError, match="cell_ids_encoding was retired"):
+                validate_config(_cfg_with_grid_knobs(cell_ids_encoding=value))
 
-        assert get_cell_ids_encoding(_cfg_with_cell_ids_encoding()) == "nested"
-
-    def test_explicit_values_accessor(self):
-        from zagg.config import get_cell_ids_encoding
-
-        assert get_cell_ids_encoding(_cfg_with_cell_ids_encoding("nested")) == "nested"
-        assert get_cell_ids_encoding(_cfg_with_cell_ids_encoding("morton")) == "morton"
-
-    def test_valid_values_validate(self):
-        validate_config(_cfg_with_cell_ids_encoding())  # absent
-        validate_config(_cfg_with_cell_ids_encoding("nested"))
-        validate_config(_cfg_with_cell_ids_encoding("morton"))
-
-    def test_invalid_value_rejected_at_load(self):
-        with pytest.raises(ValueError, match="cell_ids_encoding must be 'nested' or 'morton'"):
-            validate_config(_cfg_with_cell_ids_encoding("bogus"))
-
-    def test_rejected_on_rectilinear(self):
-        # Rectilinear grids have no cell_ids coordinate; the knob would silently
-        # do nothing, so it is rejected at load.
-        with pytest.raises(ValueError, match="only applies to healpix"):
-            validate_config(_cfg_with_cell_ids_encoding("morton", grid_type="rectilinear"))
-
-    def test_rectilinear_without_encoding_still_validates(self):
-        validate_config(_cfg_with_cell_ids_encoding(grid_type="rectilinear"))
-
-    def test_present_but_null_key_falls_back_to_nested(self):
-        # YAML `cell_ids_encoding:` (explicit null) must behave like an absent
-        # key: the accessor returns "nested" (never None) and validation passes,
-        # so the store attrs stay byte-identical to a pre-flag run.
-        from zagg.config import get_cell_ids_encoding
-
-        cfg = _cfg_with_cell_ids_encoding()
+    def test_absent_and_null_knob_validate(self):
+        validate_config(_cfg_with_grid_knobs())
+        # YAML `cell_ids_encoding:` (explicit null) behaves like absent.
+        cfg = _cfg_with_grid_knobs()
         cfg.output["grid"]["cell_ids_encoding"] = None
-        assert get_cell_ids_encoding(cfg) == "nested"
         validate_config(cfg)
 
+    def test_emit_cell_ids_accessor_and_validation(self):
+        from zagg.config import get_emit_cell_ids
+
+        assert get_emit_cell_ids(_cfg_with_grid_knobs()) is False
+        cfg = _cfg_with_grid_knobs(emit_cell_ids=True)
+        validate_config(cfg)
+        assert get_emit_cell_ids(cfg) is True
+
+    def test_emit_cell_ids_rejects_non_boolean(self):
+        with pytest.raises(ValueError, match="emit_cell_ids must be a boolean"):
+            validate_config(_cfg_with_grid_knobs(emit_cell_ids="yes"))
+
+    def test_emit_cell_ids_rejected_on_rectilinear(self):
+        # Rectilinear grids have no cell_ids coordinate; the flag would
+        # silently do nothing, so a true value is rejected at load.
+        with pytest.raises(ValueError, match="only applies to healpix"):
+            validate_config(_cfg_with_grid_knobs(emit_cell_ids=True, grid_type="rectilinear"))
+
+    def test_rectilinear_without_knobs_still_validates(self):
+        validate_config(_cfg_with_grid_knobs(grid_type="rectilinear"))
+
     def test_legacy_indexing_scheme_key_is_descriptive_only(self):
-        # The shipped configs carry output.grid.indexing_scheme: nested, which no
-        # code reads; setting it to "morton" would otherwise silently do nothing.
-        # It must fail loudly and point at the real knob.
-        cfg = _cfg_with_cell_ids_encoding()
+        # The shipped configs carry output.grid.indexing_scheme: nested, which
+        # no code reads; any other value must fail loudly.
+        cfg = _cfg_with_grid_knobs()
         cfg.output["grid"]["indexing_scheme"] = "nested"
         validate_config(cfg)  # the shipped value stays valid
         cfg.output["grid"]["indexing_scheme"] = "morton"
-        with pytest.raises(ValueError, match="cell_ids_encoding: morton"):
+        with pytest.raises(ValueError, match="declared coordinate is morton"):
             validate_config(cfg)
 
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -447,7 +447,7 @@ def _rec_meta(shard):
 
 def _carrier(grid, shard):
     coords = grid.chunk_coords(shard)
-    n = len(coords["cell_ids"])
+    n = len(coords["morton"])
     df = pd.DataFrame(
         {
             var: np.zeros(n, dtype=np.int32 if var == "count" else np.float32)

--- a/tests/test_coverage_root.py
+++ b/tests/test_coverage_root.py
@@ -544,7 +544,7 @@ class TestIntersections:
 
             coords = grid.chunk_coords(shard_key)
             df = pd.DataFrame(
-                {var: 0.0 for var in get_data_vars(cfg)}, index=range(len(coords["cell_ids"]))
+                {var: 0.0 for var in get_data_vars(cfg)}, index=range(len(coords["morton"]))
             )
             for name, vals in coords.items():
                 df[name] = vals

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -959,24 +959,22 @@ class TestShardLabel:
 
 
 class TestCellIdsEncoding:
-    """Issue #135 (``cell_ids_encoding``) + issue #304 (the D16 default flip):
-    ``morton`` is the only stored cell coordinate by default; the
-    ``emit_cell_ids: true`` transition hatch restores the legacy ``cell_ids``
-    array (NESTED uint64, or packed morton words under
-    ``cell_ids_encoding: morton``)."""
+    """Issue #304 (the D16 flip, all phases): ``morton`` is the only stored
+    cell coordinate and every HEALPix store is morton-declared; the
+    ``emit_cell_ids: true`` transition hatch adds the legacy NESTED
+    ``cell_ids`` array as an EXTRA member (the issue #135 encoding knob is
+    retired — morton stored, NESTED derived at read)."""
 
     @staticmethod
-    def _cfg(encoding=None, emit=None):
+    def _cfg(emit=None):
         cfg = default_config("atl06")
-        if encoding is not None:
-            cfg.output["grid"]["cell_ids_encoding"] = encoding
         if emit is not None:
             cfg.output["grid"]["emit_cell_ids"] = emit
         return cfg
 
-    def _grid(self, encoding=None, emit=None):
+    def _grid(self, emit=None):
         return HealpixGrid(
-            parent_order=6, child_order=8, layout="fullsphere", config=self._cfg(encoding, emit)
+            parent_order=6, child_order=8, layout="fullsphere", config=self._cfg(emit)
         )
 
     def test_default_emits_no_cell_ids(self):
@@ -990,26 +988,36 @@ class TestCellIdsEncoding:
         assert "cell_ids" not in g.shard_spec().members
         assert g.signature()["emit_cell_ids"] is False
 
-    def test_hatch_restores_declared_member(self):
-        # emit_cell_ids: true keeps the legacy array (the atl06 config still
-        # declares the coordinate, so the declared dtype/fill are honored).
+    def test_hatch_emits_nested_cell_ids(self):
+        # emit_cell_ids: true restores the legacy NESTED array — member
+        # synthesized (the shipped configs no longer declare it, issue #304
+        # phase 3) and the coords column carries the NESTED encode.
         g = self._grid(emit=True)
         parent = _valid_parents(1)[0]
         coords = g.chunk_coords(parent)
         np.testing.assert_array_equal(coords["cell_ids"], g.encode_cell_ids(g.children(parent)))
         assert str(g.spec().members["cell_ids"].data_type) == "uint64"
+        assert str(g.shard_spec().members["cell_ids"].data_type) == "uint64"
         assert g.signature()["emit_cell_ids"] is True
 
-    def test_hatch_synthesizes_member_when_undeclared(self):
-        # Phase 3 removes the shipped cell_ids declarations; the hatch must
-        # not depend on them — an undeclared cell_ids member synthesizes as
-        # the standard uint64/fill-0 array.
+    def test_hatch_honors_declared_member(self):
+        # A config that still declares the legacy coordinate (user configs in
+        # the wild) keeps its declared dtype/fill under the hatch.
         cfg = self._cfg(emit=True)
-        del cfg.aggregation["coordinates"]["cell_ids"]
+        cfg.aggregation.setdefault("coordinates", {})["cell_ids"] = {
+            "dtype": "uint64",
+            "fill_value": 0,
+        }
         g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
-        member = g.spec().members["cell_ids"]
-        assert str(member.data_type) == "uint64"
-        assert "cell_ids" in g.chunk_coords(_valid_parents(1)[0])
+        assert str(g.spec().members["cell_ids"].data_type) == "uint64"
+        # Without the hatch the declaration is skipped, not honored.
+        cfg2 = self._cfg()
+        cfg2.aggregation.setdefault("coordinates", {})["cell_ids"] = {
+            "dtype": "uint64",
+            "fill_value": 0,
+        }
+        g2 = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg2)
+        assert "cell_ids" not in g2.spec().members
 
     def test_mixed_hatch_states_do_not_nest(self):
         # One store carries the extra array, the other does not — different
@@ -1018,36 +1026,12 @@ class TestCellIdsEncoding:
         assert not self._grid(emit=True).nests_with(self._grid())
         assert self._grid(emit=True).nests_with(self._grid(emit=True))
 
-    def test_default_and_explicit_nested_identical(self):
-        parent = _valid_parents(1)[0]
-        default = self._grid(emit=True).chunk_coords(parent)
-        nested = self._grid("nested", emit=True).chunk_coords(parent)
-        np.testing.assert_array_equal(default["cell_ids"], nested["cell_ids"])
-        np.testing.assert_array_equal(
-            np.asarray(default["morton"]._data), np.asarray(nested["morton"]._data)
-        )
-        # The hatch's default stays the NESTED encode, unchanged.
-        g = self._grid(emit=True)
-        np.testing.assert_array_equal(default["cell_ids"], g.encode_cell_ids(g.children(parent)))
-
-    def test_morton_encoding_emits_words(self):
-        from zagg.grids.morton import morton_words
-
-        g = self._grid("morton", emit=True)
-        parent = _valid_parents(1)[0]
-        coords = g.chunk_coords(parent)
-        children = np.asarray(g.children(parent), dtype=np.uint64)
-        assert coords["cell_ids"].dtype == np.uint64
-        np.testing.assert_array_equal(coords["cell_ids"], children)
-        # The morton coordinate itself is unchanged (still the typed array).
-        np.testing.assert_array_equal(morton_words(coords["morton"]), children)
-
-    def test_morton_encoding_roundtrips_through_zarr(self):
+    def test_hatch_roundtrips_through_zarr(self):
         import pandas as pd
 
         from zagg.processing import write_dataframe_to_zarr
 
-        cfg = self._cfg("morton", emit=True)
+        cfg = self._cfg(emit=True)
         g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
         store = MemoryStore()
         g.emit_template(store)
@@ -1065,76 +1049,45 @@ class TestCellIdsEncoding:
         grp = open_group(store, path="8", mode="r")
         start = chunk_idx[0] * n
         stored = grp["cell_ids"][start : start + n]
-        np.testing.assert_array_equal(stored, np.asarray(g.children(parent), dtype=np.uint64))
+        np.testing.assert_array_equal(stored, g.encode_cell_ids(g.children(parent)))
         assert stored.dtype == np.uint64
 
-    def test_dggs_attrs_record_encoding(self):
-        # Nested stores are unchanged; a morton-declared store uses the
-        # DISTINCT grid name (D16 / issue #304 phase 1) — never
-        # name: "healpix" + indexing_scheme: "morton", which scheme-blind
-        # readers silently misread as NESTED.
-        assert self._grid()._dggs_attrs()["dggs"]["indexing_scheme"] == "nested"
-        assert self._grid("nested")._dggs_attrs()["dggs"]["indexing_scheme"] == "nested"
-        morton = self._grid("morton")._dggs_attrs()["dggs"]
-        assert morton["name"] == "morton"
-        assert "indexing_scheme" not in morton
-
-    def test_morton_attrs_declare_convention_block(self):
-        # Issue #304 phase 1: the morton-declared attrs flip — grid name
-        # "morton", the typed `morton` coordinate, and the self-declared
-        # convention entry (issue #305, permanent UUID) appended to the
+    def test_dggs_attrs_are_morton_declared(self):
+        # Issue #304 phase 3: EVERY HEALPix aggregation store is
+        # morton-declared — grid name "morton", typed `morton` coordinate,
+        # never name: "healpix" + indexing_scheme: "morton" (D16: scheme-blind
+        # readers must hard-reject, not silently misread), and the
+        # self-declared convention entry (issue #305, permanent UUID) on the
         # zarr_conventions LIST so future upstream entries can coexist.
         from zagg.grids.morton import MORTON_CONVENTION
 
-        attrs = self._grid("morton")._dggs_attrs()
-        assert attrs["dggs"]["coordinate"] == "morton"
-        assert attrs["dggs"]["name"] == "morton"
-        assert MORTON_CONVENTION in attrs["zarr_conventions"]
-        names = [c["name"] for c in attrs["zarr_conventions"]]
-        assert names == ["dggs", "morton-dggs"]
-
-    def test_nested_attrs_unchanged_by_flip(self):
-        # The default store's attrs block keeps the same key set and values as
-        # the pre-flip form (key order is not part of the contract; JSON attrs
-        # parse order-independently): name healpix, NESTED coordinate, one
-        # convention entry.
-        attrs = self._grid()._dggs_attrs()
-        assert attrs["dggs"]["name"] == "healpix"
-        assert attrs["dggs"]["coordinate"] == "cell_ids"
-        assert len(attrs["zarr_conventions"]) == 1
+        for emit in (None, True):
+            attrs = self._grid(emit)._dggs_attrs()
+            assert attrs["dggs"]["name"] == "morton"
+            assert attrs["dggs"]["coordinate"] == "morton"
+            assert "indexing_scheme" not in attrs["dggs"]
+            assert MORTON_CONVENTION in attrs["zarr_conventions"]
+            names = [c["name"] for c in attrs["zarr_conventions"]]
+            assert names == ["dggs", "morton-dggs"]
 
     def test_dggs_attrs_declare_resolution_exact(self):
         # O10 discriminator (issue #305): grid-derived cell coordinates are
-        # "exact" by construction, under every encoding — "point" is reserved
-        # for location-derived id paths that don't exist in zagg outputs.
+        # "exact" by construction — "point" is reserved for location-derived
+        # id paths that don't exist in zagg outputs.
         from zagg.grids.morton import RESOLUTION_EXACT
 
-        for enc in (None, "nested", "morton"):
-            assert self._grid(enc)._dggs_attrs()["dggs"]["resolution"] == RESOLUTION_EXACT
+        for emit in (None, True):
+            assert self._grid(emit)._dggs_attrs()["dggs"]["resolution"] == RESOLUTION_EXACT
 
     def test_dggs_attrs_reach_written_store(self):
-        # Round-trip past the return-value assertions above: the dggs block
-        # (incl. `resolution`) must survive spec()->emit_template->to_zarr and
-        # be readable off the WRITTEN group's attrs — that store path is what
-        # #305 readers key on.
+        # Round-trip past the return-value assertions above: the full flipped
+        # dggs block (name/coordinate "morton", resolution exact, no
+        # indexing_scheme) and BOTH convention entries must survive
+        # spec()->emit_template->to_zarr and be readable off the WRITTEN
+        # group's attrs — that store path is what #305 readers key on.
         from zagg.grids.morton import RESOLUTION_EXACT
 
         g = self._grid()
-        store = MemoryStore()
-        g.emit_template(store)
-        attrs = open_group(store, path="8", mode="r").attrs
-        assert attrs["dggs"]["resolution"] == RESOLUTION_EXACT
-        assert isinstance(attrs["zarr_conventions"], list)
-        assert len(attrs["zarr_conventions"]) >= 1
-
-    def test_morton_dggs_attrs_reach_written_store(self):
-        # Companion to the nested case above for the morton-declared grid: the
-        # full flipped dggs block (name/coordinate "morton", resolution exact,
-        # no indexing_scheme) and BOTH convention entries must survive
-        # spec()->emit_template->to_zarr and be readable off the WRITTEN group.
-        from zagg.grids.morton import RESOLUTION_EXACT
-
-        g = self._grid("morton")
         store = MemoryStore()
         g.emit_template(store)
         attrs = open_group(store, path="8", mode="r").attrs
@@ -1153,8 +1106,7 @@ class TestCellIdsEncoding:
 
         assert MORTON_CONVENTION["uuid"] == "3e22156d-ea9e-4e01-95fe-e3809a4b41e7"
         assert MORTON_CONVENTION["name"] == "morton-dggs"
-        # Same entry shape as the zarr_conventions list already emitted by
-        # _dggs_attrs, so the PR-2 attrs flip can append it verbatim.
+        # Same entry shape as the generic dggs entry it rides beside.
         emitted = self._grid()._dggs_attrs()["zarr_conventions"][0]
         assert set(MORTON_CONVENTION) == set(emitted)
         # The normative home is the mortie spec page, not the design doc.
@@ -1162,37 +1114,22 @@ class TestCellIdsEncoding:
         assert MORTON_CONVENTION["spec_url"].endswith("docs/specification.md")
         assert (RESOLUTION_EXACT, RESOLUTION_POINT) == ("exact", "point")
 
-    def test_spatial_signature_unchanged_by_encoding(self):
-        # The encoding changes coordinate VALUES, not the spatial layout, so
-        # shard maps stay reusable across the flag (#89).
-        assert self._grid("morton").spatial_signature() == self._grid().spatial_signature()
+    def test_spatial_signature_unchanged_by_hatch(self):
+        # The hatch changes the leaf schema, not the spatial layout, so shard
+        # maps stay reusable across the flag (#89).
+        assert self._grid(emit=True).spatial_signature() == self._grid().spatial_signature()
+        assert "emit_cell_ids" not in self._grid().spatial_signature()
 
-    def test_unknown_encoding_rejected_at_grid_construction(self):
-        # coords_of (values) and _dggs_attrs (recorded scheme) both interpret the
-        # string, so a grid built from an UNVALIDATED config must reject a third
-        # value here — otherwise NESTED values would be recorded under a foreign
-        # scheme name and consumers would mis-decode every cell.
-        with pytest.raises(ValueError, match="Unknown cell_ids_encoding"):
-            self._grid("ring")
+    def test_retired_knob_errors_at_config_validation(self):
+        # The issue #135 knob is retired (issue #304 phase 3): a config still
+        # carrying it fails loudly at validation with the migration pointer
+        # (grid construction no longer reads it at all).
+        from zagg.config import validate_config
 
-    def test_signature_records_encoding(self):
-        # The full fingerprint carries the encoding (issue #135) so the
-        # validate_compatible rejection message names the actual mismatch;
-        # spatial_signature (shard-map reuse) deliberately does not.
-        assert self._grid().signature()["cell_ids_encoding"] == "nested"
-        assert self._grid("morton").signature()["cell_ids_encoding"] == "morton"
-        assert "cell_ids_encoding" not in self._grid("morton").spatial_signature()
-
-    def test_mixed_encodings_do_not_nest(self):
-        # NESTED ids and morton words are different id spaces: co-aggregating
-        # them would let a consumer join on cell_ids and silently mismatch.
-        nested, morton = self._grid(), self._grid("morton")
-        assert not nested.nests_with(morton)
-        assert not morton.nests_with(nested)
-        # Same encoding still nests — including default vs explicit "nested",
-        # so the gate changes nothing for anyone not using the flag.
-        assert nested.nests_with(self._grid("nested"))
-        assert morton.nests_with(self._grid("morton"))
+        cfg = self._cfg()
+        cfg.output["grid"]["cell_ids_encoding"] = "morton"
+        with pytest.raises(ValueError, match="cell_ids_encoding was retired"):
+            validate_config(cfg)
 
 
 class TestChunkInnerMultiChunk:

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1028,6 +1028,32 @@ class TestCellIdsEncoding:
         assert self._grid("nested")._dggs_attrs()["dggs"]["indexing_scheme"] == "nested"
         assert self._grid("morton")._dggs_attrs()["dggs"]["indexing_scheme"] == "morton"
 
+    def test_dggs_attrs_declare_resolution_exact(self):
+        # O10 discriminator (issue #305): grid-derived cell coordinates are
+        # "exact" by construction, under every encoding — "point" is reserved
+        # for location-derived id paths that don't exist in zagg outputs.
+        from zagg.grids.morton import RESOLUTION_EXACT
+
+        for enc in (None, "nested", "morton"):
+            assert self._grid(enc)._dggs_attrs()["dggs"]["resolution"] == RESOLUTION_EXACT
+
+    def test_morton_convention_constants_pinned(self):
+        # The self-declared convention identity (issue #305): the UUID is
+        # minted once and PERMANENT — this pin makes an accidental regeneration
+        # a test failure, not a silent identity change.
+        from zagg.grids.morton import MORTON_CONVENTION, RESOLUTION_EXACT, RESOLUTION_POINT
+
+        assert MORTON_CONVENTION["uuid"] == "3e22156d-ea9e-4e01-95fe-e3809a4b41e7"
+        assert MORTON_CONVENTION["name"] == "morton-dggs"
+        # Same entry shape as the zarr_conventions list already emitted by
+        # _dggs_attrs, so the PR-2 attrs flip can append it verbatim.
+        emitted = self._grid()._dggs_attrs()["zarr_conventions"][0]
+        assert set(MORTON_CONVENTION) == set(emitted)
+        # The normative home is the mortie spec page, not the design doc.
+        assert "espg/mortie" in MORTON_CONVENTION["spec_url"]
+        assert MORTON_CONVENTION["spec_url"].endswith("docs/specification.md")
+        assert (RESOLUTION_EXACT, RESOLUTION_POINT) == ("exact", "point")
+
     def test_spatial_signature_unchanged_by_encoding(self):
         # The encoding changes coordinate VALUES, not the spatial layout, so
         # shard maps stay reusable across the flag (#89).

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1116,7 +1116,12 @@ class TestCellIdsEncoding:
         # The self-declared convention identity (issue #305): the UUID is
         # minted once and PERMANENT — this pin makes an accidental regeneration
         # a test failure, not a silent identity change.
-        from zagg.grids.morton import MORTON_CONVENTION, RESOLUTION_EXACT, RESOLUTION_POINT
+        from zagg.grids.morton import (
+            MORTON_CONVENTION,
+            RESOLUTION_EXACT,
+            RESOLUTION_MIXED,
+            RESOLUTION_POINT,
+        )
 
         assert MORTON_CONVENTION["uuid"] == "3e22156d-ea9e-4e01-95fe-e3809a4b41e7"
         assert MORTON_CONVENTION["name"] == "morton-dggs"
@@ -1126,7 +1131,15 @@ class TestCellIdsEncoding:
         # The normative home is the mortie spec page, not the design doc.
         assert "espg/mortie" in MORTON_CONVENTION["spec_url"]
         assert MORTON_CONVENTION["spec_url"].endswith("docs/specification.md")
-        assert (RESOLUTION_EXACT, RESOLUTION_POINT) == ("exact", "point")
+        # The full declared-value set (mortie spec §4; "mixed" espg-proposed
+        # on the PR #118 review, 2026-07-21 — order-29 ids are points, all
+        # other orders exact, clip rule inapplicable). zagg writers emit only
+        # "exact"; the constants are the seam for the point/mixed paths.
+        assert (RESOLUTION_EXACT, RESOLUTION_POINT, RESOLUTION_MIXED) == (
+            "exact",
+            "point",
+            "mixed",
+        )
 
     def test_spatial_signature_unchanged_by_hatch(self):
         # The hatch changes the leaf schema, not the spatial layout, so shard

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -710,7 +710,9 @@ class TestPlainConfigByteIdentical:
 
 class TestMortonCoordinate:
     """The ``morton`` coordinate is a mortie ``MortonIndexArray`` stored as
-    ``uint64`` on disk (#71); ``cell_ids`` stays NESTED ``uint64`` (DGGS)."""
+    ``uint64`` on disk (#71); it is the ONLY stored cell coordinate by
+    default (D16, issue #304 — legacy ``cell_ids`` only under the
+    ``emit_cell_ids`` transition hatch)."""
 
     def test_chunk_coords_morton_is_extension_array(self, cfg):
         from mortie import MortonIndexArray
@@ -719,8 +721,8 @@ class TestMortonCoordinate:
         parent = _valid_parents(1)[0]
         coords = g.chunk_coords(parent)
         assert isinstance(coords["morton"], MortonIndexArray)
-        # cell_ids stays a plain NESTED integer array, unchanged.
-        assert not isinstance(coords["cell_ids"], MortonIndexArray)
+        # D16 flip (issue #304 phase 2): no legacy cell_ids column by default.
+        assert "cell_ids" not in coords
 
     def test_morton_words_match_generate_children(self, cfg):
         """The typed coordinate carries the same packed words generate_morton_children
@@ -770,9 +772,9 @@ class TestMortonCoordinate:
 
         parent = _valid_parents(1)[0]
         coords = g.chunk_coords(parent)
-        n = len(coords["cell_ids"])
-        df = pd.DataFrame({"cell_ids": coords["cell_ids"]})
-        df["morton"] = coords["morton"]
+        nested = g.encode_cell_ids(g.children(parent))
+        n = len(nested)
+        df = pd.DataFrame({"morton": coords["morton"]})
         for var in get_data_vars(cfg):
             df[var] = np.zeros(n, dtype=np.int32 if var == "count" else np.float32)
 
@@ -780,8 +782,8 @@ class TestMortonCoordinate:
 
         grp = open_group(store, path=str(child_order), mode="r")
         assert grp["morton"].dtype == np.uint64
-        lo = int(np.asarray(coords["cell_ids"]).min())
-        hi = int(np.asarray(coords["cell_ids"]).max())
+        lo = int(np.asarray(nested).min())
+        hi = int(np.asarray(nested).max())
         stored = grp["morton"][lo : hi + 1]
         expected = morton_words(coords["morton"])
         np.testing.assert_array_equal(stored, expected)
@@ -957,38 +959,81 @@ class TestShardLabel:
 
 
 class TestCellIdsEncoding:
-    """Issue #135: ``output.grid.cell_ids_encoding`` — ``cell_ids`` stays NESTED
-    HEALPix uint64 by default; ``morton`` emits the packed morton words instead
-    (a test/prototype capability). Default behavior is byte-identical."""
+    """Issue #135 (``cell_ids_encoding``) + issue #304 (the D16 default flip):
+    ``morton`` is the only stored cell coordinate by default; the
+    ``emit_cell_ids: true`` transition hatch restores the legacy ``cell_ids``
+    array (NESTED uint64, or packed morton words under
+    ``cell_ids_encoding: morton``)."""
 
     @staticmethod
-    def _cfg(encoding=None):
+    def _cfg(encoding=None, emit=None):
         cfg = default_config("atl06")
         if encoding is not None:
             cfg.output["grid"]["cell_ids_encoding"] = encoding
+        if emit is not None:
+            cfg.output["grid"]["emit_cell_ids"] = emit
         return cfg
 
-    def _grid(self, encoding=None):
+    def _grid(self, encoding=None, emit=None):
         return HealpixGrid(
-            parent_order=6, child_order=8, layout="fullsphere", config=self._cfg(encoding)
+            parent_order=6, child_order=8, layout="fullsphere", config=self._cfg(encoding, emit)
         )
+
+    def test_default_emits_no_cell_ids(self):
+        # The D16 flip (issue #304 phase 2): by default neither the coords
+        # column nor the template member exists — keyed off ONE flag so the
+        # writer and the template cannot disagree.
+        parent = _valid_parents(1)[0]
+        g = self._grid()
+        assert "cell_ids" not in g.chunk_coords(parent)
+        assert "cell_ids" not in g.spec().members
+        assert "cell_ids" not in g.shard_spec().members
+        assert g.signature()["emit_cell_ids"] is False
+
+    def test_hatch_restores_declared_member(self):
+        # emit_cell_ids: true keeps the legacy array (the atl06 config still
+        # declares the coordinate, so the declared dtype/fill are honored).
+        g = self._grid(emit=True)
+        parent = _valid_parents(1)[0]
+        coords = g.chunk_coords(parent)
+        np.testing.assert_array_equal(coords["cell_ids"], g.encode_cell_ids(g.children(parent)))
+        assert str(g.spec().members["cell_ids"].data_type) == "uint64"
+        assert g.signature()["emit_cell_ids"] is True
+
+    def test_hatch_synthesizes_member_when_undeclared(self):
+        # Phase 3 removes the shipped cell_ids declarations; the hatch must
+        # not depend on them — an undeclared cell_ids member synthesizes as
+        # the standard uint64/fill-0 array.
+        cfg = self._cfg(emit=True)
+        del cfg.aggregation["coordinates"]["cell_ids"]
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        member = g.spec().members["cell_ids"]
+        assert str(member.data_type) == "uint64"
+        assert "cell_ids" in g.chunk_coords(_valid_parents(1)[0])
+
+    def test_mixed_hatch_states_do_not_nest(self):
+        # One store carries the extra array, the other does not — different
+        # leaf schemas must never co-aggregate.
+        assert not self._grid().nests_with(self._grid(emit=True))
+        assert not self._grid(emit=True).nests_with(self._grid())
+        assert self._grid(emit=True).nests_with(self._grid(emit=True))
 
     def test_default_and_explicit_nested_identical(self):
         parent = _valid_parents(1)[0]
-        default = self._grid().chunk_coords(parent)
-        nested = self._grid("nested").chunk_coords(parent)
+        default = self._grid(emit=True).chunk_coords(parent)
+        nested = self._grid("nested", emit=True).chunk_coords(parent)
         np.testing.assert_array_equal(default["cell_ids"], nested["cell_ids"])
         np.testing.assert_array_equal(
             np.asarray(default["morton"]._data), np.asarray(nested["morton"]._data)
         )
-        # Default stays the NESTED encode, unchanged.
-        g = self._grid()
+        # The hatch's default stays the NESTED encode, unchanged.
+        g = self._grid(emit=True)
         np.testing.assert_array_equal(default["cell_ids"], g.encode_cell_ids(g.children(parent)))
 
     def test_morton_encoding_emits_words(self):
         from zagg.grids.morton import morton_words
 
-        g = self._grid("morton")
+        g = self._grid("morton", emit=True)
         parent = _valid_parents(1)[0]
         coords = g.chunk_coords(parent)
         children = np.asarray(g.children(parent), dtype=np.uint64)
@@ -1002,7 +1047,7 @@ class TestCellIdsEncoding:
 
         from zagg.processing import write_dataframe_to_zarr
 
-        cfg = self._cfg("morton")
+        cfg = self._cfg("morton", emit=True)
         g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
         store = MemoryStore()
         g.emit_template(store)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1084,30 +1084,26 @@ class TestCellIdsEncoding:
             names = [c["name"] for c in attrs["zarr_conventions"]]
             assert names == ["dggs", "morton-dggs"]
 
-    def test_dggs_attrs_declare_resolution_exact(self):
-        # O10 discriminator (issue #305): grid-derived cell coordinates are
-        # "exact" by construction — "point" is reserved for location-derived
-        # id paths that don't exist in zagg outputs.
-        from zagg.grids.morton import RESOLUTION_EXACT
-
+    def test_dggs_attrs_carry_no_kind_field(self):
+        # O10 final ruling (espg 2026-07-21): kind is carried by the word
+        # ENCODING (mortie spec §4), never by attrs — no resolution field.
         for emit in (None, True):
-            assert self._grid(emit)._dggs_attrs()["dggs"]["resolution"] == RESOLUTION_EXACT
+            assert "resolution" not in self._grid(emit)._dggs_attrs()["dggs"]
 
     def test_dggs_attrs_reach_written_store(self):
         # Round-trip past the return-value assertions above: the full flipped
-        # dggs block (name/coordinate "morton", resolution exact, no
-        # indexing_scheme) and BOTH convention entries must survive
-        # spec()->emit_template->to_zarr and be readable off the WRITTEN
-        # group's attrs — that store path is what #305 readers key on.
-        from zagg.grids.morton import RESOLUTION_EXACT
-
+        # dggs block (name/coordinate "morton", no indexing_scheme, no
+        # kind/resolution field — O10 final ruling) and BOTH convention
+        # entries must survive spec()->emit_template->to_zarr and be readable
+        # off the WRITTEN group's attrs — that store path is what #305
+        # readers key on.
         g = self._grid()
         store = MemoryStore()
         g.emit_template(store)
         attrs = open_group(store, path="8", mode="r").attrs
         assert attrs["dggs"]["name"] == "morton"
         assert attrs["dggs"]["coordinate"] == "morton"
-        assert attrs["dggs"]["resolution"] == RESOLUTION_EXACT
+        assert "resolution" not in attrs["dggs"]
         assert "indexing_scheme" not in attrs["dggs"]
         names = [c["name"] for c in attrs["zarr_conventions"]]
         assert names == ["dggs", "morton-dggs"]
@@ -1116,12 +1112,7 @@ class TestCellIdsEncoding:
         # The self-declared convention identity (issue #305): the UUID is
         # minted once and PERMANENT — this pin makes an accidental regeneration
         # a test failure, not a silent identity change.
-        from zagg.grids.morton import (
-            MORTON_CONVENTION,
-            RESOLUTION_EXACT,
-            RESOLUTION_MIXED,
-            RESOLUTION_POINT,
-        )
+        from zagg.grids.morton import MORTON_CONVENTION
 
         assert MORTON_CONVENTION["uuid"] == "3e22156d-ea9e-4e01-95fe-e3809a4b41e7"
         assert MORTON_CONVENTION["name"] == "morton-dggs"
@@ -1131,15 +1122,6 @@ class TestCellIdsEncoding:
         # The normative home is the mortie spec page, not the design doc.
         assert "espg/mortie" in MORTON_CONVENTION["spec_url"]
         assert MORTON_CONVENTION["spec_url"].endswith("docs/specification.md")
-        # The full declared-value set (mortie spec §4; "mixed" espg-proposed
-        # on the PR #118 review, 2026-07-21 — order-29 ids are points, all
-        # other orders exact, clip rule inapplicable). zagg writers emit only
-        # "exact"; the constants are the seam for the point/mixed paths.
-        assert (RESOLUTION_EXACT, RESOLUTION_POINT, RESOLUTION_MIXED) == (
-            "exact",
-            "point",
-            "mixed",
-        )
 
     def test_spatial_signature_unchanged_by_hatch(self):
         # The hatch changes the leaf schema, not the spatial layout, so shard

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1019,6 +1019,20 @@ class TestCellIdsEncoding:
         g2 = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg2)
         assert "cell_ids" not in g2.spec().members
 
+    def test_hatch_with_aoi_mask_emits_both_members(self):
+        # emit_cell_ids and output.aoi_mask are independent template branches
+        # (#304 phase 2 hatch vs #101 strict-AOI mask). Exercise the combined
+        # template so both extra members ride alongside the always-present
+        # morton coordinate in one spec.
+        cfg = self._cfg(emit=True)
+        cfg.output["aoi_mask"] = True
+        g = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+        members = g.spec().members
+        assert "morton" in members
+        assert "cell_ids" in members
+        assert "aoi_mask" in members
+        assert str(members["aoi_mask"].data_type) == "bool"
+
     def test_mixed_hatch_states_do_not_nest(self):
         # One store carries the extra array, the other does not — different
         # leaf schemas must never co-aggregate.

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1125,6 +1125,24 @@ class TestCellIdsEncoding:
         assert isinstance(attrs["zarr_conventions"], list)
         assert len(attrs["zarr_conventions"]) >= 1
 
+    def test_morton_dggs_attrs_reach_written_store(self):
+        # Companion to the nested case above for the morton-declared grid: the
+        # full flipped dggs block (name/coordinate "morton", resolution exact,
+        # no indexing_scheme) and BOTH convention entries must survive
+        # spec()->emit_template->to_zarr and be readable off the WRITTEN group.
+        from zagg.grids.morton import RESOLUTION_EXACT
+
+        g = self._grid("morton")
+        store = MemoryStore()
+        g.emit_template(store)
+        attrs = open_group(store, path="8", mode="r").attrs
+        assert attrs["dggs"]["name"] == "morton"
+        assert attrs["dggs"]["coordinate"] == "morton"
+        assert attrs["dggs"]["resolution"] == RESOLUTION_EXACT
+        assert "indexing_scheme" not in attrs["dggs"]
+        names = [c["name"] for c in attrs["zarr_conventions"]]
+        assert names == ["dggs", "morton-dggs"]
+
     def test_morton_convention_constants_pinned(self):
         # The self-declared convention identity (issue #305): the UUID is
         # minted once and PERMANENT — this pin makes an accidental regeneration

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1024,9 +1024,37 @@ class TestCellIdsEncoding:
         assert stored.dtype == np.uint64
 
     def test_dggs_attrs_record_encoding(self):
+        # Nested stores are unchanged; a morton-declared store uses the
+        # DISTINCT grid name (D16 / issue #304 phase 1) — never
+        # name: "healpix" + indexing_scheme: "morton", which scheme-blind
+        # readers silently misread as NESTED.
         assert self._grid()._dggs_attrs()["dggs"]["indexing_scheme"] == "nested"
         assert self._grid("nested")._dggs_attrs()["dggs"]["indexing_scheme"] == "nested"
-        assert self._grid("morton")._dggs_attrs()["dggs"]["indexing_scheme"] == "morton"
+        morton = self._grid("morton")._dggs_attrs()["dggs"]
+        assert morton["name"] == "morton"
+        assert "indexing_scheme" not in morton
+
+    def test_morton_attrs_declare_convention_block(self):
+        # Issue #304 phase 1: the morton-declared attrs flip — grid name
+        # "morton", the typed `morton` coordinate, and the self-declared
+        # convention entry (issue #305, permanent UUID) appended to the
+        # zarr_conventions LIST so future upstream entries can coexist.
+        from zagg.grids.morton import MORTON_CONVENTION
+
+        attrs = self._grid("morton")._dggs_attrs()
+        assert attrs["dggs"]["coordinate"] == "morton"
+        assert attrs["dggs"]["name"] == "morton"
+        assert MORTON_CONVENTION in attrs["zarr_conventions"]
+        names = [c["name"] for c in attrs["zarr_conventions"]]
+        assert names == ["dggs", "morton-dggs"]
+
+    def test_nested_attrs_unchanged_by_flip(self):
+        # The default store's attrs block is byte-identical in shape to the
+        # pre-flip form: name healpix, NESTED coordinate, one convention entry.
+        attrs = self._grid()._dggs_attrs()
+        assert attrs["dggs"]["name"] == "healpix"
+        assert attrs["dggs"]["coordinate"] == "cell_ids"
+        assert len(attrs["zarr_conventions"]) == 1
 
     def test_dggs_attrs_declare_resolution_exact(self):
         # O10 discriminator (issue #305): grid-derived cell coordinates are

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1094,8 +1094,10 @@ class TestCellIdsEncoding:
         assert names == ["dggs", "morton-dggs"]
 
     def test_nested_attrs_unchanged_by_flip(self):
-        # The default store's attrs block is byte-identical in shape to the
-        # pre-flip form: name healpix, NESTED coordinate, one convention entry.
+        # The default store's attrs block keeps the same key set and values as
+        # the pre-flip form (key order is not part of the contract; JSON attrs
+        # parse order-independently): name healpix, NESTED coordinate, one
+        # convention entry.
         attrs = self._grid()._dggs_attrs()
         assert attrs["dggs"]["name"] == "healpix"
         assert attrs["dggs"]["coordinate"] == "cell_ids"

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1037,6 +1037,21 @@ class TestCellIdsEncoding:
         for enc in (None, "nested", "morton"):
             assert self._grid(enc)._dggs_attrs()["dggs"]["resolution"] == RESOLUTION_EXACT
 
+    def test_dggs_attrs_reach_written_store(self):
+        # Round-trip past the return-value assertions above: the dggs block
+        # (incl. `resolution`) must survive spec()->emit_template->to_zarr and
+        # be readable off the WRITTEN group's attrs — that store path is what
+        # #305 readers key on.
+        from zagg.grids.morton import RESOLUTION_EXACT
+
+        g = self._grid()
+        store = MemoryStore()
+        g.emit_template(store)
+        attrs = open_group(store, path="8", mode="r").attrs
+        assert attrs["dggs"]["resolution"] == RESOLUTION_EXACT
+        assert isinstance(attrs["zarr_conventions"], list)
+        assert len(attrs["zarr_conventions"]) >= 1
+
     def test_morton_convention_constants_pinned(self):
         # The self-declared convention identity (issue #305): the UUID is
         # minted once and PERMANENT — this pin makes an accidental regeneration

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -18,7 +18,7 @@ from zarr.storage import MemoryStore
 from zagg import hive
 from zagg.config import default_config, get_data_vars, validate_config
 from zagg.grids import HealpixGrid
-from zagg.grids.morton import morton_decimal
+from zagg.grids.morton import morton_decimal, morton_words
 
 
 @pytest.fixture
@@ -303,7 +303,7 @@ class TestLeafTemplateAndStamp:
         store = MemoryStore()
         g.emit_shard_template(store, overwrite=True)
         grp = zarr.open_group(store, path=g.group_path, mode="r", zarr_format=3)
-        for name in ("morton", "cell_ids", *get_data_vars(cfg)):
+        for name in ("morton", *get_data_vars(cfg)):
             assert grp[name].shape == (g.cells_per_shard,)
             assert grp[name].chunks == (g.cells_per_chunk,)
 
@@ -328,7 +328,7 @@ class TestLeafTemplateAndStamp:
         store = MemoryStore()
         g.emit_shard_template(store, overwrite=True)
         grp = zarr.open_group(store, path=g.group_path, mode="r", zarr_format=3)
-        for name in ("morton", "cell_ids", *get_data_vars(cfg)):
+        for name in ("morton", *get_data_vars(cfg)):
             assert grp[name].shape == (g.cells_per_shard,)
             assert grp[name].shards == (g.cells_per_shard,)
             assert grp[name].chunks == (g.cells_per_chunk,)
@@ -384,7 +384,7 @@ class TestProcessAndWriteHive:
         from zagg.config import get_agg_fields, get_output_signature
 
         coords = grid.chunk_coords(shard)
-        n = len(coords["cell_ids"])
+        n = len(coords["morton"])
         agg = get_agg_fields(grid.config)
         df = pd.DataFrame(
             {
@@ -442,8 +442,8 @@ class TestProcessAndWriteHive:
         # Dense data landed at the leaf-LOCAL block 0.
         grp = zarr.open_group(leaf_store, path=grid.group_path, mode="r", zarr_format=3)
         np.testing.assert_array_equal(
-            np.asarray(grp["cell_ids"][:]),
-            np.asarray(grid.chunk_coords(shard)["cell_ids"]),
+            np.asarray(grp["morton"][:]),
+            morton_words(grid.chunk_coords(shard)["morton"]),
         )
         # The ragged payload sits in the leaf's vlen-bytes array at its cell
         # position (issue #209), as ONE data object.
@@ -748,7 +748,7 @@ class TestProcessAndWriteHiveSharded:
         leaf = hive.shard_leaf_path(root, shard)
         leaf_store = open_store(leaf)
         base = grid.block_index(shard)[0] * grid.cells_per_shard
-        names = ["morton", "cell_ids", "h", *get_data_vars(cfg)]
+        names = ["morton", "h", *get_data_vars(cfg)]
         for name in names:
             # ONE ShardingCodec object per array (was K per-chunk objects).
             assert self._leaf_object_count(leaf, grid, name) == 1, name
@@ -1286,7 +1286,7 @@ class TestRunnerWiring:
         agg(cfg, catalog=catalog_path, store=root, backend="local")
 
         leaf = hive.shard_leaf_path(root, shard)
-        for name in ("morton", "cell_ids", "h"):
+        for name in ("morton", "h"):
             chunk_dir = os.path.join(leaf, grid.group_path, name, "c")
             n_objects = sum(len(files) for _d, _s, files in os.walk(chunk_dir))
             assert n_objects == 1, name

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -1081,7 +1081,7 @@ class TestProcessAndWriteHiveWindowed:
         from zagg.config import get_agg_fields, get_data_vars, get_output_signature
 
         coords = grid.chunk_coords(shard)
-        n = len(coords["cell_ids"])
+        n = len(coords["morton"])
         agg = get_agg_fields(grid.config)
         df = pd.DataFrame(
             {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 import numpy as np
 import zarr
+from conftest import nested_ids
 from zarr.storage import MemoryStore
 
 from zagg.config import default_config, get_coords, get_data_vars
@@ -13,7 +14,8 @@ def test_full_integration(zarr_store, mock_dataframe_factory):
     child_order = 8
 
     cfg = default_config()
-    coords = get_coords(cfg)
+    # D16 flip (issue #304): the stored coordinate set excludes cell_ids.
+    coords = [c for c in get_coords(cfg) if c != "cell_ids"]
     data_vars = get_data_vars(cfg)
 
     grid = HealpixGrid(parent_order, child_order, layout="fullsphere", config=cfg)
@@ -23,12 +25,12 @@ def test_full_integration(zarr_store, mock_dataframe_factory):
     df_out = mock_dataframe_factory(-78.5, -132.0, parent_order, child_order)
 
     n_children = 4 ** (child_order - parent_order)
-    chunk_idx = (int(df_out["cell_ids"].min()) // n_children,)
+    chunk_idx = (int(nested_ids(df_out).min()) // n_children,)
     write_dataframe_to_zarr(df_out, store, grid=grid, chunk_idx=chunk_idx)
 
     group = zarr.open_group(store=store, path=str(child_order), mode="r")
-    min_idx = int(df_out["cell_ids"].min())
-    max_idx = int(df_out["cell_ids"].max())
+    min_idx = int(nested_ids(df_out).min())
+    max_idx = int(nested_ids(df_out).max())
 
     for col in coords + data_vars:
         actual = group[col][min_idx : max_idx + 1]
@@ -92,7 +94,8 @@ def test_multiple_parent_cells(zarr_store, mock_dataframe_factory):
     child_order = 8
 
     cfg = default_config()
-    coords = get_coords(cfg)
+    # D16 flip (issue #304): the stored coordinate set excludes cell_ids.
+    coords = [c for c in get_coords(cfg) if c != "cell_ids"]
     data_vars = get_data_vars(cfg)
 
     grid = HealpixGrid(parent_order, child_order, layout="fullsphere", config=cfg)
@@ -109,7 +112,7 @@ def test_multiple_parent_cells(zarr_store, mock_dataframe_factory):
         df_out = mock_dataframe_factory(lat, lon, parent_order, child_order)
 
         n_children = 4 ** (child_order - parent_order)
-        chunk_idx = (int(df_out["cell_ids"].min()) // n_children,)
+        chunk_idx = (int(nested_ids(df_out).min()) // n_children,)
         write_dataframe_to_zarr(df_out, store, grid=grid, chunk_idx=chunk_idx)
 
         all_data[(lat, lon)] = df_out
@@ -117,8 +120,8 @@ def test_multiple_parent_cells(zarr_store, mock_dataframe_factory):
     group = zarr.open_group(store=store, path=str(child_order), mode="r")
 
     for (lat, lon), df_out in all_data.items():
-        min_idx = int(df_out["cell_ids"].min())
-        max_idx = int(df_out["cell_ids"].max())
+        min_idx = int(nested_ids(df_out).min())
+        max_idx = int(nested_ids(df_out).max())
 
         for col in coords + data_vars:
             actual = group[col][min_idx : max_idx + 1]

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -23,6 +23,7 @@ from zarr.storage import MemoryStore
 
 from zagg.config import default_config
 from zagg.grids import HEALPIX_BASE_CELLS, from_config
+from zagg.grids.morton import morton_words
 
 REPO_ROOT = Path(__file__).parent.parent
 HANDLER_PATH = REPO_ROOT / "deployment" / "aws" / "lambda_handler.py"
@@ -884,7 +885,7 @@ class TestProcessHive:
         from zagg.config import get_agg_fields, get_data_vars, get_output_signature
 
         coords = grid.chunk_coords(shard)
-        n = len(coords["cell_ids"])
+        n = len(coords["morton"])
         agg = get_agg_fields(grid.config)
         df = pd.DataFrame(
             {
@@ -945,8 +946,8 @@ class TestProcessHive:
         # its vlen-bytes array at the cell position (issue #209), ONE object.
         grp = zarr.open_group(leaf_store, path=grid.group_path, mode="r", zarr_format=3)
         np.testing.assert_array_equal(
-            np.asarray(grp["cell_ids"][:]),
-            np.asarray(grid.chunk_coords(self._WORD)["cell_ids"]),
+            np.asarray(grp["morton"][:]),
+            morton_words(grid.chunk_coords(self._WORD)["morton"]),
         )
         ragged_arr = zarr.open_array(leaf_store, path=f"{grid.group_path}/h", mode="r")
         np.testing.assert_array_equal(np.frombuffer(ragged_arr[0:1][0], "<f4"), [1.0, 2.0])
@@ -1015,15 +1016,15 @@ class TestProcessHive:
         leaf = hive.shard_leaf_path(event["store_path"], self._WORD)
         leaf_store = open_store(leaf)
         cfg = load_config_from_dict(cfg_dict)
-        for name in ("morton", "cell_ids", "h", *get_data_vars(cfg)):
+        for name in ("morton", "h", *get_data_vars(cfg)):
             chunk_dir = os.path.join(leaf, grid.group_path, name, "c")
             n_objects = sum(len(files) for _d, _s, files in os.walk(chunk_dir))
             assert n_objects == 1, name
         # Whole-leaf contents readable after a fresh open; stamp is present.
         grp = zarr.open_group(leaf_store, path=grid.group_path, mode="r", zarr_format=3)
         np.testing.assert_array_equal(
-            np.asarray(grp["cell_ids"][:]),
-            np.asarray(grid.chunk_coords(self._WORD)["cell_ids"]),
+            np.asarray(grp["morton"][:]),
+            morton_words(grid.chunk_coords(self._WORD)["morton"]),
         )
         assert hive.read_commit(leaf_store)["complete"] is True
 
@@ -1536,7 +1537,7 @@ class TestSetupTemplate:
     def _template_chunk_count(store, worker_grid):
         """Number of chunks in the emitted cell-resolution array."""
         group = open_group(store, path=str(worker_grid.child_order), mode="r")
-        cell_arr = group["cell_ids"]
+        cell_arr = group["morton"]
         return cell_arr.shape[0] // cell_arr.chunks[0]
 
     def test_setup_template_chunked_at_chunk_inner(self, handler_mod, monkeypatch):

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -117,13 +117,13 @@ class TestProcessRasterMode:
         np.testing.assert_array_equal(got[valid], data[rows[valid], cols[valid]])
         assert (got[~valid] == 0).all()
         ids = open_array(
-            event["store_path"] + f"/{grid.group_path}/cell_ids",
+            event["store_path"] + f"/{grid.group_path}/morton",
             zarr_format=3,
             consolidated=False,
         )
         np.testing.assert_array_equal(
             ids[start : start + grid.cells_per_shard],
-            np.asarray(grid.encode_cell_ids(cells), dtype=np.uint64),
+            np.asarray(cells, dtype=np.uint64),
         )
 
     def test_handler_streams_slabs_incrementally(self, handler_mod, raster_event, monkeypatch):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -3,6 +3,7 @@ import gc
 import numpy as np
 import pandas as pd
 import pytest
+from conftest import nested_ids
 from zarr import open_group
 from zarr.storage import MemoryStore
 
@@ -48,7 +49,8 @@ class TestWriteDataframeToZarr:
         child_order = 8
 
         cfg = default_config()
-        coords = get_coords(cfg)
+        # D16 flip (issue #304): the stored coordinate set excludes cell_ids.
+        coords = [c for c in get_coords(cfg) if c != "cell_ids"]
         data_vars = get_data_vars(cfg)
 
         grid = HealpixGrid(parent_order, child_order, layout="fullsphere", config=cfg)
@@ -58,12 +60,12 @@ class TestWriteDataframeToZarr:
         df_out = mock_dataframe_factory(-78.5, -132.0, parent_order, child_order)
 
         n_children = 4 ** (child_order - parent_order)
-        chunk_idx = (int(df_out["cell_ids"].min()) // n_children,)
+        chunk_idx = (int(nested_ids(df_out).min()) // n_children,)
         assert write_dataframe_to_zarr(df_out, store, grid=grid, chunk_idx=chunk_idx)
 
         group = open_group(store=store, mode="r", path=str(child_order))
-        min_idx = int(df_out["cell_ids"].min())
-        max_idx = int(df_out["cell_ids"].max())
+        min_idx = int(nested_ids(df_out).min())
+        max_idx = int(nested_ids(df_out).max())
 
         for col in coords + data_vars:
             actual = group[col][min_idx : max_idx + 1]
@@ -87,7 +89,7 @@ class TestWriteDataframeToZarr:
         df_out = mock_dataframe_factory(-78.5, -132.0, parent_order, child_order)
         df_out = df_out.iloc[: len(df_out) // 2]
         n_children = 4 ** (child_order - parent_order)
-        chunk_idx = (int(df_out["cell_ids"].min()) // n_children,)
+        chunk_idx = (int(nested_ids(df_out).min()) // n_children,)
         with pytest.raises(ValueError, match="Expected.*rows for chunk_shape"):
             write_dataframe_to_zarr(df_out, store, grid=grid, chunk_idx=chunk_idx)
 
@@ -3142,8 +3144,8 @@ class TestTypedMortonCarrier:
         cfg, grid, parent, stats = self._setup()
         carrier = self._carrier(cfg, grid, parent, stats, use_arrow=True)
         assert is_morton_arrow(carrier.column("morton"))
-        # cell_ids stays a plain NESTED uint64 column, no extension metadata.
-        assert not is_morton_arrow(carrier.column("cell_ids"))
+        # D16 flip (issue #304): no legacy cell_ids column in the carrier.
+        assert "cell_ids" not in carrier.schema.names
 
     def test_extraction_yields_uint64_words(self):
         pytest.importorskip("arro3.core")
@@ -3215,13 +3217,11 @@ class TestTypedMortonCarrier:
         # word replaced by the sentinel (0), so the typed column carries a null.
         words = np.asarray(grid.children(parent), dtype=np.uint64).copy()
         words[0] = 0
-        cell_ids = grid.encode_cell_ids(grid.children(parent))
         mia = to_morton_array(words)
         assert mia.isna()[0]  # the sentinel really is a missing entry
 
         typed_cols = {var: ac.Array.from_numpy(stats[var]) for var in get_data_vars(cfg)}
         typed_cols["morton"] = morton_to_arrow(mia)
-        typed_cols["cell_ids"] = ac.Array.from_numpy(np.asarray(cell_ids))
         typed = self._store_bytes(ac.Table.from_pydict(typed_cols), grid, parent)
 
         strip_cols = dict(typed_cols)
@@ -3230,7 +3230,6 @@ class TestTypedMortonCarrier:
 
         df = pd.DataFrame({var: stats[var] for var in get_data_vars(cfg)})
         df["morton"] = mia
-        df["cell_ids"] = cell_ids
         via_pandas = self._store_bytes(df, grid, parent)
 
         assert typed.keys() == via_pandas.keys() == stripped.keys()

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -931,6 +931,19 @@ class TestRasterMortonCoordinate:
         assert grp.attrs["dggs"]["coordinate"] == "morton"
         assert "cell_ids" not in grp
 
+    def test_written_flat_attrs_round_trip(self, tmp_path):
+        # F14: the FLAT write is the one that changed from attributes={} to
+        # grid._dggs_attrs(); pin the written-store attrs there too, not just
+        # on the leaf.
+        import zarr
+
+        cfg, grid, _shard = _healpix_setup(tmp_path)
+        store = MemoryStore()
+        emit_raster_template(store, grid, cfg, np.array([0], dtype=np.int64))
+        grp = zarr.open_group(store, path=grid.group_path, mode="r", zarr_format=3)
+        assert grp.attrs["dggs"]["coordinate"] == "morton"
+        assert "cell_ids" not in grp
+
 
 class TestGeometryCache:
     """Issue #244: the pull-NN mapping is memoized per (epsg, transform, shape)

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -25,6 +25,7 @@ from zagg.processing.raster import (
     new_stage_stats,
     process_raster_shard,
     raster_group_spec,
+    raster_leaf_spec,
     raster_time_index,
     sample_item_async,
     write_raster_coords,
@@ -657,7 +658,7 @@ class TestTemplateAndSlabs:
         assert red.attributes["scale_factor"] == 0.0001
         assert red.attributes["add_offset"] == -0.1
         assert tuple(spec.members["time"].shape) == (3,)
-        assert tuple(spec.members["cell_ids"].shape) == (n_cells,)
+        assert tuple(spec.members["morton"].shape) == (n_cells,)
 
     def test_sharded_grid_rejected(self, tmp_path):
         cfg, grid, _shard = _healpix_setup(tmp_path)
@@ -698,13 +699,10 @@ class TestTemplateAndSlabs:
         # time coordinate round-trips as microseconds since epoch.
         tarr = open_array(store, path=f"{grid.group_path}/time", zarr_format=3, consolidated=False)
         np.testing.assert_array_equal(tarr[:], times)
-        # cell_ids written for the shard's block, in children order.
-        ids = open_array(
-            store, path=f"{grid.group_path}/cell_ids", zarr_format=3, consolidated=False
-        )
-        np.testing.assert_array_equal(
-            ids[start:stop], np.asarray(grid.encode_cell_ids(cells), dtype=np.uint64)
-        )
+        # morton written for the shard's block, in children order (D16 —
+        # packed words are the sole stored cell coordinate, issue #304).
+        ids = open_array(store, path=f"{grid.group_path}/morton", zarr_format=3, consolidated=False)
+        np.testing.assert_array_equal(ids[start:stop], np.asarray(cells, dtype=np.uint64))
         assert valid.sum() > 50  # the 960 m raster covers many ~97 m cells
 
     def test_zero_time_template(self, tmp_path):
@@ -798,7 +796,7 @@ class TestLeafTemplate:
         assert tuple(cfg_block["chunk_shape"]) == (1, grid.cells_per_chunk)
         assert red.attributes["scale_factor"] == 0.0001
         assert tuple(inner.members["time"].shape) == (3,)
-        assert tuple(inner.members["cell_ids"].shape) == (grid.cells_per_shard,)
+        assert tuple(inner.members["morton"].shape) == (grid.cells_per_shard,)
 
     def test_leaf_spec_sharded_rejected(self, tmp_path):
         from zagg.processing.raster import raster_leaf_spec
@@ -811,7 +809,7 @@ class TestLeafTemplate:
     def test_leaf_template_round_trip(self, tmp_path):
         # Emit one leaf, stream the shard's slabs into it at leaf-local
         # indices, and read everything back: per-band dtype/fill, the leaf's
-        # own time axis, and the shard's cell_ids — written at template time,
+        # own time axis, and the shard's morton words — written at template time,
         # not per-slab.
         from zagg.processing.raster import emit_raster_leaf_template, write_raster_leaf_slab
 
@@ -843,12 +841,8 @@ class TestLeafTemplate:
         tarr = open_array(store, path=f"{grid.group_path}/time", zarr_format=3, consolidated=False)
         np.testing.assert_array_equal(tarr[:], times)
         assert tarr.attrs["units"] == "microseconds since 1970-01-01T00:00:00"
-        ids = open_array(
-            store, path=f"{grid.group_path}/cell_ids", zarr_format=3, consolidated=False
-        )
-        np.testing.assert_array_equal(
-            ids[:], np.asarray(grid.encode_cell_ids(cells), dtype=np.uint64)
-        )
+        ids = open_array(store, path=f"{grid.group_path}/morton", zarr_format=3, consolidated=False)
+        np.testing.assert_array_equal(ids[:], np.asarray(cells, dtype=np.uint64))
 
     def test_leaf_overwrite_replaces_wholesale(self, tmp_path):
         # Retry semantics (D4): re-emitting with overwrite=True replaces the
@@ -872,13 +866,70 @@ class TestLeafTemplate:
         # byte-identical: same member set, shapes, chunking, codecs.
         cfg, grid, _shard = _healpix_setup(tmp_path)
         spec = raster_group_spec(grid, cfg, 2)
-        assert set(spec.members) == {"time", "cell_ids", "red"}
+        assert set(spec.members) == {"time", "morton", "red"}
         # Fullsphere cell axis (issue #88: the dense pack is gone; shape is
         # metadata — writes stay sparse).
         assert tuple(spec.members["red"].shape) == (2, 12 * 4**16)
         codecs = spec.members["red"].codecs
         names = [c["name"] if isinstance(c, dict) else c.name for c in codecs]
         assert names == ["bytes", "zstd"]
+
+
+class TestRasterMortonCoordinate:
+    """Issue #304 raster extension (espg-ruled): morton is the sole stored
+    cell coordinate on the raster path too, with the same dggs attrs block
+    and the same emit_cell_ids transition hatch as the spatial path."""
+
+    def test_default_has_no_cell_ids(self, tmp_path):
+        cfg, grid, _shard = _healpix_setup(tmp_path)
+        assert "cell_ids" not in raster_group_spec(grid, cfg, 2).members
+        inner = raster_leaf_spec(grid, cfg, 2).members[grid.group_path]
+        assert "cell_ids" not in inner.members
+
+    def test_hatch_restores_cell_ids(self, tmp_path):
+        cfg, grid, _shard = _healpix_setup(tmp_path)
+        cfg.output["grid"]["emit_cell_ids"] = True
+        grid = HealpixGrid(10, 16, config=cfg)
+        spec = raster_group_spec(grid, cfg, 2)
+        assert str(spec.members["cell_ids"].data_type) == "uint64"
+        # And the leaf writer fills BOTH coords under the hatch.
+        from zagg.processing.raster import emit_raster_leaf_template
+
+        store = MemoryStore()
+        emit_raster_leaf_template(store, grid, cfg, _shard, np.array([0], dtype=np.int64))
+        ids = open_array(
+            store, path=f"{grid.group_path}/cell_ids", zarr_format=3, consolidated=False
+        )
+        cells = grid.children(_shard)
+        np.testing.assert_array_equal(
+            ids[:], np.asarray(grid.encode_cell_ids(cells), dtype=np.uint64)
+        )
+
+    def test_dggs_attrs_match_spatial_contract(self, tmp_path):
+        # One reader contract everywhere: the raster group carries the same
+        # morton-declared block HealpixGrid emits for aggregation stores.
+        cfg, grid, _shard = _healpix_setup(tmp_path)
+        for attrs in (
+            raster_group_spec(grid, cfg, 2).attributes,
+            raster_leaf_spec(grid, cfg, 2).members[grid.group_path].attributes,
+        ):
+            assert attrs == grid._dggs_attrs()
+            assert attrs["dggs"]["name"] == "morton"
+            assert attrs["dggs"]["coordinate"] == "morton"
+            names = [c["name"] for c in attrs["zarr_conventions"]]
+            assert names == ["dggs", "morton-dggs"]
+
+    def test_written_leaf_attrs_round_trip(self, tmp_path):
+        import zarr
+
+        from zagg.processing.raster import emit_raster_leaf_template
+
+        cfg, grid, shard = _healpix_setup(tmp_path)
+        store = MemoryStore()
+        emit_raster_leaf_template(store, grid, cfg, shard, np.array([0], dtype=np.int64))
+        grp = zarr.open_group(store, path=grid.group_path, mode="r", zarr_format=3)
+        assert grp.attrs["dggs"]["coordinate"] == "morton"
+        assert "cell_ids" not in grp
 
 
 class TestGeometryCache:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -17,7 +17,9 @@ def cfg():
 
 @pytest.fixture
 def coords(cfg):
-    return get_coords(cfg)
+    # The D16 flip (issue #304): a declared legacy cell_ids coordinate is not
+    # emitted by default — morton is the only stored cell coordinate.
+    return [c for c in get_coords(cfg) if c != "cell_ids"]
 
 
 @pytest.fixture
@@ -78,11 +80,12 @@ class TestCreateZarrTemplate:
         xdggs_zarr_template(store, parent_order=6, child_order=8)
 
         group = open_group(store, path="8", mode="r")
-        assert group["cell_ids"].dtype == np.uint64
         # morton is stored as uint64 (#71): the mortie MortonIndexArray's packed
         # words are unsigned, so base cells 7-11 (bit 63 set) no longer read back
-        # negative as they did under the old int64 coordinate.
+        # negative as they did under the old int64 coordinate. It is the only
+        # stored cell coordinate (D16, issue #304).
         assert group["morton"].dtype == np.uint64
+        assert "cell_ids" not in group
 
     def test_count_dtype(self):
         store = MemoryStore()
@@ -108,7 +111,6 @@ class TestCreateZarrTemplate:
         group = open_group(store, path="8", mode="r")
 
         # Coordinates have fill_value 0
-        assert group["cell_ids"].fill_value == 0
         assert group["morton"].fill_value == 0
 
         # Count has fill_value 0
@@ -157,7 +159,9 @@ class TestConfigDrivenFields:
         ]
 
     def test_expected_coords(self, coords):
-        assert coords == ["cell_ids", "morton"]
+        # The declared config still carries the legacy cell_ids coordinate
+        # (phase 3 of issue #304 removes it); the EMITTED set is morton-only.
+        assert coords == ["morton"]
 
     def test_all_agg_fields_have_required_metadata(self, cfg):
         for name, meta in get_agg_fields(cfg).items():

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -541,7 +541,7 @@ class TestBuildAOIMask:
 
 class TestSpatialSignature:
     """``spatial_signature()`` is the full signature minus the co-aggregation
-    components — ``output_fields`` (#89) and, for HEALPix, ``cell_ids_encoding``
+    components — ``output_fields`` (#89) and, for HEALPix, ``emit_cell_ids``
     (issue #135)."""
 
     def test_healpix_excludes_output_fields(self):
@@ -552,9 +552,9 @@ class TestSpatialSignature:
         assert g.signature() == {
             **spatial,
             "output_fields": g.signature()["output_fields"],
-            "cell_ids_encoding": "nested",
             # The issue #304 transition hatch is part of the full fingerprint
             # (an extra cell_ids array changes the leaf schema), default off.
+            # (The #135 cell_ids_encoding field retired with the knob.)
             "emit_cell_ids": False,
         }
 

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -553,6 +553,9 @@ class TestSpatialSignature:
             **spatial,
             "output_fields": g.signature()["output_fields"],
             "cell_ids_encoding": "nested",
+            # The issue #304 transition hatch is part of the full fingerprint
+            # (an extra cell_ids array changes the leaf schema), default off.
+            "emit_cell_ids": False,
         }
 
     def test_rectilinear_excludes_output_fields(self, grid):


### PR DESCRIPTION
Closes #304. **Blocked by #312** (issue #305 — this branch is based on `claude/305-morton-convention` and consumes its `MORTON_CONVENTION` / `RESOLUTION_EXACT` constants; merge #312 first, then this).

Implements the writer half of #262 (D16 — morton-only storage): stop writing the redundant `cell_ids` array, re-point the convention attrs at the `morton` coordinate under the **distinct grid `name: "morton"`** (never `name: "healpix"` + `indexing_scheme: "morton"` — scheme-blind readers must hard-reject, not silently misread; matches moczarr's xdggs `grid_name`). This is the **one remaining breaking store change** in this family (D19 made #299 additive); moczarr golden-vector coordination for this change is tracked on espg/moczarr#11.

## Phases

- [x] Phase 1 — **attrs flip behind the `cell_ids_encoding` seam**: a morton-declared store (`cell_ids_encoding: morton`) now emits `dggs: {name: "morton", coordinate: "morton", resolution: "exact", ...}` (no `indexing_scheme` key) and appends the self-declared convention entry (#305, permanent UUID) to the `zarr_conventions` list. Nested stores byte-unchanged.
- [x] Phase 2 — **default flip**: `cell_ids` no longer written by default (template member + coords column both keyed off the flag); `output.grid.emit_cell_ids: true` escape hatch for transition stores (gridlook demos until the TS morton decode lands — espg/gridlook#1 Phases 4/6).
- [x] Phase 4 — **raster path joins the flip** (espg-ruled 2026-07-21, overruling this PR's earlier "distinct design change / S2 PR #219 follow-on" scope-out — the D16 premise is ONE default cell coordinate everywhere): the `(time, cells)` raster writer stores `morton` (packed u64 words) as its sole cell coordinate, the raster group/leaf specs carry the SAME morton-declared dggs attrs block as the spatial path (one reader contract), and raster `cell_ids` follows the same lifecycle — behind `emit_cell_ids`, retired with the same knob, never a separate schedule. No schema blocker surfaced — the flip was mechanical (`_raster_members`, `raster_group_spec`/`raster_leaf_spec` attrs, `emit_raster_leaf_template`, `write_raster_coords`; commit `03b3b51`).
- [x] Phase 3 — **removal + knob retirement**: `cell_ids_encoding` retires with a pointed error (#135 inverts: morton stored, NESTED derived at read via moczarr fabrication); shipped configs drop the `cell_ids` coordinate declarations; fixtures/tests regenerate; docs (`docs/morton_arrow.md`, `docs/design/architecture.md`) updated to the morton-only default. **`.github/` note:** `.github/scripts/bench_objects.py` needed NO change — its expected-count model derives from `grid.spec()`/`grid.shard_spec()` by design, so dropping the cell_ids member flows through automatically; only the test-side expected constants updated (`tests/test_benchmark_objects.py`, `tests/test_benchmark.py`: per-shard 4→3 arrays, hive per-leaf 12→10 objects).

## Branch state after the main merge (espg-directed, merge commit `ddd53fd`)

`origin/main` merged in (merge commit, no rebase): the branch is now **current with the full finalized spec surface** — #312/#305 conventions, #316/#299 product roots + semantic-core hasher + `has_run`, D16–D24 — with the raster phases the remaining in-flight work of this PR. **One conflicted file**: `tests/test_benchmark.py` (hive object-count assertion) — both sides changed it and the effects COMPOSE (this branch: one fewer array per leaf, 3 arrays; main/#299: +`aggregation.yaml` optional root object) — resolved to the observed merged model (`per_shard 10/10, metadata 4/min 1, total 11–14`), verified by running `bench_objects.expected_object_counts` against the merged tree. Everything else auto-merged with both intents preserved (main's D19 `pipeline.type` text AND this branch's O10 encoding-carried rewrite both survive in `sparse_coverage.md`). Full suite post-merge: 2562 passed, 12 skipped. Pre-existing (not merge-related): `test_runner.py`'s `./out.zarr` cwd-scribbling can flake under random test ordering — test-isolation debt flagged, untouched here.

## Post-review supersession (2026-07-21)

- **O10 final ruling (espg, via the mortie PR #118 review)**: the `resolution` declaration is **deleted** — kind is carried by the packed-word encoding itself (area words exact at every order; point ids are points; no metadata field; the 29→24 clip is a viewer-side transient cast, not spec semantics). Commit `ea35021` removes the field emission + `RESOLUTION_*` constants and rewrites the O10 record in `docs/design/sparse_coverage.md`; the order-29 decimal parse tie-break is pinned on the mortie spec page §4. The optional decimal kind suffix `p` (espg-ruled) is mortie-side only; zagg strings are all unmarked area words and unchanged.

## Scope notes

- ~~Raster stores are out of scope~~ **Overruled by espg (2026-07-21)** — raster is IN scope; see Phase 4 above.
- The `emit_cell_ids` hatch emits the legacy NESTED `cell_ids` array *in addition to* morton; the dggs attrs stay morton-declared. The hatch exists only until the gridlook morton path lands.

## Testing

- Phase 3: default store attrs are morton-declared for every HEALPix store; retired-knob pointed error; hatch emits NESTED only; `signature()` swaps `cell_ids_encoding` for `emit_cell_ids`; full suite green locally (2517 passed, 12 skipped, lambda-build excluded as below).
- Phase 2: default flip green across 13 test files (2524 passed at that commit); new `conftest.nested_ids()` derives NESTED index positions from morton (the same read-side fabrication moczarr performs).
- Phase 1: attrs assertions in `tests/test_grids.py` (`TestCellIdsEncoding`) — morton-declared block shape, convention-entry list, nested-store byte-stability; full suite green locally (2519 passed, 12 skipped; `tests/test_lambda_build.py` excluded — its function-build test fails on this machine for an environmental reason (local pip resolves against Python 3.10, pre-existing on `main`), unrelated).
- `ruff check` / `ruff format --check` clean (pre-existing `N818` in `src/zagg/registry.py` on `main` excluded, flagged in #312 too).

## Questions for review

1. *(resolved — espg ruled raster IN scope; implemented as Phase 4.)*
2. **Post-retirement attrs for hatch stores** (phase 3): a store written with `emit_cell_ids: true` keeps the morton-declared dggs attrs (cell_ids is a legacy extra array, not the declared coordinate). Confirm that's the intended transition-store shape for gridlook.
