### PR TITLE
zagg.client facade: notebook API, v1 shard futures, tqdm progress (issue #326)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,10 @@ viz = [
     "ipyleaflet>=0.19",
 ]
 analysis = [
+    # tqdm drives zagg.client's RunHandle.progress() bar (issue #326); espg
+    # ratified adding it to this existing extra — never to `lambda` — on
+    # https://github.com/englacial/zagg/issues/265#issuecomment-5124017044
+    "tqdm>=4.66",
     "cubed>=0.24.0",
     "cubed-xarray>=0.0.9",
     "xarray[io]",

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -13,6 +13,15 @@ shardmap → dispatch → harvest — as library API::
         r = fut.result()                       # worker envelope / raises ShardError
     handle.status()                            # {"pending", "ok", "failed"}
 
+Draining the harvest iterator to exhaustion (``as_completed`` / ``progress`` /
+``results`` / a clean ``raise_first``) also joins the post-run tail — the
+finalize backstop and the coverage/stats/sweep rollup invokes — so the loop
+above IS the whole run and :meth:`RunHandle.wait` is only needed for explicit
+control (a timeout, or a handle harvested some other way). Abandoning a handle
+without draining it is the one flow that truncates the tail: the finisher is a
+daemon thread, so an undrained handle cannot wedge interpreter exit (review
+finding, PR #333).
+
 **v1 transport** (ratified on issue #265): a ``ThreadPoolExecutor`` over the
 existing synchronous ``RequestResponse`` invokes — each shard is one
 :func:`zagg.runner._invoke_lambda_cell` call and its pool future is the
@@ -109,7 +118,12 @@ class RunHandle:
     A background finisher thread waits for every shard, then runs the same
     worker-invoke tail as ``agg``'s lambda path: the finalize backstop, plus
     the fail-open coverage/stats/sweep rollup invokes (D8: all worker-side).
-    :meth:`wait` joins it and surfaces a finalize failure.
+    Draining any of the harvest iterators (:meth:`as_completed`,
+    :meth:`progress`, :meth:`results`, a clean :meth:`raise_first`) joins that
+    finisher before returning and surfaces a finalize failure, so a completed
+    harvest loop means a completed run; :meth:`wait` is the explicit form (and
+    the only one taking a timeout). Only a handle nobody drains truncates the
+    tail — the finisher is a daemon so that case cannot hang exit.
     """
 
     def __init__(self, futures: dict[int, Future], *, store_path: str):
@@ -129,8 +143,15 @@ class RunHandle:
         )
 
     def as_completed(self, timeout: float | None = None) -> Iterator[Future]:
-        """Yield each shard future as it completes (``concurrent.futures`` order)."""
-        return as_completed(self.futures.values(), timeout=timeout)
+        """Yield each shard future as it completes (``concurrent.futures`` order).
+
+        Exhausting this iterator joins the post-run tail (see :meth:`wait`) and
+        re-raises a finalize failure, so the documented harvest loop finishes a
+        complete run without calling :meth:`wait` (review finding, PR #333).
+        Breaking out early skips that join — call :meth:`wait` if you do.
+        """
+        yield from as_completed(self.futures.values(), timeout=timeout)
+        self._join_tail()
 
     def status(self) -> dict[str, int]:
         """Non-blocking snapshot: ``{"pending": n, "ok": n, "failed": n}``."""
@@ -150,19 +171,31 @@ class RunHandle:
         With ``return_exceptions=False`` (default) the first failed shard's
         :class:`ShardError` propagates (key order); with ``True`` failures
         appear as the exception object in the mapping instead — the
-        ``asyncio.gather`` convention.
+        ``asyncio.gather`` convention. Either way the post-run tail is joined
+        first (see :meth:`as_completed`), so a shard failure does not truncate
+        the rollups.
         """
         out: dict[int, Any] = {}
+        first_exc: BaseException | None = None
         for key, fut in self.futures.items():
-            if return_exceptions:
-                exc = fut.exception()
-                out[key] = exc if exc is not None else fut.result()
-            else:
+            exc = fut.exception()
+            if exc is None:
                 out[key] = fut.result()
+            else:
+                out[key] = exc
+                if first_exc is None:
+                    first_exc = exc
+        self._join_tail()
+        if first_exc is not None and not return_exceptions:
+            raise first_exc
         return out
 
     def raise_first(self) -> None:
-        """Block until the first failure (raising it) or all shards complete."""
+        """Block until the first failure (raising it) or all shards complete.
+
+        A clean run drains :meth:`as_completed`, so it joins the post-run tail;
+        raising on a failure leaves the tail in flight (:meth:`wait` joins it).
+        """
         for fut in self.as_completed():
             exc = fut.exception()
             if exc is not None:
@@ -193,11 +226,27 @@ class RunHandle:
         reader-facing schema, D6); the coverage/stats/sweep rollups are
         fail-open by design and never raise here. Raises ``TimeoutError``
         when the tail is still running at ``timeout``.
+
+        Draining a harvest iterator already joins the tail, so ``wait`` is for
+        explicit control.
         """
         if self._finisher is not None:
             self._finisher.join(timeout)
             if self._finisher.is_alive():
                 raise TimeoutError(f"run tail still in flight after {timeout}s")
+        self._raise_tail_error()
+
+    def _join_tail(self) -> None:
+        """Join the post-run finisher, then re-raise what it recorded.
+
+        Idempotent (joining a finished thread is a no-op), so draining a
+        harvest iterator and then calling :meth:`wait` is safe.
+        """
+        if self._finisher is not None:
+            self._finisher.join()
+        self._raise_tail_error()
+
+    def _raise_tail_error(self) -> None:
         if self._finalize_error is not None:
             raise self._finalize_error
 

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -225,7 +225,8 @@ class RunHandle:
         """Block until every shard AND the post-run tail finish.
 
         Re-raises a failed finalize backstop (the manifest is required
-        reader-facing schema, D6); the coverage/stats/sweep rollups are
+        reader-facing schema, D6 — also warned at the moment it fails, so it is
+        visible before this join); the coverage/stats/sweep rollups are
         fail-open by design and never raise here, but an exception in the
         tail's own plumbing does surface (it would otherwise vanish into the
         finisher thread). Raises ``TimeoutError`` when the tail is still
@@ -776,8 +777,10 @@ class Run:
         flat only under ``consolidate_metadata``), then the fail-open rollups:
         root ``coverage.moc``, the run-stats record, and the sweep trigger —
         each a fire-and-forget worker invoke (D8), each swallowed on failure
-        exactly like ``_run_lambda``'s tail. A finalize failure is recorded on
-        the handle and re-raised from :meth:`RunHandle.wait`.
+        exactly like ``_run_lambda``'s tail. A finalize failure warns
+        immediately (``RuntimeWarning`` — notebook-visible while the tail is
+        still running), is recorded on the handle, and re-raises from
+        :meth:`RunHandle.wait` / a drained harvest iterator.
 
         Every shard contributes exactly one result dict, so every shard gets a
         run-stats row: a worker envelope, a :class:`ShardError` payload, or —
@@ -831,6 +834,23 @@ class Run:
         except Exception as e:
             handle._finalize_error = e
             logger.warning(f"finalize invoke failed (surfaced via handle.wait()): {e}")
+            # Warn AT THE FAILURE, not only when the harvest loop finally joins
+            # (espg ruling on PR #333, middle option): the tail goes on and the
+            # error still re-raises from wait()/drain, but a notebook shows this
+            # in-stream immediately instead of leaving the window between
+            # finalize and the join silent. Every shard's data is written — only
+            # the root manifest is stale — and the backstop is idempotent, so
+            # the remedy is a re-run, not a re-compute.
+            warnings.warn(
+                f"finalize (manifest backstop) failed for {self.store}: {e}. "
+                f"Shard outputs are written; the store's root manifest may be "
+                f"stale until finalize runs again. It is idempotent — re-run "
+                f"the dispatch (or re-dispatch finalize) to stamp the manifest. "
+                f"This error also re-raises from handle.wait() / draining the "
+                f"harvest iterator.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
         ok_results = [r for r in results if r.get("status_code") == 200 and not r.get("error")]
         if layout == "hive" and get_coverage_moc(self.config):

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -73,11 +73,10 @@ from zagg.config import (
     load_config_from_dict,
     validate_config,
 )
-from zagg.dispatch import LAMBDA_ARCH, max_cost_usd
+from zagg.dispatch import BENIGN_ERRORS, LAMBDA_ARCH, max_cost_usd
 from zagg.grids import from_config as grid_from_config
 from zagg.grids.morton import morton_word
 from zagg.hive import effective_store_root
-from zagg.notebook import _BENIGN_ERRORS
 
 logger = logging.getLogger(__name__)
 
@@ -679,7 +678,7 @@ class Run:
         error = result.get("error")
         if result.get("status_code") == 200 and not error:
             return result
-        if error in _BENIGN_ERRORS:
+        if error in BENIGN_ERRORS:
             # "Nothing to do" is a normal outcome, not a failure — matching
             # _run_lambda's error counting (neither with_data nor error).
             return result

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -718,18 +718,36 @@ class Run:
         each a fire-and-forget worker invoke (D8), each swallowed on failure
         exactly like ``_run_lambda``'s tail. A finalize failure is recorded on
         the handle and re-raised from :meth:`RunHandle.wait`.
+
+        Every shard contributes exactly one result dict, so every shard gets a
+        run-stats row: a worker envelope, a :class:`ShardError` payload, or —
+        for a transport-level exception that never produced an envelope (the
+        payload-cap ``ValueError``, an fd-exhaustion re-raise, a botocore error
+        escaping the retry loop) — a synthesized failure dict, which
+        ``_lambda_result_rows`` turns into a ``failure_record`` row rather than
+        dropping the shard from telemetry (review finding, PR #333).
         """
         from zagg import runner
 
         futures = list(handle.futures.values())
         futures_wait(futures)
         results = []
-        for fut in futures:
+        for key, fut in handle.futures.items():
             exc = fut.exception()
             if exc is None:
                 results.append(fut.result())
             elif isinstance(exc, ShardError):
                 results.append(exc.payload)
+            else:
+                results.append(
+                    {
+                        "shard_key": key,
+                        "status_code": None,
+                        "body": {},
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "retries": None,
+                    }
+                )
         layout = get_store_layout(self.config)
         try:
             if layout == "hive":

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -1,0 +1,734 @@
+"""Notebook-first dispatch facade: per-shard futures over Lambda (issue #326).
+
+:class:`Run` owns the composition that ``.github/scripts/run_benchmark.py``
+and the dispatch scratch scripts do imperatively today — config-load →
+shardmap → dispatch → harvest — as library API::
+
+    from zagg.client import Run
+
+    run = Run.from_config("atl03_tdigest_healpix_o9_hive.yaml",
+                          shardmap="shardmap.json", store="s3://bucket/out.zarr")
+    handle = run.dispatch()                    # returns after the setup handshake
+    for fut in handle.progress():              # tqdm over as_completed
+        r = fut.result()                       # worker envelope / raises ShardError
+    handle.status()                            # {"pending", "ok", "failed"}
+
+**v1 transport** (ratified on issue #265): a ``ThreadPoolExecutor`` over the
+existing synchronous ``RequestResponse`` invokes — each shard is one
+:func:`zagg.runner._invoke_lambda_cell` call and its pool future is the
+shard's :class:`concurrent.futures.Future`, wrapping exactly what the worker
+returns today (timings, error payloads). Zero worker-side change; the cost is
+one held connection per in-flight shard and the client staying alive. The v2
+transport (``Event`` invoke + status-object resolver, issue #327) swaps the
+resolver under this same public surface.
+
+The dispatcher-never-writes invariant (D8) is untouched: every store write —
+template setup, shard output, finalize, coverage/stats/sweep rollups — rides a
+worker invoke; this module only holds futures over those invokes.
+
+Scope (v1): the spatial point path on the ``lambda`` backend. Temporal,
+raster, and windowed configs are refused with a pointer to
+:func:`zagg.runner.agg` / :func:`zagg.notebook.run`, which already run them.
+
+tqdm is an *optional* import (``analysis`` extra, espg-ratified on issue
+#265): only :meth:`RunHandle.progress` touches it, so importing this module —
+and everything else in zagg — works without it.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from concurrent.futures import wait as futures_wait
+from dataclasses import asdict
+from typing import Any, Iterator
+
+from zagg.config import (
+    PipelineConfig,
+    get_child_order,
+    get_consolidate_metadata,
+    get_coverage_moc,
+    get_driver,
+    get_handoff,
+    get_output_endpoint_url,
+    get_output_region,
+    get_parent_order,
+    get_pipeline_type,
+    get_store_layout,
+    get_store_path,
+    get_sweep,
+    get_windowing,
+    load_config,
+    load_config_from_dict,
+    validate_config,
+)
+from zagg.dispatch import LAMBDA_ARCH, max_cost_usd
+from zagg.grids import from_config as grid_from_config
+from zagg.grids.morton import morton_word
+from zagg.hive import effective_store_root
+from zagg.notebook import _BENIGN_ERRORS
+
+logger = logging.getLogger(__name__)
+
+#: Fan-out width when ``dispatch(max_workers=...)`` is not given. Deliberately
+#: modest: the v1 sync transport holds one connection per in-flight shard and
+#: this path runs no account-concurrency probe (unlike ``agg``'s preflight,
+#: which clamps against account limits before sizing the pool) — fine at
+#: notebook/NEON scale; pass ``max_workers`` explicitly for bigger fan-outs.
+_DEFAULT_MAX_WORKERS = 64
+
+
+class ShardError(RuntimeError):
+    """A shard's worker invoke failed; raised from that shard's ``future.result()``.
+
+    Carries the full per-shard result dict (``payload``) the dispatch loop
+    accumulates on the ``agg`` path — ``{shard_key, status_code, body,
+    wall_time, lambda_duration, error, retries, ...}`` — so timings and the
+    worker's error body survive into the exception.
+    """
+
+    def __init__(self, message: str, *, shard_key: int, label: str, payload: dict):
+        super().__init__(message)
+        self.shard_key = shard_key
+        self.label = label
+        self.payload = payload
+
+
+class RunHandle:
+    """Live handle over one dispatched fan-out: per-shard futures + rollup.
+
+    ``futures`` maps the shardmap's shard key (int) to that shard's
+    :class:`~concurrent.futures.Future`. A future resolves to the worker's
+    result dict; a failed shard raises :class:`ShardError` from ``.result()``.
+    Benign no-work outcomes (``"No granules found"`` / ``"No data after
+    filtering"``) resolve normally and count as ``ok`` — matching how the
+    ``agg`` path counts them (neither data nor error).
+
+    A background finisher thread waits for every shard, then runs the same
+    worker-invoke tail as ``agg``'s lambda path: the finalize backstop, plus
+    the fail-open coverage/stats/sweep rollup invokes (D8: all worker-side).
+    :meth:`wait` joins it and surfaces a finalize failure.
+    """
+
+    def __init__(self, futures: dict[int, Future], *, store_path: str):
+        self.futures = futures
+        self.store_path = store_path
+        self._finisher: threading.Thread | None = None
+        self._finalize_error: BaseException | None = None
+
+    def __len__(self) -> int:
+        return len(self.futures)
+
+    def __repr__(self) -> str:
+        s = self.status()
+        return (
+            f"RunHandle({len(self)} shards: {s['pending']} pending, "
+            f"{s['ok']} ok, {s['failed']} failed)"
+        )
+
+    def as_completed(self, timeout: float | None = None) -> Iterator[Future]:
+        """Yield each shard future as it completes (``concurrent.futures`` order)."""
+        return as_completed(self.futures.values(), timeout=timeout)
+
+    def status(self) -> dict[str, int]:
+        """Non-blocking snapshot: ``{"pending": n, "ok": n, "failed": n}``."""
+        counts = {"pending": 0, "ok": 0, "failed": 0}
+        for fut in self.futures.values():
+            if not fut.done():
+                counts["pending"] += 1
+            elif fut.exception() is not None:
+                counts["failed"] += 1
+            else:
+                counts["ok"] += 1
+        return counts
+
+    def results(self, *, return_exceptions: bool = False) -> dict[int, Any]:
+        """Block until every shard completes; return ``{shard_key: result}``.
+
+        With ``return_exceptions=False`` (default) the first failed shard's
+        :class:`ShardError` propagates (key order); with ``True`` failures
+        appear as the exception object in the mapping instead — the
+        ``asyncio.gather`` convention.
+        """
+        out: dict[int, Any] = {}
+        for key, fut in self.futures.items():
+            if return_exceptions:
+                exc = fut.exception()
+                out[key] = exc if exc is not None else fut.result()
+            else:
+                out[key] = fut.result()
+        return out
+
+    def raise_first(self) -> None:
+        """Block until the first failure (raising it) or all shards complete."""
+        for fut in self.as_completed():
+            exc = fut.exception()
+            if exc is not None:
+                raise exc
+
+    def progress(self, **tqdm_kwargs) -> Iterator[Future]:
+        """:meth:`as_completed` under a ``tqdm.auto`` bar (one tick per shard).
+
+        tqdm is optional (the ``analysis`` extra, espg-ratified on issue
+        #265); without it this raises ``ImportError`` with the install hint —
+        :meth:`as_completed` is the bar-free equivalent.
+        """
+        try:
+            from tqdm.auto import tqdm
+        except ImportError as e:
+            raise ImportError(
+                "RunHandle.progress() needs tqdm (`pip install 'zagg[analysis]'`, "
+                "issue #326); handle.as_completed() is the bar-free equivalent"
+            ) from e
+        kwargs: dict[str, Any] = {"total": len(self), "desc": "shards", "unit": "shard"}
+        kwargs.update(tqdm_kwargs)
+        return tqdm(self.as_completed(), **kwargs)
+
+    def wait(self, timeout: float | None = None) -> None:
+        """Block until every shard AND the post-run tail finish.
+
+        Re-raises a failed finalize backstop (the manifest is required
+        reader-facing schema, D6); the coverage/stats/sweep rollups are
+        fail-open by design and never raise here. Raises ``TimeoutError``
+        when the tail is still running at ``timeout``.
+        """
+        if self._finisher is not None:
+            self._finisher.join(timeout)
+            if self._finisher.is_alive():
+                raise TimeoutError(f"run tail still in flight after {timeout}s")
+        if self._finalize_error is not None:
+            raise self._finalize_error
+
+
+class Run:
+    """A configured-but-not-dispatched zagg Lambda run (issue #326).
+
+    Build one with :meth:`from_config`; :meth:`dispatch` fans the shards out
+    and returns a :class:`RunHandle` of per-shard futures. One ``Run`` may be
+    dispatched more than once (each dispatch is an independent fan-out with
+    its own run id and pool).
+    """
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        catalog_data: dict,
+        *,
+        store: str,
+        function_name: str,
+        region: str,
+        lambda_client=None,
+        driver: str,
+        handoff: str,
+        profile: bool = False,
+        max_retries: int = 3,
+        overwrite: bool = False,
+        output_credentials: dict | None = None,
+        output_endpoint_url: str | None = None,
+        source_credentials: dict | None = None,
+    ):
+        from zagg import runner
+
+        self.config = config
+        self.catalog_data = catalog_data
+        self.store = store
+        self.function_name = function_name
+        self.region = region
+        self.driver = driver
+        self.handoff = handoff
+        self.profile = profile
+        self.max_retries = max_retries
+        self.overwrite = overwrite
+        self._lambda_client = lambda_client
+        self._output_credentials = output_credentials
+        self._output_endpoint_url = output_endpoint_url
+        self._source_credentials = source_credentials
+
+        grid_type = (config.output.get("grid") or {}).get("type", "healpix")
+        self._grid_type = grid_type
+        self._parent_order = get_parent_order(config) if grid_type == "healpix" else None
+        self._child_order = get_child_order(config) if grid_type == "healpix" else None
+        self.grid = grid_from_config(config)
+        runner._check_signature(self.grid, catalog_data)
+
+    def __repr__(self) -> str:
+        return (
+            f"Run({len(self.catalog_data['shard_keys'])} shards -> {self.store!r}, "
+            f"function={self.function_name!r}, region={self.region!r})"
+        )
+
+    def __len__(self) -> int:
+        return len(self.catalog_data["shard_keys"])
+
+    @classmethod
+    def from_config(
+        cls,
+        config: PipelineConfig | dict | str,
+        *,
+        shardmap: dict | str | None = None,
+        store: str | None = None,
+        function_name: str | None = None,
+        region: str = "us-west-2",
+        lambda_client=None,
+        driver: str | None = None,
+        handoff: str | None = None,
+        profile: bool = False,
+        max_retries: int = 3,
+        overwrite: bool = False,
+        output_credentials: dict | None = None,
+        output_endpoint_url: str | None = None,
+        source_credentials: dict | None = None,
+    ) -> "Run":
+        """Build a :class:`Run` from a config plus a shard map.
+
+        Parameters
+        ----------
+        config : PipelineConfig, dict, or str
+            A loaded :class:`~zagg.config.PipelineConfig`, a plain config
+            dict, or a path to a YAML config file. Dicts and paths are
+            validated on load.
+        shardmap : dict or str, optional
+            A loaded ShardMap manifest dict or a path to its JSON. Falls back
+            to the config's ``catalog:`` key. The map's grid signature must
+            match the config's grid (same guard as ``agg``).
+        store : str, optional
+            Output store; falls back to ``output.store:``. Must be ``s3://``
+            (this facade is Lambda-only; the local backend stays on ``agg``).
+        function_name : str, optional
+            Lambda function name; default resolves ``ZAGG_LAMBDA_FUNCTION_NAME``
+            plus the config ``worker:`` variant suffix, exactly like ``agg``.
+        region : str
+            AWS region (default ``us-west-2``; a config ``output.region``
+            overrides the default, mirroring ``agg``).
+        lambda_client : optional
+            An injected boto3 Lambda client (testability / custom botocore
+            config). Default ``None`` builds one per dispatch, sized to the
+            fan-out (``read_timeout`` above the 900 s function ceiling). With
+            an injected client no STS caller-identity probe runs, so worker
+            stats records carry a null ``invoked_by`` (fail-open, issue #297).
+        driver, handoff, profile, max_retries, overwrite,
+        output_credentials, output_endpoint_url
+            Same semantics as the matching :func:`zagg.runner.agg` kwargs.
+        source_credentials : dict, optional
+            Explicit source-read S3 credentials (camelCase ``accessKeyId`` /
+            ``secretAccessKey`` / ``sessionToken``). Default ``None`` resolves
+            the config's credentials provider (NSIDC by default) at dispatch
+            time, exactly like ``agg``.
+        """
+        from zagg import runner
+
+        if isinstance(config, str):
+            config = load_config(config)
+        elif isinstance(config, dict):
+            config = load_config_from_dict(config)
+            validate_config(config)
+
+        # v1 scope gate: the spatial point path only. The other pipelines
+        # already run through agg()/zagg.notebook.run; refusing here beats a
+        # wrong fan-out (windowed units are (shard, window) pairs, not shards).
+        kind = get_pipeline_type(config)
+        if kind != "spatial":
+            raise NotImplementedError(
+                f"zagg.client v1 covers the spatial point path (got pipeline "
+                f"type {kind!r}); temporal runs go through zagg.runner.agg(events=...)"
+            )
+        if (config.data_source or {}).get("reader") == "raster":
+            raise NotImplementedError(
+                "zagg.client v1 covers the spatial point path (got reader: "
+                "raster); raster runs go through zagg.runner.agg / zagg.notebook.run"
+            )
+        if get_windowing(config) is not None:
+            raise NotImplementedError(
+                "zagg.client v1 dispatches one future per shard; windowed "
+                "configs fan out (shard, window) units — use zagg.runner.agg / "
+                "zagg.notebook.run until the v2 transport (issue #327)"
+            )
+
+        if isinstance(shardmap, dict):
+            catalog_data = shardmap
+            if not all(k in catalog_data for k in ("shard_keys", "granules", "grid_signature")):
+                raise ValueError(
+                    "shardmap dict is not a Phase-5 ShardMap (needs shard_keys "
+                    "+ granules + grid_signature)"
+                )
+        else:
+            catalog_path = shardmap or config.catalog
+            if not catalog_path:
+                raise ValueError("No shardmap specified (pass shardmap= or set catalog: in config)")
+            catalog_data = runner._load_catalog(catalog_path)
+
+        store_path = store or get_store_path(config)
+        if not store_path:
+            raise ValueError("No store path specified (pass store= or set output.store: in config)")
+        store_path = effective_store_root(store_path, config)
+        if not store_path.startswith("s3://"):
+            raise ValueError(f"Lambda dispatch requires an s3:// store path, got: {store_path}")
+
+        config_region = get_output_region(config)
+        if config_region and region == "us-west-2":
+            region = config_region
+
+        return cls(
+            config,
+            catalog_data,
+            store=store_path,
+            function_name=runner._resolve_function_name(config, function_name),
+            region=region,
+            lambda_client=lambda_client,
+            driver=driver or get_driver(config),
+            handoff=handoff if handoff is not None else get_handoff(config),
+            profile=profile,
+            max_retries=max_retries,
+            overwrite=overwrite,
+            output_credentials=output_credentials,
+            # Non-secret endpoint: runtime kwarg > config (mirrors agg).
+            output_endpoint_url=output_endpoint_url or get_output_endpoint_url(config),
+            source_credentials=source_credentials,
+        )
+
+    # -- shard selection ----------------------------------------------------
+
+    def _resolve_key(self, key) -> int:
+        """One requested shard key -> the shardmap's raw int key.
+
+        Ints pass through as raw shardmap keys (packed morton words for
+        HEALPix); strings are the external form — the decimal morton string
+        for HEALPix (issue #199), stringified ints otherwise.
+        """
+        if isinstance(key, str):
+            if self._grid_type == "healpix":
+                return morton_word(key)
+            return int(key)
+        return int(key)
+
+    def _select(self, shard_keys) -> list[tuple]:
+        """(shard_key, records) pairs to dispatch, biggest-work-first ordered."""
+        from zagg import runner
+
+        pairs = runner._select_cells(self.catalog_data)
+        if shard_keys is not None:
+            wanted = {self._resolve_key(k) for k in shard_keys}
+            missing = wanted - {int(k) for k, _ in pairs}
+            if missing:
+                raise ValueError(f"shard key(s) not in shardmap: {sorted(missing)}")
+            pairs = [(k, recs) for k, recs in pairs if int(k) in wanted]
+        return runner._lambda_dispatch_order(pairs)
+
+    # -- dispatch -----------------------------------------------------------
+
+    def dispatch(self, shard_keys=None, max_workers: int | None = None) -> RunHandle:
+        """Fan the shards out; return a :class:`RunHandle` of per-shard futures.
+
+        Returns as soon as the setup handshake completes (worker-side template
+        / manifest write — one short synchronous invoke; hive additionally
+        fail-fast-pings first): the fan-out itself runs on a background pool
+        and each shard's outcome arrives through its future.
+
+        Parameters
+        ----------
+        shard_keys : iterable, optional
+            Subset of shards to dispatch — raw int shardmap keys or external
+            string labels (decimal morton for HEALPix). Default all shards.
+        max_workers : int, optional
+            Pool width, clamped to the shard count. Default
+            :data:`_DEFAULT_MAX_WORKERS`; no account-concurrency probe runs
+            on this path (see the constant's note).
+        """
+        from zagg import runner
+
+        cells = self._select(shard_keys)
+        if not cells:
+            raise ValueError("no shards selected")
+        n = len(cells)
+        workers = min(max_workers or _DEFAULT_MAX_WORKERS, n)
+
+        client = self._lambda_client
+        invoked_by = None
+        if client is None:
+            import boto3
+            from botocore.config import Config
+
+            session = boto3.Session()
+            # read_timeout must exceed the 900 s function ceiling (same
+            # rationale as agg's preflight-built client, issue #148); the
+            # connection pool tracks the fan-out width.
+            client = session.client(
+                "lambda",
+                region_name=self.region,
+                config=Config(
+                    read_timeout=960,
+                    connect_timeout=10,
+                    retries={"max_attempts": 0},
+                    max_pool_connections=workers,
+                ),
+            )
+            invoked_by = runner._resolve_invoked_by(session, self.region)
+
+        # Pre-invoke cost ceiling (issue #298): displayed, never gated — the
+        # notebook path never blocks on cost (ratified on issue #298).
+        memory_gb = runner._worker_memory_gb(self.config)
+        ceiling = max_cost_usd(n, memory_gb, timeout_s=runner._DEFAULT_FUNCTION_TIMEOUT_S)
+        logger.info(
+            f"Max cost ceiling: ~${ceiling:.2f} ({n} units x {memory_gb:g} GB x "
+            f"{runner._DEFAULT_FUNCTION_TIMEOUT_S}s, {LAMBDA_ARCH})"
+        )
+
+        s3_creds = self._source_credentials or runner._resolve_source_credentials(self.config)
+        config_dict = asdict(self.config)
+        output_creds_event = runner._build_output_creds_event(
+            self._output_credentials, self._output_endpoint_url, self.region
+        )
+        run_id = uuid.uuid4().hex
+
+        # Setup handshake, synchronous and load-bearing (worker-side writes
+        # only — D8). Hive: fail-fast ping + fire-and-forget manifest write;
+        # finalize below is the idempotent backstop (issue #252 hybrid). Flat:
+        # the template write itself.
+        dataset = None
+        if get_store_layout(self.config) == "hive":
+            md = self.catalog_data.get("metadata") or {}
+            dataset = {"short_name": md.get("short_name"), "version": md.get("version")}
+            runner._invoke_lambda_ping(
+                client,
+                self.function_name,
+                self.store,
+                config_dict=config_dict,
+                dataset=dataset,
+                parent_order=self._parent_order,
+                overwrite=self.overwrite,
+                output_creds_event=output_creds_event,
+            )
+            runner._invoke_lambda_setup_async(
+                client,
+                self.function_name,
+                self.store,
+                config_dict=config_dict,
+                dataset=dataset,
+                parent_order=self._parent_order,
+                overwrite=self.overwrite,
+                output_creds_event=output_creds_event,
+            )
+        else:
+            runner._invoke_lambda_setup(
+                client,
+                self.function_name,
+                self.store,
+                parent_order=self._parent_order,
+                child_order=self._child_order,
+                overwrite=self.overwrite,
+                config_dict=config_dict,
+                output_creds_event=output_creds_event,
+            )
+
+        aoi_by_shard = runner._aoi_payload_map(self.catalog_data)
+        pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="zagg-client")
+        futures: dict[int, Future] = {}
+        for key, records in cells:
+            futures[int(key)] = pool.submit(
+                self._shard_work,
+                client,
+                int(key),
+                records,
+                config_dict=config_dict,
+                s3_creds=s3_creds,
+                output_creds_event=output_creds_event,
+                aoi_payload=aoi_by_shard.get(int(key)),
+                invoked_by=invoked_by,
+                run_id=run_id,
+                max_workers=workers,
+            )
+
+        handle = RunHandle(futures, store_path=self.store)
+        finisher = threading.Thread(
+            target=self._post_run,
+            args=(handle, client, pool, config_dict, dataset, output_creds_event, run_id),
+            name="zagg-client-finish",
+            daemon=True,
+        )
+        handle._finisher = finisher
+        finisher.start()
+        return handle
+
+    def _shard_work(
+        self,
+        client,
+        shard_key: int,
+        records: list,
+        *,
+        config_dict: dict,
+        s3_creds: dict,
+        output_creds_event: dict | None,
+        aoi_payload,
+        invoked_by: dict | None,
+        run_id: str,
+        max_workers: int,
+    ) -> dict:
+        """One synchronous shard invoke; the pool future over this IS the API.
+
+        Mirrors ``_run_lambda``'s ``_cell_work`` payload construction (labels,
+        granule-worker clamp, leaf sub-map) minus the async result channel —
+        v1 is the legacy sync ``RequestResponse`` path by design.
+        """
+        from zagg import runner
+
+        label = runner._safe_label(self.grid, shard_key)
+        granule_urls = runner._resolve_urls(records, self.driver)
+        ds = runner._clamped_data_source(dict(self.config.data_source), len(granule_urls))
+        cell_config = {**config_dict, "data_source": ds} if ds is not None else config_dict
+        submap = {
+            "grid_signature": self.catalog_data["grid_signature"],
+            "metadata": self.catalog_data.get("metadata"),
+            "granules": records,
+        }
+        result = runner._invoke_lambda_cell(
+            client,
+            self.grid.block_index(shard_key),
+            shard_key,
+            self._parent_order,
+            self._child_order,
+            granule_urls,
+            self.store,
+            s3_creds,
+            function_name=self.function_name,
+            config_dict=cell_config,
+            output_creds_event=output_creds_event,
+            max_retries=self.max_retries,
+            max_workers=max_workers,
+            handoff=self.handoff,
+            profile=self.profile,
+            aoi_payload=aoi_payload,
+            label=label,
+            invoked_by=invoked_by,
+            run_id=run_id,
+            submap=submap,
+        )
+        error = result.get("error")
+        if result.get("status_code") == 200 and not error:
+            return result
+        if error in _BENIGN_ERRORS:
+            # "Nothing to do" is a normal outcome, not a failure — matching
+            # _run_lambda's error counting (neither with_data nor error).
+            return result
+        detail = error or f"status {result.get('status_code')}"
+        raise ShardError(
+            f"shard {label}: {detail}",
+            shard_key=shard_key,
+            label=label,
+            payload=result,
+        )
+
+    def _post_run(
+        self,
+        handle: RunHandle,
+        client,
+        pool: ThreadPoolExecutor,
+        config_dict: dict,
+        dataset: dict | None,
+        output_creds_event: dict | None,
+        run_id: str,
+    ) -> None:
+        """After every shard settles: the same worker-invoke tail as ``agg``.
+
+        Finalize backstop (hive always — the idempotent manifest self-heal;
+        flat only under ``consolidate_metadata``), then the fail-open rollups:
+        root ``coverage.moc``, the run-stats record, and the sweep trigger —
+        each a fire-and-forget worker invoke (D8), each swallowed on failure
+        exactly like ``_run_lambda``'s tail. A finalize failure is recorded on
+        the handle and re-raised from :meth:`RunHandle.wait`.
+        """
+        from zagg import runner
+
+        futures = list(handle.futures.values())
+        futures_wait(futures)
+        results = []
+        for fut in futures:
+            exc = fut.exception()
+            if exc is None:
+                results.append(fut.result())
+            elif isinstance(exc, ShardError):
+                results.append(exc.payload)
+        layout = get_store_layout(self.config)
+        try:
+            if layout == "hive":
+                runner._invoke_lambda_finalize(
+                    client,
+                    self.function_name,
+                    self.store,
+                    output_creds_event=output_creds_event,
+                    config_dict=config_dict,
+                    dataset=dataset,
+                    parent_order=self._parent_order,
+                    overwrite=self.overwrite,
+                )
+            elif get_consolidate_metadata(self.config):
+                runner._invoke_lambda_finalize(
+                    client,
+                    self.function_name,
+                    self.store,
+                    output_creds_event=output_creds_event,
+                )
+        except Exception as e:
+            handle._finalize_error = e
+            logger.warning(f"finalize invoke failed (surfaced via handle.wait()): {e}")
+
+        ok_results = [r for r in results if r.get("status_code") == 200 and not r.get("error")]
+        if layout == "hive" and get_coverage_moc(self.config):
+            try:
+                from zagg.hive import build_root_coverage
+                from zagg.windows import union_time_range
+
+                done = [r["shard_key"] for r in ok_results]
+                # hive is HEALPix-only (validated), so parent_order is set here.
+                if done and self._parent_order is not None:
+                    envelope = build_root_coverage(
+                        done,
+                        int(self._parent_order),
+                        time_range=union_time_range(
+                            *(r.get("body", {}).get("time_range") for r in ok_results)
+                        ),
+                    )
+                    runner._invoke_lambda_coverage(
+                        client,
+                        self.function_name,
+                        self.store,
+                        envelope,
+                        output_creds_event=output_creds_event,
+                    )
+            except Exception as e:
+                logger.warning(f"root coverage.moc dispatch failed (fail-open, D9): {e}")
+
+        # Run-record + sweep, both fail-open (issues #297/#313/#300): sync
+        # transport -> no status prefix, so oversized row sets skip inside
+        # _dispatch_run_stats exactly like agg's invocation="sync" path.
+        stats_rows, stats_inline = runner._lambda_result_rows(results, run_id=run_id)
+        runner._dispatch_run_stats(
+            client,
+            self.function_name,
+            self.store,
+            stats_rows,
+            run_id=run_id,
+            result_prefix=None,
+            output_creds_event=output_creds_event,
+            store_kwargs=runner._output_store_kwargs(output_creds_event, self.region),
+            inline_rows=stats_inline,
+        )
+        if layout == "hive" and get_sweep(self.config):
+            try:
+                from zagg.sweep import leaves_from_stats_records
+
+                leaves = leaves_from_stats_records(
+                    [(r.get("body") or {}).get("stats") for r in ok_results]
+                )
+                if leaves:
+                    runner._invoke_lambda_sweep(
+                        client,
+                        self.function_name,
+                        self.store,
+                        leaves,
+                        output_creds_event=output_creds_event,
+                    )
+            except Exception as e:
+                logger.warning(f"rollup sweep dispatch failed (fail-open, D9): {e}")
+        pool.shutdown(wait=False)

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -632,15 +632,10 @@ class Run:
         granule-worker clamp, leaf sub-map) minus the async result channel —
         v1 is the legacy sync ``RequestResponse`` path by design.
 
-        One deliberate divergence (review finding, PR #333): the url selection
-        below honors ``data_source.driver``, where ``_cell_work`` hardcodes
-        ``"s3"`` (``_run_lambda`` takes no ``driver`` at all — ``agg`` forwards
-        it only to ``_run_local``). The worker picks its driver from that same
-        config key (``processing/worker.py``) and ``processing/read.py`` passes
-        an https url through unrewritten, so honoring it is the more correct
-        behavior; whether ``_run_lambda`` should be fixed to match is an open
-        question on PR #333. Pinned both ways in
-        ``TestRunnerParity.test_driver_https_is_the_one_deliberate_divergence``.
+        The url selection honors ``data_source.driver`` — as does ``_cell_work``
+        since the espg ruling on PR #333 (it hardcoded ``"s3"`` before), so the
+        two paths build identical events for an ``https`` config too;
+        ``TestRunnerParity`` asserts that field-by-field.
         """
         from zagg import runner
 

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -231,7 +231,13 @@ class RunHandle:
         running at ``timeout``.
 
         Draining a harvest iterator already joins the tail, so ``wait`` is for
-        explicit control.
+        explicit control. Size ``timeout`` off the tail's own floor, not the
+        shard work: the run-stats leg fires its Event invoke, then *verifies*
+        the parquet landed over a read-only poll window
+        (``runner._RUN_STATS_VERIFY_WINDOW_S``, 20 s as shipped) and re-fires
+        once if it has not — so even a fully successful run can spend ~2x that
+        window here. Anything under ~40 s risks a false ``TimeoutError``; pass
+        ``None`` to just block (review finding, PR #333).
         """
         if self._finisher is not None:
             self._finisher.join(timeout)

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -131,6 +131,7 @@ class RunHandle:
         self.store_path = store_path
         self._finisher: threading.Thread | None = None
         self._finalize_error: BaseException | None = None
+        self._tail_error: BaseException | None = None
 
     def __len__(self) -> int:
         return len(self.futures)
@@ -224,8 +225,10 @@ class RunHandle:
 
         Re-raises a failed finalize backstop (the manifest is required
         reader-facing schema, D6); the coverage/stats/sweep rollups are
-        fail-open by design and never raise here. Raises ``TimeoutError``
-        when the tail is still running at ``timeout``.
+        fail-open by design and never raise here, but an exception in the
+        tail's own plumbing does surface (it would otherwise vanish into the
+        finisher thread). Raises ``TimeoutError`` when the tail is still
+        running at ``timeout``.
 
         Draining a harvest iterator already joins the tail, so ``wait`` is for
         explicit control.
@@ -247,8 +250,12 @@ class RunHandle:
         self._raise_tail_error()
 
     def _raise_tail_error(self) -> None:
+        # Finalize first: it is the D6 manifest backstop, a strictly more
+        # load-bearing failure than a crashed fail-open rollup leg.
         if self._finalize_error is not None:
             raise self._finalize_error
+        if self._tail_error is not None:
+            raise self._tail_error
 
 
 class Run:
@@ -678,6 +685,31 @@ class Run:
         output_creds_event: dict | None,
         run_id: str,
     ) -> None:
+        """Finisher-thread entry point: run the tail, never lose its failure.
+
+        Anything the tail raises outside its own fail-open guards would
+        otherwise die in ``threading.excepthook`` while ``wait()`` reported a
+        clean run, so it is recorded on the handle as ``_tail_error`` (kept
+        distinct from the D6-load-bearing ``_finalize_error``) and the pool is
+        shut down either way (review finding, PR #333).
+        """
+        try:
+            self._run_tail(handle, client, config_dict, dataset, output_creds_event, run_id)
+        except BaseException as e:
+            handle._tail_error = e
+            logger.warning(f"post-run tail failed (surfaced via handle.wait()): {e}")
+        finally:
+            pool.shutdown(wait=False)
+
+    def _run_tail(
+        self,
+        handle: RunHandle,
+        client,
+        config_dict: dict,
+        dataset: dict | None,
+        output_creds_event: dict | None,
+        run_id: str,
+    ) -> None:
         """After every shard settles: the same worker-invoke tail as ``agg``.
 
         Finalize backstop (hive always — the idempotent manifest self-heal;
@@ -780,4 +812,3 @@ class Run:
                     )
             except Exception as e:
                 logger.warning(f"rollup sweep dispatch failed (fail-open, D9): {e}")
-        pool.shutdown(wait=False)

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import logging
 import threading
 import uuid
+import warnings
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from concurrent.futures import wait as futures_wait
 from dataclasses import asdict
@@ -80,11 +81,12 @@ from zagg.hive import effective_store_root
 
 logger = logging.getLogger(__name__)
 
-#: Fan-out width when ``dispatch(max_workers=...)`` is not given. Deliberately
-#: modest: the v1 sync transport holds one connection per in-flight shard and
-#: this path runs no account-concurrency probe (unlike ``agg``'s preflight,
-#: which clamps against account limits before sizing the pool) — fine at
-#: notebook/NEON scale; pass ``max_workers`` explicitly for bigger fan-outs.
+#: Fallback fan-out width: used when ``dispatch(max_workers=...)`` is not given
+#: AND the account-concurrency preflight cannot run (a custom ``lambda_client``
+#: is injected, or the probe was denied — see :meth:`Run._probe_workers`).
+#: Deliberately modest, since the v1 sync transport holds one connection per
+#: in-flight shard: fine at notebook/NEON scale, and ``max_workers`` is the
+#: explicit override for bigger fan-outs.
 _DEFAULT_MAX_WORKERS = 64
 
 
@@ -367,8 +369,11 @@ class Run:
             An injected boto3 Lambda client (testability / custom botocore
             config). Default ``None`` builds one per dispatch, sized to the
             fan-out (``read_timeout`` above the 900 s function ceiling). With
-            an injected client no STS caller-identity probe runs, so worker
-            stats records carry a null ``invoked_by`` (fail-open, issue #297).
+            an injected client neither the STS caller-identity probe nor the
+            account-concurrency preflight runs, so worker stats records carry a
+            null ``invoked_by`` (fail-open, issue #297) and the fan-out falls
+            back to :data:`_DEFAULT_MAX_WORKERS` unless ``max_workers`` is
+            given — a stub client must not have to answer either probe.
         driver, handoff, profile, max_retries, overwrite,
         output_credentials, output_endpoint_url
             Same semantics as the matching :func:`zagg.runner.agg` kwargs.
@@ -479,6 +484,45 @@ class Run:
 
     # -- dispatch -----------------------------------------------------------
 
+    def _probe_workers(self, session, n: int) -> int:
+        """Account-concurrency preflight, degrading to the default on denial.
+
+        Runs ``agg``'s own :func:`~zagg.concurrency.compute_available_workers`
+        (local FD ceiling ∩ account-wide Lambda headroom) against the work
+        size, so a notebook fan-out is sized by what the account can actually
+        take rather than by a hardcoded guess (espg ruling on PR #333: whoever
+        can invoke the workers normally can read the concurrency too).
+
+        Fail-open by design: ANY probe failure — ``AccessDenied`` under a
+        narrow-permission deployment (the cryocloud case, where the worker role
+        holds the perms and the caller only deploys), missing CloudWatch
+        permissions, a throttle — falls back to :data:`_DEFAULT_MAX_WORKERS`
+        with a ``warnings.warn`` naming the denial. A run the caller is allowed
+        to dispatch must not fail on an optional preflight read. Skipped
+        entirely when ``max_workers`` is explicit or a client was injected.
+        """
+        from zagg import runner
+
+        try:
+            workers, report = runner.compute_available_workers(
+                n,
+                session.client("lambda", region_name=self.region),
+                session.client("cloudwatch", region_name=self.region),
+                self.function_name,
+            )
+            runner._log_concurrency_report(report, workers)
+            return workers
+        except Exception as e:
+            warnings.warn(
+                f"account-concurrency preflight failed ({type(e).__name__}: {e}); "
+                f"sizing the fan-out at the default max_workers="
+                f"{_DEFAULT_MAX_WORKERS} instead. Pass max_workers= to set it "
+                f"explicitly and skip the probe.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+            return _DEFAULT_MAX_WORKERS
+
     def dispatch(self, shard_keys=None, max_workers: int | None = None) -> RunHandle:
         """Fan the shards out; return a :class:`RunHandle` of per-shard futures.
 
@@ -493,9 +537,10 @@ class Run:
             Subset of shards to dispatch — raw int shardmap keys or external
             string labels (decimal morton for HEALPix). Default all shards.
         max_workers : int, optional
-            Pool width, clamped to the shard count. Default
-            :data:`_DEFAULT_MAX_WORKERS`; no account-concurrency probe runs
-            on this path (see the constant's note).
+            Pool width, clamped to the shard count. An explicit value wins
+            verbatim and skips the preflight probe; omitted, the account
+            concurrency probe sizes the pool (see :meth:`_probe_workers`) and
+            :data:`_DEFAULT_MAX_WORKERS` is the fallback when it cannot run.
         """
         from zagg import runner
 
@@ -503,15 +548,20 @@ class Run:
         if not cells:
             raise ValueError("no shards selected")
         n = len(cells)
-        workers = min(max_workers or _DEFAULT_MAX_WORKERS, n)
 
         client = self._lambda_client
         invoked_by = None
-        if client is None:
+        if client is not None:
+            # Injected client (the test seam): no probe, no STS — a stub must
+            # not need to answer GetAccountSettings or get-caller-identity.
+            workers = min(max_workers or _DEFAULT_MAX_WORKERS, n)
+        else:
             import boto3
             from botocore.config import Config
 
             session = boto3.Session()
+            requested = max_workers if max_workers is not None else self._probe_workers(session, n)
+            workers = max(1, min(requested, n))
             # read_timeout must exceed the 900 s function ceiling (same
             # rationale as agg's preflight-built client, issue #148); the
             # connection pool tracks the fan-out width.

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -626,6 +626,16 @@ class Run:
         Mirrors ``_run_lambda``'s ``_cell_work`` payload construction (labels,
         granule-worker clamp, leaf sub-map) minus the async result channel —
         v1 is the legacy sync ``RequestResponse`` path by design.
+
+        One deliberate divergence (review finding, PR #333): the url selection
+        below honors ``data_source.driver``, where ``_cell_work`` hardcodes
+        ``"s3"`` (``_run_lambda`` takes no ``driver`` at all — ``agg`` forwards
+        it only to ``_run_local``). The worker picks its driver from that same
+        config key (``processing/worker.py``) and ``processing/read.py`` passes
+        an https url through unrewritten, so honoring it is the more correct
+        behavior; whether ``_run_lambda`` should be fixed to match is an open
+        question on PR #333. Pinned both ways in
+        ``TestRunnerParity.test_driver_https_is_the_one_deliberate_divergence``.
         """
         from zagg import runner
 

--- a/src/zagg/dispatch.py
+++ b/src/zagg/dispatch.py
@@ -335,6 +335,13 @@ LAMBDA_PRICE_PER_GB_SEC_BY_ARCH = {"arm64": 0.0000133334}
 LAMBDA_MEMORY_GB = 4.0  # issue #193: production worker sized to 4 GB (2.3 vCPU)
 LAMBDA_PRICE_PER_GB_SEC = LAMBDA_PRICE_PER_GB_SEC_BY_ARCH[LAMBDA_ARCH]
 
+#: Worker errors that mean "nothing to do", not "something broke": counted
+#: neither as data nor as an error by the dispatch accounting, kept out of the
+#: notebook failures table, and resolved (not raised) by ``zagg.client``. One
+#: definition for all three -- it used to be duplicated in ``notebook`` and
+#: inlined in ``runner`` (review finding, PR #333).
+BENIGN_ERRORS = ("No granules found", "No data after filtering")
+
 
 def max_cost_usd(
     n_units: int,

--- a/src/zagg/notebook.py
+++ b/src/zagg/notebook.py
@@ -21,7 +21,7 @@ import html
 import logging
 
 from zagg.config import PipelineConfig, get_pipeline_type, get_store_layout, get_windowing
-from zagg.dispatch import LAMBDA_ARCH, max_cost_usd
+from zagg.dispatch import BENIGN_ERRORS, LAMBDA_ARCH, max_cost_usd
 
 logger = logging.getLogger(__name__)
 
@@ -180,10 +180,6 @@ def _make_progress(total: int, desc: str = "shards"):
 # Run wrapper + report view
 # ---------------------------------------------------------------------------
 
-#: Errors that mean "nothing to do", not "something broke" -- excluded from the
-#: failures table, matching ``_run_lambda``'s error counting.
-_BENIGN_ERRORS = ("No granules found", "No data after filtering")
-
 #: Row cap for the per-shard table in ``_repr_html_``; full detail stays in
 #: ``summary["results"]``.
 _HTML_MAX_ROWS = 20
@@ -216,7 +212,7 @@ class RunView:
         rows = []
         for r in self.summary.get("results") or []:
             error = r.get("error")
-            if error and str(error) not in _BENIGN_ERRORS:
+            if error and str(error) not in BENIGN_ERRORS:
                 rows.append(r)
         return rows
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -48,6 +48,7 @@ from zagg.config import (
     get_windowing,
 )
 from zagg.dispatch import (
+    BENIGN_ERRORS,
     LAMBDA_ARCH,
     LAMBDA_MEMORY_GB,
     LAMBDA_PRICE_PER_GB_SEC,
@@ -3402,7 +3403,7 @@ def _run_lambda(
             obs = result.get("body", {}).get("total_obs", 0)
             report.total_obs += obs
             report.cells_with_data += 1
-        elif error not in ("No granules found", "No data after filtering"):
+        elif error not in BENIGN_ERRORS:
             report.cells_error += 1
             key = result.get("shard_key")
             # _safe_label: error reporting must not raise on the bad key itself.

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -182,7 +182,13 @@ def agg(
     driver : str, optional
         Data access driver: ``"s3"`` (direct S3, us-west-2 only) or
         ``"https"`` (HTTPS, works anywhere). Overrides
-        ``config.data_source.driver``. Default ``"s3"``.
+        ``config.data_source.driver``. Default ``"s3"``. Honored on **both**
+        backends: the lambda backend selects each cell event's granule href
+        with it, so a catalog carrying an https substitute for an unreadable s3
+        object (requester-pays, cross-region) is ingestible as an explicit
+        override (espg ruling on PR #333; the Lambda path previously always
+        resolved the s3 href while the worker still built its driver from the
+        config key).
     max_cells : int, optional
         Limit number of cells to process (for testing).
     morton_cell : str, optional
@@ -454,6 +460,7 @@ class SpatialStrategy:
                 dry_run=dry_run,
                 region=region,
                 function_name=function_name,
+                driver=resolved_driver,
                 output_credentials=output_credentials,
                 output_endpoint_url=resolved_endpoint,
                 handoff=resolved_handoff,
@@ -3007,6 +3014,7 @@ def _run_lambda(
     dry_run,
     region,
     function_name,
+    driver="s3",
     output_credentials=None,
     output_endpoint_url=None,
     handoff="arrow",
@@ -3017,6 +3025,11 @@ def _run_lambda(
     on_progress=None,
 ):
     """Run processing via AWS Lambda invocation.
+
+    ``driver`` is the resolved data-access driver (kwarg > config, same value
+    ``_run_local`` gets): it selects which catalog href each cell event carries.
+    Defaults to ``"s3"`` — the pre-#333 hardcoded behavior — so a direct caller
+    that omits it is unchanged.
 
     The fan-out -> retry -> measured-cost loop is the generic
     :func:`zagg.dispatch.dispatch`; this function owns the Lambda-specific
@@ -3222,7 +3235,14 @@ def _run_lambda(
         # Clamp on the RESOLVED url count — what the worker actually reads —
         # since _resolve_urls drops href-less records (review finding,
         # PR #187).
-        granule_urls = _resolve_urls(records, "s3")
+        # ``driver`` (espg ruling on PR #333) selects the href: s3 dominates,
+        # but a catalog may carry an https substitute for an s3 object this
+        # account cannot (or should not) read — requester-pays, cross-region —
+        # and the worker already picks HTTPDriver off the same config key
+        # (processing/worker.py:250-254), so an explicit override has to reach
+        # the url selection. Was hardcoded "s3" while ``agg`` resolved driver
+        # for _run_local only, which handed s3:// urls to an HTTP driver.
+        granule_urls = _resolve_urls(records, driver)
         ds = _clamped_data_source(config.data_source, len(granule_urls))
         cell_config_dict = {**config_dict, "data_source": ds} if ds is not None else config_dict
         # Leaf sub-map fields (issue #300, D22): the worker writes the full

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ tests exercise the real payload construction, future resolution, error
 surfacing, and the worker-invoke post-run tail.
 """
 
+import errno
 import importlib
 import json
 import sys
@@ -362,6 +363,46 @@ class TestFutures:
         # try/finally ran: the pool refuses new work.
         with pytest.raises(RuntimeError, match="shutdown"):
             pools[0].submit(len, "")
+
+    def test_transport_exception_still_gets_a_failure_row(self, catalog, monkeypatch):
+        # Regression (review finding, PR #333): a shard failing with something
+        # other than ShardError — fd exhaustion here, likewise the payload-cap
+        # ValueError or a botocore error escaping the retry loop — contributed
+        # no run-stats row at all, vanishing from telemetry while status() still
+        # counted it failed.
+        from zagg import runner
+
+        real_rows = runner._lambda_result_rows
+        captured: dict = {}
+
+        def _capture(results, *, run_id=None):
+            out = real_rows(results, run_id=run_id)
+            captured["rows"] = out[0]
+            return out
+
+        monkeypatch.setattr(runner, "_lambda_result_rows", _capture)
+
+        class _FdExhaustedStub(StubLambdaClient):
+            def invoke(self, **kwargs):
+                event = json.loads(kwargs["Payload"])
+                if event.get("mode") is None and event["shard_key"] == _WORDS[0]:
+                    # What botocore surfaces at the fd ceiling; runner's
+                    # raise_for_fd_exhaustion re-raises it past the retry loop.
+                    raise OSError(errno.EMFILE, "Too many open files")
+                return super().invoke(**kwargs)
+
+        handle = _run(catalog, client=_FdExhaustedStub()).dispatch()
+        with pytest.raises(OSError, match="Too many open files"):
+            handle.futures[_WORDS[0]].result()
+        mapped = handle.results(return_exceptions=True)  # also joins the tail
+        assert isinstance(mapped[_WORDS[0]], OSError)
+        assert handle.status() == {"pending": 0, "ok": 2, "failed": 1}
+        # All three shards are in the run record, the dropped one as a failure.
+        rows = captured["rows"]
+        assert sorted(r["shard_key"] for r in rows) == sorted(_WORDS)
+        (bad,) = [r for r in rows if r["shard_key"] == _WORDS[0]]
+        assert bad["success"] is False
+        assert "Too many open files" in bad["error"]
 
     def test_finalize_failure_wins_over_a_tail_crash(self, catalog, monkeypatch):
         # Two distinct channels: the D6 manifest backstop failure is the one

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -333,7 +333,9 @@ class TestRunnerParity:
     Spot-checking hand-picked keys cannot catch a divergence the facade grows
     later, so drive the SAME config + shardmap through ``runner.agg(backend=
     "lambda", invocation="sync")`` against an equivalent stub and compare the
-    cell events field-by-field.
+    cell events field-by-field — with **no carve-outs** now that
+    ``_run_lambda`` threads ``driver`` too (espg ruling on PR #333): the
+    ``driver: s3`` and ``driver: https`` configs both have to match whole.
     """
 
     @staticmethod
@@ -382,10 +384,15 @@ class TestRunnerParity:
         )
         return {e["shard_key"]: e for _, _, e in stub.cell_events()}
 
-    def test_cell_events_match_the_runner_lambda_path(self, catalog, catalog_file, monkeypatch):
-        agg_events = self._agg_cell_events(catalog_file, monkeypatch)
+    @pytest.mark.parametrize("driver", ["s3", "https"])
+    def test_cell_events_match_the_runner_lambda_path(
+        self, catalog, catalog_file, monkeypatch, driver
+    ):
+        cfg = default_config("atl06")
+        cfg.data_source["driver"] = driver
+        agg_events = self._agg_cell_events(catalog_file, monkeypatch, cfg=cfg)
         stub = StubLambdaClient()
-        _run(catalog, client=stub).dispatch().results()
+        _run(catalog, client=stub, config=cfg).dispatch().results()
         client_events = {e["shard_key"]: e for _, _, e in stub.cell_events()}
 
         assert set(client_events) == set(agg_events) == set(_WORDS)
@@ -394,36 +401,12 @@ class TestRunnerParity:
             # run_id is a fresh uuid per dispatch by construction; both paths
             # carry one and the worker only echoes it into the stats record.
             assert mine.pop("run_id") and theirs.pop("run_id")
-            assert mine == theirs
-
-    def test_driver_https_is_the_one_deliberate_divergence(
-        self, catalog, catalog_file, monkeypatch
-    ):
-        # The facade resolves granule_urls through the config's data_source
-        # driver; runner._cell_work hardcodes "s3" (_run_lambda takes no driver
-        # at all), so a `driver: https` config is the ONE field where the two
-        # paths differ. Kept deliberately — the worker selects HTTPDriver from
-        # that same config key (processing/worker.py) and read.py passes an
-        # https url through unrewritten, so agg's lambda path hands s3:// urls
-        # to an HTTP driver. Pinned here in both directions; whether _run_lambda
-        # should be fixed to match is an espg call (PR #333 "Questions for
-        # review").
-        cfg = default_config("atl06")
-        cfg.data_source["driver"] = "https"
-        agg_events = self._agg_cell_events(catalog_file, monkeypatch, cfg=cfg)
-        stub = StubLambdaClient()
-        _run(catalog, client=stub, config=cfg).dispatch().results()
-        client_events = {e["shard_key"]: e for _, _, e in stub.cell_events()}
-
-        key = _WORDS[1]
-        assert client_events[key]["granule_urls"] == [_rec(3)["https"]]
-        assert agg_events[key]["granule_urls"] == [_rec(3)["s3"]]
-        # granule_urls is the ONLY divergence: everything else still matches.
-        mine, theirs = dict(client_events[key]), dict(agg_events[key])
-        for ev in (mine, theirs):
-            ev.pop("granule_urls")
-            ev.pop("run_id")
-        assert mine == theirs
+            assert mine == theirs  # every other field, both drivers
+        # And the driver actually moved the href — otherwise the equality above
+        # would pass on two identically-wrong url lists.
+        href = _rec(3)["s3"] if driver == "s3" else _rec(3)["https"]
+        assert client_events[_WORDS[1]]["granule_urls"] == [href]
+        assert agg_events[_WORDS[1]]["granule_urls"] == [href]
 
 
 # -- futures -----------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,388 @@
+"""Tests for the zagg.client facade (issue #326): Run / RunHandle / ShardError.
+
+All Lambda traffic goes through a stub client object (no moto, no network):
+the stub records every invoke and answers per-mode canned envelopes, so the
+tests exercise the real payload construction, future resolution, error
+surfacing, and the worker-invoke post-run tail.
+"""
+
+import importlib
+import json
+import sys
+import threading
+import time
+
+import pytest
+
+import zagg.client
+from zagg.client import Run, RunHandle, ShardError
+from zagg.config import PipelineConfig, default_config
+
+# -- fixtures ----------------------------------------------------------------
+
+# HealpixGrid(parent_order=6, child_order=12, layout="fullsphere").signature();
+# packed morton words whose decimal morton labels (the external form, issue
+# #199) are -4211324 / -4211323 / -4211322. Mirrors tests/test_runner.py.
+_ATL06_SIG = {
+    "type": "healpix",
+    "indexing_scheme": "nested",
+    "parent_order": 6,
+    "child_order": 12,
+    "layout": "fullsphere",
+}
+_WORDS = [11828422946311897094, 11828141471335186438, 11827859996358475782]
+_LABELS = ["-4211324", "-4211323", "-4211322"]
+
+_CREDS = {"accessKeyId": "AK", "secretAccessKey": "SK", "sessionToken": "TK"}
+_STORE = "s3://test-bucket/out.zarr"
+
+
+def _rec(n):
+    return {"id": f"g{n}", "s3": f"s3://bucket/granule{n}.h5", "https": f"https://h/granule{n}.h5"}
+
+
+def _catalog_dict():
+    return {
+        "metadata": {"short_name": "ATL06", "version": "006"},
+        "grid_signature": dict(_ATL06_SIG),
+        "shard_keys": list(_WORDS),
+        "granules": [[_rec(4), _rec(5), _rec(6)], [_rec(3)], [_rec(1), _rec(2)]],
+    }
+
+
+@pytest.fixture
+def catalog():
+    return _catalog_dict()
+
+
+@pytest.fixture
+def catalog_file(tmp_path, catalog):
+    p = tmp_path / "shardmap.json"
+    p.write_text(json.dumps(catalog))
+    return str(p)
+
+
+@pytest.fixture(autouse=True)
+def _no_stats_verify(monkeypatch):
+    # The post-run tail's run-stats invoke verifies the parquet landed with a
+    # read-only poll (issue #313); zero window skips it so the finisher thread
+    # never opens a (fake) store.
+    from zagg import runner
+
+    monkeypatch.setattr(runner, "_RUN_STATS_VERIFY_WINDOW_S", 0)
+
+
+class _Payload:
+    def __init__(self, raw: bytes):
+        self._raw = raw
+
+    def read(self):
+        return self._raw
+
+
+def _envelope(body: dict, status=200):
+    raw = json.dumps({"statusCode": status, "body": json.dumps(body)}).encode()
+    return {"Payload": _Payload(raw), "FunctionError": None}
+
+
+class StubLambdaClient:
+    """boto3-Lambda-shaped stub: records invokes, answers canned envelopes."""
+
+    def __init__(self, *, fail=(), benign=(), timeout=(), delays=None):
+        self.events: list[tuple[str, str, dict]] = []
+        self._lock = threading.Lock()
+        self._fail = set(fail)
+        self._benign = set(benign)
+        self._timeout = set(timeout)
+        self._delays = delays or {}
+        self.gate: threading.Event | None = None  # holds cell invokes open
+
+    def invoke(self, **kwargs):
+        event = json.loads(kwargs["Payload"])
+        with self._lock:
+            self.events.append((kwargs["FunctionName"], kwargs["InvocationType"], event))
+        if event.get("mode") is not None:  # ping/setup/finalize/coverage/stats/sweep
+            return _envelope({"zagg_version": "stub"})
+        key = event["shard_key"]
+        if self.gate is not None:
+            self.gate.wait(5)
+        time.sleep(self._delays.get(key, 0))
+        if key in self._timeout:
+            return {
+                "Payload": _Payload(b"Task timed out after 900.00 seconds"),
+                "FunctionError": "Unhandled",
+            }
+        if key in self._fail:
+            return _envelope({"error": "boom"}, status=500)
+        if key in self._benign:
+            return _envelope({"error": "No granules found"})
+        return _envelope({"total_obs": 7, "duration_s": 1.5})
+
+    def cell_events(self):
+        return [(n, t, e) for n, t, e in self.events if e.get("mode") is None]
+
+    def modes(self):
+        return [e.get("mode") for _, _, e in self.events]
+
+
+def _run(catalog, *, client, config=None, **kwargs):
+    return Run.from_config(
+        config if config is not None else default_config("atl06"),
+        shardmap=catalog,
+        store=_STORE,
+        function_name="process-shard-test",
+        lambda_client=client,
+        source_credentials=_CREDS,
+        **kwargs,
+    )
+
+
+# -- construction ------------------------------------------------------------
+
+
+class TestFromConfig:
+    def test_shardmap_path_and_dict_are_equivalent(self, catalog, catalog_file):
+        stub = StubLambdaClient()
+        by_dict = _run(catalog, client=stub)
+        by_path = _run(catalog_file, client=stub)
+        assert len(by_dict) == len(by_path) == 3
+        assert by_dict.store == by_path.store == _STORE
+
+    def test_config_dict_is_loaded_and_validated(self, catalog):
+        from dataclasses import asdict
+
+        cfg_dict = asdict(default_config("atl06"))
+        run = _run(catalog, client=StubLambdaClient(), config=cfg_dict)
+        assert isinstance(run.config, PipelineConfig)
+
+    def test_config_yaml_path(self, tmp_path, catalog):
+        from dataclasses import asdict
+
+        import yaml
+
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml.safe_dump(asdict(default_config("atl06"))))
+        run = _run(catalog, client=StubLambdaClient(), config=str(p))
+        assert run.function_name == "process-shard-test"
+
+    def test_store_falls_back_to_config(self, catalog):
+        cfg = default_config("atl06")
+        cfg.output["store"] = "s3://cfg-bucket/cfg.zarr"
+        run = Run.from_config(cfg, shardmap=catalog, lambda_client=StubLambdaClient())
+        assert run.store == "s3://cfg-bucket/cfg.zarr"
+
+    def test_missing_shardmap_raises(self):
+        with pytest.raises(ValueError, match="No shardmap"):
+            Run.from_config(default_config("atl06"), store=_STORE)
+
+    def test_missing_store_raises(self, catalog):
+        with pytest.raises(ValueError, match="No store path"):
+            Run.from_config(default_config("atl06"), shardmap=catalog)
+
+    def test_non_s3_store_raises(self, catalog):
+        with pytest.raises(ValueError, match="s3://"):
+            Run.from_config(default_config("atl06"), shardmap=catalog, store="./local.zarr")
+
+    def test_grid_signature_mismatch_raises(self, catalog):
+        cfg = default_config("atl06")
+        cfg.output["grid"]["parent_order"] = 7
+        with pytest.raises(ValueError, match="different grid"):
+            Run.from_config(cfg, shardmap=catalog, store=_STORE)
+
+    def test_non_phase5_shardmap_dict_raises(self):
+        with pytest.raises(ValueError, match="Phase-5"):
+            Run.from_config(default_config("atl06"), shardmap={"shard_keys": []}, store=_STORE)
+
+    def test_temporal_config_refused(self):
+        cfg = PipelineConfig(pipeline={"type": "temporal"})
+        with pytest.raises(NotImplementedError, match="temporal"):
+            Run.from_config(cfg, shardmap={}, store=_STORE)
+
+    def test_raster_config_refused(self, catalog):
+        cfg = default_config("atl06")
+        cfg.data_source["reader"] = "raster"
+        with pytest.raises(NotImplementedError, match="raster"):
+            Run.from_config(cfg, shardmap=catalog, store=_STORE)
+
+    def test_windowed_config_refused(self, catalog):
+        cfg = default_config("atl06")
+        cfg.output["windowing"] = {
+            "schedule": "explicit",
+            "time_field": "delta_time",
+            "epoch": "2018-01-01T00:00:00Z",
+            "windows": [
+                {"label": "w1", "start": "2020-01-01T00:00:00Z", "end": "2021-01-01T00:00:00Z"}
+            ],
+        }
+        with pytest.raises(NotImplementedError, match="windowed"):
+            Run.from_config(cfg, shardmap=catalog, store=_STORE)
+
+
+# -- dispatch fan-out --------------------------------------------------------
+
+
+class TestDispatch:
+    def test_fanout_one_sync_invoke_per_shard(self, catalog):
+        stub = StubLambdaClient()
+        handle = _run(catalog, client=stub).dispatch()
+        assert isinstance(handle, RunHandle)
+        assert len(handle) == 3
+        assert set(handle.futures) == set(_WORDS)
+        results = handle.results()
+        assert all(r["body"]["total_obs"] == 7 for r in results.values())
+        cells = stub.cell_events()
+        assert len(cells) == 3
+        # v1 transport: the existing synchronous RequestResponse invoke, no
+        # async result channel (issue #326 / ratified on #265).
+        assert all(t == "RequestResponse" for _, t, _ in cells)
+        assert all("result_url" not in e for _, _, e in cells)
+        assert all(n == "process-shard-test" for n, _, _ in cells)
+
+    def test_cell_event_payload_shape(self, catalog):
+        stub = StubLambdaClient()
+        handle = _run(catalog, client=stub).dispatch(shard_keys=[_WORDS[1]])
+        handle.results()
+        (_, _, event) = stub.cell_events()[0]
+        assert event["shard_key"] == _WORDS[1]
+        assert event["granule_urls"] == [_rec(3)["s3"]]
+        assert event["store_path"] == _STORE
+        assert event["s3_credentials"]["accessKeyId"] == "AK"
+        assert event["config"]["output"]["grid"]["parent_order"] == 6
+        assert event["handoff"] == "arrow"
+        assert event["run_id"]
+        assert event["submap"]["granules"] == [_rec(3)]
+
+    def test_hive_setup_handshake_precedes_cells(self, catalog):
+        stub = StubLambdaClient()
+        _run(catalog, client=stub).dispatch().wait(timeout=10)
+        modes = stub.modes()
+        first_cell = modes.index(None)
+        assert modes[:first_cell] == ["ping", "setup"]  # fail-fast ping, then manifest write
+        setup_invocations = [(t, e["mode"]) for _, t, e in stub.events if e.get("mode")]
+        assert ("RequestResponse", "ping") in setup_invocations
+        assert ("Event", "setup") in setup_invocations
+        # Post-run tail (all worker invokes, D8): finalize backstop + fail-open
+        # coverage/stats rollups.
+        assert "finalize" in modes
+        assert "stats" in modes
+        assert "coverage" in modes
+
+    def test_flat_setup_and_no_finalize_by_default(self, catalog):
+        cfg = default_config("atl06")
+        cfg.output["store_layout"] = "flat"
+        stub = StubLambdaClient()
+        _run(catalog, client=stub, config=cfg).dispatch().wait(timeout=10)
+        modes = stub.modes()
+        assert modes[0] == "setup"
+        assert stub.events[0][1] == "RequestResponse"  # flat template write is sync
+        assert stub.events[0][2]["child_order"] == 12
+        assert "ping" not in modes
+        assert "finalize" not in modes  # consolidate_metadata defaults off (issue #191)
+
+    def test_shard_keys_subset_by_label_and_int(self, catalog):
+        stub = StubLambdaClient()
+        run = _run(catalog, client=stub)
+        by_label = run.dispatch(shard_keys=[_LABELS[2]])
+        assert set(by_label.futures) == {_WORDS[2]}
+        by_int = run.dispatch(shard_keys=[_WORDS[0], _WORDS[1]])
+        assert set(by_int.futures) == {_WORDS[0], _WORDS[1]}
+        by_label.results(), by_int.results()
+
+    def test_unknown_shard_key_raises(self, catalog):
+        run = _run(catalog, client=StubLambdaClient())
+        with pytest.raises(ValueError, match="not in shardmap"):
+            run.dispatch(shard_keys=[123])
+
+
+# -- futures -----------------------------------------------------------------
+
+
+class TestFutures:
+    def test_as_completed_yields_in_completion_order(self, catalog):
+        slow = {_WORDS[0]: 0.25, _WORDS[1]: 0.25}
+        stub = StubLambdaClient(delays=slow)
+        handle = _run(catalog, client=stub).dispatch(max_workers=3)
+        first = next(iter(handle.as_completed()))
+        assert first is handle.futures[_WORDS[2]]  # the undelayed shard lands first
+        handle.results()
+
+    def test_error_payload_surfaces_as_shard_error(self, catalog):
+        stub = StubLambdaClient(fail={_WORDS[1]})
+        handle = _run(catalog, client=stub).dispatch()
+        fut = handle.futures[_WORDS[1]]
+        with pytest.raises(ShardError, match="boom") as excinfo:
+            fut.result()
+        err = excinfo.value
+        assert err.shard_key == _WORDS[1]
+        assert err.label == _LABELS[1]
+        assert err.payload["status_code"] == 500
+        assert err.payload["error"] == "boom"
+        assert "lambda_duration" in err.payload  # timings ride the payload
+
+    def test_function_error_timeout_surfaces(self, catalog):
+        stub = StubLambdaClient(timeout={_WORDS[0]})
+        handle = _run(catalog, client=stub).dispatch()
+        with pytest.raises(ShardError, match="timeout") as excinfo:
+            handle.futures[_WORDS[0]].result()
+        assert excinfo.value.payload["timeout"] is True
+
+    def test_status_counts_and_len(self, catalog):
+        stub = StubLambdaClient(fail={_WORDS[1]})
+        stub.gate = threading.Event()
+        handle = _run(catalog, client=stub).dispatch()
+        assert len(handle) == 3
+        assert handle.status() == {"pending": 3, "ok": 0, "failed": 0}
+        stub.gate.set()
+        handle.wait(timeout=10)
+        assert handle.status() == {"pending": 0, "ok": 2, "failed": 1}
+        assert "3 shards" in repr(handle)
+
+    def test_benign_no_data_counts_ok(self, catalog):
+        stub = StubLambdaClient(benign={_WORDS[2]})
+        handle = _run(catalog, client=stub).dispatch()
+        assert handle.results()[_WORDS[2]]["error"] == "No granules found"
+        assert handle.status() == {"pending": 0, "ok": 3, "failed": 0}
+
+    def test_results_raises_or_maps_exceptions(self, catalog):
+        stub = StubLambdaClient(fail={_WORDS[0]})
+        handle = _run(catalog, client=stub).dispatch()
+        with pytest.raises(ShardError):
+            handle.results()
+        mapped = handle.results(return_exceptions=True)
+        assert isinstance(mapped[_WORDS[0]], ShardError)
+        assert mapped[_WORDS[1]]["status_code"] == 200
+
+    def test_raise_first(self, catalog):
+        failing = StubLambdaClient(fail={_WORDS[2]})
+        handle = _run(catalog, client=failing).dispatch()
+        with pytest.raises(ShardError):
+            handle.raise_first()
+        clean = _run(catalog, client=StubLambdaClient()).dispatch()
+        assert clean.raise_first() is None
+
+
+# -- tqdm optionality --------------------------------------------------------
+
+
+class TestTqdmOptional:
+    def test_module_imports_without_tqdm(self, monkeypatch):
+        # zagg core must import fine without tqdm (issue #326): blocking the
+        # package and re-executing the module proves nothing at module level
+        # touches it.
+        monkeypatch.setitem(sys.modules, "tqdm", None)
+        monkeypatch.setitem(sys.modules, "tqdm.auto", None)
+        importlib.reload(zagg.client)
+
+    def test_progress_without_tqdm_raises_with_hint(self, catalog, monkeypatch):
+        handle = _run(catalog, client=StubLambdaClient()).dispatch()
+        handle.results()
+        monkeypatch.setitem(sys.modules, "tqdm", None)
+        monkeypatch.setitem(sys.modules, "tqdm.auto", None)
+        with pytest.raises(ImportError, match="analysis"):
+            handle.progress()
+
+    def test_progress_iterates_futures(self, catalog):
+        pytest.importorskip("tqdm")
+        handle = _run(catalog, client=StubLambdaClient()).dispatch()
+        seen = [fut.result()["shard_key"] for fut in handle.progress(leave=False)]
+        assert sorted(seen) == sorted(_WORDS)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -250,14 +250,35 @@ class TestDispatch:
         handle = _run(catalog, client=stub).dispatch(shard_keys=[_WORDS[1]])
         handle.results()
         (_, _, event) = stub.cell_events()[0]
+        # The complete key set, not a spot check: a key added to or dropped
+        # from the cell event has to fail here (review finding, PR #333).
+        assert set(event) == {
+            "chunk_idx",
+            "shard_key",
+            "parent_order",
+            "child_order",
+            "granule_urls",
+            "store_path",
+            "s3_credentials",
+            "config",
+            "handoff",
+            "run_id",
+            "submap",
+        }
         assert event["shard_key"] == _WORDS[1]
+        assert event["parent_order"] == 6
+        assert event["child_order"] == 12
         assert event["granule_urls"] == [_rec(3)["s3"]]
         assert event["store_path"] == _STORE
-        assert event["s3_credentials"]["accessKeyId"] == "AK"
+        assert event["s3_credentials"] == _CREDS
         assert event["config"]["output"]["grid"]["parent_order"] == 6
         assert event["handoff"] == "arrow"
         assert event["run_id"]
-        assert event["submap"]["granules"] == [_rec(3)]
+        assert event["submap"] == {
+            "grid_signature": _ATL06_SIG,
+            "metadata": {"short_name": "ATL06", "version": "006"},
+            "granules": [_rec(3)],
+        }
 
     def test_hive_setup_handshake_precedes_cells(self, catalog):
         stub = StubLambdaClient()
@@ -299,6 +320,108 @@ class TestDispatch:
         run = _run(catalog, client=StubLambdaClient())
         with pytest.raises(ValueError, match="not in shardmap"):
             run.dispatch(shard_keys=[123])
+
+
+# -- parity with the runner's lambda path -------------------------------------
+
+
+class TestRunnerParity:
+    """The PR's central claim, made differential (review finding, PR #333).
+
+    Spot-checking hand-picked keys cannot catch a divergence the facade grows
+    later, so drive the SAME config + shardmap through ``runner.agg(backend=
+    "lambda", invocation="sync")`` against an equivalent stub and compare the
+    cell events field-by-field.
+    """
+
+    @staticmethod
+    def _agg_cell_events(catalog_file, monkeypatch, cfg=None, **agg_kwargs):
+        from unittest.mock import MagicMock
+
+        import boto3
+
+        from zagg import hive, runner
+        from zagg.concurrency import ConcurrencyReport
+
+        stub = StubLambdaClient()
+        session = MagicMock()
+        session.client.side_effect = lambda service, **k: (
+            stub if service == "lambda" else MagicMock()
+        )
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: session)
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 900)
+        monkeypatch.setattr(
+            runner,
+            "compute_available_workers",
+            lambda requested, *a, **k: (
+                3,
+                ConcurrencyReport(
+                    account_limit=1000,
+                    current_concurrent=0,
+                    padding=100,
+                    available=900,
+                    function_reserved=None,
+                ),
+            ),
+        )
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: dict(_CREDS))
+        # The hive manifest checker (issue #274) polls the output store; keep
+        # this run read-free rather than reaching for a bucket that isn't there.
+        monkeypatch.setattr(hive, "read_manifest", lambda *a, **k: None)
+        runner.agg(
+            cfg if cfg is not None else default_config("atl06"),
+            catalog=catalog_file,
+            store=_STORE,
+            backend="lambda",
+            invocation="sync",
+            function_name="process-shard-test",
+            max_workers=3,
+            **agg_kwargs,
+        )
+        return {e["shard_key"]: e for _, _, e in stub.cell_events()}
+
+    def test_cell_events_match_the_runner_lambda_path(self, catalog, catalog_file, monkeypatch):
+        agg_events = self._agg_cell_events(catalog_file, monkeypatch)
+        stub = StubLambdaClient()
+        _run(catalog, client=stub).dispatch().results()
+        client_events = {e["shard_key"]: e for _, _, e in stub.cell_events()}
+
+        assert set(client_events) == set(agg_events) == set(_WORDS)
+        for key in _WORDS:
+            mine, theirs = dict(client_events[key]), dict(agg_events[key])
+            # run_id is a fresh uuid per dispatch by construction; both paths
+            # carry one and the worker only echoes it into the stats record.
+            assert mine.pop("run_id") and theirs.pop("run_id")
+            assert mine == theirs
+
+    def test_driver_https_is_the_one_deliberate_divergence(
+        self, catalog, catalog_file, monkeypatch
+    ):
+        # The facade resolves granule_urls through the config's data_source
+        # driver; runner._cell_work hardcodes "s3" (_run_lambda takes no driver
+        # at all), so a `driver: https` config is the ONE field where the two
+        # paths differ. Kept deliberately — the worker selects HTTPDriver from
+        # that same config key (processing/worker.py) and read.py passes an
+        # https url through unrewritten, so agg's lambda path hands s3:// urls
+        # to an HTTP driver. Pinned here in both directions; whether _run_lambda
+        # should be fixed to match is an espg call (PR #333 "Questions for
+        # review").
+        cfg = default_config("atl06")
+        cfg.data_source["driver"] = "https"
+        agg_events = self._agg_cell_events(catalog_file, monkeypatch, cfg=cfg)
+        stub = StubLambdaClient()
+        _run(catalog, client=stub, config=cfg).dispatch().results()
+        client_events = {e["shard_key"]: e for _, _, e in stub.cell_events()}
+
+        key = _WORDS[1]
+        assert client_events[key]["granule_urls"] == [_rec(3)["https"]]
+        assert agg_events[key]["granule_urls"] == [_rec(3)["s3"]]
+        # granule_urls is the ONLY divergence: everything else still matches.
+        mine, theirs = dict(client_events[key]), dict(agg_events[key])
+        for ev in (mine, theirs):
+            ev.pop("granule_urls")
+            ev.pop("run_id")
+        assert mine == theirs
 
 
 # -- futures -----------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,6 +11,7 @@ import json
 import sys
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -331,6 +332,54 @@ class TestFutures:
         # Whole tail landed, in order, with no wait() call anywhere above.
         assert stub.modes()[-3:] == ["finalize", "coverage", "stats"]
         assert not handle._finisher.is_alive()
+
+    def test_tail_exception_surfaces_and_still_shuts_the_pool_down(self, catalog, monkeypatch):
+        # Regression (review finding, PR #333): _post_run's plumbing used to sit
+        # outside every try, so a crash there died in threading.excepthook while
+        # wait() reported a clean run and the pool was never shut down.
+        from zagg import runner
+
+        def _boom(*a, **k):
+            raise RuntimeError("tail blew up")
+
+        monkeypatch.setattr(runner, "_lambda_result_rows", _boom)
+        stub = StubLambdaClient()
+        run = _run(catalog, client=stub)
+        pools: list = []
+
+        class _TrackedPool(ThreadPoolExecutor):
+            def __init__(self, *a, **k):
+                super().__init__(*a, **k)
+                pools.append(self)
+
+        monkeypatch.setattr(zagg.client, "ThreadPoolExecutor", _TrackedPool)
+        handle = run.dispatch()
+        with pytest.raises(RuntimeError, match="tail blew up"):
+            handle.wait(timeout=10)
+        # ... and the same failure is what a plain drain surfaces.
+        with pytest.raises(RuntimeError, match="tail blew up"):
+            handle.results()
+        # try/finally ran: the pool refuses new work.
+        with pytest.raises(RuntimeError, match="shutdown"):
+            pools[0].submit(len, "")
+
+    def test_finalize_failure_wins_over_a_tail_crash(self, catalog, monkeypatch):
+        # Two distinct channels: the D6 manifest backstop failure is the one
+        # raised when both a finalize failure and a tail crash are recorded.
+        from zagg import runner
+
+        def _fail(*a, **k):
+            raise RuntimeError("finalize down")
+
+        def _boom(*a, **k):
+            raise RuntimeError("tail blew up")
+
+        monkeypatch.setattr(runner, "_invoke_lambda_finalize", _fail)
+        monkeypatch.setattr(runner, "_lambda_result_rows", _boom)
+        handle = _run(catalog, client=StubLambdaClient()).dispatch()
+        with pytest.raises(RuntimeError, match="finalize down"):
+            handle.wait(timeout=10)
+        assert isinstance(handle._tail_error, RuntimeError)
 
     def test_break_out_of_the_loop_leaves_the_tail_to_wait(self, catalog):
         # The documented escape hatch: an undrained iterator does not join, so

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -88,13 +88,14 @@ def _envelope(body: dict, status=200):
 class StubLambdaClient:
     """boto3-Lambda-shaped stub: records invokes, answers canned envelopes."""
 
-    def __init__(self, *, fail=(), benign=(), timeout=(), delays=None):
+    def __init__(self, *, fail=(), benign=(), timeout=(), delays=None, mode_delay=0):
         self.events: list[tuple[str, str, dict]] = []
         self._lock = threading.Lock()
         self._fail = set(fail)
         self._benign = set(benign)
         self._timeout = set(timeout)
         self._delays = delays or {}
+        self._mode_delay = mode_delay
         self.gate: threading.Event | None = None  # holds cell invokes open
 
     def invoke(self, **kwargs):
@@ -102,6 +103,10 @@ class StubLambdaClient:
         with self._lock:
             self.events.append((kwargs["FunctionName"], kwargs["InvocationType"], event))
         if event.get("mode") is not None:  # ping/setup/finalize/coverage/stats/sweep
+            # A non-zero mode_delay stands in for a real tail round trip, so a
+            # test that fails to join the finisher observes a truncated tail
+            # deterministically rather than racily.
+            time.sleep(self._mode_delay)
             return _envelope({"zagg_version": "stub"})
         key = event["shard_key"]
         if self.gate is not None:
@@ -305,6 +310,39 @@ class TestFutures:
         first = next(iter(handle.as_completed()))
         assert first is handle.futures[_WORDS[2]]  # the undelayed shard lands first
         handle.results()
+
+    @pytest.mark.parametrize("drain", ["as_completed", "progress", "results", "raise_first"])
+    def test_draining_joins_the_post_run_tail(self, catalog, drain):
+        # Regression (review finding, PR #333): the documented flow never calls
+        # wait(), so the finisher used to be cut off at process exit with the
+        # coverage/stats rollups undispatched. Draining any harvest iterator
+        # joins the tail, so the loop alone completes the run.
+        if drain == "progress":
+            pytest.importorskip("tqdm")
+        stub = StubLambdaClient(mode_delay=0.05)
+        handle = _run(catalog, client=stub).dispatch()
+        if drain == "results":
+            handle.results()
+        elif drain == "raise_first":
+            handle.raise_first()
+        else:
+            for fut in getattr(handle, drain)():
+                fut.result()
+        # Whole tail landed, in order, with no wait() call anywhere above.
+        assert stub.modes()[-3:] == ["finalize", "coverage", "stats"]
+        assert not handle._finisher.is_alive()
+
+    def test_break_out_of_the_loop_leaves_the_tail_to_wait(self, catalog):
+        # The documented escape hatch: an undrained iterator does not join, so
+        # wait() stays the explicit form (and the finisher is a daemon, so an
+        # abandoned handle cannot wedge interpreter exit).
+        stub = StubLambdaClient(mode_delay=0.05)
+        handle = _run(catalog, client=stub).dispatch()
+        for fut in handle.as_completed():
+            fut.result()
+            break
+        handle.wait(timeout=10)
+        assert "stats" in stub.modes()
 
     def test_error_payload_surfaces_as_shard_error(self, catalog):
         stub = StubLambdaClient(fail={_WORDS[1]})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -324,6 +324,121 @@ class TestDispatch:
             run.dispatch(shard_keys=[123])
 
 
+# -- concurrency preflight ----------------------------------------------------
+
+
+class TestConcurrencyPreflight:
+    """`dispatch()` sizes the pool with agg's probe, degrading on denial.
+
+    espg ruling on PR #333, option (a): a notebook caller who can invoke the
+    workers can normally read the account concurrency too, so probe by default;
+    but a narrow-permission deployment (cryocloud: worker role holds the perms,
+    caller only deploys) must degrade, not fail.
+    """
+
+    @staticmethod
+    def _dispatch(catalog, monkeypatch, *, probe=None, **dispatch_kwargs):
+        """Dispatch with NO injected client; return (pool_width, probe_calls)."""
+        from unittest.mock import MagicMock
+
+        import boto3
+
+        from zagg import runner
+
+        stub = StubLambdaClient()
+        session = MagicMock()
+        session.client.side_effect = lambda service, **k: (
+            stub if service == "lambda" else MagicMock()
+        )
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: session)
+
+        calls: list = []
+        if probe is not None:
+
+            def _probe(requested, lambda_client, cloudwatch_client, function_name, **k):
+                calls.append((requested, function_name))
+                return probe(requested)
+
+            monkeypatch.setattr(runner, "compute_available_workers", _probe)
+
+        widths: list = []
+
+        class _TrackedPool(ThreadPoolExecutor):
+            def __init__(self, *a, **k):
+                widths.append(k.get("max_workers"))
+                super().__init__(*a, **k)
+
+        monkeypatch.setattr(zagg.client, "ThreadPoolExecutor", _TrackedPool)
+        run = Run.from_config(
+            default_config("atl06"),
+            shardmap=catalog,
+            store=_STORE,
+            function_name="process-shard-test",
+            source_credentials=_CREDS,
+        )
+        run.dispatch(**dispatch_kwargs).results()
+        return widths[0], calls
+
+    @staticmethod
+    def _report():
+        from zagg.concurrency import ConcurrencyReport
+
+        return ConcurrencyReport(
+            account_limit=1000,
+            current_concurrent=0,
+            padding=100,
+            available=900,
+            function_reserved=None,
+        )
+
+    def test_probe_sizes_the_pool(self, catalog, monkeypatch):
+        width, calls = self._dispatch(
+            catalog, monkeypatch, probe=lambda requested: (2, self._report())
+        )
+        assert width == 2  # the probe's clamp, not _DEFAULT_MAX_WORKERS
+        # It asks for the work size and names the dispatch target.
+        assert calls == [(3, "process-shard-test")]
+
+    def test_probe_denial_falls_back_with_a_warning(self, catalog, monkeypatch):
+        # Distinguish the fallback from the shard-count clamp by shrinking the
+        # default below the shard count.
+        monkeypatch.setattr(zagg.client, "_DEFAULT_MAX_WORKERS", 2)
+
+        def _denied(requested):
+            from botocore.exceptions import ClientError
+
+            raise ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "no cloudwatch for you"}},
+                "GetMetricStatistics",
+            )
+
+        with pytest.warns(RuntimeWarning, match="AccessDenied"):
+            width, calls = self._dispatch(catalog, monkeypatch, probe=_denied)
+        assert width == 2  # degraded to the default, run still dispatched
+        assert calls == [(3, "process-shard-test")]
+
+    def test_explicit_max_workers_skips_the_probe(self, catalog, monkeypatch):
+        def _must_not_run(requested):
+            raise AssertionError("probe ran despite an explicit max_workers")
+
+        width, calls = self._dispatch(catalog, monkeypatch, probe=_must_not_run, max_workers=1)
+        assert width == 1
+        assert calls == []
+
+    def test_injected_client_skips_the_probe(self, catalog, monkeypatch):
+        # The stub-client seam: a test double must not have to answer
+        # GetAccountSettings/GetMetricStatistics (nor the STS identity probe).
+        from zagg import runner
+
+        def _must_not_run(*a, **k):
+            raise AssertionError("probe ran with an injected lambda_client")
+
+        monkeypatch.setattr(runner, "compute_available_workers", _must_not_run)
+        handle = _run(catalog, client=StubLambdaClient()).dispatch()
+        handle.results()
+        assert len(handle) == 3
+
+
 # -- parity with the runner's lambda path -------------------------------------
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,7 +68,9 @@ def catalog_file(tmp_path, catalog):
 def _no_stats_verify(monkeypatch):
     # The post-run tail's run-stats invoke verifies the parquet landed with a
     # read-only poll (issue #313); zero window skips it so the finisher thread
-    # never opens a (fake) store.
+    # never opens a (fake) store. TestTailTiming re-enables a scaled window so
+    # the fire -> verify -> re-fire path is exercised somewhere (review
+    # finding, PR #333).
     from zagg import runner
 
     monkeypatch.setattr(runner, "_RUN_STATS_VERIFY_WINDOW_S", 0)
@@ -610,6 +612,37 @@ class TestFutures:
             handle.raise_first()
         clean = _run(catalog, client=StubLambdaClient()).dispatch()
         assert clean.raise_first() is None
+
+
+# -- tail timing -------------------------------------------------------------
+
+
+class TestTailTiming:
+    def test_wait_timeout_must_clear_the_stats_verify_window(self, catalog, monkeypatch):
+        # With the verify window zeroed everywhere else, nothing in the suite
+        # sees the tail's real floor: the run-stats leg fires, polls for the
+        # parquet over _RUN_STATS_VERIFY_WINDOW_S (20 s shipped), then re-fires
+        # once and polls again — so a successful run can spend ~2x the window
+        # in the tail and a "generous" wait(timeout=30) reports a false
+        # timeout. Scaled 100x down here, with the poll faked so no store is
+        # opened (review finding, PR #333).
+        from zagg import runner
+
+        window = 0.2
+        monkeypatch.setattr(runner, "_RUN_STATS_VERIFY_WINDOW_S", window)
+
+        def _never_visible(store_path, key, store_kwargs, *, window_s=None):
+            time.sleep(window)  # stands in for the read-only HEAD poll
+            return False
+
+        monkeypatch.setattr(runner, "_await_run_stats_object", _never_visible)
+        stub = StubLambdaClient()
+        handle = _run(catalog, client=stub).dispatch()
+        with pytest.raises(TimeoutError, match="still in flight"):
+            handle.wait(timeout=window / 4)  # the "obviously generous" choice
+        handle.wait(timeout=10)  # > 2x the window: clean
+        # Fire -> verify -> re-fire: the stats invoke went out twice.
+        assert stub.modes().count("stats") == 2
 
 
 # -- tqdm optionality --------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,7 @@ import json
 import sys
 import threading
 import time
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -626,6 +627,40 @@ class TestFutures:
         (bad,) = [r for r in rows if r["shard_key"] == _WORDS[0]]
         assert bad["success"] is False
         assert "Too many open files" in bad["error"]
+
+    def test_finalize_failure_warns_immediately(self, catalog, monkeypatch):
+        # espg ruling on PR #333 (middle option): the failure is warned the
+        # moment it happens — not only when the harvest loop finally joins — so
+        # a notebook shows it in-stream; the tail still runs and the error still
+        # re-raises. The stats leg is gated open so the assertion lands while
+        # the tail is demonstrably still in flight.
+        from zagg import runner
+
+        gate = threading.Event()
+
+        def _fail(*a, **k):
+            raise RuntimeError("finalize down")
+
+        monkeypatch.setattr(runner, "_invoke_lambda_finalize", _fail)
+        monkeypatch.setattr(runner, "_dispatch_run_stats", lambda *a, **k: gate.wait(10))
+
+        def _finalize_warnings(caught):
+            return [str(w.message) for w in caught if "finalize" in str(w.message)]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            handle = _run(catalog, client=StubLambdaClient()).dispatch()
+            deadline = time.time() + 10
+            while not _finalize_warnings(caught):
+                assert time.time() < deadline, "no finalize warning while the tail ran"
+                time.sleep(0.01)
+            assert handle._finisher.is_alive()  # warned before the join, not at it
+            (msg,) = _finalize_warnings(caught)
+            assert _STORE in msg and "idempotent" in msg
+            gate.set()
+        # Re-raise semantics unchanged.
+        with pytest.raises(RuntimeError, match="finalize down"):
+            handle.wait(timeout=10)
 
     def test_finalize_failure_wins_over_a_tail_crash(self, catalog, monkeypatch):
         # Two distinct channels: the D6 manifest backstop failure is the one

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1211,6 +1211,9 @@ class TestInvocationPassthrough:
                 poll_timeout_s=k.get("poll_timeout_s"),
                 label=k.get("label"),
             )
+            # positional 5 is granule_urls; accumulated across cells so
+            # TestDriverPassthroughLambda can assert the resolved hrefs.
+            captured.setdefault("granule_urls", []).extend(a[5])
             return {
                 "status_code": 200,
                 "body": {"total_obs": 1},
@@ -1290,6 +1293,37 @@ class TestInvocationPassthrough:
                 backend="lambda",
                 invocation="poll",
             )
+
+
+class TestDriverPassthroughLambda:
+    """`driver` reaches the LAMBDA path's url selection (espg ruling, PR #333).
+
+    ``_cell_work`` hardcoded ``_resolve_urls(records, "s3")`` while ``agg``
+    resolved ``driver`` for ``_run_local`` only, so a ``driver: https`` config
+    (a STAC catalog substituting https for an s3 object this account can't read
+    — requester-pays, cross-region) still dispatched ``s3://`` urls to a worker
+    that builds ``HTTPDriver`` from the same config key.
+    """
+
+    def _urls(self, monkeypatch, atl06_config, catalog_file, **agg_kwargs):
+        captured = TestInvocationPassthrough()._drive(
+            monkeypatch, atl06_config, catalog_file, invocation="sync", **agg_kwargs
+        )
+        return captured["granule_urls"]
+
+    def test_default_resolves_s3_hrefs(self, monkeypatch, atl06_config, catalog_file):
+        urls = self._urls(monkeypatch, atl06_config, catalog_file)
+        assert urls and all(u.startswith("s3://") for u in urls)
+
+    def test_https_kwarg_resolves_https_hrefs(self, monkeypatch, atl06_config, catalog_file):
+        urls = self._urls(monkeypatch, atl06_config, catalog_file, driver="https")
+        assert urls and all(u.startswith("https://") for u in urls)
+
+    def test_https_config_resolves_https_hrefs(self, monkeypatch, atl06_config, catalog_file):
+        # No kwarg: the config key alone has to reach the Lambda path too.
+        atl06_config.data_source["driver"] = "https"
+        urls = self._urls(monkeypatch, atl06_config, catalog_file)
+        assert urls and all(u.startswith("https://") for u in urls)
 
 
 class TestHandoffPassthrough:


### PR DESCRIPTION
Closes #326. Refs #265 ([ratified API shape](https://github.com/englacial/zagg/issues/265#issuecomment-5123966118), [espg sign-off, incl. tqdm into the existing `analysis` extra](https://github.com/englacial/zagg/issues/265#issuecomment-5124017044)).

## What

`zagg.client` — a notebook-first facade owning the config-load → shardmap → dispatch → harvest composition that `.github/scripts/run_benchmark.py` and the dispatch scratch scripts do imperatively today, with **per-shard `concurrent.futures.Future`s** as the public contract:

```python
from zagg.client import Run

run = Run.from_config("cfg.yaml", shardmap="shardmap.json", store="s3://bucket/out.zarr")
handle = run.dispatch()                    # returns after the setup handshake
for fut in handle.progress():              # tqdm.auto over as_completed()
    r = fut.result()                       # worker envelope (timings) / raises ShardError
handle.status()                            # {"pending": n, "ok": n, "failed": n}
```

Public surface: `Run.from_config(config_path_or_dict_or_PipelineConfig, shardmap=, store=, function_name=, region=, lambda_client=, **knobs)`, `Run.dispatch(shard_keys=None, max_workers=None) -> RunHandle`; `RunHandle.futures` (dict `shard_key -> Future`), `.as_completed()`, `.status()`, `.results(return_exceptions=False)`, `.raise_first()`, `.progress()` (tqdm, optional import), `.wait()`, `__len__`. Worker error payloads surface as `ShardError` from `future.result()` with the full per-shard result dict attached (`.payload`: status_code, body, timings, retries).

## Approach

- **v1 transport** (as ratified on #265): a `ThreadPoolExecutor` over the **existing synchronous `RequestResponse` invokes** — each shard is one `runner._invoke_lambda_cell` call and the pool future over it *is* the shard's future. Zero worker-side change; payloads are built with the same runner helpers `_run_lambda`'s `_cell_work` uses (`_safe_label`, `_resolve_urls`, `_clamped_data_source`, aoi payload map, leaf submap, `run_id`/`invoked_by` threading), so cell events stay byte-compatible with the `agg` path.
- **Dispatcher-never-writes (D8) untouched**: setup handshake (hive ping + fire-and-forget manifest write / flat template write), finalize backstop, and the fail-open coverage.moc / run-stats / sweep rollups all remain **worker invokes**; a background finisher thread runs that tail after the last shard settles, and `handle.wait()` surfaces a finalize failure. The client holds futures; it never PUTs.
- **boto3 client injection**: `from_config(lambda_client=...)` takes any invoke-shaped client (tests use an in-memory stub — no moto, no network). Default `None` builds a per-dispatch client mirroring `_run_lambda`'s botocore config (960 s read timeout, pool sized to the fan-out) and resolves STS `invoked_by`; injected clients skip the STS probe (fail-open, #297 semantics).
- **tqdm** is imported only inside `RunHandle.progress()`; `import zagg.client` works without it (regression-tested). Added `tqdm>=4.66` to the **existing `analysis` extra** — never `lambda` — per the espg sign-off linked above.
- **v1 scope gate**: temporal, raster, and windowed configs are refused with a `NotImplementedError` pointing at `zagg.runner.agg` / `zagg.notebook.run` (windowed fan-out units are `(shard, window)` pairs, not shards, so per-shard future keys would collide).

## Phases

- [x] Phase 1: `src/zagg/client.py` (`Run` / `RunHandle` / `ShardError`, v1 sync transport, worker-invoke post-run tail) + `tqdm` in the `analysis` extra
- [x] Phase 2: stub-Lambda-client unit tests (`tests/test_client.py`, 28 tests)
- [x] Adversarial-review fold (7 findings): tail joined when the harvest iterator drains, whole tail guarded with the failure surfaced, failure rows for non-`ShardError` shard failures, differential `TestRunnerParity` against `runner.agg`, run-stats verify-window timing test, `zagg.dispatch.BENIGN_ERRORS` as one public home
- [x] Phase 3: **driver fix in `agg`'s Lambda path** — `_run_lambda` threads the resolved `driver` into `_cell_work`, replacing the hardcoded `_resolve_urls(records, "s3")` ([espg ruling](https://github.com/englacial/zagg/pull/333#issuecomment-5124576186))
- [x] Phase 4: **concurrency preflight, option (a)** — `dispatch()` sizes the pool with `compute_available_workers` when `max_workers` is omitted and no client is injected; any probe failure degrades to `_DEFAULT_MAX_WORKERS` with a `RuntimeWarning` naming the denial
- [x] Phase 5: **finalize warns immediately** — fail-open + recorded + re-raise as before, plus a `RuntimeWarning` at the moment of failure naming the store and the idempotent remedy
- [ ] Follow-up (separate PR, deliberately not here): refactor `.github/scripts/run_benchmark.py` / the dispatch scratch scripts into thin wrappers over the facade so the notebook API cannot drift from what CI tests
- [ ] v2 transport (issue #327, out of scope): `Event` invoke + status-object resolver behind this same public surface — no held connections, reattachable runs

## How it was tested

- `pytest tests/test_client.py -v` — **44 tests**, all against a stub Lambda client: fan-out (one sync `RequestResponse` invoke per shard, no `result_url`), the complete cell-event key set, hive ping→setup ordering + finalize/stats/coverage tail, flat setup + finalize gating, `as_completed` resolution order, error payload → `ShardError` (incl. `FunctionError` timeout), `status()` counts with a gated in-flight snapshot, benign "No granules found" counted ok, `results(return_exceptions=)`, `raise_first()`, shard-subset selection by label and raw key, config/shardmap loading (dict / path / `PipelineConfig`), scope-gate refusals, and no-tqdm import safety. Added by the review fold and the phase 3-5 rulings:
  - `TestRunnerParity` — differential against `runner.agg(backend="lambda", invocation="sync")` on the same stub, parametrized over `driver: s3` / `driver: https`, comparing whole cell events field-by-field.
  - `TestConcurrencyPreflight` — probe sizes the pool, denial degrades with a `RuntimeWarning`, explicit `max_workers` skips the probe, injected client skips the probe.
  - Tail behavior — draining (`as_completed` / `progress` / `results` / `raise_first`) dispatches the whole tail without `wait()`; a tail exception surfaces and still shuts the pool down; finalize failure warns immediately while the tail is still in flight and still re-raises; a non-`ShardError` shard failure still gets a run-stats failure row; `TestTailTiming` exercises the run-stats verify window.
- `pytest tests/test_runner.py -v` — plus `TestDriverPassthroughLambda` (3 tests): the Lambda path resolves s3 hrefs by default, https from the `driver=` kwarg, and https from the config key alone.
- Full suite: `uv sync --extra test && uv run pytest --ignore=tests/test_lambda_build.py` → **2671 passed, 34 skipped**. `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` still fails as it does on `main` (unrelated to this PR; not touched per conventions).
- `ruff check src tests` / `ruff format --check src tests`: clean for the changed files. Pre-existing on `main` and left alone: `N818` on `src/zagg/registry.py:64` (the PR lint bot runs without `N`), and the mypy hook's pre-existing noise (e.g. missing `yaml` stubs, `runner.py` union-attr notes) — `src/zagg/client.py` itself is mypy-clean.

## Questions for review

1. ~~**Fan-out width / no concurrency probe**~~ — **RESOLVED** ([espg](https://github.com/englacial/zagg/pull/333#issuecomment-5124576186), option (a)): the probe now runs by default and degrades gracefully. When `max_workers` is omitted **and** no custom `lambda_client` was injected, `dispatch()` runs `agg`'s `compute_available_workers` (FD ceiling ∩ account headroom, requested at the work size) to size the pool; **any** probe failure — `AccessDenied` in a future narrow-permission cryocloud deployment, missing CloudWatch perms, a throttle — falls back to `_DEFAULT_MAX_WORKERS` with a `RuntimeWarning` naming the denial, so a run the caller may dispatch never fails on an optional preflight read. Explicit `max_workers=` wins verbatim and skips the probe; an injected client skips it too (stub-client seam). Phase 4, `e51acfc`.
2. **`dispatch()` returns after the setup handshake** (one short synchronous worker invoke; hive fail-fast-pings first) rather than backgrounding setup into the futures. This keeps the #252 fail-fast property — an incompatible store refuses before any shard is paid for — at the cost of "immediately" meaning "after ~one invoke round-trip". Acceptable reading of the ratified sketch?
3. **Post-run tail scope**: the finisher thread mirrors `agg`'s full lambda tail (finalize backstop always on hive — no overlapped manifest checker, so one extra idempotent invoke vs `_run_lambda`; coverage.moc; run-stats record; sweep trigger — all fail-open worker invokes). Alternative was to skip the rollups in v1 and leave client-run stores thinner than agg-run stores; went with parity.
4. **Benign outcomes**: shards returning `"No granules found"` / `"No data after filtering"` resolve normally and count `ok` in `status()` (matching `_run_lambda`'s error accounting, which counts them neither with-data nor error). Flag if they should be a third status bucket instead.

5. ~~**Two deliberate divergences from the byte-compatible-events claim**~~ — **RESOLVED** ([espg ruling](https://github.com/englacial/zagg/pull/333#issuecomment-5124576186)); both were folded into this PR, so nothing here is outstanding:
   - **`data_source.driver` — fixed in `agg`, not worked around in the facade** ("yes, this should be fixed — and we might as well fix it here"). `runner._run_lambda` now takes the resolved `driver` and `_cell_work` selects the href with it, replacing the hardcoded `_resolve_urls(records, "s3")`; `agg` forwards the same value it already gave `_run_local`. Use case per the ruling: a STAC catalog supplying an **https substitute** for an s3 object this account cannot or should not read (requester-pays, cross-region) — s3 dominates, but https must work as an explicit override, and the worker already builds `HTTPDriver` from the same config key (`processing/worker.py:250-254`). `TestRunnerParity` drops its carve-out: it is now parametrized over `driver: s3` **and** `driver: https` and asserts the full cell event equal field-by-field on both (`run_id` popped, since it is a fresh uuid per dispatch), plus that the href actually moved on each. Runner-side coverage in `TestDriverPassthroughLambda` (kwarg, config key, and the s3 default). Phase 3, `8520fb5`.
   - **Finalize failure — the middle option** (asked: "is there a fix or recommendation... fatal, or try block with a warning?"). Kept fail-open + recorded + re-raising, and added an immediate `RuntimeWarning` at the moment finalize fails: it names the store path, states that shard outputs are all written and only the root manifest may be stale, and that the backstop is **idempotent** so a re-run (or re-dispatched finalize) stamps it. The tail's rollups still run and `wait()` / a drained harvest iterator still re-raise, so nothing is silent and nothing is lost. Phase 5, `bb9fa27`. Making `agg` itself run the rollups before exiting nonzero (rather than dying pre-tail) remains out of scope here — flag if you want it filed.

---
Authored by a Claude Code session working issue #326.


