### PR TITLE
Named product roots + semantic-core hash (issue #299)

### DIFF
--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -20,7 +20,8 @@ so it cannot drift from what the template actually emits:
   array at K>1 gives 1..K objects (zarr's default ``write_empty_chunks=False``
   omits all-fill chunks, so empty inner chunks write nothing).
 - **hive** (per-shard leaf zarrs): store-root objects (``morton_hive.json``,
-  plus ``coverage.moc`` when ``output.coverage_moc`` is on — the hive default)
+  plus ``coverage.moc`` when ``output.coverage_moc`` is on — the hive default —
+  plus the fail-open ``aggregation.yaml`` semantic core, issue #299)
   plus, per populated leaf, the leaf metadata (root + group + per-array
   ``zarr.json``), the in-leaf ``coverage.moc`` sidecar (depth > 0), one
   whole-leaf ragged object per ragged field, and — since issue #236 — one
@@ -141,10 +142,12 @@ def expected_object_counts(
         # the floor is the manifest alone, the ceiling adds the MOC. A real
         # sharded-write bypass lands in the per-shard DATA counts (asserted
         # exactly in object_count_mismatch), never in this metadata window.
-        # ... plus the OPTIONAL run-level stats parquet (issue #297), same
+        # ... plus the OPTIONAL run-level stats parquet (issue #297) and the
+        # OPTIONAL aggregation.yaml semantic core (issue #299, D19 — a
+        # fail-open derived convenience riding the manifest write), same
         # fail-open posture as the root MOC.
         metadata_min = 1
-        metadata_max = 1 + (1 if coverage_moc else 0) + 1
+        metadata_max = 1 + (1 if coverage_moc else 0) + 1 + 1
         # Leaf fixed objects: leaf root zarr.json + group zarr.json + one
         # zarr.json per array, plus the in-leaf coverage.moc sidecar (written
         # for any populated leaf when the leaf has depth, i.e. child_order >
@@ -267,7 +270,10 @@ def store_object_counts(
             prefix.rstrip("/").rsplit("/", 1)[0] + "/": label for prefix, label in leaf_of.items()
         }
         for key in keys:
-            if key in (hive.MANIFEST_NAME, hive.ROOT_COVERAGE_NAME) or _is_run_parquet(key):
+            if (
+                key in (hive.MANIFEST_NAME, hive.ROOT_COVERAGE_NAME, hive.AGGREGATION_CORE_NAME)
+                or _is_run_parquet(key)
+            ):
                 metadata += 1
                 continue
             for prefix, label in leaf_of.items():

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -643,8 +643,13 @@ rollup leaves all leaf reads intact.
   **`semantic_hash`** verifies it — sha256 over the canonicalized
   **output-defining subset only**: the `aggregation` block (functions +
   params + dtypes + fills + ragged kinds), the `data_source` semantics
-  (dataset/product, groups, coordinates, variables, filters), and the
-  grid *type + indexing scheme*. Excluded as packaging: cell order (a
+  (dataset/product, groups, coordinates, variables, filters), the
+  grid *type + indexing scheme*, and the **pipeline type** (`spatial` |
+  `temporal` | `event`, absent ⇒ `spatial` — espg-ruled on the PR #316
+  review, 2026-07-21: a temporal engine over the same aggregation block is
+  a different product; the original list omitted it only because the
+  temporal path wasn't in frame, and pre-merge was the free moment to add
+  it — no store carries a hash yet). Excluded as packaging: cell order (a
   resolution axis — D24), parent/shard order, `chunk_inner`/`sharded`,
   worker size, streaming mode (merge-vs-spill lands `np.isclose` and
   shares one store, with the actual mode recorded per-run), and read

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -716,6 +716,13 @@ def _validate_store_layout_keys(config: PipelineConfig) -> None:
     store_layout = config.output.get("store_layout")
     if store_layout is not None and store_layout not in ("flat", "hive"):
         raise ValueError(f"output.store_layout must be 'flat' or 'hive' (got {store_layout!r})")
+    # D19 product name (issue #299): validated at load so a bad name fails
+    # before any store I/O. The grammar lives in hive.py (one source).
+    name = config.output.get("product_name")
+    if name is not None:
+        from zagg.hive import validate_product_name
+
+        validate_product_name(name)
     if get_store_layout(config) == "hive":
         if (grid or {}).get("type", "healpix") != "healpix":
             raise ValueError(
@@ -2068,6 +2075,17 @@ def get_cell_ids_encoding(config: PipelineConfig) -> str:
     # A present-but-null key (YAML ``cell_ids_encoding:``) must fall back to the
     # default too — the same treatment ``from_config`` gives a null ``layout``.
     return config.output.get("grid", {}).get("cell_ids_encoding") or "nested"
+
+
+def get_product_name(config: PipelineConfig) -> str | None:
+    """The D19 product name (issue #299), or ``None`` for a bare store.
+
+    When set, the run's effective store root becomes
+    ``{output.store}/{product_name}/`` (``zagg.hive.effective_store_root``) —
+    a NAMED product root in a multi-product store. Absent (the default),
+    stores keep today's bare single-product layout byte-identically.
+    """
+    return config.output.get("product_name")
 
 
 def get_store_path(config: PipelineConfig) -> str | None:

--- a/src/zagg/dedup.py
+++ b/src/zagg/dedup.py
@@ -1,0 +1,139 @@
+"""Per-shard dedup status: ``has_run`` (issue #299 phase 4, D19).
+
+Answers "has this exact product already produced this shard?" from durable
+store state, for the estimate/skip flows (#298) to consume. Three signals, in
+strictly increasing cost:
+
+1. **The commit stamp** (D4): a leaf whose root attrs lack the stamp — or no
+   leaf at all — is a plain ``"miss"`` (debris is invisible).
+2. **The D20 stats sidecar**: the recorded ``semantic_hash`` (intended
+   identity, D19) and ``granules_sha256`` (catalog identity — the output is
+   ``f(template, shard, catalog snapshot)``, and ATL03 is a living
+   collection). A stamped leaf whose sidecar is missing, records a different
+   or absent ``semantic_hash``, or hashes a different granule set is
+   ``"stale"`` — present but not provably this product over this catalog;
+   a catalog-grown shard is stale, **never** a hit.
+3. **The O11 content hashes**, surfaced (not recomputed) when the sidecar
+   carries them: the *verifier* — "intended identical" (semantic hash) vs
+   "actually byte-identical" (per-array decoded-value hashes) — for callers
+   that go on to compare two stores.
+
+Statuses are conservative by construction: every ambiguity degrades toward
+recompute (``stale``/``miss``), never toward a false ``hit`` — a wrong "skip"
+silently ships wrong data; a wrong "recompute" costs one shard's work.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from zagg.hive import read_commit, read_manifest, shard_leaf_path
+from zagg.store import open_store
+from zagg.telemetry import granules_sha256, read_sidecar
+
+logger = logging.getLogger(__name__)
+
+#: ``has_run`` statuses: complete + verified for THIS product and catalog
+#: snapshot / present but unverifiable-or-outdated / not (completely) there.
+STATUSES = ("hit", "stale", "miss")
+
+
+def shard_status(
+    store_root: str,
+    shard_key,
+    *,
+    semantic_hash: str,
+    granule_ids=None,
+    window: str | None = None,
+    spec: str | None = None,
+    **store_kwargs,
+) -> dict:
+    """Dedup status of ONE (shard, window) leaf; see :func:`has_run`.
+
+    ``granule_ids`` is the shard's CURRENT catalog snapshot in the same id
+    space the sidecars record (resolved granule URLs on the aggregation
+    path, STAC item ids/datetimes for raster — cf.
+    :func:`zagg.telemetry.granules_sha256`); ``None`` skips the catalog
+    check (identity match alone then gates the hit).
+    """
+    leaf = shard_leaf_path(store_root, int(shard_key), window=window)
+    stamp = read_commit(open_store(leaf, **store_kwargs))
+    if stamp is None:
+        return {"status": "miss"}
+    sidecar = read_sidecar(leaf, spec=spec, **store_kwargs)
+    if sidecar is None:
+        # Stamped but unverifiable (pre-#297 leaf, or a lost fail-open PUT):
+        # never a hit — the leaf may be any product/catalog vintage.
+        return {"status": "stale", "reason": "no stats sidecar"}
+    detail: dict = {
+        "semantic_hash_match": sidecar.get("semantic_hash") == semantic_hash,
+        "catalog_match": None,
+    }
+    if content := sidecar.get("content_hashes"):
+        # O11 verifier, surfaced when recorded (never recomputed here).
+        detail["content_hashes"] = content
+    if granule_ids is not None:
+        detail["catalog_match"] = sidecar.get("granules_sha256") == granules_sha256(granule_ids)
+    if not detail["semantic_hash_match"]:
+        return {"status": "stale", "reason": "semantic_hash mismatch or unrecorded", **detail}
+    if detail["catalog_match"] is False:
+        return {"status": "stale", "reason": "catalog grown/changed", **detail}
+    return {"status": "hit", **detail}
+
+
+def has_run(
+    store_root: str,
+    config,
+    shards,
+    *,
+    window: str | None = None,
+    spec: str | None = None,
+    **store_kwargs,
+) -> dict:
+    """Per-shard dedup status for a prospective run (issue #299 phase 4).
+
+    Parameters
+    ----------
+    store_root : str
+        The PRODUCT root (apply :func:`zagg.hive.effective_store_root` /
+        :func:`zagg.hive.product_root` first for multi-product stores).
+    config : PipelineConfig
+        The prospective run's config; its ``semantic_hash`` is the identity
+        compared against each sidecar.
+    shards : mapping or iterable
+        ``{shard_key: granule_ids}`` (current catalog snapshot per shard —
+        the same id space the sidecars record) or a bare iterable of shard
+        keys (catalog check skipped).
+    window : str, optional
+        Window label for windowed stores (one status per (shard, window)).
+    spec : str, optional
+        The store's naming spec for sidecar keys; default: read once from
+        the manifest (``None`` on a manifest-less root = the ``/1`` legacy
+        names).
+
+    Returns
+    -------
+    dict
+        ``{int(shard_key): {"status": "hit"|"stale"|"miss", ...detail}}``.
+    """
+    from zagg.semantics import semantic_hash as _semantic_hash
+
+    want = _semantic_hash(config)
+    if spec is None:
+        spec = (read_manifest(store_root, **store_kwargs) or {}).get("spec")
+    items = shards.items() if hasattr(shards, "items") else ((k, None) for k in shards)
+    return {
+        int(key): shard_status(
+            store_root,
+            key,
+            semantic_hash=want,
+            granule_ids=ids,
+            window=window,
+            spec=spec,
+            **store_kwargs,
+        )
+        for key, ids in items
+    }
+
+
+__all__ = ["STATUSES", "has_run", "shard_status"]

--- a/src/zagg/dedup.py
+++ b/src/zagg/dedup.py
@@ -55,6 +55,17 @@ def shard_status(
     path, STAC item ids/datetimes for raster — cf.
     :func:`zagg.telemetry.granules_sha256`); ``None`` skips the catalog
     check (identity match alone then gates the hit).
+
+    .. warning::
+       The catalog check is an EXACT ``granules_sha256`` comparison, so
+       ``granule_ids`` must be the same id space the writer recorded — a
+       caller that supplies a different space (bare short-names vs resolved
+       URLs, sorted vs dispatch order) makes EVERY stamped shard report
+       ``stale`` on ``catalog_match`` rather than a genuine catalog change.
+       A ``"catalog grown/changed"`` stale carries both
+       ``granules_sha256_recorded`` and ``granules_sha256_current`` so a
+       mis-spaced caller can see the mismatch is systematic (every shard
+       differs), not a real snapshot drift.
     """
     leaf = shard_leaf_path(store_root, int(shard_key), window=window)
     stamp = read_commit(open_store(leaf, **store_kwargs))
@@ -73,11 +84,21 @@ def shard_status(
         # O11 verifier, surfaced when recorded (never recomputed here).
         detail["content_hashes"] = content
     if granule_ids is not None:
-        detail["catalog_match"] = sidecar.get("granules_sha256") == granules_sha256(granule_ids)
+        recorded = sidecar.get("granules_sha256")
+        current = granules_sha256(granule_ids)
+        detail["catalog_match"] = recorded == current
     if not detail["semantic_hash_match"]:
         return {"status": "stale", "reason": "semantic_hash mismatch or unrecorded", **detail}
     if detail["catalog_match"] is False:
-        return {"status": "stale", "reason": "catalog grown/changed", **detail}
+        # Surface both digests so a systematic id-space mismatch (every shard
+        # differs) is distinguishable from a genuine per-shard catalog change.
+        return {
+            "status": "stale",
+            "reason": "catalog grown/changed",
+            "granules_sha256_recorded": recorded,
+            "granules_sha256_current": current,
+            **detail,
+        }
     return {"status": "hit", **detail}
 
 

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -441,8 +441,10 @@ def write_semantic_core(store_root: str, config, **store_kwargs) -> None:
     A derived convenience next to the manifest (D9 cache class): sorted-key,
     deterministic YAML of the output-defining subset, so product names stay
     human-inspectable without a registry. FAIL-OPEN — the manifest's
-    ``semantic_hash`` is the truth and the sweep can regenerate this; a
-    failed PUT must not fail the run.
+    ``semantic_hash`` is the truth, and the core is regenerable straight from
+    the config (rewriting it is a single :func:`write_semantic_core` call), so
+    a failed PUT must not fail the run. The D22 pyramid sweep is the intended
+    owner of the rewrite once it lands; there is no regenerator today.
     """
     import obstore
     import yaml

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -100,27 +100,44 @@ ROOT_COVERAGE_NAME = "coverage.moc"
 AGGREGATION_CORE_NAME = "aggregation.yaml"
 
 #: Product-name grammar (D19; normative on the mortie spec page §6.5):
-#: URL-safe lowercase alphanumerics plus ``-``/``_``. The base-component
-#: exclusion (``-?[1-6]``, :func:`_is_base_component`) is checked separately —
-#: a name shaped like a hive base component would make the walker's child
-#: classification ambiguous at a multi-product store root.
+#: URL-safe lowercase alphanumerics plus ``-``/``_``, at most
+#: :data:`PRODUCT_NAME_MAX` chars. The base-component exclusion (``-?[1-6]``,
+#: :func:`_is_base_component`) is checked separately — a name shaped like a
+#: hive base component would make the walker's child classification ambiguous
+#: at a multi-product store root.
 _PRODUCT_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
+
+#: Product-name length cap (D19; espg ruling mirrored from the mortie spec page
+#: §6.5). Derivation: a POSIX filename component is 255 bytes; the immutable-
+#: provenance decoration reserves 13 (``+`` + a 12-hex digest) ⇒ a 242-byte
+#: hard ceiling. 192 sits 50 under that, and leaves the S3 total-key and
+#: PATH_MAX budgets comfortable (the name also nests under the store prefix and
+#: the digit tree). The grammar is single-byte per char, so char count == byte
+#: count here.
+PRODUCT_NAME_MAX = 192
 
 
 def validate_product_name(name: str) -> str:
     """Validate a D19 product name; returns it.
 
     Grammar (normative on the mortie spec page §6.5): one or more of
-    ``[a-z0-9_-]``, and never matching the morton base-component grammar
-    ``-?[1-6]`` — the root-form discrimination
-    (:func:`classify_store_root`) depends on names and digit components
-    being disjoint. Names are URL-safe by construction (they appear in
-    gridlook deep-links and web paths).
+    ``[a-z0-9_-]``, at most :data:`PRODUCT_NAME_MAX` characters, and never
+    matching the morton base-component grammar ``-?[1-6]`` — the root-form
+    discrimination (:func:`classify_store_root`) depends on names and digit
+    components being disjoint. Names are URL-safe by construction (they appear
+    in gridlook deep-links and web paths).
     """
     if not isinstance(name, str) or not _PRODUCT_NAME_RE.match(name):
         raise ValueError(
             f"product name {name!r} does not match the D19 grammar ([a-z0-9_-]+, "
             f"lowercase; normative on the mortie spec page)"
+        )
+    if len(name) > PRODUCT_NAME_MAX:
+        raise ValueError(
+            f"product name {name!r} is {len(name)} chars; the D19 grammar caps names "
+            f"at {PRODUCT_NAME_MAX} (normative on the mortie spec page §6.5 — a POSIX "
+            f"255-byte filename component less the 13-byte immutable-provenance "
+            f"decoration)"
         )
     if _is_base_component(name):
         raise ValueError(

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 import warnings
 from datetime import datetime, timezone
@@ -91,6 +92,115 @@ _ZSTD_LEVEL = 3
 #: invariant, next to the manifest. Same name as the in-leaf sidecar
 #: (:data:`COVERAGE_SIDECAR`), different location and encoding.
 ROOT_COVERAGE_NAME = "coverage.moc"
+
+#: Product-name grammar (D19; normative on the mortie spec page §6.5):
+#: URL-safe lowercase alphanumerics plus ``-``/``_``. The base-component
+#: exclusion (``-?[1-6]``, :func:`_is_base_component`) is checked separately —
+#: a name shaped like a hive base component would make the walker's child
+#: classification ambiguous at a multi-product store root.
+_PRODUCT_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
+
+
+def validate_product_name(name: str) -> str:
+    """Validate a D19 product name; returns it.
+
+    Grammar (normative on the mortie spec page §6.5): one or more of
+    ``[a-z0-9_-]``, and never matching the morton base-component grammar
+    ``-?[1-6]`` — the root-form discrimination
+    (:func:`classify_store_root`) depends on names and digit components
+    being disjoint. Names are URL-safe by construction (they appear in
+    gridlook deep-links and web paths).
+    """
+    if not isinstance(name, str) or not _PRODUCT_NAME_RE.match(name):
+        raise ValueError(
+            f"product name {name!r} does not match the D19 grammar ([a-z0-9_-]+, "
+            f"lowercase; normative on the mortie spec page)"
+        )
+    if _is_base_component(name):
+        raise ValueError(
+            f"product name {name!r} matches the morton base-component grammar "
+            f"(-?[1-6]); such names are excluded so a store root's children stay "
+            f"unambiguous (D19)"
+        )
+    return name
+
+
+def product_root(store_root: str, name: str) -> str:
+    """Root prefix of product ``name`` under a multi-product store (D19).
+
+    A product subtree is a COMPLETE, unmodified morton-hive store (bare-named
+    manifest + MOC + digit tree), so everything that takes a ``store_root``
+    takes this value unchanged.
+    """
+    return f"{store_root.rstrip('/')}/{validate_product_name(name)}"
+
+
+def effective_store_root(store_path: str, config) -> str:
+    """The store root a run writes into: the product root when one is named.
+
+    ``output.product_name`` (issue #299) prefixes the configured store path
+    with the D19 ``{name}/`` product root; absent, the bare single-product
+    layout is unchanged (byte-identical stores — the D19 revision is
+    additive).
+    """
+    from zagg.config import get_product_name
+
+    name = get_product_name(config)
+    return product_root(store_path, name) if name else store_path
+
+
+def classify_store_root(store_root: str, **store_kwargs) -> str:
+    """Root-form discrimination by CONTENT (D19): what sits at ``store_root``.
+
+    Returns ``"bare"`` (a manifest at the root ⇒ a single-product store — the
+    digit tree lives right here), ``"products"`` (no manifest, and at least
+    one name-shaped child prefix ⇒ a directory of product roots), or
+    ``"empty"`` (neither). Base-component-shaped children without a manifest
+    still classify as ``"bare"`` — the manifest write is async (issue #252),
+    so a store mid-first-run must not be misread as a product directory.
+    """
+    import obstore
+
+    store = open_object_store(store_root, **store_kwargs)
+    if _read_json(store, MANIFEST_NAME) is not None:
+        return "bare"
+    listing = obstore.list_with_delimiter(store)
+    children = [p.rstrip("/").split("/")[-1] for p in listing["common_prefixes"]]
+    if any(_is_base_component(c) for c in children):
+        return "bare"
+    names = [c for c in children if _is_valid_product_name(c)]
+    return "products" if names else "empty"
+
+
+def list_products(store_root: str, **store_kwargs) -> dict:
+    """``{name: manifest}`` for every product under a multi-product root (D19).
+
+    Discovery is the root listing itself — no name↔hash translation layer:
+    each name-shaped child prefix is read for its bare-named
+    ``morton_hive.json``. Children without a readable manifest are skipped
+    (debris or mid-write; the D4 posture — absence of a manifest means the
+    product is not yet discoverable).
+    """
+    import obstore
+
+    store = open_object_store(store_root, **store_kwargs)
+    listing = obstore.list_with_delimiter(store)
+    children = [p.rstrip("/").split("/")[-1] for p in listing["common_prefixes"]]
+    products = {}
+    for name in sorted(c for c in children if _is_valid_product_name(c)):
+        manifest = read_manifest(product_root(store_root, name), **store_kwargs)
+        if manifest is not None:
+            products[name] = manifest
+    return products
+
+
+def _is_valid_product_name(name: str) -> bool:
+    """Whether ``name`` satisfies the D19 product-name grammar (no raise)."""
+    try:
+        validate_product_name(name)
+    except ValueError:
+        return False
+    return True
 
 
 def shard_leaf_path(store_root: str, shard_key, window: str | None = None) -> str:

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -460,21 +460,6 @@ def write_semantic_core(store_root: str, config, **store_kwargs) -> None:
         logger.warning(f"{AGGREGATION_CORE_NAME} write failed (fail-open, D9 cache class): {e}")
 
 
-def append_spec(existing: dict | None, manifest: dict) -> str:
-    """The naming spec in effect for this run's writes (issue #299).
-
-    On append into an existing store the writer honors the EXISTING
-    manifest's declared spec — one grammar per product tree (D6/D23): a
-    future ``morton-hive/3``-emitting writer must not emit ``/3`` names into
-    a ``/2`` tree (the frozen ``spec`` key would refuse the manifest, but
-    naming calls run per-shard and must agree too). Fresh stores use the
-    run's own manifest spec. The PR #307 seam
-    (:func:`zagg.telemetry.sidecar_key`, :func:`zagg.windows.leaf_name_v3`)
-    is keyed by exactly this value.
-    """
-    return (existing or manifest)["spec"]
-
-
 #: Manifest keys the resume match-check compares (orders + identity + split
 #: and temporal schedules — a windowing change re-partitions the leaf names,
 #: so it must refuse resume exactly like an orders change). ``generated_at``

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -93,6 +93,12 @@ _ZSTD_LEVEL = 3
 #: (:data:`COVERAGE_SIDECAR`), different location and encoding.
 ROOT_COVERAGE_NAME = "coverage.moc"
 
+#: Canonical semantic core object name at the product root (D19): a DERIVED
+#: convenience (D9 cache class) — deterministic YAML of the output-defining
+#: subset. The manifest's ``semantic_hash`` is the truth; divergence resolves
+#: to the hash.
+AGGREGATION_CORE_NAME = "aggregation.yaml"
+
 #: Product-name grammar (D19; normative on the mortie spec page §6.5):
 #: URL-safe lowercase alphanumerics plus ``-``/``_``. The base-component
 #: exclusion (``-?[1-6]``, :func:`_is_base_component`) is checked separately —
@@ -276,6 +282,8 @@ def build_manifest(grid, dataset: dict | None = None, windowing: dict | None = N
     leaf-stamp truth and root-summary cache. ``None`` writes the ``/1``
     manifest byte-identical to pre-windowing runs.
     """
+    from zagg.semantics import semantic_hash
+
     dataset = dataset or {}
     manifest = {
         "spec": HIVE_SPEC_V2 if windowing else HIVE_SPEC,
@@ -283,9 +291,17 @@ def build_manifest(grid, dataset: dict | None = None, windowing: dict | None = N
             "short_name": dataset.get("short_name"),
             "version": dataset.get("version"),
         },
+        # D19 (issue #299): the FULL sha256 of the canonicalized semantic
+        # core — a frozen key, so reusing a product name/root with different
+        # aggregation semantics refuses up front like an orders mismatch.
+        "semantic_hash": semantic_hash(grid.config),
         "cell_order": int(grid.child_order),
         "shard_order": int(grid.parent_order),
         "split_schedule": [1] * int(grid.parent_order),
+        # D21: how many morton digits each path component chunks. Existing
+        # stores are retroactively 1 (the _frozen normalization); new stores
+        # declare it explicitly.
+        "path_grouping": 1,
         "pyramid": {"orders": [], "aggregation": {}},
         "generated_at": _utcnow(),
     }
@@ -341,7 +357,7 @@ def validate_manifest(
 
     store = open_object_store(store_root, **store_kwargs)
     existing = _read_json(store, MANIFEST_NAME)
-    frozen_matches = existing is not None and _frozen(existing) == _frozen(manifest)
+    frozen_matches = _frozen_matches(existing, manifest)
     if existing is not None and not overwrite:
         if not frozen_matches:
             raise ValueError(
@@ -368,7 +384,14 @@ def validate_manifest(
     return existing
 
 
-def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False, **store_kwargs):
+def ensure_manifest(
+    store_root: str,
+    manifest: dict,
+    *,
+    overwrite: bool = False,
+    config=None,
+    **store_kwargs,
+):
     """Write the root manifest; verify it on reruns (idempotent).
 
     Lifecycle (issue #252 hybrid): the PRIMARY write runs at init — the local
@@ -407,7 +430,49 @@ def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False,
     if existing is not None and not overwrite:
         return existing
     obstore.put(store, MANIFEST_NAME, json.dumps(manifest, indent=1).encode())
+    if config is not None:
+        write_semantic_core(store_root, config, **store_kwargs)
     return manifest
+
+
+def write_semantic_core(store_root: str, config, **store_kwargs) -> None:
+    """PUT the canonical semantic core as ``aggregation.yaml`` (D19).
+
+    A derived convenience next to the manifest (D9 cache class): sorted-key,
+    deterministic YAML of the output-defining subset, so product names stay
+    human-inspectable without a registry. FAIL-OPEN — the manifest's
+    ``semantic_hash`` is the truth and the sweep can regenerate this; a
+    failed PUT must not fail the run.
+    """
+    import obstore
+    import yaml
+
+    from zagg.semantics import semantic_core
+
+    try:
+        payload = yaml.safe_dump(semantic_core(config), sort_keys=True)
+        obstore.put(
+            open_object_store(store_root, **store_kwargs),
+            AGGREGATION_CORE_NAME,
+            payload.encode(),
+        )
+    except Exception as e:
+        logger.warning(f"{AGGREGATION_CORE_NAME} write failed (fail-open, D9 cache class): {e}")
+
+
+def append_spec(existing: dict | None, manifest: dict) -> str:
+    """The naming spec in effect for this run's writes (issue #299).
+
+    On append into an existing store the writer honors the EXISTING
+    manifest's declared spec — one grammar per product tree (D6/D23): a
+    future ``morton-hive/3``-emitting writer must not emit ``/3`` names into
+    a ``/2`` tree (the frozen ``spec`` key would refuse the manifest, but
+    naming calls run per-shard and must agree too). Fresh stores use the
+    run's own manifest spec. The PR #307 seam
+    (:func:`zagg.telemetry.sidecar_key`, :func:`zagg.windows.leaf_name_v3`)
+    is keyed by exactly this value.
+    """
+    return (existing or manifest)["spec"]
 
 
 #: Manifest keys the resume match-check compares (orders + identity + split
@@ -419,16 +484,42 @@ def ensure_manifest(store_root: str, manifest: dict, *, overwrite: bool = False,
 _FROZEN_MANIFEST_KEYS = (
     "spec",
     "dataset",
+    "semantic_hash",
     "cell_order",
     "shard_order",
     "split_schedule",
+    "path_grouping",
     "temporal",
 )
 
 
 def _frozen(manifest: dict) -> dict:
-    """The frozen-key projection of a manifest (resume/overwrite match-check)."""
-    return {k: manifest.get(k) for k in _FROZEN_MANIFEST_KEYS}
+    """The frozen-key projection of a manifest (resume/overwrite match-check).
+
+    ``path_grouping`` normalizes ``absent -> 1`` (D21: existing stores are
+    retroactively ``1``), so appends to pre-D21 manifests never refuse on it.
+    """
+    frozen = {k: manifest.get(k) for k in _FROZEN_MANIFEST_KEYS}
+    frozen["path_grouping"] = manifest.get("path_grouping") or 1
+    return frozen
+
+
+def _frozen_matches(existing: dict | None, manifest: dict) -> bool:
+    """Whether two manifests agree on every frozen key (issue #299).
+
+    ``semantic_hash`` is compared only when BOTH sides declare it: a
+    pre-#299 manifest lacks the key, and refusing every append to an
+    existing store on its absence would brick resumes — the orders/schedule
+    keys still guard those stores. Two hash-carrying manifests must match
+    exactly (D19: the hash is a frozen key).
+    """
+    if existing is None:
+        return False
+    fa, fb = _frozen(existing), _frozen(manifest)
+    if fa["semantic_hash"] is None or fb["semantic_hash"] is None:
+        fa.pop("semantic_hash")
+        fb.pop("semantic_hash")
+    return fa == fb
 
 
 def _is_base_component(name: str) -> bool:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -859,8 +859,10 @@ class RasterStrategy:
         max_workers = min(max_workers or 4, len(cells)) or 1
         # Run identity for the stats records (issue #297): generated once per
         # run, stamped into every record so leaf sidecars join back to the
-        # run-level parquet (which reuses it in its object name).
+        # run-level parquet (which reuses it in its object name). The
+        # semantic-core hash (issue #299) rides every record the same way.
         run_id = uuid.uuid4().hex
+        run_semantic_hash = _semantic_hash(config)
         t0 = time.time()
         shards_with_data = 0
         errors = 0
@@ -951,6 +953,7 @@ class RasterStrategy:
                 metadata=meta,
                 granule_ids=raster_granule_ids(granules),
                 run_id=run_id,
+                semantic_hash=run_semantic_hash,
             )
             meta["stats"] = record
             if store_layout == "hive" and meta.get("leaf_written"):
@@ -2460,6 +2463,9 @@ def _run_local(
     # stamped into every record so leaf sidecars join back to the run-level
     # parquet (which reuses it in its object name).
     run_id = uuid.uuid4().hex
+    # The run config's semantic-core hash (issue #299, D19): stamped into
+    # every stats record so has_run's identity check has a recorded value.
+    run_semantic_hash = _semantic_hash(config)
     store_layout = get_store_layout(config)
     store_kwargs = {
         "region": region,
@@ -2570,6 +2576,7 @@ def _run_local(
                 metadata=meta,
                 granule_ids=_resolve_urls(records, driver),
                 run_id=run_id,
+                semantic_hash=run_semantic_hash,
             )
             meta["stats"] = record
             if store_layout == "hive" and not meta.get("error"):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -68,6 +68,7 @@ from zagg.processing import (
     write_ragged_to_zarr,
     write_shard_to_zarr,
 )
+from zagg.semantics import semantic_hash as _semantic_hash
 from zagg.store import open_object_store, open_store
 
 logger = logging.getLogger(__name__)
@@ -839,7 +840,12 @@ class RasterStrategy:
             manifest = build_manifest(
                 grid, dataset=catalog_data.get("metadata"), windowing=windowing
             )
-            ensure_manifest(store_path, manifest, overwrite=overwrite, **store_kwargs)
+            # The manifest IN EFFECT (an accepted existing one on append)
+            # keys the writers' naming spec (issue #299 spec-compat) and the
+            # D19 aggregation.yaml core rides the primary write.
+            manifest = ensure_manifest(
+                store_path, manifest, overwrite=overwrite, config=config, **store_kwargs
+            )
         else:
             zarr_store = open_store(store_path, **store_kwargs)
             emit_raster_template(zarr_store, grid, config, times_us, overwrite=overwrite)
@@ -954,7 +960,11 @@ class RasterStrategy:
                     leaf = shard_leaf_path(
                         store_path, int(shard_key), window=window["label"] if window else None
                     )
-                    write_sidecar(leaf, record, **store_kwargs)
+                    # Sidecar naming keys on the manifest spec IN EFFECT
+                    # (issue #299 spec-compat; the #307 seam).
+                    write_sidecar(
+                        leaf, record, spec=manifest["spec"] if manifest else None, **store_kwargs
+                    )
                 except Exception as e:
                     logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
             return meta, stage_stats, write_s
@@ -1000,7 +1010,9 @@ class RasterStrategy:
             # (D9), fail-open.
             from zagg.hive import ensure_manifest
 
-            ensure_manifest(store_path, manifest, overwrite=overwrite, **store_kwargs)
+            ensure_manifest(
+                store_path, manifest, overwrite=overwrite, config=config, **store_kwargs
+            )
             if get_coverage_moc(config):
                 from zagg.hive import build_root_coverage, write_root_coverage
                 from zagg.windows import union_time_range
@@ -2479,7 +2491,12 @@ def _run_local(
         # existing store refuses in ~0s, before any leaf write (D2), instead
         # of mixing new-order leaves into an old-order store.
         manifest = build_manifest(grid, dataset=catalog_data.get("metadata"), windowing=windowing)
-        ensure_manifest(store_path, manifest, overwrite=overwrite, **store_kwargs)
+        # Capture the manifest IN EFFECT (the accepted existing one on
+        # append): its spec keys the writers' naming calls (issue #299
+        # spec-compat), and the D19 aggregation.yaml core rides the write.
+        manifest = ensure_manifest(
+            store_path, manifest, overwrite=overwrite, config=config, **store_kwargs
+        )
         # Temporal fan-out (issue #246 phase 5): one work unit per (shard,
         # window). None (schedule none/absent) keeps the (shard, records)
         # pairs — dispatch byte-identical to pre-windowing runs.
@@ -2562,7 +2579,9 @@ def _run_local(
                     leaf = shard_leaf_path(
                         store_path, int(shard_key), window=window["label"] if window else None
                     )
-                    write_sidecar(leaf, record, **store_kwargs)
+                    # Sidecar naming keys on the manifest spec IN EFFECT
+                    # (issue #299 spec-compat; the #307 seam).
+                    write_sidecar(leaf, record, spec=manifest["spec"], **store_kwargs)
                 except Exception as e:
                     logger.warning(f"stats sidecar write failed (fail-open, issue #297): {e}")
             return {"shard_key": shard_key, "ok": True, "meta": meta}

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -61,6 +61,7 @@ from zagg.dispatch import (
 )
 from zagg.grids.base import shard_label
 from zagg.grids.morton import morton_word
+from zagg.hive import effective_store_root
 from zagg.processing import (
     process_shard,
     write_dataframe_to_zarr,
@@ -377,6 +378,9 @@ class SpatialStrategy:
         store_path = store or get_store_path(config)
         if not store_path:
             raise ValueError("No store path specified (pass store= or set output.store: in config)")
+        # D19 product root (issue #299): a named product writes into
+        # {store}/{name}/ — a complete, unmodified store under that prefix.
+        store_path = effective_store_root(store_path, config)
 
         # child_order is HEALPix-specific (leaf order); other grids don't define it.
         grid_type = config.output.get("grid", {}).get("type", "healpix")
@@ -515,6 +519,9 @@ class TemporalStrategy:
             )
 
         store_path = store or get_store_path(config)
+        if store_path:
+            # D19 product root (issue #299) — same treatment as the spatial run.
+            store_path = effective_store_root(store_path, config)
         specs = specs_from_config(config)
         event_list = list(events)
         if max_cells is not None:
@@ -750,6 +757,9 @@ class RasterStrategy:
         store_path = store or get_store_path(config)
         if not store_path:
             raise ValueError("No store path specified (pass store= or set output.store: in config)")
+        # D19 product root (issue #299): a named product writes into
+        # {store}/{name}/ — a complete, unmodified store under that prefix.
+        store_path = effective_store_root(store_path, config)
         if backend not in ("local", "lambda"):
             raise ValueError(f"Unknown backend: {backend!r} (expected 'local' or 'lambda')")
         if backend == "lambda" and not store_path.startswith("s3://"):

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -20,7 +20,11 @@ Included (the semantic core):
 - the grid **type + indexing scheme** (D19: cell order is a resolution axis
   (D24), parent/shard order and chunking are packaging — hashing the whole
   template would have made o8 and o9 runs different products and blocked
-  mixed-order processing).
+  mixed-order processing);
+- the **pipeline type** (``spatial`` | ``temporal`` | ``event``; absent
+  normalizes to ``spatial`` — espg-ruled on the PR #316 review: a temporal
+  engine over the same aggregation block is a different product; D19's
+  ratified list omitted it only because the temporal path wasn't in frame).
 
 Excluded as packaging: all orders (``parent_order``/``child_order``/
 ``chunk_inner``), ``sharded``, store layout/path, ``emit_cell_ids`` (the
@@ -46,7 +50,7 @@ from __future__ import annotations
 import hashlib
 import json
 
-from zagg.config import PipelineConfig
+from zagg.config import PipelineConfig, get_pipeline_type
 
 #: ``data_source`` keys that are read machinery, not output semantics (D19).
 #: Changing any of these must never change the ``semantic_hash``.
@@ -115,6 +119,13 @@ def semantic_core(config: PipelineConfig) -> dict:
         "aggregation": _without(config.aggregation, AGGREGATION_PACKAGING_KEYS),
         "data_source": _without(config.data_source, DATA_SOURCE_PACKAGING_KEYS),
         "grid": grid,
+        # pipeline.type is output-defining (espg-ruled on the PR #316
+        # review, 2026-07-21): a temporal/event engine over an identical
+        # aggregation block is a DIFFERENT product. Absent normalizes to
+        # the "spatial" default on both sides (get_pipeline_type's default),
+        # the same discipline as the manifest's path_grouping absent=>1, so
+        # every existing config hashes stably.
+        "pipeline": {"type": get_pipeline_type(config)},
     }
     return _prune_nulls(core)
 

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -1,0 +1,127 @@
+"""Semantic-core canonicalization + hash (issue #299, D19).
+
+A product's identity splits in two (D19, ``docs/design/sparse_coverage.md``):
+the **name** addresses it (the ``{store_root}/{name}/`` product root), and the
+**``semantic_hash``** verifies it — sha256 over the canonicalized
+**output-defining subset only**. Two configs with the same semantic core
+produce the same values in every cell they share; everything else is
+packaging.
+
+Included (the semantic core):
+
+- the ``aggregation`` block — functions, params, dtypes, fills, ragged kinds,
+  declared coordinates, ``chunk_precompute`` — minus the ``handoff`` carrier
+  choice (arrow vs pandas is a worker-internal transport);
+- the ``data_source`` **semantics** — which groups/variables/coordinates are
+  read and how observations are filtered (``filters``/``quality_filter``,
+  photon ``base_level``/``levels``, raster ``bands``/``nodata``/
+  ``collections``/``static_data``) — minus the read machinery (``reader``,
+  ``driver``, ``read_plan``, ``anonymous``);
+- the grid **type + indexing scheme** (D19: cell order is a resolution axis
+  (D24), parent/shard order and chunking are packaging — hashing the whole
+  template would have made o8 and o9 runs different products and blocked
+  mixed-order processing).
+
+Excluded as packaging: all orders (``parent_order``/``child_order``/
+``chunk_inner``), ``sharded``, store layout/path, ``emit_cell_ids`` (the
+issue #304 transition hatch), worker sizing, streaming mode, read knobs,
+catalog/bounds (run inputs, recorded per-run — catalog identity lives in the
+D20 sidecar, never the product identity).
+
+Canonical form: the core dict serialized as sorted-key, compact,
+ASCII-escaped JSON — so YAML comments, whitespace, and key order can never
+change the hash (§8.3 canonicalization obligations). The hash is the **full
+sha256 hex digest** (git-style: the full digest is what is compared; the
+12-hex :func:`semantic_fingerprint` is the display/CLI shorthand — 48 bits,
+comfortable for the only collision domain that matters, display within one
+store's product listing).
+
+This module formalizes the #89 signature seam (``grid.spatial_signature`` /
+``config.output_field_signature`` are dict fingerprints; this is the
+content-addressed form) — see the issue #299 thread for the design record.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from zagg.config import PipelineConfig
+
+#: ``data_source`` keys that are read machinery, not output semantics (D19).
+#: Changing any of these must never change the ``semantic_hash``.
+DATA_SOURCE_PACKAGING_KEYS = ("reader", "driver", "read_plan", "anonymous")
+
+#: ``aggregation`` keys that are packaging: the per-cell carrier choice
+#: (issue #132) transports identical values either way.
+AGGREGATION_PACKAGING_KEYS = ("handoff",)
+
+#: Display length of :func:`semantic_fingerprint` (12 hex = 48 bits; the
+#: birthday bound puts same-store collision odds around 1e-8 at 1e4 products
+#: — recorded rationale on the issue #299 thread).
+FINGERPRINT_HEX = 12
+
+
+def _without(mapping: dict, keys: tuple[str, ...]) -> dict:
+    return {k: v for k, v in (mapping or {}).items() if k not in keys and v is not None}
+
+
+def semantic_core(config: PipelineConfig) -> dict:
+    """The output-defining subset of ``config`` (D19), as a plain dict.
+
+    Deterministic given the config's semantics: two configs differing only in
+    packaging knobs (orders, chunking, worker size, read machinery, carrier)
+    map to the same core. The returned structure is JSON-serializable plain
+    data (the YAML loader guarantees it).
+    """
+    grid_cfg = (config.output or {}).get("grid", {}) or {}
+    grid_type = grid_cfg.get("type", "healpix")
+    core: dict = {
+        "aggregation": _without(config.aggregation, AGGREGATION_PACKAGING_KEYS),
+        "data_source": _without(config.data_source, DATA_SOURCE_PACKAGING_KEYS),
+        "grid": {"type": grid_type},
+    }
+    if grid_type == "healpix":
+        # The one indexing scheme zagg writes (the morton store convention
+        # rides D16 attrs; the underlying cell tiling is HEALPix NESTED).
+        core["grid"]["indexing_scheme"] = "nested"
+    return core
+
+
+def canonical_semantic_json(config: PipelineConfig) -> str:
+    """The canonical serialized form the hash is computed over.
+
+    Sorted keys, compact separators, ASCII-escaped: syntactic YAML edits
+    (comments, whitespace, key order) cannot reach this string.
+    """
+    return json.dumps(
+        semantic_core(config), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+
+
+def semantic_hash(config: PipelineConfig) -> str:
+    """Full sha256 hex digest of the canonical semantic core (64 hex chars).
+
+    The frozen manifest key (D19): reusing a product name with a different
+    semantic hash refuses up front, exactly as an orders mismatch does. Always
+    compare the FULL digest; display via :func:`semantic_fingerprint`.
+    """
+    return hashlib.sha256(canonical_semantic_json(config).encode()).hexdigest()
+
+
+def semantic_fingerprint(digest: str) -> str:
+    """12-hex display shorthand of a full ``semantic_hash`` digest."""
+    if len(digest) < FINGERPRINT_HEX:
+        raise ValueError(f"not a semantic hash digest: {digest!r}")
+    return digest[:FINGERPRINT_HEX]
+
+
+__all__ = [
+    "AGGREGATION_PACKAGING_KEYS",
+    "DATA_SOURCE_PACKAGING_KEYS",
+    "FINGERPRINT_HEX",
+    "canonical_semantic_json",
+    "semantic_core",
+    "semantic_fingerprint",
+    "semantic_hash",
+]

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -61,6 +61,14 @@ AGGREGATION_PACKAGING_KEYS = ("handoff",)
 #: — recorded rationale on the issue #299 thread).
 FINGERPRINT_HEX = 12
 
+#: Non-healpix grid keys that spatially define the product (F1, issue #299).
+#: For rect/other grids the cell geometry is fixed by CRS + resolution +
+#: bounds, so two such products differing in any of these are different
+#: products (D24's resolution-axis exclusion is a HEALPix/morton composability
+#: argument that does not extend to rect — over-discriminating is safe, a
+#: semantic collision is not). HEALPix stays type + indexing scheme only.
+GRID_SPATIAL_KEYS = ("crs", "resolution", "bounds")
+
 
 def _without(mapping: dict, keys: tuple[str, ...]) -> dict:
     return {k: v for k, v in (mapping or {}).items() if k not in keys and v is not None}
@@ -76,15 +84,21 @@ def semantic_core(config: PipelineConfig) -> dict:
     """
     grid_cfg = (config.output or {}).get("grid", {}) or {}
     grid_type = grid_cfg.get("type", "healpix")
-    core: dict = {
-        "aggregation": _without(config.aggregation, AGGREGATION_PACKAGING_KEYS),
-        "data_source": _without(config.data_source, DATA_SOURCE_PACKAGING_KEYS),
-        "grid": {"type": grid_type},
-    }
+    grid: dict = {"type": grid_type}
     if grid_type == "healpix":
         # The one indexing scheme zagg writes (the morton store convention
         # rides D16 attrs; the underlying cell tiling is HEALPix NESTED).
-        core["grid"]["indexing_scheme"] = "nested"
+        grid["indexing_scheme"] = "nested"
+    else:
+        # Rect/other: fold in the spatially-defining params when present (F1).
+        for key in GRID_SPATIAL_KEYS:
+            if key in grid_cfg:
+                grid[key] = grid_cfg[key]
+    core: dict = {
+        "aggregation": _without(config.aggregation, AGGREGATION_PACKAGING_KEYS),
+        "data_source": _without(config.data_source, DATA_SOURCE_PACKAGING_KEYS),
+        "grid": grid,
+    }
     return core
 
 
@@ -120,6 +134,7 @@ __all__ = [
     "AGGREGATION_PACKAGING_KEYS",
     "DATA_SOURCE_PACKAGING_KEYS",
     "FINGERPRINT_HEX",
+    "GRID_SPATIAL_KEYS",
     "canonical_semantic_json",
     "semantic_core",
     "semantic_fingerprint",

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -71,7 +71,23 @@ GRID_SPATIAL_KEYS = ("crs", "resolution", "bounds")
 
 
 def _without(mapping: dict, keys: tuple[str, ...]) -> dict:
-    return {k: v for k, v in (mapping or {}).items() if k not in keys and v is not None}
+    return {k: v for k, v in (mapping or {}).items() if k not in keys}
+
+
+def _prune_nulls(obj):
+    """Recursively drop ``None``-valued keys from every dict in ``obj``.
+
+    §8.3 canonicalization: a YAML explicit-null (``key:``) must hash identically
+    to an absent key, at every depth — not just the top level. Applied to the
+    whole core so a nested ``None`` (e.g. ``quality_filter.value:``) drops out.
+    Lists are recursed but never pruned by value: list entries are positional,
+    so a ``None`` element is content, not an absent key.
+    """
+    if isinstance(obj, dict):
+        return {k: _prune_nulls(v) for k, v in obj.items() if v is not None}
+    if isinstance(obj, list):
+        return [_prune_nulls(v) for v in obj]
+    return obj
 
 
 def semantic_core(config: PipelineConfig) -> dict:
@@ -79,8 +95,9 @@ def semantic_core(config: PipelineConfig) -> dict:
 
     Deterministic given the config's semantics: two configs differing only in
     packaging knobs (orders, chunking, worker size, read machinery, carrier)
-    map to the same core. The returned structure is JSON-serializable plain
-    data (the YAML loader guarantees it).
+    map to the same core. ``None``-valued keys are pruned recursively so a
+    YAML explicit-null hashes identically to an absent key (§8.3). The returned
+    structure is JSON-serializable plain data (the YAML loader guarantees it).
     """
     grid_cfg = (config.output or {}).get("grid", {}) or {}
     grid_type = grid_cfg.get("type", "healpix")
@@ -99,7 +116,7 @@ def semantic_core(config: PipelineConfig) -> dict:
         "data_source": _without(config.data_source, DATA_SOURCE_PACKAGING_KEYS),
         "grid": grid,
     }
-    return core
+    return _prune_nulls(core)
 
 
 def canonical_semantic_json(config: PipelineConfig) -> str:

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -116,6 +116,7 @@ def build_record(
     granule_ids: Iterable[str] | None = None,
     invoked_by: dict | None = None,
     run_id: str | None = None,
+    semantic_hash: str | None = None,
     lambda_config: dict | None = None,
 ) -> dict:
     """Build one shard's stats record from the worker's ``metadata`` dict.
@@ -128,7 +129,9 @@ def build_record(
     ``sts get-caller-identity`` once per run; workers cannot see the invoker.
     ``run_id`` is threaded the same way (dispatcher-generated, stamped through
     the invoke payload, copied verbatim) so a leaf sidecar joins back to its
-    run-level parquet.
+    run-level parquet. ``semantic_hash`` (issue #299, D19) is the run
+    config's semantic-core hash — the identity half the ``has_run`` dedup
+    check compares; ``granules_sha256`` below is the catalog half.
     ``lambda_config`` is :func:`lambda_env` on Lambda, ``None`` locally;
     when present it prices ``gb_seconds`` / ``est_cost_usd`` from
     ``duration_s`` (the billed-duration approximation the dispatcher's cost
@@ -163,10 +166,10 @@ def build_record(
         "schema_version": SCHEMA_VERSION,
         "shard_key": int(shard_key),
         "run_id": run_id,
-        # The semantic-core hash (D19 rev 2, docs/design/sparse_coverage.md):
-        # hashes the config's semantic core, NOT the whole template. Nullable
-        # until issue #299 lands the hasher.
-        "semantic_hash": None,
+        # The semantic-core hash (D19 rev 2, issue #299): hashes the config's
+        # semantic core, NOT the whole template. Nullable for callers without
+        # a config in scope.
+        "semantic_hash": semantic_hash,
         "zagg_version": _zagg_version(),
         "n_shards": 1,
         "n_granules": int(n_granules),

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2069,14 +2069,15 @@ def test_hive_config_expected_counts_root_moc_optional():
     # + 4 array zarr.json + 4 sharded data objects + coverage sidecar +
     # stats.json sibling (issue #297) = 12.
     # Store root: morton_hive.json (always) + coverage.moc (optional) + the
-    # run stats parquet (optional, issue #297) -> [1, 3].
+    # run stats parquet (optional, issue #297) + aggregation.yaml (optional,
+    # issue #299) -> [1, 4].
     assert exp == {
-        "metadata": 3,
+        "metadata": 4,
         "metadata_min": 1,
         "per_shard_min": 12,
         "per_shard_max": 12,
         "total_min": 13,
-        "total_max": 15,
+        "total_max": 16,
         "exact": True,
     }
 

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -305,8 +305,9 @@ def test_hive_store_matches_model(tmp_path, monkeypatch):
     # K == 1 leaf: every per-array count is deterministic, so the hive model
     # is exact here and the real store matches it object-for-object.
     assert expected["exact"] is True
-    # Through the runner: manifest + root MOC + the run stats parquet (#297).
-    assert measured["objects_metadata"] == expected["metadata"] == 3
+    # Through the runner: manifest + aggregation.yaml (issue #299) + root
+    # MOC + the run stats parquet (#297).
+    assert measured["objects_metadata"] == expected["metadata"] == 4
     assert measured["objects_other"] == 0
     assert list(measured["objects_per_shard"]) == [_KEY_A]
     assert measured["objects_total"] == expected["total_max"]
@@ -554,11 +555,12 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     )
     # Exact: per leaf = root+group zarr.json (2) + one zarr.json AND one data
     # object per array + the coverage sidecar + the stats.json sibling
-    # (issue #297); store root = manifest + MOC + the run stats parquet.
+    # (issue #297); store root = manifest + aggregation.yaml (issue #299)
+    # + MOC + the run stats parquet.
     n_arrays = len(grid.shard_spec().members)
     assert expected["exact"] is True
     assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 1
-    assert expected["metadata"] == 3
+    assert expected["metadata"] == 4
     assert measured["objects_total"] == expected["total_max"]
     assert measured["objects_other"] == 0
     assert bench_objects.object_count_mismatch(measured, expected) is None

--- a/tests/test_coverage_root.py
+++ b/tests/test_coverage_root.py
@@ -297,7 +297,8 @@ class TestLocalRootCoverage:
         assert hive.ROOT_COVERAGE_NAME not in listing
         assert hive.MANIFEST_NAME in listing
         assert any(n.startswith("stats_") and n.endswith(".parquet") for n in listing)
-        assert len(listing) == 3
+        # node dir + manifest + aggregation.yaml (issue #299) + run parquet.
+        assert len(listing) == 4
 
 
 class TestLambdaCoverageDispatch:

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -16,7 +16,7 @@ from zagg.grids import HealpixGrid
 from zagg.grids.morton import morton_word
 from zagg.semantics import semantic_hash
 from zagg.store import open_store
-from zagg.telemetry import build_record, write_sidecar
+from zagg.telemetry import build_record, sidecar_key, write_sidecar
 
 WORD = morton_word("1121121")  # order-6 shard key
 GRANULES = ["s3://b/g1.h5", "s3://b/g2.h5"]
@@ -156,3 +156,30 @@ class TestHasRun:
         out = has_run(str(tmp_path), cfg, [WORD, other])
         assert out[WORD]["status"] == "hit"
         assert out[other]["status"] == "miss"
+
+    def test_windowed_leaf_status(self, tmp_path):
+        # A windowed store (issue #246): the (shard, window) leaf carries its
+        # own legacy `stats_{window}.json` sidecar (spec=None), and has_run must
+        # key on the window so a hit for one window is a miss for another.
+        cfg = _cfg()
+        root = str(tmp_path)
+        leaf = hive.shard_leaf_path(root, WORD, window="2025")
+        assert sidecar_key(leaf.rstrip("/").rsplit("/", 1)[-1]) == "stats_2025.json"
+        store = open_store(leaf)
+        _grid(cfg).emit_shard_template(store, overwrite=True)
+        group = zarr.open_group(store, path="", mode="a", zarr_format=3)
+        group.attrs[hive.COMMIT_ATTR] = {"cells_with_data": 1}
+        write_sidecar(
+            leaf,
+            build_record(
+                shard_key=WORD,
+                metadata={"total_obs": 2, "cells_with_data": 1, "duration_s": 0.1},
+                granule_ids=GRANULES,
+                semantic_hash=semantic_hash(cfg),
+            ),
+        )
+        hit = has_run(root, cfg, {WORD: GRANULES}, window="2025")
+        assert hit[WORD]["status"] == "hit"
+        # A different window has no leaf: a plain miss (windows are disjoint).
+        miss = has_run(root, cfg, {WORD: GRANULES}, window="2024")
+        assert miss[WORD]["status"] == "miss"

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,155 @@
+"""has_run dedup statuses (issue #299 phase 4, D19).
+
+The acceptance criteria from the issue thread: "hit" only when identity AND
+catalog match; a catalog-grown shard reports "stale", never "hit"; debris and
+absent leaves are plain misses.
+"""
+
+import copy
+
+import zarr
+
+from zagg import hive
+from zagg.config import default_config
+from zagg.dedup import has_run, shard_status
+from zagg.grids import HealpixGrid
+from zagg.grids.morton import morton_word
+from zagg.semantics import semantic_hash
+from zagg.store import open_store
+from zagg.telemetry import build_record, write_sidecar
+
+WORD = morton_word("1121121")  # order-6 shard key
+GRANULES = ["s3://b/g1.h5", "s3://b/g2.h5"]
+
+
+def _cfg():
+    return default_config("atl06")
+
+
+def _grid(cfg):
+    return HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+
+
+def _write_leaf(root, cfg, *, stamp=True, sidecar=True, sidecar_hash="match", granules=GRANULES):
+    """Emit + optionally stamp a leaf, optionally with a stats sidecar."""
+    leaf = hive.shard_leaf_path(root, WORD)
+    store = open_store(leaf)
+    _grid(cfg).emit_shard_template(store, overwrite=True)
+    if stamp:
+        group = zarr.open_group(store, path="", mode="a", zarr_format=3)
+        group.attrs[hive.COMMIT_ATTR] = {"cells_with_data": 1}
+    if sidecar:
+        recorded = {
+            "match": semantic_hash(cfg),
+            "other": "0" * 64,
+            "absent": None,
+        }[sidecar_hash]
+        record = build_record(
+            shard_key=WORD,
+            metadata={"total_obs": 2, "cells_with_data": 1, "duration_s": 0.1},
+            granule_ids=granules,
+            semantic_hash=recorded,
+        )
+        write_sidecar(leaf, record)
+    return leaf
+
+
+class TestShardStatus:
+    def test_absent_leaf_is_miss(self, tmp_path):
+        cfg = _cfg()
+        status = shard_status(str(tmp_path), WORD, semantic_hash=semantic_hash(cfg))
+        assert status == {"status": "miss"}
+
+    def test_unstamped_leaf_is_miss(self, tmp_path):
+        # Debris (D4): a template without the commit stamp is invisible.
+        cfg = _cfg()
+        _write_leaf(str(tmp_path), cfg, stamp=False, sidecar=False)
+        status = shard_status(str(tmp_path), WORD, semantic_hash=semantic_hash(cfg))
+        assert status["status"] == "miss"
+
+    def test_stamped_without_sidecar_is_stale(self, tmp_path):
+        cfg = _cfg()
+        _write_leaf(str(tmp_path), cfg, sidecar=False)
+        status = shard_status(str(tmp_path), WORD, semantic_hash=semantic_hash(cfg))
+        assert status["status"] == "stale"
+        assert "sidecar" in status["reason"]
+
+    def test_full_match_is_hit(self, tmp_path):
+        cfg = _cfg()
+        _write_leaf(str(tmp_path), cfg)
+        status = shard_status(
+            str(tmp_path), WORD, semantic_hash=semantic_hash(cfg), granule_ids=GRANULES
+        )
+        assert status["status"] == "hit"
+        assert status["semantic_hash_match"] is True
+        assert status["catalog_match"] is True
+
+    def test_catalog_growth_is_stale_never_hit(self, tmp_path):
+        # The headline acceptance criterion: ATL03 is a living collection —
+        # a grown catalog must recompute, not skip.
+        cfg = _cfg()
+        _write_leaf(str(tmp_path), cfg)
+        status = shard_status(
+            str(tmp_path),
+            WORD,
+            semantic_hash=semantic_hash(cfg),
+            granule_ids=[*GRANULES, "s3://b/g3.h5"],
+        )
+        assert status["status"] == "stale"
+        assert status["catalog_match"] is False
+        assert status["semantic_hash_match"] is True
+
+    def test_semantic_mismatch_is_stale(self, tmp_path):
+        cfg = _cfg()
+        _write_leaf(str(tmp_path), cfg)
+        other = copy.deepcopy(cfg)
+        other.aggregation["variables"]["count"]["dtype"] = "int64"
+        status = shard_status(
+            str(tmp_path), WORD, semantic_hash=semantic_hash(other), granule_ids=GRANULES
+        )
+        assert status["status"] == "stale"
+        assert status["semantic_hash_match"] is False
+
+    def test_pre299_sidecar_is_stale(self, tmp_path):
+        # A pre-#299 sidecar records no semantic_hash: unverifiable identity
+        # degrades to recompute, never to a false hit.
+        cfg = _cfg()
+        _write_leaf(str(tmp_path), cfg, sidecar_hash="absent")
+        status = shard_status(
+            str(tmp_path), WORD, semantic_hash=semantic_hash(cfg), granule_ids=GRANULES
+        )
+        assert status["status"] == "stale"
+
+
+class TestHasRun:
+    def test_mapping_input_checks_catalog(self, tmp_path):
+        cfg = _cfg()
+        _write_leaf(str(tmp_path), cfg)
+        out = has_run(str(tmp_path), cfg, {WORD: GRANULES})
+        assert out[WORD]["status"] == "hit"
+        grown = has_run(str(tmp_path), cfg, {WORD: [*GRANULES, "s3://b/new.h5"]})
+        assert grown[WORD]["status"] == "stale"
+
+    def test_iterable_input_skips_catalog_check(self, tmp_path):
+        cfg = _cfg()
+        _write_leaf(str(tmp_path), cfg)
+        out = has_run(str(tmp_path), cfg, [WORD])
+        assert out[WORD]["status"] == "hit"
+        assert out[WORD]["catalog_match"] is None
+
+    def test_spec_defaults_from_manifest(self, tmp_path):
+        # The sidecar key grammar is spec-keyed (#307); has_run reads the
+        # manifest once for it. A manifest-less root uses the legacy names.
+        cfg = _cfg()
+        root = str(tmp_path)
+        hive.ensure_manifest(root, hive.build_manifest(_grid(cfg)))
+        _write_leaf(root, cfg)
+        assert has_run(root, cfg, [WORD])[WORD]["status"] == "hit"
+
+    def test_missing_shards_reported(self, tmp_path):
+        cfg = _cfg()
+        _write_leaf(str(tmp_path), cfg)
+        other = morton_word("2431123")
+        out = has_run(str(tmp_path), cfg, [WORD, other])
+        assert out[WORD]["status"] == "hit"
+        assert out[other]["status"] == "miss"

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -98,6 +98,9 @@ class TestShardStatus:
         assert status["status"] == "stale"
         assert status["catalog_match"] is False
         assert status["semantic_hash_match"] is True
+        # F8: the recorded vs current digests are surfaced so a systematic
+        # id-space mismatch is distinguishable from a genuine catalog change.
+        assert status["granules_sha256_recorded"] != status["granules_sha256_current"]
 
     def test_semantic_mismatch_is_stale(self, tmp_path):
         cfg = _cfg()

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -294,6 +294,89 @@ class TestManifest:
 # ── leaf template + commit stamp (D3/D4) ─────────────────────────────────────
 
 
+class TestSemanticManifest:
+    """Issue #299 phase 3: semantic_hash + path_grouping frozen keys, the
+    aggregation.yaml derived core, and the append-spec seam."""
+
+    def _grid(self, cfg):
+        return HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+
+    def test_manifest_carries_semantic_hash_and_grouping(self, cfg):
+        from zagg.semantics import semantic_hash
+
+        m = hive.build_manifest(self._grid(cfg))
+        assert m["semantic_hash"] == semantic_hash(cfg) and len(m["semantic_hash"]) == 64
+        assert m["path_grouping"] == 1
+
+    def test_append_to_pre299_manifest_accepted(self, cfg, tmp_path):
+        # A pre-#299 manifest lacks semantic_hash/path_grouping; appends must
+        # not refuse on the new keys (absent-side tolerance / absent=>1).
+        root = str(tmp_path / "store")
+        grid = self._grid(cfg)
+        old = hive.build_manifest(grid)
+        del old["semantic_hash"]
+        del old["path_grouping"]
+        hive.ensure_manifest(root, old)
+        fresh = hive.build_manifest(grid)
+        assert hive.validate_manifest(root, fresh) == old
+        # And the accepted manifest (no second PUT) is the existing one.
+        assert hive.ensure_manifest(root, fresh) == old
+
+    def test_semantic_mismatch_refuses(self, cfg, tmp_path):
+        # Both manifests carry the hash and they differ -> frozen-key refusal,
+        # exactly like an orders mismatch (D19).
+        root = str(tmp_path / "store")
+        hive.ensure_manifest(root, hive.build_manifest(self._grid(cfg)))
+        import copy
+
+        other_cfg = copy.deepcopy(cfg)
+        other_cfg.aggregation["variables"]["count"]["dtype"] = "int64"
+        other = hive.build_manifest(self._grid(other_cfg))
+        with pytest.raises(ValueError, match="does not match this run"):
+            hive.validate_manifest(root, other)
+
+    def test_grouping_mismatch_refuses(self, cfg, tmp_path):
+        # path_grouping IS frozen (path shape): an explicit different value
+        # refuses; only ABSENT normalizes to 1.
+        root = str(tmp_path / "store")
+        grid = self._grid(cfg)
+        grouped = hive.build_manifest(grid)
+        grouped["path_grouping"] = 3
+        hive.ensure_manifest(root, grouped)
+        with pytest.raises(ValueError, match="does not match this run"):
+            hive.validate_manifest(root, hive.build_manifest(grid))
+
+    def test_aggregation_core_written_with_manifest(self, cfg, tmp_path):
+        import yaml as _yaml
+
+        from zagg.semantics import semantic_core
+
+        root = str(tmp_path / "store")
+        hive.ensure_manifest(root, hive.build_manifest(self._grid(cfg)), config=cfg)
+        payload = (tmp_path / "store" / hive.AGGREGATION_CORE_NAME).read_text()
+        assert _yaml.safe_load(payload) == semantic_core(cfg)
+        # Deterministic: a rewrite is byte-identical (sorted-key dump).
+        hive.write_semantic_core(root, cfg)
+        assert (tmp_path / "store" / hive.AGGREGATION_CORE_NAME).read_text() == payload
+
+    def test_aggregation_core_write_is_fail_open(self, cfg, monkeypatch, caplog):
+        import obstore
+
+        def boom(*a, **k):
+            raise OSError("no")
+
+        monkeypatch.setattr(obstore, "put", boom)
+        with caplog.at_level("WARNING"):
+            hive.write_semantic_core("/nonexistent-root-zzz", cfg)
+        assert any("fail-open" in r.message for r in caplog.records)
+
+    def test_append_spec_honors_existing(self, cfg):
+        manifest = hive.build_manifest(self._grid(cfg))
+        assert hive.append_spec(None, manifest) == manifest["spec"]
+        existing = dict(manifest, spec="morton-hive/2")
+        assert hive.append_spec(existing, manifest) == "morton-hive/2"
+
+
 class TestProductRoots:
     """D19 named product roots (issue #299 phase 2): additive — a product
     subtree is a complete, unmodified morton-hive store."""
@@ -1242,16 +1325,23 @@ class TestRunnerWiring:
         agg(cfg, catalog=catalog_path, store=root, backend="local")
 
         assert calls == [(shard, root)]
-        # The run wrote ONLY the manifest at the root — no shared zarr
-        # template (D5). The root coverage.moc (issue #200 phase 3,
-        # default-on for hive) is the only other root object, plus the
-        # successful shard's node dir carrying its stats sidecar (issue #297;
-        # the mocked worker wrote no leaf, so the node holds only stats.json).
+        # The run wrote ONLY root-level objects at the root — no shared zarr
+        # template (D5): the manifest, its aggregation.yaml semantic core
+        # (issue #299, D19 — rides the manifest write), the root coverage.moc
+        # (issue #200 phase 3, default-on for hive), plus the successful
+        # shard's node dir carrying its stats sidecar (issue #297; the mocked
+        # worker wrote no leaf, so the node holds only stats.json).
         listing = sorted(os.listdir(root))
         node = listing[0]
         parquets = [n for n in listing if n.startswith("stats_") and n.endswith(".parquet")]
         assert len(parquets) == 1  # run-level stats parquet (issue #297 phase 3)
-        assert listing == [node, hive.ROOT_COVERAGE_NAME, hive.MANIFEST_NAME, parquets[0]]
+        assert listing == [
+            node,
+            hive.AGGREGATION_CORE_NAME,
+            hive.ROOT_COVERAGE_NAME,
+            hive.MANIFEST_NAME,
+            parquets[0],
+        ]
         from zagg.telemetry import read_sidecar
 
         leaf = hive.shard_leaf_path(root, shard)

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -294,6 +294,88 @@ class TestManifest:
 # ── leaf template + commit stamp (D3/D4) ─────────────────────────────────────
 
 
+class TestProductRoots:
+    """D19 named product roots (issue #299 phase 2): additive — a product
+    subtree is a complete, unmodified morton-hive store."""
+
+    def _grid(self, cfg):
+        return HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)
+
+    def test_name_grammar(self):
+        for good in ("atl06", "atl06_h_li", "s2-serc-2025", "x", "88s_o9"):
+            assert hive.validate_product_name(good) == good
+        for bad in ("ATL06", "a b", "", "a/b", "a.b", "café", None, 7):
+            with pytest.raises((ValueError, TypeError)):
+                hive.validate_product_name(bad)
+
+    def test_base_component_exclusion(self):
+        # Names shaped like hive base components would make the walker's
+        # child classification ambiguous (D19).
+        for bad in ("1", "6", "-1", "-6", "3"):
+            with pytest.raises(ValueError, match="base-component"):
+                hive.validate_product_name(bad)
+        # Digit-LEADING names longer than a base component are fine.
+        assert hive.validate_product_name("2019_run") == "2019_run"
+
+    def test_product_root_join(self):
+        assert hive.product_root("s3://b/root/", "atl06") == "s3://b/root/atl06"
+        with pytest.raises(ValueError, match="grammar"):
+            hive.product_root("s3://b/root", "BAD")
+
+    def test_leaf_path_under_product_root_is_unchanged(self, cfg):
+        # A product subtree is byte-identical to a bare store: the same leaf
+        # path arithmetic applies below the product root.
+        word = _shard_word()
+        bare = hive.shard_leaf_path("s3://b/root", word)
+        under = hive.shard_leaf_path(hive.product_root("s3://b/root", "atl06"), word)
+        assert under == bare.replace("s3://b/root/", "s3://b/root/atl06/")
+
+    def test_effective_store_root(self, cfg):
+        assert hive.effective_store_root("s3://b/root", cfg) == "s3://b/root"
+        cfg.output["product_name"] = "atl06_h_li"
+        assert hive.effective_store_root("s3://b/root", cfg) == "s3://b/root/atl06_h_li"
+
+    def test_product_name_validated_at_config_load(self, cfg):
+        from zagg.config import validate_config
+
+        cfg.output["product_name"] = "UPPER"
+        with pytest.raises(ValueError, match="grammar"):
+            validate_config(cfg)
+
+    def test_classify_store_root(self, cfg, tmp_path):
+        root = str(tmp_path / "store")
+        (tmp_path / "store").mkdir()
+        assert hive.classify_store_root(root) == "empty"
+        # A product directory: manifests only under {name}/.
+        m = hive.build_manifest(self._grid(cfg))
+        hive.ensure_manifest(hive.product_root(root, "atl06"), m)
+        assert hive.classify_store_root(root) == "products"
+        # A manifest at the root wins: bare single-product store.
+        bare = str(tmp_path / "bare")
+        hive.ensure_manifest(bare, m)
+        assert hive.classify_store_root(bare) == "bare"
+
+    def test_mid_write_bare_store_not_misread(self, cfg, tmp_path):
+        # The manifest write is async (issue #252): digit-shaped children
+        # without a manifest are a bare store mid-first-run, never "products".
+        root = tmp_path / "store"
+        (root / "3" / "1").mkdir(parents=True)
+        (root / "3" / "1" / "obj").write_text("x")
+        assert hive.classify_store_root(str(root)) == "bare"
+
+    def test_list_products(self, cfg, tmp_path):
+        root = str(tmp_path / "store")
+        m = hive.build_manifest(self._grid(cfg))
+        hive.ensure_manifest(hive.product_root(root, "atl06"), m)
+        hive.ensure_manifest(hive.product_root(root, "atl03_tdigest"), m)
+        # An undiscoverable (manifest-less) child prefix is skipped, not an error.
+        (tmp_path / "store" / "debris_product").mkdir()
+        (tmp_path / "store" / "debris_product" / "junk").write_text("x")
+        products = hive.list_products(root)
+        assert sorted(products) == ["atl03_tdigest", "atl06"]
+        assert products["atl06"]["spec"] == m["spec"]
+
+
 class TestLeafTemplateAndStamp:
     def _grid(self, cfg):
         return HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg)

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -370,12 +370,6 @@ class TestSemanticManifest:
             hive.write_semantic_core("/nonexistent-root-zzz", cfg)
         assert any("fail-open" in r.message for r in caplog.records)
 
-    def test_append_spec_honors_existing(self, cfg):
-        manifest = hive.build_manifest(self._grid(cfg))
-        assert hive.append_spec(None, manifest) == manifest["spec"]
-        existing = dict(manifest, spec="morton-hive/2")
-        assert hive.append_spec(existing, manifest) == "morton-hive/2"
-
 
 class TestProductRoots:
     """D19 named product roots (issue #299 phase 2): additive — a product

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -385,6 +385,14 @@ class TestProductRoots:
             with pytest.raises((ValueError, TypeError)):
                 hive.validate_product_name(bad)
 
+    def test_name_length_cap(self):
+        # D19 length cap (espg ruling, mortie spec §6.5): 192 accepts, 193
+        # rejects — the boundary of the POSIX-255-less-13-decoration budget.
+        assert hive.validate_product_name("a" * hive.PRODUCT_NAME_MAX) == "a" * 192
+        assert hive.PRODUCT_NAME_MAX == 192
+        with pytest.raises(ValueError, match="caps names"):
+            hive.validate_product_name("a" * (hive.PRODUCT_NAME_MAX + 1))
+
     def test_base_component_exclusion(self):
         # Names shaped like hive base components would make the walker's
         # child classification ambiguous (D19).

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -334,13 +334,16 @@ class TestManifestTemporal:
         m = hive.build_manifest(self._grid(cfg), dataset={"short_name": "ATL06", "version": "007"})
         assert m["spec"] == "morton-hive/1"
         assert "temporal" not in m
-        # The exact pre-#246 key set: no new keys leak into unwindowed stores.
+        # The exact key set: no TEMPORAL keys leak into unwindowed stores
+        # (semantic_hash/path_grouping joined for every store — issue #299).
         assert set(m) == {
             "spec",
             "dataset",
+            "semantic_hash",
             "cell_order",
             "shard_order",
             "split_schedule",
+            "path_grouping",
             "pyramid",
             "generated_at",
         }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1433,9 +1433,16 @@ class TestProcessAndWriteStreaming:
 def _stub_grid():
     from unittest.mock import MagicMock
 
+    from zagg.config import default_config
+
     grid = MagicMock()
     grid.signature.return_value = {}
     grid.spatial_signature.return_value = {}
+    # build_manifest hashes grid.config's semantic core (issue #299), so the
+    # stub needs a real config, not a MagicMock (JSON-unserializable).
+    grid.config = default_config("atl06")
+    grid.parent_order = 6
+    grid.child_order = 8
     grid.block_index.side_effect = lambda k: (k,)
     # Deterministic decimal-string-shaped labels (issue #199) so status keys
     # built off the stub are real strings.

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -169,6 +169,19 @@ class TestCanonicalization:
         b.data_source["read_plan"] = None
         assert semantic_hash(a) == semantic_hash(b)
 
+    def test_nested_null_values_drop_out(self):
+        # F2: an explicit null NESTED inside a semantic dict (YAML `value:`)
+        # hashes identically to the key being absent — pruning is recursive.
+        absent = _cfg()
+        absent.data_source["quality_filter"] = {"dataset": "/q"}
+        null_valued = _cfg()
+        null_valued.data_source["quality_filter"] = {"dataset": "/q", "value": None}
+        assert semantic_hash(null_valued) == semantic_hash(absent)
+        # ...but a real value (0 included) is content, not an absent key.
+        zero_valued = _cfg()
+        zero_valued.data_source["quality_filter"] = {"dataset": "/q", "value": 0}
+        assert semantic_hash(zero_valued) != semantic_hash(absent)
+
     def test_fingerprint_rejects_short_input(self):
         with pytest.raises(ValueError, match="not a semantic hash"):
             semantic_fingerprint("abc")

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -96,6 +96,11 @@ class TestCanonicalization:
         cfg = _cfg()
         cfg.worker = {"memory": 8192, "extra_disk": True}
         assert semantic_hash(cfg) == base
+        # emit_cell_ids is the issue #304 transition hatch, not identity (F4):
+        # the core reads only the grid type/scheme, so it drops out.
+        cfg = _cfg()
+        cfg.output["grid"]["emit_cell_ids"] = True
+        assert semantic_hash(cfg) == base
 
     def test_semantic_edits_always_change_hash(self):
         base = semantic_hash(_cfg())
@@ -181,6 +186,35 @@ class TestCanonicalization:
         zero_valued = _cfg()
         zero_valued.data_source["quality_filter"] = {"dataset": "/q", "value": 0}
         assert semantic_hash(zero_valued) != semantic_hash(absent)
+
+    def test_golden_hash_pin(self):
+        # F4: a fully-inline config with fixed dicts, pinned to its exact
+        # digest. This catches accidental canonicalization drift — any change
+        # to key ordering, null pruning, the packaging-key sets, or the JSON
+        # separators would move this hash, so an unintended edit fails loudly.
+        cfg = PipelineConfig(
+            data_source={
+                "reader": "h5coro",
+                "groups": ["gt1l", "gt2l"],
+                "variables": {"h_li": "/land_ice_segments/h_li"},
+                "coordinates": {
+                    "latitude": "/land_ice_segments/latitude",
+                    "longitude": "/land_ice_segments/longitude",
+                },
+                "quality_filter": {"dataset": "/land_ice_segments/atl06_quality_summary"},
+            },
+            aggregation={
+                "handoff": "arrow",
+                "variables": {
+                    "count": {"function": "len", "source": "h_li", "dtype": "int32"},
+                    "h_mean": {"function": "mean", "source": "h_li", "dtype": "float32"},
+                },
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+        assert semantic_hash(cfg) == (
+            "c17f7523ffb21e7b5a33d092f4ab12eaf805b1f88117f592132805458f354f86"
+        )
 
     def test_fingerprint_rejects_short_input(self):
         with pytest.raises(ValueError, match="not a semantic hash"):

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -134,8 +134,33 @@ class TestCanonicalization:
             "resolution": 100,
             "bounds": [0, 0, 1000, 1000],
         }
-        assert semantic_core(rect)["grid"] == {"type": "rectilinear"}
+        # F1: rect folds in the spatially-defining params (crs/resolution/
+        # bounds) — D24's resolution-axis exclusion is HEALPix-only.
+        assert semantic_core(rect)["grid"] == {
+            "type": "rectilinear",
+            "crs": "EPSG:3031",
+            "resolution": 100,
+            "bounds": [0, 0, 1000, 1000],
+        }
         assert semantic_hash(rect) != semantic_hash(_cfg())
+
+    def test_rect_resolution_changes_hash(self):
+        # F1: two rect products differing only in resolution (or CRS) are
+        # different products — they must not collide on semantic_hash.
+        base = default_config("atl06_polar")
+        base = copy.deepcopy(base)
+        base.output["grid"] = {
+            "type": "rectilinear",
+            "crs": "EPSG:3031",
+            "resolution": 100,
+            "bounds": [0, 0, 1000, 1000],
+        }
+        finer = copy.deepcopy(base)
+        finer.output["grid"]["resolution"] = 50
+        assert semantic_hash(finer) != semantic_hash(base)
+        other_crs = copy.deepcopy(base)
+        other_crs.output["grid"]["crs"] = "EPSG:3413"
+        assert semantic_hash(other_crs) != semantic_hash(base)
 
     def test_null_packaging_values_drop_out(self):
         # A present-but-null read knob (YAML `driver:`) is identical to an

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -189,7 +189,8 @@ class TestCanonicalization:
 
     def test_golden_hash_pin(self):
         # F4: a fully-inline config with fixed dicts, pinned to its exact
-        # digest. This catches accidental canonicalization drift — any change
+        # digest (re-pinned when pipeline.type joined the core, espg-ruled
+        # 2026-07-21). This catches accidental canonicalization drift — any change
         # to key ordering, null pruning, the packaging-key sets, or the JSON
         # separators would move this hash, so an unintended edit fails loudly.
         cfg = PipelineConfig(
@@ -213,8 +214,21 @@ class TestCanonicalization:
             output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
         )
         assert semantic_hash(cfg) == (
-            "c17f7523ffb21e7b5a33d092f4ab12eaf805b1f88117f592132805458f354f86"
+            "98450eb2909a105f8989c55e317d27180bf92c559859ad1415bf77445f925f22"
         )
+
+    def test_pipeline_type_is_semantic(self):
+        # espg-ruled on the PR #316 review (2026-07-21): a temporal engine
+        # over the same aggregation block is a DIFFERENT product. Absent
+        # normalizes to the spatial default, so existing configs hash stably.
+        base = _cfg()
+        explicit = _cfg()
+        explicit.pipeline = {"type": "spatial"}
+        assert semantic_hash(base) == semantic_hash(explicit)
+        temporal = _cfg()
+        temporal.pipeline = {"type": "temporal"}
+        assert semantic_hash(temporal) != semantic_hash(base)
+        assert semantic_core(temporal)["pipeline"] == {"type": "temporal"}
 
     def test_fingerprint_rejects_short_input(self):
         with pytest.raises(ValueError, match="not a semantic hash"):

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -1,0 +1,149 @@
+"""Semantic-core hash canonicalization (issue #299 phase 1, D19 / §8.3).
+
+The §8.3 obligations: syntactic edits (whitespace, key order, comments) never
+change the hash; packaging-knob edits (orders, chunking, worker size, read
+machinery, carrier) never change it; any semantic edit does.
+"""
+
+import copy
+
+import pytest
+import yaml
+
+from zagg.config import PipelineConfig, default_config
+from zagg.semantics import (
+    canonical_semantic_json,
+    semantic_core,
+    semantic_fingerprint,
+    semantic_hash,
+)
+
+
+def _cfg(**overrides) -> PipelineConfig:
+    cfg = default_config("atl06")
+    for dotted, value in overrides.items():
+        parts = dotted.split("__")
+        target = getattr(cfg, parts[0])
+        for p in parts[1:-1]:
+            target = target.setdefault(p, {})
+        target[parts[-1]] = value
+    return cfg
+
+
+class TestCanonicalization:
+    def test_hash_shape(self):
+        h = semantic_hash(_cfg())
+        assert len(h) == 64 and int(h, 16) >= 0
+        assert semantic_fingerprint(h) == h[:12]
+
+    def test_deterministic(self):
+        assert semantic_hash(_cfg()) == semantic_hash(_cfg())
+
+    def test_yaml_syntax_never_changes_hash(self):
+        # Same semantics, different comments/whitespace/key order.
+        a = yaml.safe_load(
+            "data_source:\n"
+            "  reader: h5coro\n"
+            "  groups: [gt1l]\n"
+            "  variables: {h_li: /p}\n"
+            "  coordinates: {latitude: /lat, longitude: /lon}\n"
+            "aggregation:\n"
+            "  variables:\n"
+            "    c: {function: len, source: h_li, dtype: int32}\n"
+            "output:\n"
+            "  grid: {type: healpix, parent_order: 6, child_order: 12}\n"
+        )
+        b = yaml.safe_load(
+            "# a comment\n"
+            "output:\n"
+            "  grid:\n"
+            "    child_order:   12\n"
+            "    parent_order:  6\n"
+            "    type: healpix   # trailing comment\n"
+            "aggregation:\n"
+            "  variables:\n"
+            "    c:\n"
+            "      dtype: int32\n"
+            "      source: h_li\n"
+            "      function: len\n"
+            "data_source:\n"
+            "  coordinates: {longitude: /lon, latitude: /lat}\n"
+            "  variables: {h_li: /p}\n"
+            "  groups: [gt1l]\n"
+            "  reader: h5coro\n"
+        )
+        ca = PipelineConfig(**a)
+        cb = PipelineConfig(**b)
+        assert canonical_semantic_json(ca) == canonical_semantic_json(cb)
+        assert semantic_hash(ca) == semantic_hash(cb)
+
+    def test_packaging_knobs_never_change_hash(self):
+        base = semantic_hash(_cfg())
+        packaging = [
+            _cfg(output__grid__parent_order=9),
+            _cfg(output__grid__child_order=19),
+            _cfg(output__grid__chunk_inner=11),
+            _cfg(output__grid__sharded=False),
+            _cfg(output__store_layout="hive"),
+            _cfg(output__store="s3://elsewhere/prefix"),
+            _cfg(aggregation__handoff="pandas"),
+            _cfg(data_source__reader="xarray"),
+            _cfg(data_source__driver="https"),
+        ]
+        for cfg in packaging:
+            assert semantic_hash(cfg) == base
+        # Worker sizing (issue #235) and read knobs are packaging too.
+        cfg = _cfg()
+        cfg.worker = {"memory": 8192, "extra_disk": True}
+        assert semantic_hash(cfg) == base
+
+    def test_semantic_edits_always_change_hash(self):
+        base = semantic_hash(_cfg())
+        cfg = _cfg()
+        cfg.aggregation["variables"]["h_min"]["function"] = "max"
+        assert semantic_hash(cfg) != base
+        cfg = _cfg()
+        cfg.aggregation["variables"]["count"]["dtype"] = "int64"
+        assert semantic_hash(cfg) != base
+        cfg = _cfg()
+        cfg.aggregation["variables"]["extra"] = {
+            "function": "len",
+            "source": "h_li",
+            "dtype": "int32",
+        }
+        assert semantic_hash(cfg) != base
+        cfg = _cfg()
+        cfg.data_source["groups"] = ["gt1l"]
+        assert semantic_hash(cfg) != base
+        cfg = _cfg()
+        cfg.data_source["quality_filter"]["value"] = 1
+        assert semantic_hash(cfg) != base
+        cfg = _cfg()
+        cfg.data_source["variables"]["h_li"] = "/other/path"
+        assert semantic_hash(cfg) != base
+
+    def test_grid_family_is_semantic(self):
+        # Grid TYPE (+ indexing scheme) is identity; the orders are not (D24).
+        healpix = semantic_core(_cfg())
+        assert healpix["grid"] == {"type": "healpix", "indexing_scheme": "nested"}
+        rect = default_config("atl06_polar")
+        rect = copy.deepcopy(rect)
+        rect.output["grid"] = {
+            "type": "rectilinear",
+            "crs": "EPSG:3031",
+            "resolution": 100,
+            "bounds": [0, 0, 1000, 1000],
+        }
+        assert semantic_core(rect)["grid"] == {"type": "rectilinear"}
+        assert semantic_hash(rect) != semantic_hash(_cfg())
+
+    def test_null_packaging_values_drop_out(self):
+        # A present-but-null read knob (YAML `driver:`) is identical to an
+        # absent one — the canonical core omits nulls.
+        a, b = _cfg(), _cfg()
+        b.data_source["read_plan"] = None
+        assert semantic_hash(a) == semantic_hash(b)
+
+    def test_fingerprint_rejects_short_input(self):
+        with pytest.raises(ValueError, match="not a semantic hash"):
+            semantic_fingerprint("abc")


### PR DESCRIPTION
Closes #299. Implements the **final** form of the issue — named product roots + semantic-core hash — per the governing record: the [Plan v2 comment](https://github.com/englacial/zagg/issues/299#issuecomment-5025685368) and [Scope revision 3](https://github.com/englacial/zagg/issues/299#issuecomment-5024857268) (which supersede the original leaf-basename plan), plus D19 rev 2, D24, and §3 in the merged `docs/design/sparse_coverage.md`. **Additive, not breaking**: bare single-product stores stay byte-identical and fully valid; there is no old-store error path.

## Phases

- [x] Phase 1 — **semantic-core canonicalization + hash** (`src/zagg/semantics.py`): the output-defining subset only (aggregation block minus the `handoff` carrier; `data_source` semantics minus `reader`/`driver`/`read_plan`/`anonymous`; grid **type + indexing scheme** — never orders/chunking/worker/store knobs) → sorted-key compact JSON → **full sha256** (git-style: full digest compared; 12-hex `semantic_fingerprint` for display, 48-bit rationale from the [thread](https://github.com/englacial/zagg/issues/299#issuecomment-5017334704)). Formalizes the #89 `spatial_signature`/`output_field_signature` seam. §8.3 property tests: syntactic edits never change the hash, packaging-knob edits never change it, semantic edits always do (`tests/test_semantics.py`).
- [x] Phase 2 — **named product roots (additive)**: product-name grammar validation (URL-safe lowercase `[a-z0-9_-]+`, base-component exclusion `-?[1-6]`), `product_root()` path construction, root-form discrimination by content (manifest ⇒ bare store; name-shaped prefixes ⇒ product directory), product listing.
- [x] Phase 3 — **manifest additions**: `semantic_hash` as a frozen key (absent-tolerant for pre-#299 stores), `path_grouping` frozen-key comparison with absent⇒1 normalization on both sides, the canonical core written as `{name}/aggregation.yaml` (derived convenience — the manifest hash is truth, D9 cache class), append-path spec-compat (writer honors the existing manifest's declared spec; the PR #307 seam is already spec-keyed).
- [x] Phase 4 — **`has_run` dedup API**: computed leaf path + `semantic_hash` + sidecar catalog identity (`granules_sha256`); catalog-grown shard reports **"stale"**, never "hit"; O11 per-array content hash is the verifier when present.
- [x] Phase 5 (verification) — **`template_hash` → `semantic_hash` rename**: the deferral from the PR #309 review thread was already discharged by the PR #309 fold itself ([thread](https://github.com/englacial/zagg/pull/309#discussion_r3616135096), fix `13b54e9` — `estimate_cost_usd(semantic_hash=...)`); a full-tree grep on this branch confirms **zero** `template_hash` references remain. Nothing to rename; recorded here for provenance.

## Implementation notes

- **`.github/` touch (flagged prominently, per the PR #302 precedent)**: `.github/scripts/bench_objects.py` hive object-count model gains the fail-open `aggregation.yaml` root object (metadata ceiling +1; measured-side classification includes `hive.AGGREGATION_CORE_NAME`). No workflow files touched.
- **Lambda worker parity (deployment/aws — NOT touched, per §1)**: the local runner writes `aggregation.yaml` (rides `ensure_manifest(config=...)`) and stamps `semantic_hash` into stats records; the Lambda worker's handler (`deployment/aws/lambda_handler.py`) does neither yet — its sidecars keep `semantic_hash: null` (which `has_run` conservatively reports as "stale", never a false hit). Wiring the handler needs an issue that names it, per the repo's infra rule — flagged under Questions.
- `has_run` lives in a new small module `src/zagg/dedup.py` (and the hasher in `src/zagg/semantics.py`) rather than growing `hive.py`, which already exceeds the ~1000-line discussion threshold.
- The spec-compat seam: `ensure_manifest` now RETURNS the manifest in effect (the accepted existing one on append), the runner threads its `spec` into sidecar naming (`write_sidecar(spec=...)` — the #307 seam), and `hive.append_spec` documents the rule for the future `/3` writer. For `/1`–`/2` stores the emitted names are byte-identical.

## Interactions

- **Independent of PR #314** (#304 attrs/cell_ids flip): based off `main`; the overlap is small (grid signature surfaces) — whichever merges second integrates by merge. (#312/#305 has since MERGED; #314 is unblocked and carries the writer flip.)
- **#308 re-template conflict**: untouched here; the frozen-key changes are confined to the two new keys with explicit absent-side normalization, so `validate_manifest`'s existing behavior on pre-#299 manifests is unchanged (tests pin appends to old manifests still pass the precheck).
- **D24 cross-order guard**: flagged rather than forced — see Questions.
- moczarr churn from this issue is **root-level product discovery only**; no golden-vector regeneration ([issue record](https://github.com/englacial/zagg/issues/299#issuecomment-5025685368)).

## Testing

Per-phase test files noted in the checklist; full `pytest` run locally before each push (`tests/test_lambda_build.py` excluded — pre-existing environmental failure on this machine, local pip resolves against Python 3.10; also flagged on #312/#314). Pre-existing `N818` in `src/zagg/registry.py` on `main` excluded from ruff runs, flagged not fixed (§4).

## Questions for review

1. *(folded during review)* The product-name grammar gained the espg-ruled **192-char length cap** (mirrored from the mortie spec page ruling) — `PRODUCT_NAME_MAX` in `hive.py`.
1. *(resolved — espg-ruled 2026-07-21)* **`pipeline.type` is IN the semantic core** (commit `d689348`): output-defining — a temporal/event engine over an identical aggregation block is a different product; absent normalizes to `spatial` on both sides (same discipline as `path_grouping` absent⇒1), so existing configs hash stably; golden pin re-pinned; D19 doc parenthetical updated in the same commit.
2. **Rectilinear grids** — resolved conservatively during review fold (F1): rect cores now fold in `crs`/`resolution`/`bounds` (D24's resolution-axis exclusion is a HEALPix/morton composability argument that doesn't extend to rect; over-discriminating is safe, colliding is not). Relax if D24-style polymorphism ever lands for rect.
3. *(confirmed — espg, 2026-07-21)* **D24 cross-order guard** stays with the #304-family writer work; not in this PR.
