### PR TITLE
fix LAMBDA_DEPLOYMENT.md layer build drift (issue #325)

### DIFF
--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -81,8 +81,9 @@ the prompt). See
 [docs/deployment/lambda.md](../docs/deployment/lambda.md) for the parameter
 table and overrides.
 
-`deploy.sh` (below) is the maintainer path for *in-place updates* to an
-already-deployed function and does not create the role/function/bucket.
+`deploy.sh` is the maintainer path for *in-place updates* to an already-deployed
+function and does not create the role/function/bucket — see
+[Rebuilding the Layer](#rebuilding-the-layer) below for what it consumes.
 
 ---
 
@@ -144,8 +145,19 @@ The zip lands in `deployment/layers/lambda_layer_<arch>.zip`. The script
 enforces the 250 MB unzipped limit itself; CI additionally gates the combined
 layer + function size. CI builds both arches this same way on arch-matched
 runners (`lambda-build.yml` → `lambda-build-reusable.yml`), and release zips
-come from `publish.yml` calling the same reusable workflow — deploys consume
-those via `stand_up.sh` (above).
+come from `publish.yml` calling the same reusable workflow.
+
+**What consumes the zip:** nothing in the repo deploys
+`deployment/layers/lambda_layer_<arch>.zip` — it is for local verification and
+size-checking. To actually put a layer on a function:
+
+- **in-place maintainer update** — `deployment/aws/deploy.sh`. Note it pulls the
+  **CI artifact**, not your local build (`gh run download --name
+  "lambda-layer-${ARCH}"`), then `publish-layer-version` (staging through S3
+  when the zip is >50 MB) and `update-function-configuration`.
+- **full standup, or a fresh account/region** — cut a release and use
+  `stand_up.sh`, which deploys the release zips staged on the distribution
+  bucket (above), not local ones.
 
 ---
 

--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -21,7 +21,7 @@ x86_64 / py3.12 is available for local/testing parity.
 ### Current Config
 - **Runtime**: python3.12
 - **Architecture**: arm64 (default; x86_64 also supported)
-- **Layer**: `zagg-deps-{arch}` (py3.12, pyproj/odc-geo for rectilinear grids, h5coro==0.0.8)
+- **Layer**: `zagg-deps-{arch}` (py3.12; contents defined by `build_layer.sh` — see below)
 - **Function code**: `lambda_handler.py` + `zagg/` package + obstore/zarr/pydantic-zarr/pyyaml
 - **Role**: created by `template.yaml` (CloudFormation-auto-named; the template
   sets no `RoleName`), scoped least-privilege to the `OutputBucketName` bucket
@@ -33,11 +33,12 @@ x86_64 / py3.12 is available for local/testing parity.
 
 ### What's in the layer vs function code
 
-**Layer** (built by `build_layer.sh`):
-numpy, pandas, fastparquet, cramjam, shapely, pyproj, odc-geo, affine, cachetools,
-h5coro, mortie, and their transitive deps. (Corrected: `earthaccess` is
-orchestrator-only and **not** in the layer; `boto3` is provided by the Lambda
-runtime; `astropy`/`s3fs`/`pyarrow` are not installed by `build_layer.sh`. The old
+**Layer** (built by `build_layer.sh` — the script is the single source of truth):
+numpy, pandas, arro3-core, fastparquet, cramjam, xarray, h5netcdf, h5py, shapely,
+pyproj, odc-geo, affine, cachetools, h5coro, h5coro-hidefix, mortie, async-tiff,
+obspec, and their transitive deps. (`earthaccess` is orchestrator-only and
+**not** in the layer; `boto3` is provided by the Lambda runtime and explicitly
+stripped; `pyarrow` was replaced by `arro3-core` — issue #130. The old
 `xagg-dependencies:1`/222MB figure is historical.)
 
 **Function code** (built by `build_function.sh`):
@@ -83,124 +84,79 @@ already-deployed function and does not create the role/function/bucket.
 
 ---
 
-## Rebuilding the ARM64 Layer
+## Rebuilding the Layer
 
-### Why
+### Why arm64
 ARM64 Lambda is 20% cheaper ($0.0000133334 vs $0.0000166667 per GB-second). At ~90,000
 GB-seconds per full run, this saves ~$0.60/run. Over many runs it adds up.
 
-### What needs to happen
+### The build (containerized — the one normative path)
 
-1. Build a new layer with all deps compiled for `manylinux2014_aarch64` + `cp312`
-2. The layer must include the same packages as `xagg-dependencies:1` but for ARM64/py3.12
-3. Deploy the function with architecture `arm64` and runtime `python3.12`
+`deployment/aws/build_layer.sh` is the single source of truth for layer
+contents (package set, pins, numpy page-alignment build, bloat strip, 250 MB
+gate). Do not hand-maintain a parallel pip recipe — the script must run inside
+an arch-matched `manylinux_2_28` container (cp312), exactly as CI does in
+`.github/workflows/lambda-build-reusable.yml`.
 
-### Option A: Build on Apple Silicon (manual)
-
-On an Apple Silicon Mac:
+With podman (what we use locally), from the repo root:
 
 ```bash
-# Create build directory
-mkdir -p /tmp/layer_build/python
+# arm64 (native on Apple Silicon)
+podman run --rm \
+  -v "$(pwd)":/workspace \
+  -w /workspace/deployment/aws \
+  quay.io/pypa/manylinux_2_28_aarch64 \
+  bash -c "yum install -y zip && chmod +x build_layer.sh && ./build_layer.sh arm64"
 
-# Install deps targeting Lambda's manylinux environment
-pip install \
-  --platform manylinux2014_aarch64 \
-  --target /tmp/layer_build/python \
-  --implementation cp \
-  --python-version 3.12 \
-  --only-binary=:all: \
-  numpy==2.2.6 pandas==2.2.3 h5coro==0.0.8 mortie earthaccess \
-  boto3 fastparquet pyarrow shapely pyproj odc-geo cramjam astropy requests
-
-# Trim bloat
-find /tmp/layer_build -type d -name '__pycache__' -exec rm -rf {} +
-find /tmp/layer_build -type d -name '*.dist-info' -exec rm -rf {} +
-find /tmp/layer_build -type d -name 'tests' -exec rm -rf {} +
-
-# Check size (must be <250MB unzipped when combined with function code)
-du -sh /tmp/layer_build/
-
-# Zip
-cd /tmp/layer_build && zip -qr /tmp/lambda_layer_arm64.zip python/
-
-# Publish
-aws lambda publish-layer-version \
-  --layer-name zagg-deps-arm64 \
-  --compatible-runtimes python3.12 \
-  --compatible-architectures arm64 \
-  --zip-file fileb:///tmp/lambda_layer_arm64.zip \
-  --region us-west-2
-
-# Update function
-aws lambda update-function-configuration \
-  --function-name process-shard \
-  --runtime python3.12 \
-  --layers "arn:aws:lambda:us-west-2:429435741471:layer:zagg-deps-arm64:1" \
-  --region us-west-2
-
-# Then update code with arm64 arch
-aws lambda update-function-code \
-  --function-name process-shard \
-  --zip-file fileb:///tmp/lambda_function.zip \
-  --architectures arm64 \
-  --region us-west-2
+# x86_64 (on Apple Silicon this is emulated — needs Rosetta/qemu in the podman machine)
+podman run --rm \
+  -v "$(pwd)":/workspace \
+  -w /workspace/deployment/aws \
+  quay.io/pypa/manylinux_2_28_x86_64 \
+  bash -c "yum install -y zip && chmod +x build_layer.sh && ./build_layer.sh x86_64"
 ```
 
-### Option B: CI/CD on GitHub Actions with macOS Apple Silicon (recommended)
+Docker equivalents are identical apart from the binary name:
 
-GitHub provides free macOS Apple Silicon runners for public repos. This is the best
-option because Linux ARM64 runners have had issues building some of our deps.
-
-Key findings:
-- `macos-15` runners use M1 Apple Silicon (ARM64), 3 CPUs, 7GB RAM
-- Free for public repos (englacial/zagg is public), $0.062/min for private
-- Docker is NOT available on macOS ARM64 runners (Apple Virtualization limitation)
-- `pip install --platform manylinux2014_aarch64 --only-binary=:all:` works from macOS
-  to cross-compile Lambda layers — no Docker needed
-- All our deps have pre-built `manylinux2014_aarch64` wheels on PyPI
-
-The layer + function are now built in CI by `.github/workflows/lambda-build.yml` (both arches, with the combined 250MB size gate); the originally-planned `deploy-lambda.yml` was never added. The manual/CI options below are historical design notes.
-
-### Option C: Cross-compile from x86_64 (current approach for testing)
-
-Works for packages with pre-built `manylinux_2_17_x86_64` wheels. Download with:
 ```bash
-pip download --python-version 311 --platform manylinux_2_17_x86_64 \
-  --only-binary :all: --no-deps <package> -d /tmp/wheels
+docker run --rm \
+  -v "$(pwd)":/workspace \
+  -w /workspace/deployment/aws \
+  quay.io/pypa/manylinux_2_28_aarch64 \
+  bash -c "yum install -y zip && chmod +x build_layer.sh && ./build_layer.sh arm64"
 ```
-Then unzip wheels into the build directory. This is what we're doing now for testing.
+
+On an SELinux-enforcing Linux host, add `:z` to the podman volume mount
+(`-v "$(pwd)":/workspace:z`) so the container can write the zip back; it is
+not needed on macOS (`podman machine`).
+
+The zip lands in `deployment/layers/lambda_layer_<arch>.zip`. The script
+enforces the 250 MB unzipped limit itself; CI additionally gates the combined
+layer + function size. CI builds both arches this same way on arch-matched
+runners (`lambda-build.yml` → `lambda-build-reusable.yml`), and release zips
+come from `publish.yml` calling the same reusable workflow — deploys consume
+those via `stand_up.sh` (above).
 
 ---
 
 ## Deploying Updated Function Code (no layer change)
 
-When only `lambda_handler.py` or `zagg/` package code changes (no new deps):
+When only `lambda_handler.py` or `zagg/` package code changes (no new deps),
+build with the script (it owns the function dep list, the layer-overlap strip,
+and the dist-info handling — zarr/pydantic_zarr keep theirs, stripping them
+breaks `importlib.metadata`):
 
 ```bash
-# Build zip
-rm -rf /tmp/lambda_build && mkdir -p /tmp/lambda_build
-cp deployment/aws/lambda_handler.py /tmp/lambda_build/
-cp -r src/zagg /tmp/lambda_build/zagg
-
-# Add deps not in layer (skip native ones if already unpacked)
-pip install --target /tmp/lambda_build --no-deps \
-  zarr pydantic-zarr pyyaml pydantic typeguard typing_inspect annotated-types
-
-# For obstore (native): download correct wheel and unzip
-pip download --python-version <VER> --platform <PLAT> --only-binary :all: \
-  --no-deps obstore -d /tmp/wheels
-unzip -qo /tmp/wheels/obstore-*.whl -d /tmp/lambda_build
-
-# Clean and zip
-find /tmp/lambda_build -type d -name '*.dist-info' -exec rm -rf {} +
-find /tmp/lambda_build -type d -name '__pycache__' -exec rm -rf {} +
-cd /tmp/lambda_build && zip -qr /tmp/lambda_function.zip .
+# Build zip (auto-detects arch and Python). Native deps (obstore) resolve for
+# the host, so run on Linux with the function's arch/Python — CI uses
+# arch-matched ubuntu runners; on a Mac, run inside a Linux container as with
+# the layer build.
+deployment/aws/build_function.sh
 
 # Deploy
 aws lambda update-function-code \
   --function-name process-shard \
-  --zip-file fileb:///tmp/lambda_function.zip \
+  --zip-file fileb://deployment/builds/lambda_function_arm64_py312.zip \
   --region us-west-2
 ```
 
@@ -249,7 +205,7 @@ deps from the layer into the function code (or vice versa).
 ## Build Infrastructure
 
 ### Scripts
-- `deployment/aws/build_layer.sh [x86_64|arm64]` — Lambda layer build (runs in an arch-matched Docker container)
+- `deployment/aws/build_layer.sh [x86_64|arm64]` — Lambda layer build (runs in an arch-matched manylinux container via podman/docker — see "Rebuilding the Layer" above)
 - `deployment/aws/build_function.sh` — function code build (handler + zagg + non-layer deps)
 
 ### CI/CD

--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -95,31 +95,32 @@ GB-seconds per full run, this saves ~$0.60/run. Over many runs it adds up.
 ### The build (containerized — the one normative path)
 
 `deployment/aws/build_layer.sh` is the normative build entry point for the layer
-(package set, numpy page-alignment build, bloat strip, 250 MB gate). Its pins
+(package set, numpy page-alignment build, bloat strip, 250 MB gate). The script must run inside an arch-matched `manylinux_2_28` container
+(cp312) — it hard-fails on a mismatch (`ERROR: building <arch> layer on
+<machine> machine`, `build_layer.sh` L27-33), so there is no cross-arch build:
+CI builds each arch on a native runner (`ubuntu-latest` / `ubuntu-24.04-arm`,
+`lambda-build-reusable.yml`). Its pins
 are co-owned with the `lambda` extra in `pyproject.toml` — the script says "keep
 in sync" at each one — and mortie's spec is read out of `pyproject.toml`
 directly (issue #322), so a floor bump there reaches the layer with no second
-edit. Do not hand-maintain a parallel pip recipe — the script must run inside
-an arch-matched `manylinux_2_28` container (cp312), exactly as CI does in
-`.github/workflows/lambda-build-reusable.yml`.
+edit. Do not hand-maintain a parallel pip recipe.
 
-With podman (what we use locally), from the repo root:
+Production is **arm64**, and Apple Silicon runs `linux/arm64` containers
+natively, so the local recipe is the arm64 one. With podman (what we use
+locally), from the repo root:
 
 ```bash
-# arm64 (native on Apple Silicon)
 podman run --rm \
   -v "$(pwd)":/workspace \
   -w /workspace/deployment/aws \
   quay.io/pypa/manylinux_2_28_aarch64 \
   bash -c "yum install -y zip && chmod +x build_layer.sh && ./build_layer.sh arm64"
-
-# x86_64 (on Apple Silicon this is emulated — needs Rosetta/qemu in the podman machine)
-podman run --rm \
-  -v "$(pwd)":/workspace \
-  -w /workspace/deployment/aws \
-  quay.io/pypa/manylinux_2_28_x86_64 \
-  bash -c "yum install -y zip && chmod +x build_layer.sh && ./build_layer.sh x86_64"
 ```
+
+**x86_64 is not a local-Mac path.** It exists for testing parity only; build it
+on an x86_64 Linux host (same command with `manylinux_2_28_x86_64` /
+`build_layer.sh x86_64`) or just take CI's `lambda-layer-x86_64` artifact. Don't
+try to emulate it on Apple Silicon.
 
 Docker equivalents are identical apart from the binary name:
 

--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -169,10 +169,16 @@ and the dist-info handling — zarr/pydantic_zarr keep theirs, stripping them
 breaks `importlib.metadata`):
 
 ```bash
-# Build zip (auto-detects arch and Python). Native deps (obstore) resolve for
-# the host, so run on Linux with the function's arch/Python — CI uses
-# arch-matched ubuntu runners; on a Mac, run inside a Linux container as with
-# the layer build.
+# Build zip. Native deps (obstore) resolve for the host, so run on Linux with
+# the function's arch and Python 3.12. The script auto-detects both from the
+# ambient `python3`/`uname -m` and bakes them into the zip name — it has no
+# cp312 fallback (unlike build_layer.sh), so a non-3.12 `python3` silently
+# yields a mislabeled lambda_function_<arch>_py<other>.zip that stand_up.sh
+# won't find. Unlike the layer, this does NOT run in the manylinux image, whose
+# default `python3` is not cp312; CI runs it on the arch-matched ubuntu runner
+# under actions/setup-python 3.12. If you use a container, use one whose
+# `python3` IS 3.12 (e.g. python:3.12) or prepend
+# /opt/python/cp312-cp312/bin to PATH.
 deployment/aws/build_function.sh
 
 # Deploy

--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -96,15 +96,17 @@ GB-seconds per full run, this saves ~$0.60/run. Over many runs it adds up.
 ### The build (containerized — the one normative path)
 
 `deployment/aws/build_layer.sh` is the normative build entry point for the layer
-(package set, numpy page-alignment build, bloat strip, 250 MB gate). The script must run inside an arch-matched `manylinux_2_28` container
-(cp312) — it hard-fails on a mismatch (`ERROR: building <arch> layer on
-<machine> machine`, `build_layer.sh` L27-33), so there is no cross-arch build:
-CI builds each arch on a native runner (`ubuntu-latest` / `ubuntu-24.04-arm`,
-`lambda-build-reusable.yml`). Its pins
+(package set, numpy page-alignment build, bloat strip, 250 MB gate). Its pins
 are co-owned with the `lambda` extra in `pyproject.toml` — the script says "keep
 in sync" at each one — and mortie's spec is read out of `pyproject.toml`
 directly (issue #322), so a floor bump there reaches the layer with no second
 edit. Do not hand-maintain a parallel pip recipe.
+
+The script must run inside an arch-matched `manylinux_2_28` container (cp312),
+and it hard-fails on a mismatch (`ERROR: building <arch> layer on <machine>
+machine`, `build_layer.sh` L27-33) — so there is no cross-arch build. CI builds
+each arch on a native runner (`ubuntu-latest` / `ubuntu-24.04-arm`,
+`lambda-build-reusable.yml`).
 
 Production is **arm64**, and Apple Silicon runs `linux/arm64` containers
 natively, so the local recipe is the arm64 one. With podman (what we use

--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -33,7 +33,9 @@ x86_64 / py3.12 is available for local/testing parity.
 
 ### What's in the layer vs function code
 
-**Layer** (built by `build_layer.sh` — the script is the single source of truth):
+**Layer** (built by `build_layer.sh` — the normative build entry point; its pins
+are co-owned with the `lambda` extra in `pyproject.toml`, and mortie's version
+spec is read from `pyproject.toml` at build time — issue #322):
 numpy, pandas, arro3-core, fastparquet, cramjam, xarray, h5netcdf, h5py, shapely,
 pyproj, odc-geo, affine, cachetools, h5coro, h5coro-hidefix, mortie, async-tiff,
 obspec, and their transitive deps. (`earthaccess` is orchestrator-only and
@@ -92,9 +94,12 @@ GB-seconds per full run, this saves ~$0.60/run. Over many runs it adds up.
 
 ### The build (containerized — the one normative path)
 
-`deployment/aws/build_layer.sh` is the single source of truth for layer
-contents (package set, pins, numpy page-alignment build, bloat strip, 250 MB
-gate). Do not hand-maintain a parallel pip recipe — the script must run inside
+`deployment/aws/build_layer.sh` is the normative build entry point for the layer
+(package set, numpy page-alignment build, bloat strip, 250 MB gate). Its pins
+are co-owned with the `lambda` extra in `pyproject.toml` — the script says "keep
+in sync" at each one — and mortie's spec is read out of `pyproject.toml`
+directly (issue #322), so a floor bump there reaches the layer with no second
+edit. Do not hand-maintain a parallel pip recipe — the script must run inside
 an arch-matched `manylinux_2_28` container (cp312), exactly as CI does in
 `.github/workflows/lambda-build-reusable.yml`.
 

--- a/deployment/LAMBDA_DEPLOYMENT.md
+++ b/deployment/LAMBDA_DEPLOYMENT.md
@@ -133,8 +133,12 @@ docker run --rm \
 ```
 
 On an SELinux-enforcing Linux host, add `:z` to the podman volume mount
-(`-v "$(pwd)":/workspace:z`) so the container can write the zip back; it is
-not needed on macOS (`podman machine`).
+(`-v "$(pwd)":/workspace:z`). Without it the container cannot *read* the
+unlabeled mount either, so the build dies at the top (`chmod +x build_layer.sh`,
+or reading `../../pyproject.toml` for `MORTIE_SPEC`) rather than at zip-write
+time. Note `:z` relabels the mount **recursively with a shared label** — and the
+mount here is the whole repo root, not a scratch dir; `:Z` is the private-label
+variant. Neither is needed on macOS (`podman machine`).
 
 The zip lands in `deployment/layers/lambda_layer_<arch>.zip`. The script
 enforces the 250 MB unzipped limit itself; CI additionally gates the combined

--- a/docs/deployment/arm64.md
+++ b/docs/deployment/arm64.md
@@ -2,6 +2,14 @@
 
 Building an ARM64 (Graviton2) Lambda layer on Apple Silicon Mac.
 
+!!! note "The build command is normative in `deployment/LAMBDA_DEPLOYMENT.md`"
+    The containerized layer build — the exact podman/docker invocation, the
+    SELinux caveat, and what consumes the resulting zip — lives in
+    [Rebuilding the Layer](https://github.com/englacial/zagg/blob/main/deployment/LAMBDA_DEPLOYMENT.md#rebuilding-the-layer).
+    This page covers the Apple-Silicon-specific *why* (image choice, page
+    alignment, glibc) and troubleshooting. If the two disagree, that section
+    wins.
+
 ## Overview
 
 M1/M2/M3 Macs run `linux/arm64` containers natively without emulation, making ARM builds fast and reliable.
@@ -21,7 +29,7 @@ M1/M2/M3 Macs run `linux/arm64` containers natively without emulation, making AR
 | Component | Required |
 |-----------|----------|
 | macOS | Apple Silicon (M1/M2/M3) |
-| Docker Desktop | Latest (or OrbStack, Colima) |
+| Container runtime | podman (what we use; Docker Desktop / OrbStack / Colima also work) |
 | Disk space | ~5 GB free |
 
 ### Container Image
@@ -34,16 +42,23 @@ Use `quay.io/pypa/manylinux_2_28_aarch64`:
 
 ## Build Steps
 
-1. **Install Docker Desktop** (if not already installed):
+1. **Install podman** (if not already installed), and start its VM:
 
     ```bash
-    brew install --cask docker
+    brew install podman
+    podman machine init && podman machine start
     ```
 
-2. **Run the build**:
+2. **Run the build inside the container** — `build_layer.sh` is not a bare-host
+   command; it needs the manylinux cp312 toolchain and refuses to run on a
+   non-`aarch64` machine. From the repo root:
 
     ```bash
-    bash deployment/aws/build_layer.sh arm64
+    podman run --rm \
+      -v "$(pwd)":/workspace \
+      -w /workspace/deployment/aws \
+      quay.io/pypa/manylinux_2_28_aarch64 \
+      bash -c "yum install -y zip && chmod +x build_layer.sh && ./build_layer.sh arm64"
     ```
 
 3. **Transfer the zip** (if building on a different machine):
@@ -53,6 +68,11 @@ Use `quay.io/pypa/manylinux_2_28_aarch64`:
     ```
 
 ## Deploying the Layer
+
+Normally you don't publish a locally built zip: `deployment/aws/deploy.sh`
+publishes from the CI artifact and updates the function config, and
+`stand_up.sh` deploys release zips for a full standup. The manual equivalent,
+for a one-off layer of your own:
 
 ```bash
 # Upload to S3 (if >50MB)
@@ -69,8 +89,13 @@ aws lambda publish-layer-version \
 
 ## Verifying the Build
 
+Import only what the *layer* actually contains. `zarr`, `obstore` and
+`pydantic-zarr` are function-code deps (`build_function.sh`) and are stripped
+out of the layer; `earthaccess` is orchestrator-only and never installed into
+it. Expecting any of those here will fail a good layer.
+
 ```bash
-docker run --rm --platform linux/arm64 \
+podman run --rm --platform linux/arm64 \
     -v ./deployment/layers/lambda_layer_arm64.zip:/layer.zip \
     public.ecr.aws/lambda/python:3.12 \
     bash -c '
@@ -81,11 +106,10 @@ sys.path.insert(0, \"/opt/python\")
 import numpy; print(f\"numpy {numpy.__version__}\")
 import pandas; print(f\"pandas {pandas.__version__}\")
 import pyproj; print(f\"pyproj {pyproj.__version__}\")
-import zarr; print(f\"zarr {zarr.__version__}\")
-import pydantic_zarr; print(\"pydantic_zarr OK\")
-import obstore; print(\"obstore OK\")
+import shapely; print(f\"shapely {shapely.__version__}\")
+import xarray; print(f\"xarray {xarray.__version__}\")
+import mortie; print(\"mortie OK\")
 import h5coro; print(\"h5coro OK\")
-import earthaccess; print(\"earthaccess OK\")
 print(\"All imports successful!\")
 "
     '
@@ -100,7 +124,7 @@ print(\"All imports successful!\")
     Your build container has a newer glibc than Lambda. Use `manylinux_2_28` (glibc 2.28) which is compatible with Lambda's glibc 2.34.
 
 !!! info "Slow build"
-    Ensure Docker Desktop is configured for native ARM execution (not Rosetta emulation). Check: Docker Desktop → Settings → General → "Use Virtualization framework".
+    Make sure the runtime is executing the image natively rather than emulating it — an `aarch64` image on Apple Silicon needs no emulation. `podman machine inspect` should report an `aarch64` VM; on Docker Desktop, Settings → General → "Use Virtualization framework".
 
 ## Why This Works
 
@@ -108,5 +132,5 @@ print(\"All imports successful!\")
 |------------------------------|-----------------|
 | Lambda container has GCC 7.3 | manylinux_2_28 has GCC ≥9.3 |
 | Ubuntu has glibc 2.39 | manylinux_2_28 has glibc 2.28 |
-| x86 runners need QEMU for ARM | Mac runs ARM natively |
+| x86 runners would need QEMU for ARM (CI avoids this with native `ubuntu-24.04-arm` runners) | Mac runs ARM natively |
 | NumPy wheels have 4KB page alignment | Build from source with 64KB alignment |


### PR DESCRIPTION
Closes #325

Docs-only PR: reconciles `deployment/LAMBDA_DEPLOYMENT.md` with what `deployment/aws/build_layer.sh` / `build_function.sh` actually do, per the ruling on the issue — **option (b)**, delete the hand-maintained recipe and keep one normative containerized build path, **podman commands first, docker equivalents second** ([espg's approval + podman-first amendment](https://github.com/englacial/zagg/issues/325#issuecomment-5124137711)). No scripts or workflows are touched.

## Checklist
- [x] #325 — replace drifted "Option A" manual layer recipe with the containerized `build_layer.sh` path; fix the other statements the scripts contradict

## What changed
- **"Rebuilding the ARM64 Layer" → "Rebuilding the Layer"**: the drifted "Option A: Build on Apple Silicon (manual)" pip recipe (`h5coro==0.0.8`, `pyarrow`/`boto3`/`earthaccess`/`astropy`, blanket `*.dist-info` strip, hardcoded layer ARN) is deleted, along with the equally-historical "Option B" (macOS-runner pip cross-compile "key findings", contradicted by CI's arch-matched ubuntu runners) and "Option C" (x86_64 cross-compile "current approach"). Replaced by a single normative section: run `./build_layer.sh {arm64,x86_64}` inside the arch-matched `quay.io/pypa/manylinux_2_28_{aarch64,x86_64}` image — podman first, docker equivalent after. The commands mirror the CI invocation verbatim (mount → `/workspace`, `-w /workspace/deployment/aws`, `yum install -y zip && chmod +x build_layer.sh && ./build_layer.sh <arch>`): [`lambda-build-reusable.yml` L27–35 (x86_64)](https://github.com/englacial/zagg/blob/main/.github/workflows/lambda-build-reusable.yml#L27-L35) and [L108–116 (arm64)](https://github.com/englacial/zagg/blob/main/.github/workflows/lambda-build-reusable.yml#L108-L116). Podman/docker differ only in the binary name here; a note covers the `:z` SELinux mount label needed on SELinux-enforcing Linux hosts (not on macOS `podman machine`) and that x86_64 is emulated on Apple Silicon.
- **"What's in the layer vs function code"**: layer package list updated to what `build_layer.sh` installs today (adds `arro3-core`, `xarray`/`h5netcdf`/`h5py`, `h5coro-hidefix`, `async-tiff`/`obspec`; notes `boto3` is explicitly stripped and `pyarrow` → `arro3-core` per issue #130). "Current Config" layer line now defers to the script instead of pinning `h5coro==0.0.8`.
- **"Deploying Updated Function Code"**: the manual function-zip recipe stripped *all* `*.dist-info`, which `build_function.sh` explicitly avoids for `zarr`/`pydantic_zarr` (stripping breaks `importlib.metadata` → `PackageNotFoundError` in `ArraySpec.from_zarr` — see [`build_function.sh` L101–106](https://github.com/englacial/zagg/blob/main/deployment/aws/build_function.sh#L101-L106)); same drift class as Option A, so it now points at the script, keeping only the `aws lambda update-function-code` deploy step.
- **"Build Infrastructure"**: script blurb now says manylinux container via podman/docker and cross-references the rebuild section.

Left alone: the Size Budget table and other historical figures already disclaimed by the header note ("trust the scripts ... over the numbers here"), and the "CI/CD Workflow Design" section, which is explicitly marked historical.

## How tested
Docs-only. `uvx codespell deployment/LAMBDA_DEPLOYMENT.md` is clean; the podman/docker commands were checked token-for-token against the workflow steps linked above (image names, mount target, workdir, and the `yum install zip` + `chmod` preamble `build_layer.sh` relies on when run from a fresh checkout inside the container).

## Questions for review
- The x86_64-on-Apple-Silicon note says emulation (Rosetta/qemu in the podman machine) is required — that matches the script's `uname -m` arch guard, but I couldn't execute a container build here; flag if the local podman-machine setup differs.
