### PR TITLE
Move the mortie decimal-parse boundary off the private _decimal_to_word

### DIFF
--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -88,11 +88,11 @@ $PIP install \
 # one edit site: a future floor bump or exact pin there reaches the layer with
 # no second edit. The layer's mortie still floats to latest-above-floor, so
 # this is floor enforcement, not pinning.
-MORTIE_SPEC=$($PYTHON -c "
-import pathlib, re, tomllib
-deps = tomllib.loads(pathlib.Path('${SCRIPT_DIR}/../../pyproject.toml').read_text())['project']['dependencies']
-print(next(d for d in deps if re.match(r'mortie($|[\s<>=!~\[])', d)))
-")
+MORTIE_SPEC=$($PYTHON -c '
+import pathlib, re, sys, tomllib
+deps = tomllib.loads(pathlib.Path(sys.argv[1]).read_text())["project"]["dependencies"]
+print(next(d for d in deps if re.match(r"mortie($|[\s<>=!~\[])", d)))
+' "${SCRIPT_DIR}/../../pyproject.toml")
 echo "Installing h5coro, h5coro-hidefix and mortie ('$MORTIE_SPEC' from pyproject, --no-deps)..."
 $PIP install "h5coro==1.0.5" "h5coro-hidefix==0.3.1" "$MORTIE_SPEC" --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
 

--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -81,9 +81,13 @@ $PIP install \
 # sync with the `lambda` extra in pyproject.toml.
 # mortie's version spec is single-sourced from pyproject.toml (issue #322):
 # --no-deps means pip never resolves the runtime floor declared there, so an
-# unpinned install took "latest at build time" and a layer built before a
-# floor bump could silently predate it. Deriving the spec here makes bumping
-# pyproject sufficient — no second pin to keep in sync.
+# unpinned install silently accepted whatever was latest at build time -- even
+# a release below the floor. Passing the declared spec (a) makes pip error and
+# abort under `set -e` when the floor is ahead of what PyPI has published
+# (pyproject L30-38 documents that state for h5coro-hidefix), and (b) leaves
+# one edit site: a future floor bump or exact pin there reaches the layer with
+# no second edit. The layer's mortie still floats to latest-above-floor, so
+# this is floor enforcement, not pinning.
 MORTIE_SPEC=$($PYTHON -c "
 import pathlib, re, tomllib
 deps = tomllib.loads(pathlib.Path('${SCRIPT_DIR}/../../pyproject.toml').read_text())['project']['dependencies']

--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -79,8 +79,18 @@ $PIP install \
 # `sidecar` index backend. abi3 manylinux_2_28 wheel (~2.2 MB) on both arches;
 # its only runtime dep is numpy (already installed above). Keep the pin in
 # sync with the `lambda` extra in pyproject.toml.
-echo "Installing h5coro, h5coro-hidefix and mortie (--no-deps)..."
-$PIP install "h5coro==1.0.5" "h5coro-hidefix==0.3.1" mortie --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
+# mortie's version spec is single-sourced from pyproject.toml (issue #322):
+# --no-deps means pip never resolves the runtime floor declared there, so an
+# unpinned install took "latest at build time" and a layer built before a
+# floor bump could silently predate it. Deriving the spec here makes bumping
+# pyproject sufficient — no second pin to keep in sync.
+MORTIE_SPEC=$($PYTHON -c "
+import pathlib, re, tomllib
+deps = tomllib.loads(pathlib.Path('${SCRIPT_DIR}/../../pyproject.toml').read_text())['project']['dependencies']
+print(next(d for d in deps if re.match(r'mortie($|[\s<>=!~\[])', d)))
+")
+echo "Installing h5coro, h5coro-hidefix and mortie ('$MORTIE_SPEC' from pyproject, --no-deps)..."
+$PIP install "h5coro==1.0.5" "h5coro-hidefix==0.3.1" "$MORTIE_SPEC" --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
 
 # async-tiff (issue #218): the raster worker's GeoTIFF/COG decode engine
 # (mode="process_raster"). abi3 manylinux_2_28 wheel (~4 MB) on both arches;

--- a/deployment/aws/build_layer.sh
+++ b/deployment/aws/build_layer.sh
@@ -96,6 +96,14 @@ print(next(d for d in deps if re.match(r"mortie($|[\s<>=!~\[])", d)))
 echo "Installing h5coro, h5coro-hidefix and mortie ('$MORTIE_SPEC' from pyproject, --no-deps)..."
 $PIP install "h5coro==1.0.5" "h5coro-hidefix==0.3.1" "$MORTIE_SPEC" --no-deps -t "$OUTPUT_DIR/python" --no-cache-dir
 
+# Assert the derived spec actually landed: mortie is the one dep whose spec is
+# computed, and pip exits 0 on specs it skips (a PEP 508 marker that does not
+# match the build environment is "Ignoring mortie: markers ... don't match"),
+# which would ship a mortie-less layer past the size-only CI gates.
+if ! ls "$OUTPUT_DIR/python" | grep -qE "^mortie-"; then
+    echo "ERROR: mortie ('$MORTIE_SPEC') missing from layer - check the spec in pyproject.toml!"; exit 1
+fi
+
 # async-tiff (issue #218): the raster worker's GeoTIFF/COG decode engine
 # (mode="process_raster"). abi3 manylinux_2_28 wheel (~4 MB) on both arches;
 # its only dep is obspec (pure-python, tiny). Keep the pins in sync with the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     # 0.9.0 ships the decimal-emit surface shard ids route through (issue #199):
     # decimal_repr / to_decimal, the _decimal_to_word parse-back, hive_path, and
     # the MortonIndexScalar decimal display.
-    "mortie>=0.9.0",
+    "mortie>=0.9.1",
     "earthaccess",
     "boto3",
     "fastparquet",

--- a/src/zagg/coverage.py
+++ b/src/zagg/coverage.py
@@ -229,7 +229,7 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     import obstore
     from obstore.exceptions import NotFoundError
 
-    from zagg.grids.morton import morton_word
+    from zagg.grids.morton import morton_words_from_decimals
     from zagg.store import open_store
 
     manifest = read_manifest(store_root, **store_kwargs)
@@ -238,7 +238,9 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     order = int(manifest["shard_order"])
     store = open_object_store(store_root, **store_kwargs)
     root = store_root.rstrip("/")
-    keys: list = []
+    # Decimals accumulate through the walk and parse once at the end (issue
+    # #322) — a full-store refresh visits every stamped leaf.
+    decimals: list = []
     time_ranges: list = []
     stack = [""]
     while stack:
@@ -285,7 +287,7 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
                         f"foreign-order data) — it will NOT be listed in {ROOT_COVERAGE_NAME}"
                     )
                     continue
-                keys.append(morton_word(decimal))
+                decimals.append(decimal)
                 # D15: windowed stamps carry the leaf's actual time range;
                 # the rebuilt root summary re-derives the union from this
                 # walk's stamps (truth), superseding any cached value.
@@ -297,14 +299,17 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
             if is_digit_node:
                 stack.append(rel + "/")
     _stale_warned.discard(root)
-    if not keys:
+    if not decimals:
         try:
             obstore.delete(store, ROOT_COVERAGE_NAME)
         except (FileNotFoundError, NotFoundError):
             pass
         return None
     envelope = build_root_coverage(
-        keys, order, source="refresh", time_range=union_time_range(*time_ranges)
+        morton_words_from_decimals(decimals),
+        order,
+        source="refresh",
+        time_range=union_time_range(*time_ranges),
     )
     obstore.put(store, ROOT_COVERAGE_NAME, json.dumps(envelope, indent=1).encode())
     return envelope

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -118,18 +118,18 @@ def morton_word(label: str) -> int:
     external decimal id re-enters (``--morton-cell``, hive leaf ids on the
     read path). Raises ``ValueError`` on a malformed id.
 
-    Implementation note: this rides mortie's private-but-documented
-    ``_decimal_to_word`` (the issue-104 parse-back) rather than the public
-    ``MortonIndexArray.from_hive_path(label, suffix="")`` because the array
-    classes are built lazily and require pandas — the private function is
-    numpy-only, keeping the reader path light. The upstream ask (a public
-    numpy-only export) stands. Same non-injectivity caveat mortie documents: an
-    order-29 *point* id parses back to the *area* word (irrelevant for shard
-    keys at order <= 11; noted since this is a general boundary helper).
+    Rides mortie's public numpy-only parse export (``decimal_to_word``, mortie
+    0.9.1+, espg/mortie#114) — the upstream ask this boundary used to work
+    around with the private ``_decimal_to_word``. ``dtype=int`` keeps the
+    Python-``int`` return the callers (dict keys, path building) expect; the
+    default would hand back ``np.uint64``. Same non-injectivity caveat mortie
+    documents: an order-29 *point* id parses back to the *area* word
+    (irrelevant for shard keys at order <= 11; noted since this is a general
+    boundary helper). See :func:`morton_words_from_decimals` for the batch form.
     """
-    from mortie.morton_index import _decimal_to_word
+    from mortie import decimal_to_word
 
-    return _decimal_to_word(str(label))
+    return decimal_to_word(str(label), dtype=int)
 
 
 def morton_box(values) -> np.ndarray:

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -132,6 +132,25 @@ def morton_word(label: str) -> int:
     return decimal_to_word(str(label), dtype=int)
 
 
+def morton_words_from_decimals(decimals) -> np.ndarray:
+    """Parse many decimal morton strings to packed words (issue #322).
+
+    The batch form of :func:`morton_word` over mortie's vectorized
+    ``decimals_to_words`` — one call instead of a Python loop, for the paths
+    that materialize a whole cell set at once (bitmap decode, root-coverage
+    range expansion, the coverage refresh walk). Returns ``uint64`` in input
+    order; raises ``ValueError`` on any malformed member, same as the scalar.
+
+    Measured 1.6x end-to-end on a 4096-cell bitmap decode — the parse is no
+    longer the loop's cost centre, the per-cell decimal-string construction
+    is. Vectorizing *that* (base-4 digit extraction in numpy) is the next
+    lever and deliberately out of scope here.
+    """
+    from mortie import decimals_to_words
+
+    return decimals_to_words(list(decimals))
+
+
 def morton_box(values) -> np.ndarray:
     """Tier-0 morton box: canonical <= 4-member MOC covering ``values`` (issue #200).
 

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -688,7 +688,7 @@ def decode_coverage_bitmap(payload: bytes, shard_key, cell_order: int) -> np.nda
     """
     from numcodecs import Zstd
 
-    from zagg.grids.morton import morton_decimal, morton_word
+    from zagg.grids.morton import morton_decimal, morton_words_from_decimals
 
     shard = morton_decimal(shard_key)
     depth = int(cell_order) - _decimal_order(shard)
@@ -701,14 +701,8 @@ def decode_coverage_bitmap(payload: bytes, shard_key, cell_order: int) -> np.nda
             f"(a partial cell set would be a false negative)"
         )
     bits = np.unpackbits(raw, count=4**depth)
-    words = np.empty(int(bits.sum()), dtype=np.uint64)
-    for i, rank in enumerate(np.flatnonzero(bits)):
-        digits, rank = [], int(rank)
-        for _ in range(depth):
-            digits.append(str(rank % 4 + 1))
-            rank //= 4
-        words[i] = morton_word(shard + "".join(reversed(digits)))
-    return np.sort(words)
+    decimals = [shard + _rank_tail(int(rank), depth) for rank in np.flatnonzero(bits)]
+    return np.sort(morton_words_from_decimals(decimals))
 
 
 def write_coverage_sidecar(leaf_root: str, payload: bytes, **store_kwargs) -> None:
@@ -969,10 +963,10 @@ def root_coverage_words(envelope: dict) -> np.ndarray:
     no word materialization) is the upgrade path if root objects ever reach
     continental-accumulation scale; out of scope here.
     """
-    from zagg.grids.morton import morton_word
+    from zagg.grids.morton import morton_words_from_decimals
 
     order = int(envelope["order"])
-    words = []
+    decimals = []
     for lo, hi in envelope["ranges"]:
         base = _decimal_base(lo)
         lo_rank, hi_rank = _decimal_rank(lo), _decimal_rank(hi)
@@ -980,8 +974,8 @@ def root_coverage_words(envelope: dict) -> np.ndarray:
         ok = ok and _decimal_order(lo) == order and _decimal_order(hi) == order
         if not ok:
             raise ValueError(f"malformed coverage range [{lo}, {hi}] at order {order}")
-        words.extend(morton_word(base + _rank_tail(r, order)) for r in range(lo_rank, hi_rank + 1))
-    return np.unique(np.asarray(words, dtype=np.uint64))
+        decimals.extend(base + _rank_tail(r, order) for r in range(lo_rank, hi_rank + 1))
+    return np.unique(morton_words_from_decimals(decimals))
 
 
 def write_root_coverage(store_root: str, envelope: dict, **store_kwargs) -> dict:

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -927,6 +927,38 @@ class TestShardLabel:
             with pytest.raises(ValueError):
                 morton_word(bad)
 
+    def test_morton_words_from_decimals_matches_scalar(self):
+        # Issue #322: the batch parse must be the scalar parse, elementwise —
+        # same values, INPUT order (not sorted), across both hemispheres and a
+        # spread of orders. The callers (bitmap decode, root-range expansion)
+        # sort/unique afterwards, so an order-scrambling batch parse would go
+        # unnoticed there and corrupt any future positional use.
+        from mortie import geo2mort
+
+        from zagg.grids.morton import morton_decimal, morton_word, morton_words_from_decimals
+
+        decimals = [
+            morton_decimal(int(geo2mort(np.array([lat]), np.array([lon]), order=order)[0]))
+            for lat, lon in [(-78.5, -132.0), (78.3, 12.0), (-72.1, 25.4), (0.1, 0.1)]
+            for order in (0, 6, 9, 18)
+        ]
+        batch = morton_words_from_decimals(decimals)
+        assert batch.dtype == np.uint64
+        scalar = np.asarray([morton_word(d) for d in decimals], dtype=np.uint64)
+        np.testing.assert_array_equal(batch, scalar)
+
+    def test_morton_words_from_decimals_edge_cases(self):
+        from zagg.grids.morton import morton_words_from_decimals
+
+        # Empty input is legal and stays typed: a bitmap with no set bits and a
+        # store with no stamped leaves both reach the batch parse with nothing.
+        empty = morton_words_from_decimals([])
+        assert empty.dtype == np.uint64 and empty.size == 0
+        # One malformed member fails the whole batch loudly (the scalar posture:
+        # a path component must never be silently wrong).
+        with pytest.raises(ValueError):
+            morton_words_from_decimals(["-4211322", "bogus"])
+
     def test_morton_word_returns_python_int(self):
         # Issue #322: the public mortie parse defaults to np.uint64; the
         # boundary pins dtype=int. A silent uint64 return would pass every

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -927,6 +927,16 @@ class TestShardLabel:
             with pytest.raises(ValueError):
                 morton_word(bad)
 
+    def test_morton_word_returns_python_int(self):
+        # Issue #322: the public mortie parse defaults to np.uint64; the
+        # boundary pins dtype=int. A silent uint64 return would pass every
+        # equality/dict-key assertion above yet wrap on the uint64 arithmetic
+        # the hive path does (rank offsets, order deltas), so pin the type.
+        from zagg.grids.morton import morton_word
+
+        word = morton_word("-4211322")
+        assert type(word) is int
+
     def test_morton_decimal_raises_valueerror_on_invalid(self):
         # The emit direction's advertised contract (review finding, PR #205):
         # the empty sentinel raises, and a NEGATIVE input — a legacy signed

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -579,6 +579,14 @@ class TestLayerExtraParity:
     This pins the contract.
     """
 
+    # Distributions whose layer spec build_layer.sh *derives* from
+    # ``[project.dependencies]`` instead of hard-coding (issue #322), keyed to the
+    # shell fragment that does the deriving. No literal ``"name==x.y.z"`` string
+    # exists for these, so the substring check below cannot apply — and the two
+    # mechanisms are mutually exclusive: an exact pin added to the ``lambda`` extra
+    # would not reach the layer, which the failure message has to say out loud.
+    _DERIVED = {"mortie": "MORTIE_SPEC=$("}
+
     def test_every_lambda_extra_pin_is_in_build_layer(self):
         import tomllib
 
@@ -586,9 +594,13 @@ class TestLayerExtraParity:
         pins = pyproject["project"]["optional-dependencies"]["lambda"]
         script = (REPO_ROOT / "deployment" / "aws" / "build_layer.sh").read_text()
         missing = []
+        derived = []
         for pin in pins:
             m = re.match(r"([A-Za-z0-9._-]+)==([A-Za-z0-9.]+)$", pin)
             if not m:  # unpinned entries (cramjam, astropy) aren't layer-exact
+                continue
+            if m.group(1) in self._DERIVED:
+                derived.append(pin)
                 continue
             if f'"{pin}"' not in script:
                 missing.append(pin)
@@ -596,3 +608,26 @@ class TestLayerExtraParity:
             f"lambda-extra pins absent from deployment/aws/build_layer.sh: {missing} "
             "(the layer would ship without them — see issue #218's async-tiff gap)"
         )
+        assert not derived, (
+            f"{derived} is pinned in the lambda extra, but build_layer.sh derives that "
+            "spec from [project.dependencies] (issue #322), so the exact pin never "
+            "reaches the layer. Either move the pin to [project.dependencies], or "
+            "replace the derivation in build_layer.sh with a literal pin."
+        )
+
+    def test_derived_specs_still_come_from_project_dependencies(self):
+        """The derivation the test above exempts must actually exist and resolve."""
+        import tomllib
+
+        pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        deps = pyproject["project"]["dependencies"]
+        script = (REPO_ROOT / "deployment" / "aws" / "build_layer.sh").read_text()
+        for name, fragment in self._DERIVED.items():
+            assert fragment in script, (
+                f"build_layer.sh no longer derives {name}'s spec ({fragment!r} gone) — "
+                "drop it from _DERIVED so the pin-parity check covers it again"
+            )
+            assert any(re.match(rf"{re.escape(name)}($|[\s<>=!~\[])", d) for d in deps), (
+                f"{name} is derived from [project.dependencies] but is not declared "
+                "there — the layer build would fail on an empty spec"
+            )


### PR DESCRIPTION
Closes #322

## What

`zagg.grids.morton.morton_word` reached into `mortie.morton_index._decimal_to_word` — a private name on a deprecation cycle. This moves the boundary onto mortie's public parse surface (espg/mortie#114, PR espg/mortie#132), and takes the vectorized path where decimals arrive in batches.

### Approach

**Scalar parse.** `from mortie import decimal_to_word` with `dtype=int`:

```python
from mortie import decimal_to_word

return decimal_to_word(str(label), dtype=int)
```

The `dtype=int` is deliberate — the public default returns `np.uint64`, and `morton_word` is declared `-> int`. Callers use the result as dict keys and in path building, where a silent `np.uint64` would compare and hash identically (so every existing round-trip test would still pass) but wraps under the uint64 arithmetic the hive rank/order paths do. A type assertion pins it.

**Version floor.** `mortie>=0.9.0` → `mortie>=0.9.1`, per the [correction on the issue](https://github.com/englacial/zagg/issues/322#issuecomment-5080579141). 0.9.1 is the first release that both defines *and* exports `decimal_to_word` — 0.9.0 has only the private `_decimal_to_word`, so `>=0.9.1` is both correct and sufficient. **This raises the runtime floor and is the blocker in question (1) below.**

**Batch parse.** New `morton_words_from_decimals(decimals) -> np.ndarray` over mortie's vectorized `decimals_to_words`, adopted at the three genuinely batch-shaped call sites:

- `src/zagg/hive.py` `decode_coverage_bitmap` — one parse per set bit of a coverage bitmap. This site also had an inline copy of `_rank_tail`'s digit-tail loop; it now calls `_rank_tail` directly, so the duplication goes away with the change:

  ```python
  decimals = [shard + _rank_tail(int(rank), depth) for rank in np.flatnonzero(bits)]
  return np.sort(morton_words_from_decimals(decimals))
  ```

- `src/zagg/hive.py` `root_coverage_words` — one parse per rank across every MOC range; its docstring already flagged this loop as the known cost at full-sphere scale.
- `src/zagg/coverage.py` `refresh_root_coverage` — decimals now accumulate through the walk and parse once at the end.

`coverage.py`'s tier-0 `box_and` (≤ 4 members) stays scalar — not worth a helper call.

**On the speedup, measured rather than assumed.** The issue cites ~13× for `decimals_to_words` over a scalar loop. End-to-end at a real call site it is **1.64×** (4096-cell bitmap decode, 9.4 ms → 5.7 ms locally); on the parse in isolation, 1.8× over 20k ids. The gap is because the per-cell decimal-string construction, not the parse, is now the loop's cost centre. Vectorizing *that* (base-4 digit extraction in numpy) is the next lever and is deliberately out of scope — noted in the helper's docstring so the next reader doesn't re-measure it.

## Phases

- [x] **1. Public scalar parse** — `morton_word` on `decimal_to_word(..., dtype=int)`, `mortie>=0.9.1`, docstring rewritten, return-type test. (`63b839a`)
- [x] **2. Vectorized batch parse** — `morton_words_from_decimals`; adopted at the three batch sites; `_rank_tail` duplication removed; equivalence + edge-case tests. (`6b73098`)

Adversarial self-review ran on phase 1; both findings are answered on their threads (one accepted and escalated — question (1) below; one resolved by phase 2).

## How it was tested

- **Full suite green locally**: `pytest -q` → **2651 passed, 35 skipped** on the phase-2 tip.
- Targeted: `pytest tests/test_grids.py tests/test_coverage_root.py tests/test_hive.py tests/test_sweep.py` → 307 passed (the suites exercising `morton_word` directly and through the hive/coverage/sweep paths).
- `ruff check --select=E,F,W,I --ignore=E501 src tests` (the PR lint bot's ruleset) → clean; `ruff format` applied.
- **Differential equivalence, old vs new**: 120,026 inputs — 60k valid ids (both signs, bases 1–6, orders 0–29, `p`-suffixed at 29), 60k random malformed strings, plus the edge corpus (`""`, `"0"`, `"7"`, `"150"`, `"abc"`, `"-"`, `"p"`, whitespace-padded, `"+31123"`, trailing newline, `2**64`, order-30 overflow) — **zero divergences in value or exception type** (`{'ok': 62281, 'ValueError': 57745}`). This is structural, not luck: in 0.9.2 `_decimal_to_word(s)` is literally `return decimal_to_word(s, dtype=int)`.
- The one documented upstream behavior difference — `TypeError` instead of `AttributeError` for a non-`str` argument — cannot surface here: `morton_word` coerces with `str(label)` first.
- New tests: batch-vs-scalar elementwise equivalence in **input order** (the callers sort/unique afterwards, so an order-scrambling batch parse would go unnoticed there), empty-input dtype/shape, malformed-member `ValueError`, and the `type(word) is int` pin.

## Questions for review

1. **BLOCKER — the `mortie>=0.9.1` floor is not enforced on the Lambda runtime.** `deployment/aws/build_layer.sh` installs `mortie` **unpinned** (`--no-deps`), and `deployment/aws/build_function.sh` lists `mortie` in `LAYER_PACKAGES` and strips it from the function bundle — so pip never resolves this `pyproject.toml` constraint on the worker side, and the worker's mortie version is frozen into whatever layer artifact is currently published. A layer built while `>=0.9.0` was the floor can legitimately contain 0.9.0, where `from mortie import decimal_to_word` does not exist. The old private call worked there; this PR is what raises the runtime floor. Affected worker paths: `hive.py` (bitmap decode, MOC rank expansion), `coverage.py` (root-coverage refresh), `sweep.py` (leaf paths).

   I did **not** change the deploy scripts — CLAUDE.md §1 puts `deployment/` off limits unless the issue names it, and issue #322 does not. Two ways forward, both yours to pick:

   - **(a)** Pin `mortie>=0.9.1` in `build_layer.sh` and rebuild/republish the layer. A deploy-script change, so it needs your sign-off and probably its own issue.
   - **(b)** Confirm the currently published layer already carries ≥0.9.1, in which case this is a non-issue and I'll record the check here and drop the flag.

   Marking the PR `waiting` on this — it's the one thing that could break deployed workers, and it isn't mine to decide.

2. **Scope of phase 2.** The vectorized adoption is a real but modest win (1.64× measured, above) for a wider diff than the private-API swap the issue titles. Happy to drop phase 2 to its own issue and close this PR at phase 1 if you'd rather keep the small-fix small — the two phases are independent commits, so that's a clean revert of `6b73098`.

3. **Order-29 caveat.** The issue documents that an unmarked order-29 id parses to the AREA word. Unchanged by this PR (the private function behaved identically) and irrelevant at shard order ≤ 11; noted only because `morton_word` is a general boundary helper.

4. **Pre-existing, flagged not fixed** (CLAUDE.md §4):
   - `ruff format --check src tests` reports `tests/data/benchmark/README.md` would be reformatted (a python code block inside the markdown). Confirmed present on `main` at `d104dbb` with this branch's changes stashed — untouched drift, not from this PR.
   - `ruff check src tests` under the full repo `select` (including `N`) reports `N818` on `src/zagg/registry.py:64` — the same pre-existing finding PR #311 flagged; outside the lint bot's `--select=E,F,W,I`.
