### PR TITLE
Run-record write via worker invoke (D8): mode=stats transport (issue #313)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -110,6 +110,22 @@ echoes the deployed zagg version; the handler also runs the READ-ONLY
 zagg.hive.validate_manifest against any existing root so an incompatible rerun
 refuses up front (D2).
 
+Stats mode (run-level stats parquet, issue #313 — the D8 worker-invoke
+transport for the issue #297 run record; fire-and-forget Event invoke from
+the dispatcher at end of run, like coverage mode):
+{
+    "mode": "stats",
+    "store_path": str,
+    "run_id": str,
+    "timestamp": str (optional) -- pins the D20 key the dispatcher announced,
+    "rows": [dict, ...] (optional) -- inline run-parquet rows (always carries
+        the failure rows; small runs send everything inline),
+    "rows_from": str (optional) -- the run's async status prefix; the worker
+        assembles success rows from the mirrored result envelopes when the
+        row set exceeds the async payload budget,
+    "output_credentials": dict (optional, same shape as process mode),
+}
+
 Extract mode (chunk-boundary geometry extraction, issue #148 — one parquet per
 granule under an S3 prefix; a batch of granules per invocation for the fan-out):
 {
@@ -509,6 +525,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         return _handle_ping(event)
     if mode == "coverage":
         return _handle_coverage(event)
+    if mode == "stats":
+        return _handle_stats(event)
     # Extract mode returns directly: the result_url mirror below is for the
     # per-unit fan-out handlers (spatial process, temporal process_event) only.
     if mode == "extract":
@@ -895,6 +913,52 @@ def _handle_coverage(event: Dict[str, Any]) -> Dict[str, Any]:
     except Exception as e:
         logger.exception(e)
         return {"statusCode": 500, "body": json.dumps({"error": str(e), "mode": "coverage"})}
+
+
+def _handle_stats(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Write the run-level stats parquet at the store root (issue #313).
+
+    Posted fire-and-forget (``InvocationType="Event"``) by the dispatcher at
+    end of run — the D8 orchestrator-no-write invariant means the dispatcher
+    (e.g. the invoke-only CI OIDC role) cannot PUT the parquet itself, so the
+    worker role performs the write, exactly like the root ``coverage.moc``
+    (``mode="coverage"``). Two row transports, chosen dispatcher-side by
+    payload size: ``rows`` inline (small runs; always carries the failure
+    rows, which have no mirrored envelope to read back), and/or ``rows_from``
+    — the run's async status prefix, from which the worker assembles the
+    success rows (issue #151 envelopes; worker-role read). ``timestamp``
+    pins the D20 key so the dispatcher knows the path it announced. Nobody
+    reads this response on the Event invoke; errors log and fail open — the
+    run record is best-effort telemetry, never load-bearing.
+    """
+    from zagg.telemetry import rows_from_status, write_run_parquet
+
+    logger.info(f"Stats mode: writing run parquet at {event.get('store_path')}")
+    try:
+        rows = list(event.get("rows") or [])
+        if event.get("rows_from"):
+            rows += rows_from_status(event["rows_from"], store_kwargs=_output_store_kwargs(event))
+        if not rows:
+            # A pointer prefix that yielded nothing (and no inline rows):
+            # nothing to persist — not an error (fail-open telemetry).
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"ok": True, "mode": "stats", "rows": 0}),
+            }
+        path = write_run_parquet(
+            event["store_path"],
+            rows,
+            run_id=event["run_id"],
+            timestamp=event.get("timestamp"),
+            store_kwargs=_output_store_kwargs(event),
+        )
+        return {
+            "statusCode": 200,
+            "body": json.dumps({"ok": True, "mode": "stats", "rows": len(rows), "path": path}),
+        }
+    except Exception as e:
+        logger.exception(e)
+        return {"statusCode": 500, "body": json.dumps({"error": str(e), "mode": "stats"})}
 
 
 def _json_scalar(v: Any) -> Any:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2209,6 +2209,7 @@ def _dispatch_run_stats(
     result_prefix=None,
     output_creds_event=None,
     summary=None,
+    inline_rows=None,
 ) -> str | None:
     """Fire-and-forget worker-invoke run-record write (issue #313, D8).
 
@@ -2218,9 +2219,12 @@ def _dispatch_run_stats(
     Event invoke exactly like the root ``coverage.moc``. Transport is
     size-gated (the seam the PR #315 body describes): rows inline under
     :data:`_RUN_STATS_INLINE_CAP_BYTES`; above it the run's async status
-    prefix is sent as a pointer (``rows_from``) with only the failure rows
-    inline (no envelope exists to assemble them from); an oversized SYNC run
-    (no prefix) logs a fail-open skip. The D20 object key is pinned here
+    prefix is sent as a pointer (``rows_from``) with only the rows the worker
+    cannot reassemble from the mirrored envelopes riding inline. Those are
+    given by ``inline_rows`` when the caller knows them (the spatial path:
+    failure rows PLUS stale-worker fallback-success rows — issue #313); absent,
+    the failure rows alone are kept inline (the raster path builds no fallback
+    rows). An oversized SYNC run (no prefix) logs a fail-open skip. The D20 object key is pinned here
     (``timestamp`` rides the event), so the returned/announced
     ``run_stats_path`` names the real object — best-effort: the invoke is
     fire-and-forget, mirroring the root MOC's semantics. Fail-open
@@ -2247,14 +2251,18 @@ def _dispatch_run_stats(
         if len(json.dumps(rows)) <= _RUN_STATS_INLINE_CAP_BYTES:
             event["rows"] = rows
         elif result_prefix is not None:
-            failures = [r for r in rows if not r.get("success")]
-            if len(json.dumps(failures)) > _RUN_STATS_INLINE_CAP_BYTES:
+            inline = (
+                inline_rows
+                if inline_rows is not None
+                else [r for r in rows if not r.get("success")]
+            )
+            if len(json.dumps(inline)) > _RUN_STATS_INLINE_CAP_BYTES:
                 logger.warning(
-                    f"run stats failure rows alone exceed the inline budget "
-                    f"({len(failures)} rows); skipping run record (fail-open, issue #313)"
+                    f"run stats inline rows alone exceed the inline budget "
+                    f"({len(inline)} rows); skipping run record (fail-open, issue #313)"
                 )
                 return None
-            event["rows"] = failures
+            event["rows"] = inline
             event["rows_from"] = result_prefix
         else:
             logger.warning(
@@ -2277,7 +2285,7 @@ def _dispatch_run_stats(
         return None
 
 
-def _lambda_result_rows(results, *, run_id=None) -> list:
+def _lambda_result_rows(results, *, run_id=None) -> tuple[list, list]:
     """Run-parquet rows from the lambda dispatch's per-cell result dicts.
 
     Success rows come from the envelope-ridden worker record
@@ -2286,13 +2294,25 @@ def _lambda_result_rows(results, *, run_id=None) -> list:
     a failure row (error, duration until failure, retry count). ``run_id``
     stamps the dispatcher-built fallback/failure rows; envelope records
     already carry it (the worker copies it from the event).
+
+    Returns ``(rows, inline_rows)``. ``inline_rows`` is the subset that MUST
+    ride inline on the pointer transport (issue #313): the pointer path has
+    the worker re-derive success rows from the mirrored envelopes via
+    :func:`~zagg.telemetry.rows_from_status`, which reads only ``body["stats"]``
+    — so any row NOT backed by an envelope record (failure rows, and the
+    stale-worker fallback-success rows built here) would be dropped worker-side
+    and has to be sent inline alongside the pointer.
     """
     from zagg.telemetry import build_record, failure_record, flatten_record
 
     rows = []
+    inline_rows = []
     for r in results:
         body = r.get("body") or {}
         record = body.get("stats")
+        # Envelope-backed rows are re-derivable worker-side (rows_from_status);
+        # everything else the pointer path can't rebuild, so it rides inline.
+        rideable = record is not None
         if record is None:
             if r.get("status_code") == 200 and not r.get("error"):
                 # Stale deployed worker (no record in the envelope): derive one
@@ -2309,8 +2329,11 @@ def _lambda_result_rows(results, *, run_id=None) -> list:
                     duration_s=r.get("lambda_duration") or r.get("wall_time"),
                     run_id=run_id,
                 )
-        rows.append(flatten_record(record, retries=r.get("retries")))
-    return rows
+        row = flatten_record(record, retries=r.get("retries"))
+        rows.append(row)
+        if not rideable:
+            inline_rows.append(row)
+    return rows, inline_rows
 
 
 def _resolve_source_credentials(config) -> dict:
@@ -3370,15 +3393,17 @@ def _run_lambda(
     # failure rows from the dispatch results the RunReport accumulated. The
     # PUT itself rides a fire-and-forget worker invoke — the dispatcher may
     # hold an invoke-only role with no S3 write access.
+    stats_rows, stats_inline_rows = _lambda_result_rows(report.results, run_id=run_id)
     _dispatch_run_stats(
         state["lambda_client"],
         function_name,
         store_path,
-        _lambda_result_rows(report.results, run_id=run_id),
+        stats_rows,
         run_id=run_id,
         result_prefix=result_prefix,
         output_creds_event=output_creds_event,
         summary=summary,
+        inline_rows=stats_inline_rows,
     )
     logger.info(
         f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1402,11 +1402,15 @@ class RasterStrategy:
             )
             for key, error, body in stats_failures
         ]
-        run_stats_path = _write_run_stats(
+        # D8 worker-invoke transport (issue #313): mirrors the spatial path.
+        run_stats_path = _dispatch_run_stats(
+            client,
+            function_name,
             store_path,
             rows,
             run_id=run_id,
-            store_kwargs=_output_store_kwargs(output_creds_event, region),
+            result_prefix=result_prefix,
+            output_creds_event=output_creds_event,
         )
         if cells and errors == len(cells):
             raise RuntimeError(f"all {errors} raster shard(s) failed; last error: {last_error}")
@@ -2192,6 +2196,84 @@ def _write_run_stats(store_path, rows, *, run_id, store_kwargs, summary=None) ->
         return path
     except Exception as e:
         logger.warning(f"run stats parquet write failed (fail-open, issue #297): {e}")
+        return None
+
+
+def _dispatch_run_stats(
+    lambda_client,
+    function_name,
+    store_path,
+    rows,
+    *,
+    run_id,
+    result_prefix=None,
+    output_creds_event=None,
+    summary=None,
+) -> str | None:
+    """Fire-and-forget worker-invoke run-record write (issue #313, D8).
+
+    The Lambda-path twin of :func:`_write_run_stats`: the orchestrator has no
+    S3 write access (D8 — the invariant that keeps every store write behind
+    worker-role prefix grants), so the parquet PUT rides a ``mode="stats"``
+    Event invoke exactly like the root ``coverage.moc``. Transport is
+    size-gated (the seam the PR #315 body describes): rows inline under
+    :data:`_RUN_STATS_INLINE_CAP_BYTES`; above it the run's async status
+    prefix is sent as a pointer (``rows_from``) with only the failure rows
+    inline (no envelope exists to assemble them from); an oversized SYNC run
+    (no prefix) logs a fail-open skip. The D20 object key is pinned here
+    (``timestamp`` rides the event), so the returned/announced
+    ``run_stats_path`` names the real object — best-effort: the invoke is
+    fire-and-forget, mirroring the root MOC's semantics. Fail-open
+    everywhere: telemetry must never fail a run whose data landed.
+    """
+    from datetime import datetime, timezone
+
+    from zagg.telemetry import run_parquet_key
+
+    if summary is not None:
+        summary["run_stats_path"] = None
+    if not rows:
+        return None
+    try:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        event = {
+            "mode": "stats",
+            "store_path": store_path,
+            "run_id": run_id,
+            "timestamp": timestamp,
+        }
+        if output_creds_event is not None:
+            event["output_credentials"] = output_creds_event
+        if len(json.dumps(rows)) <= _RUN_STATS_INLINE_CAP_BYTES:
+            event["rows"] = rows
+        elif result_prefix is not None:
+            failures = [r for r in rows if not r.get("success")]
+            if len(json.dumps(failures)) > _RUN_STATS_INLINE_CAP_BYTES:
+                logger.warning(
+                    f"run stats failure rows alone exceed the inline budget "
+                    f"({len(failures)} rows); skipping run record (fail-open, issue #313)"
+                )
+                return None
+            event["rows"] = failures
+            event["rows_from"] = result_prefix
+        else:
+            logger.warning(
+                f"run stats rows ({len(rows)}) exceed the async payload budget and this "
+                f"sync run has no status prefix to point at; skipping (fail-open, issue #313)"
+            )
+            return None
+        lambda_client.invoke(
+            FunctionName=function_name,
+            InvocationType="Event",
+            Payload=json.dumps(event),
+        )
+        path = f"{store_path.rstrip('/')}/{run_parquet_key(run_id, timestamp)}"
+        if summary is not None:
+            summary["run_stats_path"] = path
+        logger.info(f"Dispatched run stats write ({len(rows)} rows, fire-and-forget): {path}")
+        return path
+    except Exception as e:
+        logger.warning(f"run stats dispatch failed (fail-open, issue #313): {e}")
         return None
 
 
@@ -3283,14 +3365,19 @@ def _run_lambda(
     }
     if profile:
         summary["worker_phase_max"] = worker_phase_max
-    # Run-level stats parquet (issue #297 phase 3): success rows straight off
-    # the async result envelopes (no second S3 listing), failure rows from the
-    # dispatch results the RunReport accumulated.
-    _write_run_stats(
+    # Run-level stats parquet (issue #297 phase 3; D8 worker-invoke transport,
+    # issue #313): success rows straight off the async result envelopes,
+    # failure rows from the dispatch results the RunReport accumulated. The
+    # PUT itself rides a fire-and-forget worker invoke — the dispatcher may
+    # hold an invoke-only role with no S3 write access.
+    _dispatch_run_stats(
+        state["lambda_client"],
+        function_name,
         store_path,
         _lambda_result_rows(report.results, run_id=run_id),
         run_id=run_id,
-        store_kwargs=_output_store_kwargs(output_creds_event, region),
+        result_prefix=result_prefix,
+        output_creds_event=output_creds_event,
         summary=summary,
     )
     logger.info(
@@ -3428,6 +3515,12 @@ _MANIFEST_CHECK_JOIN_TIMEOUT_S = 30.0
 # Lambda's raw RequestEntityTooLargeException does; the realistic trigger is a
 # large strict-AOI ``aoi_payload`` (issue #101).
 _ASYNC_PAYLOAD_CAP_BYTES = 250 * 1024
+
+#: Inline-rows budget for the mode="stats" run-record invoke (issue #313):
+#: the Event cap above minus ~50 KB headroom for the rest of the event
+#: (credentials block, paths). Above this the dispatcher sends the status
+#: prefix pointer instead (failure rows stay inline — they have no envelope).
+_RUN_STATS_INLINE_CAP_BYTES = 200 * 1024
 
 # The result poller owns its retrying at the loop level (a fetch every
 # _ASYNC_POLL_INTERVAL_S until the deadline), so its store gets a short

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1411,6 +1411,7 @@ class RasterStrategy:
             run_id=run_id,
             result_prefix=result_prefix,
             output_creds_event=output_creds_event,
+            store_kwargs=_output_store_kwargs(output_creds_event, region),
         )
         if cells and errors == len(cells):
             raise RuntimeError(f"all {errors} raster shard(s) failed; last error: {last_error}")
@@ -2208,6 +2209,7 @@ def _dispatch_run_stats(
     run_id,
     result_prefix=None,
     output_creds_event=None,
+    store_kwargs=None,
     summary=None,
     inline_rows=None,
 ) -> str | None:
@@ -2270,19 +2272,77 @@ def _dispatch_run_stats(
                 f"sync run has no status prefix to point at; skipping (fail-open, issue #313)"
             )
             return None
-        lambda_client.invoke(
-            FunctionName=function_name,
-            InvocationType="Event",
-            Payload=json.dumps(event),
+        key = run_parquet_key(run_id, timestamp)
+        path = f"{store_path.rstrip('/')}/{key}"
+        payload = json.dumps(event)
+        # Fire -> verify -> re-fire (the async-per-D8 hardening): the Event
+        # invoke is retries-0 and failure rows exist only in this run report,
+        # so verify the parquet landed (read-only HEAD poll on the pinned
+        # key) and re-fire ONCE if not. Bounded — the dispatcher never
+        # meaningfully blocks — then fail-open with a logged notice (success
+        # rows stay rebuildable from the leaf sidecars; a late queued invoke
+        # may still land the object after we stop looking).
+        for attempt in (1, 2):
+            lambda_client.invoke(
+                FunctionName=function_name,
+                InvocationType="Event",
+                Payload=payload,
+            )
+            if attempt == 1:
+                if summary is not None:
+                    summary["run_stats_path"] = path
+                logger.info(
+                    f"Dispatched run stats write ({len(rows)} rows, fire-and-forget): {path}"
+                )
+            if _await_run_stats_object(store_path, key, store_kwargs):
+                return path
+            if attempt == 1 and _RUN_STATS_VERIFY_WINDOW_S > 0:
+                logger.warning(
+                    f"run stats parquet not visible after "
+                    f"{_RUN_STATS_VERIFY_WINDOW_S:g}s; re-firing the Event invoke "
+                    f"once (issue #313)"
+                )
+        logger.warning(
+            f"run stats parquet still absent after the re-fire (fail-open, issue #313): "
+            f"{path} — failure rows may be lost; the run report remains in this summary"
         )
-        path = f"{store_path.rstrip('/')}/{run_parquet_key(run_id, timestamp)}"
-        if summary is not None:
-            summary["run_stats_path"] = path
-        logger.info(f"Dispatched run stats write ({len(rows)} rows, fire-and-forget): {path}")
         return path
     except Exception as e:
         logger.warning(f"run stats dispatch failed (fail-open, issue #313): {e}")
         return None
+
+
+def _await_run_stats_object(store_path, key, store_kwargs, *, window_s=None) -> bool:
+    """Bounded READ-ONLY existence poll for the run parquet (issue #313).
+
+    True once the object exists; False at the deadline. A non-positive window
+    skips verification entirely (reports True after zero reads) — the single-
+    fire escape hatch, and what unit tests set to keep dispatch synchronous
+    paths read-free. Read errors count as absent (the poll is best-effort;
+    the caller's fail-open handles a dispatcher that cannot read the store).
+    """
+    window_s = _RUN_STATS_VERIFY_WINDOW_S if window_s is None else window_s
+    if window_s <= 0:
+        return True
+    import obstore
+
+    from zagg.store import open_object_store
+
+    try:
+        store = open_object_store(store_path, **(store_kwargs or {}))
+    except Exception as e:
+        logger.warning(f"run stats verify skipped (cannot open store read-only): {e}")
+        return False
+    deadline = time.time() + window_s
+    while True:
+        try:
+            obstore.head(store, key)
+            return True
+        except Exception:
+            pass
+        if time.time() >= deadline:
+            return False
+        time.sleep(_RUN_STATS_VERIFY_INTERVAL_S)
 
 
 def _lambda_result_rows(results, *, run_id=None) -> tuple[list, list]:
@@ -3402,6 +3462,7 @@ def _run_lambda(
         run_id=run_id,
         result_prefix=result_prefix,
         output_creds_event=output_creds_event,
+        store_kwargs=_output_store_kwargs(output_creds_event, region),
         summary=summary,
         inline_rows=stats_inline_rows,
     )
@@ -3546,6 +3607,16 @@ _ASYNC_PAYLOAD_CAP_BYTES = 250 * 1024
 #: (credentials block, paths). Above this the dispatcher sends the status
 #: prefix pointer instead (failure rows stay inline — they have no envelope).
 _RUN_STATS_INLINE_CAP_BYTES = 200 * 1024
+
+#: Fire -> verify -> re-fire bounds for the mode="stats" Event invoke (issue
+#: #313 hardening): failure rows exist only in the dispatcher's run report,
+#: so a dropped retries-0 Event invoke loses them permanently. After firing,
+#: the dispatcher does a READ-ONLY existence poll on the pinned parquet key
+#: (reads were never forbidden — it already polls result objects) for at most
+#: the window, re-fires ONCE if absent, then gives up fail-open. Worst case
+#: 2 x window of end-of-run wall; <= 0 disables verification (single fire).
+_RUN_STATS_VERIFY_WINDOW_S = 20.0
+_RUN_STATS_VERIFY_INTERVAL_S = 2.0
 
 # The result poller owns its retrying at the loop level (a fetch every
 # _ASYNC_POLL_INTERVAL_S until the deadline), so its store gets a short

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2278,10 +2278,14 @@ def _dispatch_run_stats(
         # Fire -> verify -> re-fire (the async-per-D8 hardening): the Event
         # invoke is retries-0 and failure rows exist only in this run report,
         # so verify the parquet landed (read-only HEAD poll on the pinned
-        # key) and re-fire ONCE if not. Bounded — the dispatcher never
-        # meaningfully blocks — then fail-open with a logged notice (success
-        # rows stay rebuildable from the leaf sidecars; a late queued invoke
-        # may still land the object after we stop looking).
+        # key) and re-fire ONCE if not. This is not free: every successful run
+        # now waits at its tail for one async worker round-trip (cold start +
+        # envelope assemble + PUT), caught by the next <=2s HEAD tick — seconds
+        # of added wall on the common path where fire-and-forget returned
+        # instantly; the drop case pays up to 2x the verify window. Bounded, then
+        # fail-open with a logged notice (success rows stay rebuildable from the
+        # leaf sidecars; a late queued invoke may still land the object after we
+        # stop looking).
         for attempt in (1, 2):
             lambda_client.invoke(
                 FunctionName=function_name,
@@ -2325,7 +2329,6 @@ def _await_run_stats_object(store_path, key, store_kwargs, *, window_s=None) -> 
     if window_s <= 0:
         return True
     import obstore
-    from obstore.exceptions import NotFoundError
 
     from zagg.store import open_object_store
 
@@ -2335,25 +2338,12 @@ def _await_run_stats_object(store_path, key, store_kwargs, *, window_s=None) -> 
         logger.warning(f"run stats verify skipped (cannot open store read-only): {e}")
         return False
     deadline = time.time() + window_s
-    warned = False
     while True:
         try:
             obstore.head(store, key)
             return True
-        except (FileNotFoundError, NotFoundError):
-            pass  # genuinely not there yet — what the re-fire targets
-        except Exception as e:
-            # A non-not-found error (e.g. a prefix-scoped read grant that 403s
-            # HEADs at the store root) is a structural read gap the re-fire can
-            # never fix, and otherwise looks identical to a dropped invoke. Warn
-            # once so it's visible in the log; still treat as absent (we don't
-            # classify auth beyond not-FileNotFoundError — obstore's error
-            # taxonomy varies by backend).
-            if not warned:
-                logger.warning(
-                    f"run stats verify cannot read {key}: {e} — treating as absent"
-                )
-                warned = True
+        except Exception:
+            pass
         if time.time() >= deadline:
             return False
         time.sleep(_RUN_STATS_VERIFY_INTERVAL_S)

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2325,6 +2325,7 @@ def _await_run_stats_object(store_path, key, store_kwargs, *, window_s=None) -> 
     if window_s <= 0:
         return True
     import obstore
+    from obstore.exceptions import NotFoundError
 
     from zagg.store import open_object_store
 
@@ -2334,12 +2335,25 @@ def _await_run_stats_object(store_path, key, store_kwargs, *, window_s=None) -> 
         logger.warning(f"run stats verify skipped (cannot open store read-only): {e}")
         return False
     deadline = time.time() + window_s
+    warned = False
     while True:
         try:
             obstore.head(store, key)
             return True
-        except Exception:
-            pass
+        except (FileNotFoundError, NotFoundError):
+            pass  # genuinely not there yet — what the re-fire targets
+        except Exception as e:
+            # A non-not-found error (e.g. a prefix-scoped read grant that 403s
+            # HEADs at the store root) is a structural read gap the re-fire can
+            # never fix, and otherwise looks identical to a dropped invoke. Warn
+            # once so it's visible in the log; still treat as absent (we don't
+            # classify auth beyond not-FileNotFoundError — obstore's error
+            # taxonomy varies by backend).
+            if not warned:
+                logger.warning(
+                    f"run stats verify cannot read {key}: {e} — treating as absent"
+                )
+                warned = True
         if time.time() >= deadline:
             return False
         time.sleep(_RUN_STATS_VERIFY_INTERVAL_S)

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -343,7 +343,12 @@ def run_parquet_key(run_id: str, timestamp: str | None = None) -> str:
 
 
 def write_run_parquet(
-    store_root: str, rows: list, *, run_id: str, store_kwargs: dict | None = None
+    store_root: str,
+    rows: list,
+    *,
+    run_id: str,
+    timestamp: str | None = None,
+    store_kwargs: dict | None = None,
 ) -> str:
     """PUT the run-level stats parquet at the store root (issue #297 phase 3).
 
@@ -354,6 +359,11 @@ def write_run_parquet(
     precedent — pyarrow stays off the worker path, issue #130);
     ``object_encoding="utf8"`` pins string columns that may be all-null in a
     given run (e.g. ``invoked_by`` locally). Returns the object's full path.
+
+    ``timestamp`` pins the D20 key instead of stamping write time — the D8
+    worker-invoke transport (issue #313): the dispatcher names the object at
+    dispatch so ``summary["run_stats_path"]`` is knowable without reading the
+    fire-and-forget worker's response.
     """
     import tempfile
 
@@ -364,7 +374,7 @@ def write_run_parquet(
 
     if not rows:
         raise ValueError("write_run_parquet requires at least one row")
-    key = run_parquet_key(run_id)
+    key = run_parquet_key(run_id, timestamp)
     df = pd.DataFrame(rows)
     with tempfile.TemporaryDirectory() as tmp:
         local = os.path.join(tmp, key)
@@ -373,6 +383,49 @@ def write_run_parquet(
             data = fh.read()
     obstore.put(open_object_store(store_root, **(store_kwargs or {})), key, data)
     return f"{store_root.rstrip('/')}/{key}"
+
+
+def rows_from_status(status_prefix: str, *, store_kwargs: dict | None = None) -> list:
+    """Run-parquet rows assembled worker-side from the async status prefix.
+
+    The pointer transport of the D8 worker-invoke run-record write (issue
+    #313): when a run's rows exceed the async-invoke payload budget, the
+    dispatcher sends the status-prefix LOCATION instead and the worker — whose
+    role can read the store side — LISTs the per-shard result envelopes the
+    workers mirrored there (issue #151) and flattens each envelope's
+    ``body["stats"]`` record into a row. Envelopes without a record (stale
+    worker) and unparsable objects are skipped with a warning — the run
+    record is best-effort telemetry (fail-open, D9-style), never load-bearing.
+    Failure rows cannot be assembled here (a timed-out shard mirrored no
+    envelope); the dispatcher sends those few rows inline alongside the
+    pointer. Dispatcher-side ``retries`` are likewise not recoverable from
+    envelopes, so pointer-assembled success rows carry ``retries: None``.
+    """
+    import json as _json
+    import logging
+
+    import obstore
+
+    from zagg.store import open_object_store
+
+    logger = logging.getLogger(__name__)
+    store = open_object_store(status_prefix, **(store_kwargs or {}))
+    rows = []
+    for batch in obstore.list(store):
+        for meta in batch:
+            key = meta["path"]
+            if not key.endswith(".json"):
+                continue
+            try:
+                envelope = _json.loads(bytes(obstore.get(store, key).bytes()))
+                body = _json.loads(envelope.get("body", "{}"))
+                record = body.get("stats")
+            except Exception as e:
+                logger.warning(f"skipping unparsable status envelope {key}: {e}")
+                continue
+            if isinstance(record, dict):
+                rows.append(flatten_record(record))
+    return rows
 
 
 # ---------------------------------------------------------------------------

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -425,9 +425,15 @@ def rows_from_status(status_prefix: str, *, store_kwargs: dict | None = None) ->
     envelope); the dispatcher sends those few rows inline alongside the
     pointer. Dispatcher-side ``retries`` are likewise not recoverable from
     envelopes, so pointer-assembled success rows carry ``retries: None``.
+
+    The per-envelope GETs fan out over a bounded thread pool (this branch is
+    the large-run one — hundreds to thousands of shards — where thousands of
+    serial S3 round-trips would eat a real slice of the worker's 900 s budget;
+    the run record is the thing you most want kept for exactly those runs).
     """
     import json as _json
     import logging
+    from concurrent.futures import ThreadPoolExecutor
 
     import obstore
 
@@ -439,21 +445,22 @@ def rows_from_status(status_prefix: str, *, store_kwargs: dict | None = None) ->
     # so ``list_with_delimiter`` (the coverage.py/hive.py prefix-walk precedent)
     # matches the semantics and won't parse any future nested key as an envelope.
     listing = obstore.list_with_delimiter(store)
-    rows = []
-    for meta in listing["objects"]:
-        key = meta["path"]
-        if not key.endswith(".json"):
-            continue
+    keys = [meta["path"] for meta in listing["objects"] if meta["path"].endswith(".json")]
+
+    def _record(key: str) -> dict | None:
         try:
             envelope = _json.loads(bytes(obstore.get(store, key).bytes()))
             body = _json.loads(envelope.get("body", "{}"))
             record = body.get("stats")
         except Exception as e:
             logger.warning(f"skipping unparsable status envelope {key}: {e}")
-            continue
-        if isinstance(record, dict):
-            rows.append(flatten_record(record))
-    return rows
+            return None
+        return record if isinstance(record, dict) else None
+
+    if not keys:
+        return []
+    with ThreadPoolExecutor(max_workers=min(16, len(keys))) as pool:
+        return [flatten_record(rec) for rec in pool.map(_record, keys) if rec is not None]
 
 
 # ---------------------------------------------------------------------------

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -357,8 +357,7 @@ def run_parquet_key(run_id: str, timestamp: str | None = None) -> str:
     ts = timestamp or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     if not _RUN_TS_RE.match(ts):
         raise ValueError(
-            f"run parquet timestamp {ts!r} does not match the D20 grammar "
-            f"({_RUN_TS_RE.pattern})"
+            f"run parquet timestamp {ts!r} does not match the D20 grammar ({_RUN_TS_RE.pattern})"
         )
     if not isinstance(run_id, str) or not _RUN_ID_RE.match(run_id):
         raise ValueError(

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -435,21 +435,24 @@ def rows_from_status(status_prefix: str, *, store_kwargs: dict | None = None) ->
 
     logger = logging.getLogger(__name__)
     store = open_object_store(status_prefix, **(store_kwargs or {}))
+    # Immediate children only — the layout is flat (``{run_id}/{shard}.json``),
+    # so ``list_with_delimiter`` (the coverage.py/hive.py prefix-walk precedent)
+    # matches the semantics and won't parse any future nested key as an envelope.
+    listing = obstore.list_with_delimiter(store)
     rows = []
-    for batch in obstore.list(store):
-        for meta in batch:
-            key = meta["path"]
-            if not key.endswith(".json"):
-                continue
-            try:
-                envelope = _json.loads(bytes(obstore.get(store, key).bytes()))
-                body = _json.loads(envelope.get("body", "{}"))
-                record = body.get("stats")
-            except Exception as e:
-                logger.warning(f"skipping unparsable status envelope {key}: {e}")
-                continue
-            if isinstance(record, dict):
-                rows.append(flatten_record(record))
+    for meta in listing["objects"]:
+        key = meta["path"]
+        if not key.endswith(".json"):
+            continue
+        try:
+            envelope = _json.loads(bytes(obstore.get(store, key).bytes()))
+            body = _json.loads(envelope.get("body", "{}"))
+            record = body.get("stats")
+        except Exception as e:
+            logger.warning(f"skipping unparsable status envelope {key}: {e}")
+            continue
+        if isinstance(record, dict):
+            rows.append(flatten_record(record))
     return rows
 
 

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -24,6 +24,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 from datetime import datetime, timezone
 from typing import Any, Iterable
 
@@ -331,14 +332,38 @@ def flatten_record(record: dict, *, retries=None, error_class=None) -> dict:
     return row
 
 
+#: ``run_id`` charset for the parquet key: opaque, no ``/`` or ``.`` (mirrors
+#: the frozen window-label grammar in :mod:`zagg.windows`).
+_RUN_ID_RE = re.compile(r"^[0-9A-Za-z-]{1,64}$")
+#: The D20 ``%Y%m%dT%H%M%SZ`` timestamp grammar — the only shape ``run_parquet_key``
+#: emits itself, pinned so a caller-supplied value can't smuggle a path escape.
+_RUN_TS_RE = re.compile(r"^[0-9]{8}T[0-9]{6}Z$")
+
+
 def run_parquet_key(run_id: str, timestamp: str | None = None) -> str:
     """Store-root object name of a run's stats parquet: timestamp, then run id.
 
     Timestamp-first (D20, docs/design/sparse_coverage.md) so a lexicographic
     listing of ``stats_*.parquet`` is chronological and time-range queries can
     prune on the key alone.
+
+    Both components flow into the object KEY, so both are validated against
+    their frozen grammar first — the D8 worker-invoke transport (issue #313)
+    makes ``timestamp`` a caller-supplied input, and an embedded ``/`` or
+    ``..`` would escape the store root. Like :func:`sidecar_key`'s
+    ``validate_label``, a malformed value RAISES rather than composing a
+    traversing key.
     """
     ts = timestamp or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    if not _RUN_TS_RE.match(ts):
+        raise ValueError(
+            f"run parquet timestamp {ts!r} does not match the D20 grammar "
+            f"({_RUN_TS_RE.pattern})"
+        )
+    if not isinstance(run_id, str) or not _RUN_ID_RE.match(run_id):
+        raise ValueError(
+            f"run_id {run_id!r} does not match the opaque key charset ({_RUN_ID_RE.pattern})"
+        )
     return f"stats_{ts}_{run_id}.parquet"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,3 +86,18 @@ def _no_s3_run_stats(monkeypatch):
         return real(store_path, rows, summary=summary, **kwargs)
 
     monkeypatch.setattr(runner, "_write_run_stats", guard)
+
+
+@pytest.fixture(autouse=True)
+def _no_run_stats_verify(monkeypatch):
+    """Disable the issue #313 fire->verify->re-fire poll by default in tests.
+
+    The verify leg does read-only existence polls against the OUTPUT store —
+    a real network HEAD for the s3:// store paths unit harnesses use, plus a
+    bounded sleep-poll either way. A zero window reports success after zero
+    reads (the documented single-fire escape hatch), keeping dispatch tests
+    hermetic and fast; the re-fire tests set the window back explicitly.
+    """
+    from zagg import runner
+
+    monkeypatch.setattr(runner, "_RUN_STATS_VERIFY_WINDOW_S", 0.0)

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1444,6 +1444,91 @@ class TestFinalizeHive:
         assert len(calls) == 1
 
 
+class TestStatsMode:
+    """mode="stats" (issue #313): the D8 worker-invoke run-record write —
+    the dispatcher cannot PUT the run parquet (orchestrator-no-write), so a
+    fire-and-forget Event invoke has the worker role write it, like the root
+    coverage.moc."""
+
+    @staticmethod
+    def _rows():
+        from zagg.telemetry import build_record, failure_record, flatten_record
+
+        ok = build_record(shard_key=1, metadata={"total_obs": 5, "duration_s": 1.0})
+        bad = failure_record(shard_key=2, error="Lambda timeout: x", duration_s=900.0)
+        return [flatten_record(ok), flatten_record(bad, retries=3)]
+
+    def test_inline_rows_written_at_pinned_key(self, handler_mod, tmp_path):
+        import pandas as pd
+
+        root = str(tmp_path / "out")
+        event = {
+            "mode": "stats",
+            "store_path": root,
+            "run_id": "runid1",
+            "timestamp": "20260720T010203Z",
+            "rows": self._rows(),
+        }
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200, resp["body"]
+        body = json.loads(resp["body"])
+        assert body["rows"] == 2
+        # The dispatcher-pinned D20 key, so the announced path is the real one.
+        path = f"{root}/stats_20260720T010203Z_runid1.parquet"
+        assert body["path"] == path
+        df = pd.read_parquet(path, engine="fastparquet")
+        assert set(df["shard_key"]) == {1, 2}
+        assert bool(df.set_index("shard_key").loc[2, "success"]) is False
+
+    def test_pointer_rows_assembled_from_status_prefix(self, handler_mod, tmp_path):
+        import pandas as pd
+
+        from zagg.telemetry import build_record
+
+        # Mirror two per-shard result envelopes the way _write_result does.
+        prefix = tmp_path / "out.zarr.status" / "runid2"
+        prefix.mkdir(parents=True)
+        for shard in (11, 12):
+            rec = build_record(shard_key=shard, metadata={"total_obs": 1, "duration_s": 2.0})
+            envelope = {"statusCode": 200, "body": json.dumps({"stats": rec})}
+            (prefix / f"{shard}.json").write_text(json.dumps(envelope))
+        # A stale-worker envelope without a record is skipped, not fatal.
+        (prefix / "13.json").write_text(json.dumps({"statusCode": 200, "body": "{}"}))
+
+        root = str(tmp_path / "out")
+        event = {
+            "mode": "stats",
+            "store_path": root,
+            "run_id": "runid2",
+            "timestamp": "20260720T010203Z",
+            # Failure rows ride inline next to the pointer (no envelope to read).
+            "rows": [r for r in self._rows() if not r["success"]],
+            "rows_from": str(prefix),
+        }
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200, resp["body"]
+        assert json.loads(resp["body"])["rows"] == 3
+        df = pd.read_parquet(f"{root}/stats_20260720T010203Z_runid2.parquet", engine="fastparquet")
+        assert set(df["shard_key"]) == {2, 11, 12}
+
+    def test_empty_rows_is_ok_and_writes_nothing(self, handler_mod, tmp_path):
+        root = str(tmp_path / "out")
+        resp = handler_mod.lambda_handler(
+            {"mode": "stats", "store_path": root, "run_id": "r"}, MagicMock()
+        )
+        assert resp["statusCode"] == 200
+        assert json.loads(resp["body"])["rows"] == 0
+        assert not (tmp_path / "out").exists()
+
+    def test_failure_is_500_fail_open(self, handler_mod):
+        # No store_path -> the write raises; the envelope reports it, nobody
+        # reads it on the Event invoke (fail-open by design).
+        resp = handler_mod.lambda_handler(
+            {"mode": "stats", "run_id": "r", "rows": [{}]}, MagicMock()
+        )
+        assert resp["statusCode"] == 500
+
+
 class TestPingMode:
     """Issue #252: the hive pre-fan-out preflight. Answering 200 at all gates
     the deployment generation (a pre-fold function 400s the unknown mode via

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1494,6 +1494,11 @@ class TestStatsMode:
             (prefix / f"{shard}.json").write_text(json.dumps(envelope))
         # A stale-worker envelope without a record is skipped, not fatal.
         (prefix / "13.json").write_text(json.dumps({"statusCode": 200, "body": "{}"}))
+        # An unparsable-bytes object hits the except branch (logged + skipped),
+        # and a non-.json object under the prefix is filtered before any GET —
+        # neither aborts the write nor adds a row.
+        (prefix / "14.json").write_text("not json")
+        (prefix / "manifest.txt").write_text("ignore me")
 
         root = str(tmp_path / "out")
         event = {

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -354,6 +354,10 @@ def _lifecycle(responder):
                 "statusCode": 200,
                 "body": json.dumps({"ok": True, "mode": "ping", "zagg_version": "test"}),
             }
+        if event["mode"] == "stats":
+            # The issue #313 fire-and-forget run-record invoke; nobody reads
+            # the response.
+            return {"statusCode": 200, "body": json.dumps({"ok": True, "mode": "stats"})}
         if event["mode"] == "setup":
             body = {
                 "ok": True,
@@ -409,9 +413,11 @@ class TestRasterLambdaBackend:
         assert summary["backend"] == "lambda"
         assert summary["total_cells"] == 1 and summary["cells_with_data"] == 1
         assert summary["cells_error"] == 0
-        # The key is unconditional (issue #297) — None here because the
-        # conftest guard skips the live s3 PUT in unit tests.
+        # The key is unconditional (issue #297) — None here because the fake
+        # worker bodies carry no stats records and nothing failed, so there
+        # are no rows and no mode="stats" dispatch (issue #313).
         assert "run_stats_path" in summary and summary["run_stats_path"] is None
+        assert not any(e["mode"] == "stats" for e in fake.events)
         # Cost block (issue #298, rolled into the raster path here): the
         # pre-invoke ceiling, the deferred estimate stub, and the billed
         # rollup — 30 s x 4 GB x the arm64 rate — with the legacy flat key
@@ -770,8 +776,12 @@ class TestRasterLambdaBackend:
                 backend="lambda",
                 invocation="sync",
             )
-        # deterministic FunctionError -> no retry
-        assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster"]
+        # deterministic FunctionError -> no retry; the trailing mode="stats"
+        # invoke carries the failure rows (dispatched BEFORE the all-failed
+        # raise so the run record persists the evidence — issue #313).
+        assert [e["mode"] for e in fake.events] == ["ping", "setup", "process_raster", "stats"]
+        stats_event = fake.events[-1]
+        assert [r["success"] for r in stats_event["rows"]] == [False]
 
     def test_lambda_transient_retry_then_success(self, manifest, monkeypatch, tmp_path):
         # A transient invoke fault (Connection reset) on the first attempt retries

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3601,6 +3601,27 @@ class TestDispatchRunStats:
         assert path is None and client.events == []
         assert summary["run_stats_path"] is None
 
+    def test_pointer_inline_rows_over_budget_skips_fail_open(self, monkeypatch):
+        # A result_prefix IS present (pointer transport available), but the
+        # rows that MUST ride inline overflow the cap on their own — there is
+        # nothing to fall back to, so it fail-open skips: returns None, no invoke.
+        from zagg import runner
+
+        monkeypatch.setattr(runner, "_RUN_STATS_INLINE_CAP_BYTES", 8)
+        client = self._Client()
+        summary = {}
+        path = runner._dispatch_run_stats(
+            client,
+            "fn",
+            "s3://b/out.zarr",
+            self._rows(n_ok=5, n_fail=3),
+            run_id="rid",
+            result_prefix="s3://b/out.zarr.status/rid",
+            summary=summary,
+        )
+        assert path is None and client.events == []
+        assert summary["run_stats_path"] is None
+
     def test_invoke_failure_is_fail_open(self):
         from zagg import runner
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3559,6 +3559,36 @@ class TestDispatchRunStats:
         assert [r["success"] for r in event["rows"]] == [False]
         assert path is not None
 
+    def test_pointer_transport_rides_inline_rows(self, monkeypatch):
+        # The spatial path passes inline_rows = failure rows PLUS stale-worker
+        # fallback-success rows (issue #313): rows_from_status can't rebuild a
+        # fallback-success shard worker-side, so it must ride inline — not be
+        # dropped by the default `not success` failure-filter.
+        from zagg import runner
+        from zagg.telemetry import build_record, flatten_record
+
+        monkeypatch.setattr(runner, "_RUN_STATS_INLINE_CAP_BYTES", 2048)
+        client = self._Client()
+        rows = self._rows(n_ok=5, n_fail=1)
+        # A fallback-success row (success=True) the caller marked inline-required.
+        fallback = flatten_record(build_record(shard_key=999, metadata={"duration_s": 1.0}))
+        inline_rows = [fallback] + [r for r in rows if not r.get("success")]
+        path = runner._dispatch_run_stats(
+            client,
+            "fn",
+            "s3://b/out.zarr",
+            rows + [fallback],
+            run_id="rid",
+            result_prefix="s3://b/out.zarr.status/rid",
+            inline_rows=inline_rows,
+        )
+        (event,) = client.events
+        assert event["rows_from"] == "s3://b/out.zarr.status/rid"
+        # The fallback-success row rides inline despite success=True.
+        assert 999 in [r["shard_key"] for r in event["rows"]]
+        assert [r["shard_key"] for r in event["rows"]] == [r["shard_key"] for r in inline_rows]
+        assert path is not None
+
     def test_oversized_sync_run_skips_fail_open(self, monkeypatch):
         from zagg import runner
 
@@ -3616,13 +3646,17 @@ class TestRunStatsRows:
                 "wall_time": 42.0,
             },
         ]
-        rows = _lambda_result_rows(results)
+        rows, inline_rows = _lambda_result_rows(results)
         assert [r["shard_key"] for r in rows] == [1, 2, 3]
         assert rows[0]["success"] is True and rows[0]["retries"] == 0
         assert rows[1]["success"] is True and rows[1]["n_obs"] == 3
         assert rows[2]["success"] is False
         assert rows[2]["error_class"] == "Lambda timeout"
         assert rows[2]["duration_s"] == 42.0 and rows[2]["retries"] == 3
+        # inline_rows = the rows the pointer path can't reassemble worker-side:
+        # the stale-worker fallback-success row (shard 2) and the failure row
+        # (shard 3), but NOT the envelope-backed success row (shard 1).
+        assert [r["shard_key"] for r in inline_rows] == [2, 3]
 
 
 class TestWorkerPhaseTimings:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3622,6 +3622,60 @@ class TestDispatchRunStats:
         assert path is None and client.events == []
         assert summary["run_stats_path"] is None
 
+    class _VerifyClient:
+        """Fake client for the fire->verify->re-fire leg: `drop_first` Event
+        invokes vanish (retries-0 loss); the next one 'lands' by writing the
+        parquet object at the pinned key, as the worker would."""
+
+        def __init__(self, root, drop_first=0):
+            self.root = root
+            self.drop = drop_first
+            self.events = []
+
+        def invoke(self, **kwargs):
+            from zagg.telemetry import run_parquet_key
+
+            event = json.loads(kwargs["Payload"])
+            self.events.append(event)
+            if len(self.events) <= self.drop:
+                return {}  # dropped Event invoke: nothing lands
+            key = run_parquet_key(event["run_id"], event["timestamp"])
+            (self.root / key).write_bytes(b"parquet")
+            return {}
+
+    def _verify_dispatch(self, monkeypatch, tmp_path, drop_first):
+        from zagg import runner
+
+        monkeypatch.setattr(runner, "_RUN_STATS_VERIFY_WINDOW_S", 0.5)
+        monkeypatch.setattr(runner, "_RUN_STATS_VERIFY_INTERVAL_S", 0.01)
+        root = tmp_path / "out"
+        root.mkdir()
+        client = self._VerifyClient(root, drop_first=drop_first)
+        path = runner._dispatch_run_stats(client, "fn", str(root), self._rows(), run_id="rid")
+        return client, path, root
+
+    def test_verify_present_no_refire(self, monkeypatch, tmp_path):
+        # The first invoke lands -> the existence poll passes -> ONE invoke.
+        client, path, root = self._verify_dispatch(monkeypatch, tmp_path, drop_first=0)
+        assert len(client.events) == 1
+        assert (root / path.rsplit("/", 1)[1]).exists()
+
+    def test_dropped_first_invoke_refires_once(self, monkeypatch, tmp_path):
+        # Retries-0 loss on the first Event invoke: the bounded read-only
+        # check re-fires exactly once and the re-fired invoke lands.
+        client, path, root = self._verify_dispatch(monkeypatch, tmp_path, drop_first=1)
+        assert len(client.events) == 2
+        assert client.events[0] == client.events[1]  # identical payload re-fired
+        assert (root / path.rsplit("/", 1)[1]).exists()
+
+    def test_both_invokes_dropped_gives_up_fail_open(self, monkeypatch, tmp_path):
+        # Both dropped: exactly two invokes (never more), announced path still
+        # returned (a late queued invoke may still land it), nothing written.
+        client, path, root = self._verify_dispatch(monkeypatch, tmp_path, drop_first=2)
+        assert len(client.events) == 2
+        assert path is not None
+        assert not any(root.glob("stats_*.parquet"))
+
     def test_invoke_failure_is_fail_open(self):
         from zagg import runner
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3475,6 +3475,124 @@ class TestProfilePlumbing:
         assert captured["handoff"] == "pandas"
 
 
+class TestLambdaRunStatsDispatch:
+    """The spatial lambda path announces the dispatched run-record path
+    (issue #313): the PUT rides the worker invoke, so the summary carries the
+    pinned D20 key rather than a dispatcher-write result."""
+
+    def test_summary_carries_dispatched_path(self, monkeypatch, atl06_config):
+        summary = _run_lambda_with_durations(monkeypatch, atl06_config, [10.0, 11.0, 12.0, 13.0])
+        path = summary["run_stats_path"]
+        assert path.startswith("s3://out/x.zarr/stats_")
+        assert path.endswith(".parquet")
+
+
+class TestDispatchRunStats:
+    """The issue #313 D8 transport seam: the run-record PUT rides a
+    fire-and-forget mode="stats" worker invoke; transport is size-gated."""
+
+    class _Client:
+        def __init__(self, raise_on_invoke=False):
+            self.events = []
+            self._raise = raise_on_invoke
+
+        def invoke(self, **kwargs):
+            if self._raise:
+                raise RuntimeError("invoke down")
+            self.events.append(json.loads(kwargs["Payload"]))
+            assert kwargs["InvocationType"] == "Event"
+            return {}
+
+    @staticmethod
+    def _rows(n_ok=2, n_fail=1):
+        from zagg.telemetry import build_record, failure_record, flatten_record
+
+        rows = [
+            flatten_record(build_record(shard_key=i, metadata={"duration_s": 1.0}))
+            for i in range(n_ok)
+        ]
+        rows += [
+            flatten_record(failure_record(shard_key=100 + i, error="boom")) for i in range(n_fail)
+        ]
+        return rows
+
+    def test_inline_transport(self):
+        from zagg import runner
+
+        client = self._Client()
+        summary = {}
+        path = runner._dispatch_run_stats(
+            client,
+            "fn",
+            "s3://b/out.zarr",
+            self._rows(),
+            run_id="rid",
+            result_prefix="s3://b/out.zarr.status/rid",
+            output_creds_event={"accessKeyId": "a", "secretAccessKey": "s"},
+            summary=summary,
+        )
+        (event,) = client.events
+        assert event["mode"] == "stats" and event["run_id"] == "rid"
+        assert len(event["rows"]) == 3 and "rows_from" not in event
+        assert event["output_credentials"]["accessKeyId"] == "a"
+        # The announced path is the pinned D20 key (timestamp-first).
+        assert path == f"s3://b/out.zarr/stats_{event['timestamp']}_rid.parquet"
+        assert summary["run_stats_path"] == path
+
+    def test_pointer_transport_keeps_failures_inline(self, monkeypatch):
+        from zagg import runner
+
+        # Small enough that six rows overflow, one failure row still fits.
+        monkeypatch.setattr(runner, "_RUN_STATS_INLINE_CAP_BYTES", 2048)
+        client = self._Client()
+        path = runner._dispatch_run_stats(
+            client,
+            "fn",
+            "s3://b/out.zarr",
+            self._rows(n_ok=5, n_fail=1),
+            run_id="rid",
+            result_prefix="s3://b/out.zarr.status/rid",
+        )
+        (event,) = client.events
+        assert event["rows_from"] == "s3://b/out.zarr.status/rid"
+        # Only the failure row rides inline (no envelope exists for it).
+        assert [r["success"] for r in event["rows"]] == [False]
+        assert path is not None
+
+    def test_oversized_sync_run_skips_fail_open(self, monkeypatch):
+        from zagg import runner
+
+        monkeypatch.setattr(runner, "_RUN_STATS_INLINE_CAP_BYTES", 8)
+        client = self._Client()
+        summary = {}
+        path = runner._dispatch_run_stats(
+            client, "fn", "s3://b/out.zarr", self._rows(), run_id="rid", summary=summary
+        )
+        assert path is None and client.events == []
+        assert summary["run_stats_path"] is None
+
+    def test_invoke_failure_is_fail_open(self):
+        from zagg import runner
+
+        summary = {}
+        path = runner._dispatch_run_stats(
+            self._Client(raise_on_invoke=True),
+            "fn",
+            "s3://b/out.zarr",
+            self._rows(),
+            run_id="rid",
+            summary=summary,
+        )
+        assert path is None and summary["run_stats_path"] is None
+
+    def test_empty_rows_no_invoke(self):
+        from zagg import runner
+
+        client = self._Client()
+        assert runner._dispatch_run_stats(client, "fn", "s3://b/x", [], run_id="r") is None
+        assert client.events == []
+
+
 class TestRunStatsRows:
     """Run-parquet row building from lambda dispatch results (issue #297)."""
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3643,7 +3643,7 @@ class TestDispatchRunStats:
             (self.root / key).write_bytes(b"parquet")
             return {}
 
-    def _verify_dispatch(self, monkeypatch, tmp_path, drop_first):
+    def _verify_dispatch(self, monkeypatch, tmp_path, drop_first, summary=None):
         from zagg import runner
 
         monkeypatch.setattr(runner, "_RUN_STATS_VERIFY_WINDOW_S", 0.5)
@@ -3651,7 +3651,9 @@ class TestDispatchRunStats:
         root = tmp_path / "out"
         root.mkdir()
         client = self._VerifyClient(root, drop_first=drop_first)
-        path = runner._dispatch_run_stats(client, "fn", str(root), self._rows(), run_id="rid")
+        path = runner._dispatch_run_stats(
+            client, "fn", str(root), self._rows(), run_id="rid", summary=summary
+        )
         return client, path, root
 
     def test_verify_present_no_refire(self, monkeypatch, tmp_path):
@@ -3663,18 +3665,28 @@ class TestDispatchRunStats:
     def test_dropped_first_invoke_refires_once(self, monkeypatch, tmp_path):
         # Retries-0 loss on the first Event invoke: the bounded read-only
         # check re-fires exactly once and the re-fired invoke lands.
-        client, path, root = self._verify_dispatch(monkeypatch, tmp_path, drop_first=1)
+        summary = {}
+        client, path, root = self._verify_dispatch(
+            monkeypatch, tmp_path, drop_first=1, summary=summary
+        )
         assert len(client.events) == 2
         assert client.events[0] == client.events[1]  # identical payload re-fired
         assert (root / path.rsplit("/", 1)[1]).exists()
+        # Path is set once on attempt 1 and survives the re-fire, not clobbered.
+        assert summary["run_stats_path"] == path
 
     def test_both_invokes_dropped_gives_up_fail_open(self, monkeypatch, tmp_path):
         # Both dropped: exactly two invokes (never more), announced path still
         # returned (a late queued invoke may still land it), nothing written.
-        client, path, root = self._verify_dispatch(monkeypatch, tmp_path, drop_first=2)
+        summary = {}
+        client, path, root = self._verify_dispatch(
+            monkeypatch, tmp_path, drop_first=2, summary=summary
+        )
         assert len(client.events) == 2
         assert path is not None
         assert not any(root.glob("stats_*.parquet"))
+        # Set on the first fire even though verification never confirmed it.
+        assert summary["run_stats_path"] == path
 
     def test_invoke_failure_is_fail_open(self):
         from zagg import runner

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -416,6 +416,20 @@ class TestRunParquet:
         key = run_parquet_key("abc123", timestamp="20260718T010203Z")
         assert key == "stats_20260718T010203Z_abc123.parquet"
 
+    def test_run_parquet_key_rejects_traversal(self):
+        # Both components land in the object key; a ``/`` or ``..`` must RAISE
+        # (issue #313 makes timestamp caller-supplied) rather than escape root.
+        import pytest
+
+        with pytest.raises(ValueError):
+            run_parquet_key("../../etc/passwd", timestamp="20260718T010203Z")
+        with pytest.raises(ValueError):
+            run_parquet_key("ab/cd", timestamp="20260718T010203Z")
+        with pytest.raises(ValueError):
+            run_parquet_key("abc123", timestamp="../evil")
+        with pytest.raises(ValueError):
+            run_parquet_key("abc123", timestamp="2026/07/18")
+
     def test_round_trip(self, tmp_path):
         import pandas as pd
 


### PR DESCRIPTION
Closes #313

The issue #297 run-level parquet was the first orchestrator-originated PUT into a store, violating D8's orchestrator-no-write invariant (`docs/design/sparse_coverage.md`) — the benchmark CI's invoke-only role correctly 403'd it. Fix the code, not the policy (espg-ratified on the issue): on the **Lambda dispatch paths** the write moves behind a fire-and-forget worker Event invoke — the root-MOC (`mode: "coverage"`) pattern — as a new `mode: "stats"` handler branch; **local dispatch paths keep writing directly** (user credentials, no invariant). Fail-open at every step, failure rows preserved, timestamp-first D20 naming unchanged, object-count model untouched.

## Transport choice (stated per the issue's payload note)

**Async Event invoke per the D8 standing rule** (espg refinement, 2026-07-22): the run-parquet worker invoke is fire-and-forget `InvocationType="Event"`, exactly like the root-MOC `mode:"coverage"` leg — the dispatcher never blocks on it, fail-open, retries-0 (the dispatch clients run `retries: {max_attempts: 0}` and `_dispatch_run_stats` adds no retry loop; the seam test pins `InvocationType == "Event"`). Built this way from the start via the coverage pattern; nothing to flip.

**Fire → verify → re-fire hardening** (espg addendum; commit `013654c`): failure rows exist only in the dispatcher's run report — a dropped retries-0 Event invoke would lose them permanently (success rows stay rebuildable from the leaf sidecars). After firing, the dispatcher does a bounded READ-ONLY existence poll on the pinned D20 key (HEAD every 2 s, ≤ 20 s — reads were never forbidden; the dispatcher already polls result objects) and re-fires the Event invoke exactly once if the parquet hasn't appeared, then gives up fail-open with a logged notice. Worst case ≤ 2 × 20 s of end-of-run wall, zero writes (D8 intact); a non-positive window is the single-fire escape hatch (and keeps unit harnesses hermetic). Tests pin: object-present → one invoke; dropped-first → exactly one identical re-fire that lands; both-dropped → exactly two invokes, announced path retained, nothing written.

**Hybrid, size-gated, behind one seam** (`runner._dispatch_run_stats`):

- **Inline** when the serialized rows fit the async budget: the event carries `rows` directly. Threshold: rows JSON ≤ 200 KB (the existing `_ASYNC_PAYLOAD_CAP_BYTES = 250 KB` Event-invoke gate minus ~50 KB headroom for the rest of the event — creds block, paths). At ~0.5–1 KB/row that is roughly 200–400 shards; typical benchmark runs ride inline.
- **Pointer** above the threshold (async runs): the event carries `rows_from` — the run's `.status/` prefix — and the worker (whose role can read the store side) LISTs the issue-#151 mirrored result envelopes and assembles the success rows from their `body["stats"]` records. **Every dispatcher-built row rides inline next to the pointer** — failure rows (a timed-out shard mirrored no envelope) and stale-worker fallback success rows (a 200 envelope with no record; review fold `c5bce65`) cannot be assembled worker-side. Two acknowledged losses in pointer mode, stated rather than papered over: dispatcher `retries` counts are not in the envelopes (pointer-assembled success rows carry `retries: null`), and a shard whose envelope landed but whose poll timed out dispatcher-side may appear as both an inline failure row and an assembled success row (documented on the seam; the run record is best-effort telemetry, not load-bearing truth).
- **Sync-invocation runs** (`invocation="sync"`, legacy) have no status prefix; oversized row sets there log a fail-open skip. Sync is the legacy small-run path, so this corner is theoretical.

The dispatcher pins the D20 object key at dispatch (`timestamp` rides in the event), so `summary["run_stats_path"]` still names the real object — its semantics on lambda paths become "dispatched target, best-effort" (the invoke is fire-and-forget), mirroring the root MOC's semantics; local paths keep path-on-success/None-on-failure.

## Phases

- [x] Phase 1 — worker side: `mode: "stats"` handler branch (inline + pointer transports, pinned-key write, fail-open), `telemetry.write_run_parquet(timestamp=...)`, `telemetry.rows_from_status` (worker-side envelope assembly); tests against local stores
- [x] Phase 2 — dispatcher side: `_dispatch_run_stats` transport seam (size-gated inline/pointer, pinned D20 key, fail-open), wired into the spatial and raster Lambda paths (local paths untouched); seam unit tests + spatial/raster harness integration (raster dispatches the failure rows BEFORE its all-failed raise, pinned by test)

## Temporal note

The temporal Lambda path (`_run_lambda_events`) writes **no run record today** — the #297 wiring never covered it (its fan-out unit is an event, not a shard; its `store_path` is a tabular object, not a store root; its rows would need an event-keyed schema). Nothing to move behind the invoke there. When a temporal run record lands (follow-up), it inherits this PR's `mode: "stats"` transport as-is.

## Testing

- Phase 2: seam units (inline event shape + announced path == pinned key; pointer keeps only failure rows inline; oversized sync run skips fail-open; invoke failure fail-open; empty rows no invoke), spatial summary carries the dispatched path, raster all-failed run still dispatches its failure rows.
- Phase 1: inline rows written at the dispatcher-pinned key (exact D20 name asserted), pointer assembly from mirrored envelopes (stale-worker envelope skipped; inline failure rows merged), empty-rows no-op, fail-open 500 path.
- Full suite green locally; pre-existing environment-only items (lambda-build test on this machine's pip, `N818` in `registry.py`) unchanged.

## Questions for review

1. **Per-shard 11-vs-12 sidecar gap**: not touched here per the issue's scope note (separate triage, fleet-code-lag hypothesis). This PR doesn't interact with it — the sidecar writes are per-shard worker writes and unchanged; only the run-parquet transport moves.
2. **Pointer-mode `retries: null` + the double-row corner** (envelope landed after dispatcher poll deadline): accepted as stated above; if either matters for cost forensics, the alternative is the dispatcher chunking inline rows across several `mode:"stats"` invokes — say the word and it's a small change on the seam.
