### PR TITLE
Signal/noise strata + packed composition field (issue #321)

### DIFF
--- a/docs/signal_strata.md
+++ b/docs/signal_strata.md
@@ -17,7 +17,10 @@ is **committed at ingest** and carried through the store in three pieces:
    of quantized fractions of the signal stratum — five per-surface lanes
    (`signal_conf_ph` column order: land, ocean, sea_ice, land_ice,
    inland_water) and three low/med/high lanes (a signal photon's *strongest*
-   per-surface confidence, 2/3/4).
+   per-surface confidence, 2/3/4). The level lanes are **absolute** — always
+   `conf == 2/3/4`, never renumbered against the threshold — so a product
+   committing a higher threshold ships empty lower lanes rather than shifted
+   ones, and one lane layout serves every product.
 3. **Store attrs** recording the commitment: each stratum array carries
    `stratum` + `signal_threshold`, and the composition array carries the
    versioned `composition` block (`spec`, `lanes`, `of` — the digest whose

--- a/docs/signal_strata.md
+++ b/docs/signal_strata.md
@@ -74,6 +74,18 @@ streaming state. Heavy multi-block shards need the fold-law follow-up
 ## What the mask channel gains
 
 With the strata in place, the HHDC reader's occupancy mask (issue #265)
-upgrades from 2-state to 3-state from store contents alone: **unobserved**
-(both strata empty), **observed with zero signal returns** (noise occupied,
-signal empty — the laser crossed the cell), and **observed with signal**.
+upgrades from 2-state to 3-state from store contents alone. State the rule
+against `count`, which the template already writes:
+
+- **unobserved** — `count == 0`: no observation fell in the cell.
+- **observed with zero signal returns** — `count > 0` and the signal stratum
+  is empty: the laser crossed the cell and every photon was background.
+- **observed with signal** — the signal stratum is non-empty.
+
+`count` rather than "both strata empty" because the strata are keyed to
+*finite* heights: `build_tdigest_where` and `pack_composition` both drop
+non-finite `source` rows (that is what makes the `N_signal` alignment exact),
+so a cell whose every observation carried a non-finite height would report
+`count > 0`, both strata empty, `composition == 0`. ATL03 `h_ph` is not
+nullable, so the shipped template cannot produce that cell — but the `count`
+form is the robust rule for any source and costs nothing to prefer.

--- a/docs/signal_strata.md
+++ b/docs/signal_strata.md
@@ -1,0 +1,73 @@
+# Signal/noise strata and the composition field
+
+Issue #321: ATL03 photon signal confidence cannot be reconstructed after
+aggregation (the classifier needs the along-track axis, the atmospheric
+background stream, and per-surface tuning), so the signal/background decision
+is **committed at ingest** and carried through the store in three pieces:
+
+1. **Two disjoint t-digest fields** per cell — `h_tdigest_signal` and
+   `h_tdigest_noise` — split by the ATBD signal predicate: a photon is signal
+   when **any** `signal_conf_ph` surface column clears the threshold
+   (default `>= 2`, i.e. the ATBD `> 1`; selection rule A1 — the union is
+   idempotent and narrowable downstream). Each stratum digest's total weight
+   is the **exact** stratum photon count. The total photon-flux distribution
+   is recovered at read by one deterministic two-way `merge_tdigests`.
+2. **One packed `uint64` composition word** per cell
+   (`zagg.stats.composition`, spec `zagg-composition/1`): eight 8-bit lanes
+   of quantized fractions of the signal stratum — five per-surface lanes
+   (`signal_conf_ph` column order: land, ocean, sea_ice, land_ice,
+   inland_water) and three low/med/high lanes (a signal photon's *strongest*
+   per-surface confidence, 2/3/4).
+3. **Store attrs** recording the commitment: each stratum array carries
+   `stratum` + `signal_threshold`, and the composition array carries the
+   versioned `composition` block (`spec`, `lanes`, `of` — the digest whose
+   total weight is `N_signal` — and `threshold`). Readers bind to these,
+   never to config conventions.
+
+The shipped template is `zagg/configs/atl03_tdigest_strata_healpix.yaml`. The
+five confidence columns are read from the single 2-D `signal_conf_ph` dataset
+via the per-variable `column` selector (`{path: ..., column: k}` — the
+variable analogue of the structured-filter `column`); the shared path is
+still read once.
+
+## Quantization: the presence floor
+
+Lanes quantize as `k = round(255 * c / N)` **except any nonzero count
+quantizes to at least 1**. Consequences:
+
+- `lane > 0` means "this flag occurred" **exactly, at every N**, through
+  arbitrary merge chains.
+- Count recovery `round(k * N / 255)` is exact whenever `N <= 254` — the
+  entire below-compression-knee regime (measured 99.56% of non-empty cells
+  on the live NEON store, full-mission pooling).
+- Above that, counts are within `±N/510` (plus `O(N/510)` per
+  re-quantizing merge); presence stays exact.
+- A cell with one signal photon has lanes in `{0, 255}` — the lanes *are*
+  that photon's flags.
+
+The per-surface lanes are overlapping marginals (`surf_type` is multi-hot):
+they do not sum to 255, and they cannot split the height distribution per
+surface (decision D: strata stay signal/noise, never per-surface).
+
+## Merge law
+
+`merge_composition(word_a, n_a, word_b, n_b)` folds lanes as the
+digest-weighted mean `(n_a·lane_a + n_b·lane_b)/(n_a + n_b)`, re-quantized
+with the same presence floor — an order-independent monoid whose `n` inputs
+come from the signal digests' total weights.
+
+## Operational caveat
+
+Strata and composition run on the **pooled path and the single-block spill
+regime** (exact, via the pooled replay). The streaming merge surface rejects
+them: its fold rebuilds digests from the raw source column and would silently
+ignore the `where` mask, and the composition fold is not wired into the
+streaming state. Heavy multi-block shards need the fold-law follow-up
+(issue #321).
+
+## What the mask channel gains
+
+With the strata in place, the HHDC reader's occupancy mask (issue #265)
+upgrades from 2-state to 3-state from store contents alone: **unobserved**
+(both strata empty), **observed with zero signal returns** (noise occupied,
+signal empty — the laser crossed the cell), and **observed with signal**.

--- a/docs/signal_strata.md
+++ b/docs/signal_strata.md
@@ -24,7 +24,10 @@ is **committed at ingest** and carried through the store in three pieces:
    total weight is `N_signal` — and `threshold`). Readers bind to these,
    never to config conventions.
 
-The shipped template is `zagg/configs/atl03_tdigest_strata_healpix.yaml`. The
+The shipped template is `zagg/configs/atl03_tdigest_strata_healpix.yaml` —
+**located strata is the default**: both digest fields carry `location:
+leaf_id`, so each centroid stores its order-29 morton word (an exact photon
+position at weight 1) in the `{field}_locations` sibling arrays. The
 five confidence columns are read from the single 2-D `signal_conf_ph` dataset
 via the per-variable `column` selector (`{path: ..., column: k}` — the
 variable analogue of the structured-filter `column`); the shared path is

--- a/docs/signal_strata.md
+++ b/docs/signal_strata.md
@@ -21,11 +21,13 @@ is **committed at ingest** and carried through the store in three pieces:
    `conf == 2/3/4`, never renumbered against the threshold — so a product
    committing a higher threshold ships empty lower lanes rather than shifted
    ones, and one lane layout serves every product.
-3. **Store attrs** recording the commitment: each stratum array carries
-   `stratum` + `signal_threshold`, and the composition array carries the
+3. **Store attrs** recording the commitment: each stratum's *payload* array
+   carries `stratum` + `signal_threshold`, and the composition array carries the
    versioned `composition` block (`spec`, `lanes`, `of` — the digest whose
    total weight is `N_signal` — and `threshold`). Readers bind to these,
-   never to config conventions.
+   never to config conventions. The located sibling
+   (`{field}_locations`) carries no user attrs: it is addressed through its
+   payload array, which holds the pair's provenance.
 
 The shipped template is `zagg/configs/atl03_tdigest_strata_healpix.yaml` —
 **located strata is the default**: both digest fields carry `location:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - "Schema": "design/schema.md"
       - "Sharded output": "sharding.md"
       - "Ragged store layout": "ragged_layout.md"
+      - "Signal strata + composition": "signal_strata.md"
       - "Hive store layout": "hive_layout.md"
       - "Typed morton boundary": "morton_arrow.md"
       - "Temporal events": "temporal_events.md"

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -392,6 +392,10 @@ def validate_config(config: PipelineConfig) -> None:
             if "start_date" not in temporal or "end_date" not in temporal:
                 raise ValueError("bounds.temporal requires start_date and end_date")
 
+    # Validate base-level variable entries: plain path string, or the
+    # column-selector mapping form (issue #321)
+    _validate_ds_variables(config.data_source)
+
     # Validate the structured filter list (issue #43, Phase A)
     _validate_filters(config.data_source)
 
@@ -1458,6 +1462,41 @@ def _normalize_filter(f: dict) -> dict:
     else:
         out["value"] = f["value"]
     return out
+
+
+def _validate_ds_variables(data_source: dict) -> None:
+    """Validate ``data_source.variables`` entries (issue #321).
+
+    Each value is either a path-template string (reads the whole dataset) or a
+    mapping ``{path: <str>, column: <int >= 0>}`` selecting one column of a 2-D
+    dataset — the variable analogue of the ``column`` key on structured
+    filters, so several scalar columns can be declared against one shared
+    dataset path (deduped to a single read).
+    """
+    variables = (data_source or {}).get("variables", {})
+    if not isinstance(variables, dict):
+        raise ValueError("data_source.variables must be a mapping of name -> path")
+    for name, entry in variables.items():
+        if isinstance(entry, str):
+            continue
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"data_source.variables['{name}'] must be a path string or a "
+                f"{{path, column}} mapping (got {type(entry).__name__})"
+            )
+        extra = set(entry) - {"path", "column"}
+        if extra:
+            raise ValueError(
+                f"data_source.variables['{name}']: unknown keys {sorted(extra)} "
+                "(the mapping form takes exactly 'path' and 'column')"
+            )
+        if not isinstance(entry.get("path"), str):
+            raise ValueError(f"data_source.variables['{name}'].path must be a string")
+        column = entry.get("column")
+        if not isinstance(column, int) or isinstance(column, bool) or column < 0:
+            raise ValueError(
+                f"data_source.variables['{name}'].column must be an integer >= 0 (got {column!r})"
+            )
 
 
 def _validate_filters(data_source: dict) -> None:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -2314,22 +2314,46 @@ def window_time_filters(config: PipelineConfig, start: float, end: float) -> lis
     ``time_field`` is rejected at validation and never reaches here. Appended
     to :func:`filters_from_data_source`'s normalized output by the hive write
     path, preserving any declared filters.
+
+    A ``time_field`` declared in the ``{path, column}`` mapping form (issue
+    #321) carries its column selector into both predicates — a structured
+    filter takes the same ``column`` key, so a time column packed inside a 2-D
+    dataset filters at base rate like any other.
     """
     windowing = get_windowing(config)
     if windowing is None:
         raise ValueError("window_time_filters requires a windowed config (output.windowing)")
     field = windowing["time_field"]
-    path = ((config.data_source or {}).get("variables") or {}).get(field)
+    entry = ((config.data_source or {}).get("variables") or {}).get(field)
+    path, column = _variable_entry(entry)
     if not (isinstance(path, str) and path):
         raise ValueError(
             f"windowing time_field {field!r} has no base-rate dataset path in "
             f"data_source.variables — validate_config should have rejected "
             f"this configuration"
         )
+    # ``column`` is emitted only for the mapping form, so the string form's
+    # filter pair stays byte-identical to the pre-#321 shape.
+    col = {"column": column} if column is not None else {}
     return [
-        {"level": None, "dataset": path, "op": "ge", "value": float(start)},
-        {"level": None, "dataset": path, "op": "lt", "value": float(end)},
+        {"level": None, "dataset": path, **col, "op": "ge", "value": float(start)},
+        {"level": None, "dataset": path, **col, "op": "lt", "value": float(end)},
     ]
+
+
+def _variable_entry(entry) -> tuple[str | None, int | None]:
+    """``(path, column)`` of one ``data_source.variables`` entry, mapping form or not.
+
+    The read path's :func:`zagg.processing.read._variable_specs` normalizes the
+    whole block; this is the single-entry form for config-side consumers that
+    hold one name (currently the windowing time_field).
+    """
+    if isinstance(entry, str):
+        return entry, None
+    if isinstance(entry, dict):
+        col = entry.get("column")
+        return entry.get("path"), None if col is None else int(col)
+    return None, None
 
 
 def windowed_cell_config(config: PipelineConfig, window: dict) -> tuple[PipelineConfig, dict]:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -570,6 +570,64 @@ def validate_config(config: PipelineConfig) -> None:
                     f"Variable '{name}': attrs must be JSON-serializable ({exc})"
                 ) from exc
 
+            _validate_composition_attrs(name, meta, attrs, agg_vars)
+
+
+def _validate_composition_attrs(name: str, meta: dict, attrs: dict, agg_vars: dict) -> None:
+    """Cross-check a ``composition`` attrs block against the field it describes.
+
+    The whole field rests on one invariant: the ``N`` a reader divides the lanes
+    by is the total weight of the digest named by ``of``, and the lanes were
+    packed at the ``threshold`` recorded here (issue #321). Both halves are
+    silent-wrong-answer failures — lanes stay in range, only the recovered
+    counts are wrong — so they are checked at load:
+
+    * ``of`` must name another ``aggregation.variables`` entry of
+      ``kind: ragged`` (a typo or a later rename of the digest field would
+      otherwise leave readers dereferencing a field that does not exist);
+    * ``threshold`` must equal the field's own ``params.threshold`` (the value
+      the reducer actually packs at).
+
+    The third coupling — the digest fields' ``where`` predicates committing the
+    same cut as ``threshold`` — is *not* validated here: ``where`` is an
+    arbitrary expression, so any check would be a regex over Python source that
+    both misses real drift (``> 1`` is the same cut as ``>= 2``) and rejects
+    valid predicates. It is stated in :func:`zagg.stats.composition.pack_composition`'s
+    docstring instead, where it travels with the function rather than with one
+    config template.
+    """
+    block = attrs.get("composition")
+    if not isinstance(block, dict):
+        return
+    of = block.get("of")
+    if of is not None:
+        if of == name:
+            raise ValueError(
+                f"Variable '{name}': attrs.composition.of names the composition field "
+                f"itself; it must name the signal digest whose total weight is N_signal"
+            )
+        target = agg_vars.get(of)
+        if target is None:
+            raise ValueError(
+                f"Variable '{name}': attrs.composition.of '{of}' is not a declared "
+                f"aggregation.variables field (readers resolve N_signal through it)"
+            )
+        if target.get("kind") != "ragged":
+            raise ValueError(
+                f"Variable '{name}': attrs.composition.of '{of}' must be a "
+                f"'kind: ragged' digest field (got kind "
+                f"{target.get('kind', 'scalar')!r}) — N_signal is its total weight"
+            )
+    threshold = block.get("threshold")
+    if threshold is not None:
+        packed = (meta.get("params") or {}).get("threshold")
+        if packed is not None and packed != threshold:
+            raise ValueError(
+                f"Variable '{name}': attrs.composition.threshold {threshold!r} disagrees "
+                f"with params.threshold {packed!r} — the recorded threshold must be the "
+                f"one the reducer packs at (issue #321)"
+            )
+
 
 # Required per-variable keys for a temporal/event aggregation spec. ``mask``
 # is optional (``specs_from_config`` defaults it to ``"ais"``); capability

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -546,6 +546,30 @@ def validate_config(config: PipelineConfig) -> None:
                     f"field/coordinate of that name — rename one of them (issue #209)"
                 )
 
+        # Field-level store attrs (issue #321): free-form provenance the grid
+        # template merges onto the field's array spec (e.g. the composition
+        # field's lane order and signal threshold), so readers bind to
+        # metadata instead of reconstructing config conventions.
+        attrs = meta.get("attrs")
+        if attrs is not None:
+            if not isinstance(attrs, dict) or not all(isinstance(k, str) for k in attrs):
+                raise ValueError(f"Variable '{name}': attrs must be a mapping with string keys")
+            from zagg.grids.base import RAGGED_ELEMENT_ATTR
+
+            if RAGGED_ELEMENT_ATTR in attrs:
+                raise ValueError(
+                    f"Variable '{name}': attrs key {RAGGED_ELEMENT_ATTR!r} is reserved "
+                    f"for the ragged layout block (issue #209)"
+                )
+            import json
+
+            try:
+                json.dumps(attrs)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Variable '{name}': attrs must be JSON-serializable ({exc})"
+                ) from exc
+
 
 # Required per-variable keys for a temporal/event aggregation spec. ``mask``
 # is optional (``specs_from_config`` defaults it to ``"ais"``); capability

--- a/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
+++ b/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
@@ -21,6 +21,11 @@
 # ``signal_conf_ph`` dataset via the per-variable ``column`` selector (one
 # read, five columns -- the dataset path is deduped with the TEP filter's).
 #
+# Both strata carry the located channel (issue #87, espg ruling on PR #334:
+# located strata IS the default, not a variant): each centroid stores its
+# order-29 morton word (exact photon position at weight 1) in the row-aligned
+# ``{field}_locations`` sibling arrays.
+#
 # Strata + composition are pooled / single-block-spill only for now: the
 # streaming merge surface rejects them (the fold would ignore the ``where``
 # mask), so heavy multi-block shards need the fold-law follow-up (issue #321).
@@ -80,6 +85,7 @@ aggregation:
       kind: ragged
       function: "zagg.stats.tdigest.build_tdigest_where"
       source: h_ph
+      location: leaf_id
       inner_shape: [2]
       params:
         delta: 256
@@ -96,6 +102,7 @@ aggregation:
       kind: ragged
       function: "zagg.stats.tdigest.build_tdigest_where"
       source: h_ph
+      location: leaf_id
       inner_shape: [2]
       params:
         delta: 256

--- a/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
+++ b/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
@@ -17,6 +17,11 @@
 # below-compression-knee regime). The committed threshold is recorded in the
 # field's ``attrs`` so readers bind to store metadata, not this file.
 #
+# The low/med/high lanes are ABSOLUTE (conf == 2/3/4), never renumbered against
+# ``threshold``: at the default threshold 2 all three carry counts, and a
+# variant committing a higher threshold simply ships empty lower lanes rather
+# than shifted ones -- one lane layout for every product.
+#
 # The five ``signal_conf_*`` columns are read from the single 2-D
 # ``signal_conf_ph`` dataset via the per-variable ``column`` selector (one
 # read, five columns -- the dataset path is deduped with the TEP filter's).

--- a/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
+++ b/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
@@ -1,0 +1,138 @@
+# ATL03 photon-height t-digest, SIGNAL/NOISE STRATIFIED (issue #321).
+#
+# Two disjoint per-cell t-digests split at ingest by the ATBD signal predicate
+# -- ``signal_conf_ph > 1`` on ANY surface column (selection rule A1: the
+# union is idempotent, decision-free, and narrowable downstream; a committed
+# single-surface subset is not widenable). Each stratum's digest total weight
+# is the exact stratum photon count; the total photon-flux distribution is
+# recovered at read by ONE deterministic two-way merge (``merge_tdigests``).
+# Classification is committed here because signal confidence is NOT
+# reconstructable post-aggregation (issue #321 background).
+#
+# The ``composition`` field packs eight u8 lanes of quantized fractions of the
+# signal stratum into one uint64 per cell (``zagg.stats.composition``,
+# spec ``zagg-composition/1``): five per-surface lanes (signal_conf_ph column
+# order) + low/med/high lanes. Quantization carries a presence floor, so
+# ``lane > 0`` is exact at every N; counts recover exactly for N <= 254 (the
+# below-compression-knee regime). The committed threshold is recorded in the
+# field's ``attrs`` so readers bind to store metadata, not this file.
+#
+# The five ``signal_conf_*`` columns are read from the single 2-D
+# ``signal_conf_ph`` dataset via the per-variable ``column`` selector (one
+# read, five columns -- the dataset path is deduped with the TEP filter's).
+#
+# Strata + composition are pooled / single-block-spill only for now: the
+# streaming merge surface rejects them (the fold would ignore the ``where``
+# mask), so heavy multi-block shards need the fold-law follow-up (issue #321).
+# Grid geometry matches atl03_tdigest_healpix.yaml (o11 shard / o13 inner
+# chunk / o19 cells).
+data_source:
+  reader: h5coro
+  driver: s3
+  groups: [gt1l, gt1r, gt2l, gt2r, gt3l, gt3r]
+  coordinates:
+    latitude: "/{group}/heights/lat_ph"
+    longitude: "/{group}/heights/lon_ph"
+  variables:
+    h_ph: "/{group}/heights/h_ph"
+    signal_conf_land: {path: "/{group}/heights/signal_conf_ph", column: 0}
+    signal_conf_ocean: {path: "/{group}/heights/signal_conf_ph", column: 1}
+    signal_conf_sea_ice: {path: "/{group}/heights/signal_conf_ph", column: 2}
+    signal_conf_land_ice: {path: "/{group}/heights/signal_conf_ph", column: 3}
+    signal_conf_inland_water: {path: "/{group}/heights/signal_conf_ph", column: 4}
+  filters:
+    - dataset: "/{group}/heights/signal_conf_ph"
+      column: 0                  # possible_tep is uniform across columns
+      op: ne
+      value: -2
+  base_level: photons
+  levels:
+    photons:
+      path: "/{group}/heights"
+      coordinates: {latitude: lat_ph, longitude: lon_ph}
+      link: null
+    segments:
+      path: "/{group}/geolocation"
+      coordinates: {latitude: reference_photon_lat, longitude: reference_photon_lon}
+      link:
+        to: photons
+        index_beg: "/{group}/geolocation/ph_index_beg"
+        count: "/{group}/geolocation/segment_ph_cnt"
+        index_base: 1
+  read_plan:
+    spatial_index: segments
+    pad: 1
+
+aggregation:
+  coordinates:
+    morton:
+      dtype: uint64
+      fill_value: 0
+  variables:
+    count:
+      function: len
+      source: h_ph
+      dtype: int32
+      fill_value: 0
+    # The signal predicate below and the composition ``threshold`` MUST agree:
+    # both commit the same ``conf >= 2`` cut (i.e. the ATBD ``> 1``).
+    h_tdigest_signal:
+      kind: ragged
+      function: "zagg.stats.tdigest.build_tdigest_where"
+      source: h_ph
+      inner_shape: [2]
+      params:
+        delta: 256
+        where: >-
+          (signal_conf_land >= 2) | (signal_conf_ocean >= 2) |
+          (signal_conf_sea_ice >= 2) | (signal_conf_land_ice >= 2) |
+          (signal_conf_inland_water >= 2)
+      dtype: float32
+      fill_value: 0
+      attrs:
+        stratum: signal
+        signal_threshold: 2
+    h_tdigest_noise:
+      kind: ragged
+      function: "zagg.stats.tdigest.build_tdigest_where"
+      source: h_ph
+      inner_shape: [2]
+      params:
+        delta: 256
+        where: >-
+          ~((signal_conf_land >= 2) | (signal_conf_ocean >= 2) |
+          (signal_conf_sea_ice >= 2) | (signal_conf_land_ice >= 2) |
+          (signal_conf_inland_water >= 2))
+      dtype: float32
+      fill_value: 0
+      attrs:
+        stratum: noise
+        signal_threshold: 2
+    composition:
+      function: "zagg.stats.composition.pack_composition"
+      source: h_ph
+      dtype: uint64
+      fill_value: 0
+      params:
+        conf_land: signal_conf_land
+        conf_ocean: signal_conf_ocean
+        conf_sea_ice: signal_conf_sea_ice
+        conf_land_ice: signal_conf_land_ice
+        conf_inland_water: signal_conf_inland_water
+        threshold: 2
+      attrs:
+        composition:
+          spec: zagg-composition/1
+          lanes: [land, ocean, sea_ice, land_ice, inland_water, low, med, high]
+          of: h_tdigest_signal        # N_signal = this digest's total weight
+          threshold: 2
+
+output:
+  grid:
+    type: healpix
+    indexing_scheme: nested
+    parent_order: 11             # shard / dispatch unit: 4^(19-11) = 256x256 cells
+    chunk_inner: 13              # inner Zarr chunk: 4^(19-13) = 64x64 cells (K=16)
+    sharded: true
+    child_order: 19              # leaf cell resolution (~10 m)
+  store_layout: hive

--- a/src/zagg/grids/base.py
+++ b/src/zagg/grids/base.py
@@ -59,6 +59,22 @@ RAGGED_SPEC = "zagg-ragged/1"
 RAGGED_ZSTD_LEVEL = 3
 
 
+def apply_field_attrs(spec, meta: dict):
+    """Merge a variable's config-declared ``attrs`` onto its array spec.
+
+    ``aggregation.variables.{name}.attrs`` (issue #321) records field-level
+    provenance in the store — e.g. the composition field's lane order and the
+    signal threshold the split was committed at — so readers bind to metadata
+    rather than reconstructing config conventions. Declared keys are merged
+    over the spec's own attributes; the reserved ``ragged`` block cannot be
+    overridden (enforced at config validation).
+    """
+    attrs = meta.get("attrs")
+    if not attrs:
+        return spec
+    return spec.with_attributes({**dict(spec.attributes or {}), **attrs})
+
+
 def ragged_locations_name(field_name: str) -> str:
     """On-disk array name of a located ragged field's uint64 channel (issue #87).
 

--- a/src/zagg/grids/base.py
+++ b/src/zagg/grids/base.py
@@ -65,9 +65,17 @@ def apply_field_attrs(spec, meta: dict):
     ``aggregation.variables.{name}.attrs`` (issue #321) records field-level
     provenance in the store — e.g. the composition field's lane order and the
     signal threshold the split was committed at — so readers bind to metadata
-    rather than reconstructing config conventions. Declared keys are merged
-    over the spec's own attributes; the reserved ``ragged`` block cannot be
-    overridden (enforced at config validation).
+    rather than reconstructing config conventions.
+
+    Attrs land on the **payload array only**. A located ragged field's sibling
+    uint64 channel (:func:`ragged_locations_name`) is addressed *through* the
+    payload array, so it deliberately carries no user attrs — the provenance of
+    the pair lives on the field the config named (review finding, PR #334).
+
+    Declared keys are merged **over** the spec's own attributes, so a config
+    could in principle shadow spec-owned metadata; the reserved ``ragged``
+    block is the one key protected from that (enforced at config validation),
+    which is a denylist of exactly the one populated spec attr in tree today.
     """
     attrs = meta.get("attrs")
     if not attrs:

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -20,6 +20,7 @@ from zagg.config import (
 )
 from zagg.grids.base import (
     InconsistentShardError,
+    apply_field_attrs,
     chunk_array_spec,
     ragged_array_spec,
     ragged_locations_name,
@@ -614,11 +615,14 @@ class HealpixGrid:
                         "shard_shape": rag_shard,
                     }
                 located = ragged_locations_name(name) if sig.get("location") else None
-                members[name] = ragged_array_spec(
-                    element_dtype=sig["dtype"] or "float32",
-                    inner_shape=sig["inner_shape"],
-                    locations=located,
-                    **rag_kw,
+                members[name] = apply_field_attrs(
+                    ragged_array_spec(
+                        element_dtype=sig["dtype"] or "float32",
+                        inner_shape=sig["inner_shape"],
+                        locations=located,
+                        **rag_kw,
+                    ),
+                    meta,
                 )
                 if located:
                     members[located] = ragged_array_spec(element_dtype="uint64", **rag_kw)
@@ -634,26 +638,32 @@ class HealpixGrid:
                 # appends the field's trailing_shape (chunked whole) for a vector
                 # companion. A scalar/ragged field has an empty trailing_shape, so
                 # vector_array_spec returns the chunk base unchanged.
-                members[name] = vector_array_spec(
-                    chunk_array_spec(
-                        spec,
-                        chunk_grid_shape=chunk_grid_shape,
-                        chunk_dims=("chunks",),
+                members[name] = apply_field_attrs(
+                    vector_array_spec(
+                        chunk_array_spec(
+                            spec,
+                            chunk_grid_shape=chunk_grid_shape,
+                            chunk_dims=("chunks",),
+                        ),
+                        sig,
+                        base_dims=("chunks",),
+                        base_chunk_shape=(1,),
                     ),
-                    sig,
-                    base_dims=("chunks",),
-                    base_chunk_shape=(1,),
+                    meta,
                 )
                 continue
             # A vector field (issue #29) gets a trailing payload dim chunked
             # whole; scalars are returned unchanged.
-            members[name] = _shard(
-                vector_array_spec(
-                    spec,
-                    sig,
-                    base_dims=("cells",),
-                    base_chunk_shape=(self.cells_per_chunk,),
-                )
+            members[name] = apply_field_attrs(
+                _shard(
+                    vector_array_spec(
+                        spec,
+                        sig,
+                        base_dims=("cells",),
+                        base_chunk_shape=(self.cells_per_chunk,),
+                    )
+                ),
+                meta,
             )
 
         return GroupSpec(members=members, attributes=self._dggs_attrs())

--- a/src/zagg/grids/rectilinear.py
+++ b/src/zagg/grids/rectilinear.py
@@ -51,6 +51,7 @@ from zagg.config import (
     output_field_signature,
 )
 from zagg.grids.base import (
+    apply_field_attrs,
     chunk_array_spec,
     ragged_array_spec,
     ragged_locations_name,
@@ -648,11 +649,14 @@ class RectilinearGrid:
                         "shard_shape": (self.chunk_h, self.chunk_w) if self.sharded else None,
                     }
                 located = ragged_locations_name(name) if sig.get("location") else None
-                members[name] = ragged_array_spec(
-                    element_dtype=sig["dtype"] or "float32",
-                    inner_shape=sig["inner_shape"],
-                    locations=located,
-                    **rag_kw,
+                members[name] = apply_field_attrs(
+                    ragged_array_spec(
+                        element_dtype=sig["dtype"] or "float32",
+                        inner_shape=sig["inner_shape"],
+                        locations=located,
+                        **rag_kw,
+                    ),
+                    meta,
                 )
                 if located:
                     members[located] = ragged_array_spec(element_dtype="uint64", **rag_kw)
@@ -668,26 +672,32 @@ class RectilinearGrid:
                 # vector_array_spec appends the field's trailing_shape (chunked whole)
                 # for a vector companion. A scalar/ragged field has an empty
                 # trailing_shape, so vector_array_spec returns the chunk base.
-                members[name] = vector_array_spec(
-                    chunk_array_spec(
-                        spec,
-                        chunk_grid_shape=self.chunk_grid_shape,
-                        chunk_dims=("chunk_y", "chunk_x"),
+                members[name] = apply_field_attrs(
+                    vector_array_spec(
+                        chunk_array_spec(
+                            spec,
+                            chunk_grid_shape=self.chunk_grid_shape,
+                            chunk_dims=("chunk_y", "chunk_x"),
+                        ),
+                        sig,
+                        base_dims=("chunk_y", "chunk_x"),
+                        base_chunk_shape=(1, 1),
                     ),
-                    sig,
-                    base_dims=("chunk_y", "chunk_x"),
-                    base_chunk_shape=(1, 1),
+                    meta,
                 )
                 continue
             # A vector field (issue #29) gets a trailing payload dim chunked
             # whole; scalars are returned unchanged.
-            members[name] = _shard(
-                vector_array_spec(
-                    spec,
-                    sig,
-                    base_dims=("y", "x"),
-                    base_chunk_shape=self.chunk_shape,
-                )
+            members[name] = apply_field_attrs(
+                _shard(
+                    vector_array_spec(
+                        spec,
+                        sig,
+                        base_dims=("y", "x"),
+                        base_chunk_shape=self.chunk_shape,
+                    )
+                ),
+                meta,
             )
 
         return GroupSpec(members=members, attributes=self._geozarr_attrs())

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -543,10 +543,19 @@ class InlineIndex(VirtualIndex):
         group-read failure the data read would produce.
         """
         from zagg.config import filters_from_data_source
-        from zagg.processing.read import _level_coord_paths
+        from zagg.processing.read import _level_coord_paths, _variable_specs
 
         paths = [tmpl.format(group=group) for tmpl in data_source["coordinates"].values()]
-        paths += [tmpl.format(group=group) for tmpl in data_source["variables"].values()]
+        # Variables go through the read path's normalizer: an entry is either a
+        # path-template string or the ``{path, column}`` mapping form (issue
+        # #321). Chunk maps are per DATASET, so the column selector is
+        # irrelevant here — several selectors on one path collapse in the
+        # ``dict.fromkeys`` dedup below (one chunk map for all five
+        # ``signal_conf_ph`` surfaces).
+        paths += [
+            tmpl.format(group=group)
+            for tmpl, _ in _variable_specs(data_source["variables"]).values()
+        ]
         base_level = data_source.get("base_level")
         for f in filters_from_data_source(data_source):
             if "expression" in f:

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -9,6 +9,7 @@ DAG stays acyclic.
 
 import logging
 import os
+from functools import lru_cache
 from typing import Any
 
 import numpy as np
@@ -49,6 +50,21 @@ def _rss_log(stage: str) -> None:
     """Opt-in per-stage RSS trace (set ``ZAGG_PROFILE_RSS=1``) for #130 diagnostics."""
     if os.environ.get("ZAGG_PROFILE_RSS"):
         logger.info(f"  [rss] {stage:34s} {_rss_mb():7.0f} MB")
+
+
+@lru_cache(maxsize=256)
+def _compile_param_expr(expression: str):
+    """Cache the code object for a params expression (review finding, PR #334).
+
+    A params value that names columns is evaluated **per cell**, so passing the
+    source string to ``eval`` recompiles it once per cell per field. Measured on
+    the issue #321 strata config's 5-term ``where`` predicate: 18.9 us per
+    ``eval(str)`` vs 3.8 us per ``eval(code)`` — i.e. ~2.5 s of pure
+    recompilation per o11 shard (65,536 cells x two ``where`` fields). Compiling
+    in ``"eval"`` mode is semantically identical to ``eval`` on the string; the
+    bounded cache keys on the expression source, of which a config has a handful.
+    """
+    return compile(expression, "<zagg-param>", "eval")
 
 
 def _field_sentinel(meta: dict) -> float:
@@ -296,7 +312,7 @@ def _eval_chunk_precompute(config: PipelineConfig, pooled: dict[str, np.ndarray]
                     resolved_params[pkey] = pooled[pval]
                 elif isinstance(pval, str) and any(c in pval for c in pooled):
                     ns = {"__builtins__": {}, "np": np, "numpy": np, **pooled}
-                    resolved_params[pkey] = eval(pval, ns)  # noqa: S307
+                    resolved_params[pkey] = eval(_compile_param_expr(pval), ns)  # noqa: S307
                 else:
                     resolved_params[pkey] = pval
             value = resolve_function(meta["function"])(values, **resolved_params)
@@ -471,7 +487,8 @@ def calculate_cell_statistics(
                     "numpy": np,
                     **cell_data,
                 }
-                resolved_params[pkey] = eval(pval, ns)  # noqa: S307
+                # Cached code object, not the source string: this runs per cell.
+                resolved_params[pkey] = eval(_compile_param_expr(pval), ns)  # noqa: S307
             else:
                 resolved_params[pkey] = pval
 

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -449,7 +449,7 @@ def calculate_cell_statistics(
                         f"requires a scalar result (declare 'kind: vector' to store an "
                         f"array per cell)"
                     )
-                result[name] = float(out)
+                result[name] = _coerce_scalar_value(out, sig)
             continue
 
         values = cell_data[source]
@@ -520,9 +520,23 @@ def calculate_cell_statistics(
         elif sig["kind"] == "ragged":
             result[name] = _coerce_ragged_value(out, sig)
         else:
-            result[name] = float(out)
+            result[name] = _coerce_scalar_value(out, sig)
 
     return result
+
+
+def _coerce_scalar_value(out, sig: dict):
+    """Coerce one scalar field result per its declared dtype.
+
+    Float dtypes keep the pre-#29 ``float()`` round-trip byte-for-byte. An
+    integer dtype coerces via ``int()`` instead: a float64 round-trip corrupts
+    exact integers above 2**53, which a packed 64-bit lane word (the issue
+    #321 composition field) legitimately exceeds.
+    """
+    dtype = sig.get("dtype")
+    if dtype is not None and np.issubdtype(np.dtype(dtype), np.integer):
+        return int(out)
+    return float(out)
 
 
 def _empty_cell_value(meta: dict):
@@ -551,7 +565,14 @@ def _empty_cell_value(meta: dict):
     if sig["kind"] == "vector":
         dtype = np.dtype(sig["dtype"]) if sig["dtype"] is not None else np.dtype("float32")
         return np.full(sig["trailing_shape"], _field_sentinel(meta), dtype=dtype)
-    return 0 if meta.get("function") in ("len", "count") else np.nan
+    if meta.get("function") in ("len", "count"):
+        return 0
+    # An integer-dtype scalar cannot hold NaN; empty cells take the field's
+    # declared fill_value (issue #321 — e.g. the packed composition word's 0).
+    dtype_str = sig["dtype"]
+    if dtype_str is not None and np.issubdtype(np.dtype(dtype_str), np.integer):
+        return int(meta.get("fill_value", 0))
+    return np.nan
 
 
 def _coerce_field_value(value, sig: dict) -> np.ndarray:

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -79,6 +79,27 @@ def _field_sentinel(meta: dict) -> float:
     return np.nan if fill_value == "NaN" else fill_value
 
 
+def _integer_fill(meta: dict, dtype) -> int:
+    """:func:`_field_sentinel` for an INTEGER-dtype field: the sentinel must be numeric.
+
+    The float default is the string ``"NaN"``, which no integer array can hold
+    (issue #321's packed composition word declares ``fill_value: 0`` instead).
+    Reject a non-numeric sentinel by name here rather than letting it surface
+    mid-shard as a stray ``int('NaN')`` parse error or a numpy
+    ``np.full(..., np.nan, dtype=uint64)`` failure — the two integer paths
+    (empty scalar cells, ``vector`` padding) then agree with each other and with
+    :func:`_field_sentinel` on where the value comes from (review finding).
+    """
+    fill = meta.get("fill_value", 0)
+    if isinstance(fill, str):
+        raise ValueError(
+            f"integer field (dtype {np.dtype(dtype)}) declares fill_value {fill!r}: an "
+            f"integer array cannot hold a non-numeric sentinel — declare a numeric "
+            f"fill_value (e.g. 0) or a float dtype"
+        )
+    return int(fill)
+
+
 def _group_columns(
     col_dict: dict[str, np.ndarray],
     cell_col: np.ndarray,
@@ -581,14 +602,19 @@ def _empty_cell_value(meta: dict):
         return []
     if sig["kind"] == "vector":
         dtype = np.dtype(sig["dtype"]) if sig["dtype"] is not None else np.dtype("float32")
-        return np.full(sig["trailing_shape"], _field_sentinel(meta), dtype=dtype)
+        sentinel = (
+            _integer_fill(meta, dtype)
+            if np.issubdtype(dtype, np.integer)
+            else _field_sentinel(meta)
+        )
+        return np.full(sig["trailing_shape"], sentinel, dtype=dtype)
     if meta.get("function") in ("len", "count"):
         return 0
     # An integer-dtype scalar cannot hold NaN; empty cells take the field's
     # declared fill_value (issue #321 — e.g. the packed composition word's 0).
     dtype_str = sig["dtype"]
     if dtype_str is not None and np.issubdtype(np.dtype(dtype_str), np.integer):
-        return int(meta.get("fill_value", 0))
+        return _integer_fill(meta, dtype_str)
     return np.nan
 
 

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -486,7 +486,7 @@ def calculate_cell_statistics(
                         f"requires a scalar result (declare 'kind: vector' to store an "
                         f"array per cell)"
                     )
-                result[name] = _coerce_scalar_value(out, sig)
+                result[name] = _coerce_scalar_value(out, sig, name)
             continue
 
         values = cell_data[source]
@@ -558,21 +558,39 @@ def calculate_cell_statistics(
         elif sig["kind"] == "ragged":
             result[name] = _coerce_ragged_value(out, sig)
         else:
-            result[name] = _coerce_scalar_value(out, sig)
+            result[name] = _coerce_scalar_value(out, sig, name)
 
     return result
 
 
-def _coerce_scalar_value(out, sig: dict):
+def _coerce_scalar_value(out, sig: dict, name: str = "<field>"):
     """Coerce one scalar field result per its declared dtype.
 
     Float dtypes keep the pre-#29 ``float()`` round-trip byte-for-byte. An
     integer dtype coerces via ``int()`` instead: a float64 round-trip corrupts
     exact integers above 2**53, which a packed 64-bit lane word (the issue
     #321 composition field) legitimately exceeds.
+
+    An integer declaration is **verified, not trusted**: a reducer returning a
+    fractional value into an integer field is a config/reducer mismatch, and
+    bare ``int()`` would silently truncate it toward zero (``2.7 -> 2``). Python
+    and numpy integers pass through; floats pass only when they carry no
+    fractional part (``np.float64(3.0)`` is a legitimate reducer return); a
+    fractional value raises naming the field, its dtype, and the value — the
+    same fail-fast shape as :func:`_coerce_field_value`'s trailing-shape check.
     """
     dtype = sig.get("dtype")
     if dtype is not None and np.issubdtype(np.dtype(dtype), np.integer):
+        if not isinstance(out, (int, np.integer)):
+            # Anything else (float, np.floating, 0-d array) must be integral;
+            # ``float()`` first so a 0-d array or np scalar answers uniformly.
+            if not float(out).is_integer():
+                raise ValueError(
+                    f"scalar field {name!r}: declared dtype {np.dtype(dtype)} but the "
+                    f"reducer returned {out!r}, which is not integral — an integer field "
+                    f"cannot store a fractional value (declare a float dtype, or round "
+                    f"in the reducer)"
+                )
         return int(out)
     return float(out)
 

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -239,6 +239,36 @@ def _read_segment_broadcasts(
     return out
 
 
+def _variable_specs(variables: dict) -> dict[str, tuple[str, int | None]]:
+    """Normalize ``data_source.variables`` entries to ``(path_template, column)``.
+
+    A plain-string entry reads the whole dataset. The mapping form
+    ``{path: ..., column: k}`` selects one column of a 2-D dataset (issue
+    #321) — the same semantics as ``column`` on structured filters — so
+    several scalar columns can be pulled from one multi-column dataset (e.g.
+    the five ``signal_conf_ph`` surfaces) while the shared path is still read
+    once via the existing path dedup.
+    """
+    specs: dict[str, tuple[str, int | None]] = {}
+    for col, entry in variables.items():
+        if isinstance(entry, str):
+            specs[col] = (entry, None)
+        else:
+            specs[col] = (entry["path"], int(entry["column"]))
+    return specs
+
+
+def _select_column(values: np.ndarray, column: int | None, col_name: str) -> np.ndarray:
+    """Apply a variable's ``column`` selector; shape-check both directions."""
+    if column is not None:
+        if values.ndim < 2:
+            raise ValueError(f"variable '{col_name}': 'column' set but array is 1-D")
+        return values[:, column]
+    if values.ndim > 1:
+        raise ValueError(f"variable '{col_name}': N-D dataset requires an integer 'column'")
+    return values
+
+
 def _predicate_mask(arr: np.ndarray, f: dict) -> np.ndarray:
     """Build a 1-D boolean keep-mask for one structured predicate (issue #43).
 
@@ -509,7 +539,8 @@ def _execute_plan_group(
 
     # Read the variables and base-level filter datasets via the same plan. Read
     # each distinct path once (the variable and filter dataset paths can coincide).
-    var_paths = {col: tmpl.format(group=group) for col, tmpl in variables.items()}
+    var_specs = _variable_specs(variables)
+    var_paths = {col: tmpl.format(group=group) for col, (tmpl, _) in var_specs.items()}
     filter_paths = {id(f): f["dataset"].format(group=group) for f in base_structured}
     # dtype hint isn't load-bearing -- execute_read_plan dtype-casts via
     # np.asarray, which is a no-op when the source dtype already matches.
@@ -586,7 +617,8 @@ def _execute_plan_group(
     leaf_after_spatial = leaf_ids[mask_spatial]
     data_dict: dict[str, np.ndarray] = {}
     for col_name, path in var_paths.items():
-        values = arrays_by_path[path][mask_spatial]
+        values = _select_column(arrays_by_path[path], var_specs[col_name][1], col_name)
+        values = values[mask_spatial]
         if keep_mask is not None:
             values = values[keep_mask]
         data_dict[col_name] = values
@@ -864,7 +896,8 @@ def _read_group_full(
     # Read each distinct path once; flag datasets may coincide with a variable.
     datasets = []
     paths_seen = set()
-    var_paths = {col: tmpl.format(group=group) for col, tmpl in variables.items()}
+    var_specs = _variable_specs(variables)
+    var_paths = {col: tmpl.format(group=group) for col, (tmpl, _) in var_specs.items()}
     for path in var_paths.values():
         if path not in paths_seen:
             datasets.append({"dataset": path, "hyperslice": [(min_idx, max_idx)]})
@@ -914,7 +947,8 @@ def _read_group_full(
     leaf_sliced = leaf_ids[min_idx:max_idx][mask_sliced]
     data_dict = {}
     for col_name, path in var_paths.items():
-        values = data[path][mask_sliced]
+        values = _select_column(data[path], var_specs[col_name][1], col_name)
+        values = values[mask_sliced]
         if keep_mask is not None:
             values = values[keep_mask]
         data_dict[col_name] = values

--- a/src/zagg/stats/composition.py
+++ b/src/zagg/stats/composition.py
@@ -1,0 +1,147 @@
+"""Packed per-cell signal composition — the ``zagg-composition/1`` field (issue #321).
+
+One ``uint64`` per cell carries eight 8-bit lanes of quantized fractions of the
+cell's **signal stratum** (``N_signal`` = the signal digest's total weight —
+magnitude lives in the digest, composition here):
+
+======  =========================================================
+bytes   lanes
+======  =========================================================
+0–4     per-surface fractions, ``signal_conf_ph`` column order:
+        land, ocean, sea_ice, land_ice, inland_water — the count of
+        signal photons whose per-surface confidence clears the
+        threshold, over ``N_signal``
+5–7     low / med / high fractions: signal photons whose *strongest*
+        per-surface confidence is exactly 2 / 3 / 4, over ``N_signal``
+======  =========================================================
+
+Quantization uses a **presence floor**: ``k = round(255 * c / n)``, except any
+nonzero count quantizes to at least 1 — so ``lane > 0`` is exactly "this flag
+occurred" at every ``n``, through arbitrary merge chains. Count recovery
+``round(k * n / 255)`` is exact for ``n <= 254`` (quantization error
+``<= n/510 < 1/2``) — the entire below-compression-knee regime.
+
+The per-surface lanes are **overlapping marginals** (``surf_type`` is
+multi-hot): they do not sum to 255 and cannot split the height distribution
+per surface. Empty signal stratum packs to 0.
+
+Merge law (order-independent monoid over ``(word, n)`` pairs)::
+
+    lane_merged = quantize((n_a * lane_a + n_b * lane_b) / (n_a + n_b))
+
+with the same presence floor, so presence survives re-quantization exactly and
+count error stays O(n/510) per merge.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "COMPOSITION_SPEC",
+    "LANES",
+    "counts_from_composition",
+    "merge_composition",
+    "pack_composition",
+    "unpack_composition",
+]
+
+COMPOSITION_SPEC = "zagg-composition/1"
+
+#: Lane order, LSB byte first: five surfaces (``signal_conf_ph`` column
+#: order), then the three confidence levels of the union-signal stratum.
+LANES = ("land", "ocean", "sea_ice", "land_ice", "inland_water", "low", "med", "high")
+
+_SURFACES = 5
+
+
+def _quantize(counts: np.ndarray, n: int) -> np.ndarray:
+    """Quantize lane counts to u8 fractions of ``n`` with the presence floor."""
+    if n <= 0:
+        return np.zeros(len(counts), dtype=np.uint64)
+    k = np.rint(255.0 * np.asarray(counts, dtype=np.float64) / n)
+    k = np.where((np.asarray(counts) > 0) & (k == 0), 1.0, k)
+    return np.clip(k, 0, 255).astype(np.uint64)
+
+
+def _pack(lanes: np.ndarray) -> int:
+    word = np.uint64(0)
+    for i, lane in enumerate(lanes):
+        word |= np.uint64(lane) << np.uint64(8 * i)
+    return int(word)
+
+
+def unpack_composition(word: int) -> np.ndarray:
+    """Unpack a composition word into its eight u8 lanes (``LANES`` order)."""
+    w = np.uint64(word)
+    return np.array([(w >> np.uint64(8 * i)) & np.uint64(0xFF) for i in range(8)], dtype=np.uint8)
+
+
+def counts_from_composition(word: int, n_signal: int) -> np.ndarray:
+    """Recover per-lane counts; exact whenever ``n_signal <= 254``."""
+    lanes = unpack_composition(word).astype(np.float64)
+    return np.rint(lanes * n_signal / 255.0).astype(np.int64)
+
+
+def pack_composition(
+    values: np.ndarray,
+    *,
+    conf_land: np.ndarray,
+    conf_ocean: np.ndarray,
+    conf_sea_ice: np.ndarray,
+    conf_land_ice: np.ndarray,
+    conf_inland_water: np.ndarray,
+    threshold: int = 2,
+) -> int:
+    """Per-cell reducer: pack the cell's signal composition into one uint64.
+
+    ``values`` is the height column (the digest fields' ``source``); rows with
+    non-finite heights are dropped first so ``N_signal`` here equals the signal
+    digest's total weight exactly. The five ``conf_*`` kwargs are the
+    row-aligned per-surface ``signal_conf_ph`` columns (delivered by the
+    ``params``-as-columns mechanism). A photon is signal when **any** surface
+    clears ``threshold`` (the ATBD predicate at the default ``threshold=2``,
+    i.e. ``> 1``); its level lane is its *strongest* per-surface confidence.
+    """
+    values = np.asarray(values, dtype=np.float64)
+    conf = np.column_stack(
+        [conf_land, conf_ocean, conf_sea_ice, conf_land_ice, conf_inland_water]
+    ).astype(np.int64)
+    if conf.shape[0] != values.shape[0]:
+        raise ValueError(f"conf columns have {conf.shape[0]} rows, values has {values.shape[0]}")
+    finite = np.isfinite(values)
+    conf = conf[finite]
+
+    signal = (conf >= threshold).any(axis=1)
+    n = int(signal.sum())
+    if n == 0:
+        return 0
+    csig = conf[signal]
+
+    counts = np.empty(8, dtype=np.int64)
+    counts[:_SURFACES] = (csig >= threshold).sum(axis=0)
+    strongest = csig.max(axis=1)
+    for i, level in enumerate((2, 3, 4)):
+        counts[_SURFACES + i] = int((strongest == level).sum())
+    return _pack(_quantize(counts, n))
+
+
+def merge_composition(word_a: int, n_a: int, word_b: int, n_b: int) -> int:
+    """Fold two ``(word, n_signal)`` pairs — the digest-weighted-mean monoid.
+
+    Presence floor preserved: a lane nonzero on either side stays nonzero.
+    Identity element is ``(0, 0)``; the operation is symmetric and, up to the
+    bounded re-quantization error, associative — fold order does not affect
+    presence at all and affects counts only within O(n/510).
+    """
+    if n_a <= 0:
+        return int(word_b)
+    if n_b <= 0:
+        return int(word_a)
+    la = unpack_composition(word_a).astype(np.float64)
+    lb = unpack_composition(word_b).astype(np.float64)
+    n = n_a + n_b
+    merged = (n_a * la + n_b * lb) / n
+    k = np.rint(merged)
+    k = np.where(((la > 0) | (lb > 0)) & (k == 0), 1.0, k)
+    return _pack(np.clip(k, 0, 255).astype(np.uint64))

--- a/src/zagg/stats/composition.py
+++ b/src/zagg/stats/composition.py
@@ -102,6 +102,17 @@ def pack_composition(
     ``params``-as-columns mechanism). A photon is signal when **any** surface
     clears ``threshold`` (the ATBD predicate at the default ``threshold=2``,
     i.e. ``> 1``); its level lane is its *strongest* per-surface confidence.
+
+    **Caller invariant (unenforceable here):** ``threshold`` must commit the
+    same cut as the ``where`` predicate of the signal digest the lanes are
+    fractions *of* — the digest whose total weight a reader uses as ``N``.
+    Disagree and nothing raises: the lanes stay in range and only the recovered
+    counts are wrong, off by the signal/noise ratio. This reducer sees the conf
+    columns but not the digest's predicate, so it cannot check it; config
+    validation cross-checks the two *recorded* thresholds
+    (``attrs.composition.threshold`` vs ``params.threshold``) and the ``of``
+    reference, but the predicate itself is an arbitrary expression and stays
+    the config author's responsibility.
     """
     values = np.asarray(values, dtype=np.float64)
     conf = np.column_stack(

--- a/src/zagg/stats/composition.py
+++ b/src/zagg/stats/composition.py
@@ -25,6 +25,12 @@ The per-surface lanes are **overlapping marginals** (``surf_type`` is
 multi-hot): they do not sum to 255 and cannot split the height distribution
 per surface. Empty signal stratum packs to 0.
 
+The level lanes are **absolute** — always ``conf == 2 / 3 / 4``, never
+renumbered against the signal ``threshold``. Raising the threshold therefore
+empties lanes rather than shifting them (``threshold=4`` ⇒ ``low``/``med``
+structurally 0), which keeps one lane layout across every product; see
+:func:`pack_composition`.
+
 Merge law (order-independent monoid over ``(word, n)`` pairs)::
 
     lane_merged = quantize((n_a * lane_a + n_b * lane_b) / (n_a + n_b))
@@ -113,6 +119,22 @@ def pack_composition(
     (``attrs.composition.threshold`` vs ``params.threshold``) and the ``of``
     reference, but the predicate itself is an arbitrary expression and stays
     the config author's responsibility.
+
+    **Level lanes are absolute, not threshold-relative.** Lanes 5–7 always mean
+    ``strongest conf == 2 / 3 / 4`` — the meanings never renumber, so a reader
+    binding to :data:`LANES` needs no knowledge of ``threshold``. The
+    consequence at a raised threshold is *empty* lanes, not shifted ones:
+    ``threshold=3`` leaves ``low`` structurally 0, ``threshold=4`` leaves
+    ``low`` and ``med`` 0, since a signal photon is ``>= threshold`` by
+    construction. That is the ratified design (a high-only product carries the
+    same lane layout as the default one), not an accident of the reducer.
+
+    Confidence values are ATL03's ``-2..4``, so ``strongest`` always lands in
+    ``(2, 3, 4)`` for a signal photon and the three level lanes partition the
+    signal stratum exactly. A source whose confidences exceeded 4 would fall
+    outside all three lanes (``counts[5:].sum() < n``) while the surface lanes
+    stayed populated — out of contract for this spec rather than defended
+    against here.
     """
     values = np.asarray(values, dtype=np.float64)
     conf = np.column_stack(

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -292,6 +292,38 @@ def build_tdigest(
     return out
 
 
+def build_tdigest_where(
+    values: np.ndarray,
+    delta: int = _DEFAULT_DELTA,
+    *,
+    where: np.ndarray,
+    locations: np.ndarray | None = None,
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+    """t-digest of the observations selected by a row-aligned boolean mask.
+
+    The stratified reducer for issue #321: a config declares two ragged fields
+    over the same ``source`` whose ``where`` params are complementary
+    expressions (e.g. the ATBD signal predicate over the ``signal_conf``
+    columns and its negation), yielding disjoint signal/noise digests whose
+    total weights are the exact stratum counts. Everything else —
+    serialization, merge laws, the located channel — is inherited from
+    :func:`build_tdigest`, which this delegates to after masking.
+    """
+    values = np.asarray(values)
+    where = np.asarray(where)
+    if where.shape != values.shape:
+        raise ValueError(f"where shape {where.shape} does not match values shape {values.shape}")
+    where = where.astype(bool, copy=False)
+    if locations is not None:
+        locations = np.asarray(locations)
+        if locations.shape != values.shape:
+            raise ValueError(
+                f"locations shape {locations.shape} does not match values shape {values.shape}"
+            )
+        return build_tdigest(values[where], delta=delta, locations=locations[where])
+    return build_tdigest(values[where], delta=delta)
+
+
 @overload
 def merge_tdigests(
     d1: np.ndarray, d2: np.ndarray, delta: int = ..., locations1: None = ..., locations2: None = ...

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -27,6 +27,17 @@ class TestPackComposition:
         lanes = unpack_composition(word)
         assert lanes.tolist() == [255, 0, 0, 255, 0, 0, 0, 255]  # land, land_ice; strongest=4
 
+    def test_golden_word_pins_lsb_first_byte_order(self):
+        # Every other assertion goes through ``unpack_composition``, so a
+        # layout flip to MSB-first would keep the whole suite green while
+        # breaking the ratified byte order for any independent reader
+        # (moczarr). Pin the literal: lane i occupies bits 8i..8i+8, so lanes
+        # [255, 0, 0, 255, 0, 0, 0, 255] -> land (b0) | land_ice (b3) | high
+        # (b7). MSB-first would give 0xFF0000FF000000FF instead.
+        conf = np.array([[4, -1, 0, 3, 1]])
+        word = pack_composition(np.array([10.0]), **_conf_kwargs(conf), threshold=2)
+        assert word == 0xFF000000FF0000FF
+
     def test_exact_count_recovery_below_knee(self):
         rng = np.random.default_rng(321)
         n = 200

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,0 +1,184 @@
+"""Tests for the packed signal-composition field and stratified reducer (issue #321)."""
+
+import numpy as np
+import pytest
+
+from zagg.stats.composition import (
+    LANES,
+    counts_from_composition,
+    merge_composition,
+    pack_composition,
+    unpack_composition,
+)
+from zagg.stats.tdigest import build_tdigest, build_tdigest_where
+
+
+def _conf_kwargs(conf):
+    """Split an (n, 5) conf matrix into the reducer's five column kwargs."""
+    cols = ("conf_land", "conf_ocean", "conf_sea_ice", "conf_land_ice", "conf_inland_water")
+    return {name: conf[:, i] for i, name in enumerate(cols)}
+
+
+class TestPackComposition:
+    def test_single_photon_lanes_are_exact_flags(self):
+        # count == 1: the lanes ARE the photon's flags (fraction in {0, 255}).
+        conf = np.array([[4, -1, 0, 3, 1]])
+        word = pack_composition(np.array([10.0]), **_conf_kwargs(conf), threshold=2)
+        lanes = unpack_composition(word)
+        assert lanes.tolist() == [255, 0, 0, 255, 0, 0, 0, 255]  # land, land_ice; strongest=4
+
+    def test_exact_count_recovery_below_knee(self):
+        rng = np.random.default_rng(321)
+        n = 200
+        conf = rng.integers(-2, 5, size=(n, 5))
+        conf[:, 0] = 4  # make every photon signal so N == n
+        word = pack_composition(np.zeros(n), **_conf_kwargs(conf), threshold=2)
+        counts = counts_from_composition(word, n)
+        expected = (conf >= 2).sum(axis=0)
+        assert counts[:5].tolist() == expected.tolist()
+        strongest = conf.max(axis=1)
+        assert counts[5:].tolist() == [(strongest == lv).sum() for lv in (2, 3, 4)]
+
+    def test_presence_floor_keeps_rare_flags_nonzero(self):
+        n = 300  # above the exact regime; 1/300 would round to 0 without the floor
+        conf = np.full((n, 5), -1)
+        conf[:, 0] = 4  # all signal via land
+        conf[0, 4] = 2  # one photon also flags inland_water
+        word = pack_composition(np.zeros(n), **_conf_kwargs(conf), threshold=2)
+        lanes = unpack_composition(word)
+        assert lanes[4] == 1  # floored, not rounded away
+        assert lanes[0] == 255
+
+    def test_no_signal_packs_zero(self):
+        conf = np.full((10, 5), 1)  # buffer everywhere: below the >1 cut
+        assert pack_composition(np.zeros(10), **_conf_kwargs(conf), threshold=2) == 0
+
+    def test_nan_heights_align_with_signal_digest_weight(self):
+        # N_signal must equal the signal digest's total weight: both drop
+        # non-finite heights before counting.
+        values = np.array([1.0, np.nan, 2.0, 3.0, np.nan])
+        conf = np.full((5, 5), -1)
+        conf[:, 3] = 4  # all rows signal (land_ice)
+        word = pack_composition(values, **_conf_kwargs(conf), threshold=2)
+        signal = (conf >= 2).any(axis=1)
+        digest = build_tdigest_where(values, where=signal)
+        n_digest = int(digest[:, 1].sum())
+        assert n_digest == 3
+        assert counts_from_composition(word, n_digest)[3] == 3
+
+    def test_threshold_knob(self):
+        conf = np.array([[4, 0, 0, 0, 0], [3, 0, 0, 0, 0], [2, 0, 0, 0, 0]])
+        w_high_only = pack_composition(np.zeros(3), **_conf_kwargs(conf), threshold=4)
+        lanes = unpack_composition(w_high_only)
+        assert lanes[0] == 255 and lanes[7] == 255  # 1 signal photon, high
+        assert lanes[5] == 0 and lanes[6] == 0
+
+    def test_row_mismatch_raises(self):
+        conf = np.zeros((3, 5))
+        with pytest.raises(ValueError, match="rows"):
+            pack_composition(np.zeros(4), **_conf_kwargs(conf))
+
+
+class TestMergeComposition:
+    def test_identity_and_passthrough(self):
+        conf = np.array([[4, -1, -1, 2, -1]])
+        w = pack_composition(np.array([1.0]), **_conf_kwargs(conf))
+        assert merge_composition(w, 1, 0, 0) == w
+        assert merge_composition(0, 0, w, 1) == w
+
+    def test_merge_matches_pooled_recompute(self):
+        rng = np.random.default_rng(87)
+        n_a, n_b = 40, 60
+        conf = rng.integers(-2, 5, size=(n_a + n_b, 5))
+        conf[:, 1] = 4  # everything signal
+        ka = _conf_kwargs(conf[:n_a])
+        kb = _conf_kwargs(conf[n_a:])
+        wa = pack_composition(np.zeros(n_a), **ka)
+        wb = pack_composition(np.zeros(n_b), **kb)
+        merged = merge_composition(wa, n_a, wb, n_b)
+        pooled = pack_composition(np.zeros(n_a + n_b), **_conf_kwargs(conf))
+        # Merging re-quantizes already-quantized lanes, so the merged word may
+        # sit 1 LSB off the pooled word; the contract is bounded count error
+        # (±1 here) and exact presence, not word equality.
+        m_counts = counts_from_composition(merged, n_a + n_b)
+        p_counts = counts_from_composition(pooled, n_a + n_b)
+        assert np.max(np.abs(m_counts - p_counts)) <= 1
+        assert np.array_equal(unpack_composition(merged) > 0, unpack_composition(pooled) > 0)
+
+    def test_presence_survives_deep_merges(self):
+        # One rare flag in the first block must stay nonzero through a long
+        # chain of merges with blocks that never carry it.
+        conf0 = np.full((10, 5), -1)
+        conf0[:, 0] = 4
+        conf0[0, 4] = 3  # rare inland_water flag
+        w = pack_composition(np.zeros(10), **_conf_kwargs(conf0))
+        n = 10
+        confk = np.full((100, 5), -1)
+        confk[:, 0] = 4
+        wk = pack_composition(np.zeros(100), **_conf_kwargs(confk))
+        for _ in range(20):
+            w = merge_composition(w, n, wk, 100)
+            n += 100
+        assert unpack_composition(w)[4] >= 1
+
+    def test_symmetric(self):
+        rng = np.random.default_rng(5)
+        conf_a = rng.integers(-2, 5, size=(30, 5))
+        conf_b = rng.integers(-2, 5, size=(50, 5))
+        conf_a[:, 2] = 4
+        conf_b[:, 2] = 4
+        wa = pack_composition(np.zeros(30), **_conf_kwargs(conf_a))
+        wb = pack_composition(np.zeros(50), **_conf_kwargs(conf_b))
+        assert merge_composition(wa, 30, wb, 50) == merge_composition(wb, 50, wa, 30)
+
+
+class TestBuildTdigestWhere:
+    def test_equals_masked_build(self):
+        rng = np.random.default_rng(11)
+        values = rng.standard_normal(500)
+        mask = rng.random(500) > 0.4
+        assert np.array_equal(
+            build_tdigest_where(values, delta=64, where=mask),
+            build_tdigest(values[mask], delta=64),
+        )
+
+    def test_disjoint_strata_weights_sum_to_finite_count(self):
+        rng = np.random.default_rng(12)
+        values = rng.standard_normal(300)
+        values[::17] = np.nan
+        mask = rng.random(300) > 0.5
+        d_sig = build_tdigest_where(values, where=mask)
+        d_noise = build_tdigest_where(values, where=~mask)
+        total = int(d_sig[:, 1].sum() + d_noise[:, 1].sum())
+        assert total == int(np.isfinite(values).sum())
+
+    def test_locations_subset_alongside(self):
+        from conftest import point_words
+
+        values = np.arange(20, dtype=np.float64)
+        locs = point_words(20, seed=9)
+        mask = np.zeros(20, dtype=bool)
+        mask[3:9] = True
+        digest, out_locs = build_tdigest_where(values, where=mask, locations=locs)
+        assert np.array_equal(out_locs, locs[3:9])  # unit weights, sorted input
+        assert int(digest[:, 1].sum()) == 6
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError, match="where shape"):
+            build_tdigest_where(np.zeros(3), where=np.zeros(4, dtype=bool))
+        with pytest.raises(ValueError, match="locations shape"):
+            build_tdigest_where(
+                np.zeros(3), where=np.ones(3, dtype=bool), locations=np.zeros(4, dtype=np.uint64)
+            )
+
+    def test_lanes_constant_documented(self):
+        assert LANES == (
+            "land",
+            "ocean",
+            "sea_ice",
+            "land_ice",
+            "inland_water",
+            "low",
+            "med",
+            "high",
+        )

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -82,6 +82,10 @@ class TestPackComposition:
         w_high_only = pack_composition(np.zeros(3), **_conf_kwargs(conf), threshold=4)
         lanes = unpack_composition(w_high_only)
         assert lanes[0] == 255 and lanes[7] == 255  # 1 signal photon, high
+        # Documented behavior, not a surprise: level lanes are ABSOLUTE
+        # (conf == 2/3/4 at every threshold), so raising the threshold empties
+        # the lower lanes instead of renumbering them — one lane layout for
+        # every product (see pack_composition's docstring).
         assert lanes[5] == 0 and lanes[6] == 0
 
     def test_row_mismatch_raises(self):

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -136,6 +136,43 @@ class TestMergeComposition:
             n += 100
         assert unpack_composition(w)[4] >= 1
 
+    def test_n_is_the_signal_digest_weight(self):
+        # The ratified law takes ``n`` from the signal DIGEST's total weight,
+        # not from the cell's observation count. Every other merge test here
+        # passes an ``n`` it computed itself on a fixture rigged so N == n, so
+        # that half of the law was unpinned (review finding). Build two blocks
+        # with non-signal rows AND non-finite heights, so N != len(values) on
+        # both axes, and source ``n`` the way a reader would.
+        rng = np.random.default_rng(321)
+        conf = rng.integers(-2, 5, size=(100, 5))
+        values = rng.standard_normal(100)
+        values[::13] = np.nan  # dropped by BOTH the digest and the packer
+        signal = (conf >= 2).any(axis=1)
+        blocks = ((slice(0, 40), 40), (slice(40, 100), 60))
+        words, weights = [], []
+        for sl, size in blocks:
+            digest = build_tdigest_where(values[sl], where=signal[sl])
+            n = int(digest[:, 1].sum())
+            assert 0 < n < size  # both drops actually bite
+            words.append(pack_composition(values[sl], **_conf_kwargs(conf[sl]), threshold=2))
+            weights.append(n)
+        merged = merge_composition(words[0], weights[0], words[1], weights[1])
+
+        n_total = weights[0] + weights[1]
+        pooled_digest = build_tdigest_where(values, where=signal)
+        assert int(pooled_digest[:, 1].sum()) == n_total  # weights are additive
+        pooled = pack_composition(values, **_conf_kwargs(conf), threshold=2)
+        m_counts = counts_from_composition(merged, n_total)
+        p_counts = counts_from_composition(pooled, n_total)
+        assert np.max(np.abs(m_counts - p_counts)) <= 1
+        assert np.array_equal(unpack_composition(merged) > 0, unpack_composition(pooled) > 0)
+        # Ground the recovered counts in the raw rows, so a wrong ``n`` cannot
+        # pass: lanes are fractions of the SIGNAL stratum's finite rows.
+        keep = signal & np.isfinite(values)
+        assert p_counts[:5].tolist() == (conf[keep] >= 2).sum(axis=0).tolist()
+        # The observation count is the wrong divisor and shows it.
+        assert not np.array_equal(counts_from_composition(pooled, len(values)), p_counts)
+
     def test_symmetric(self):
         rng = np.random.default_rng(5)
         conf_a = rng.integers(-2, 5, size=(30, 5))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -526,6 +526,60 @@ class TestValidation:
         with pytest.raises(ValueError, match="JSON-serializable"):
             validate_config(self._config_with_field_attrs({"arr": np.zeros(2)}))
 
+    def _config_with_composition(self, block, *, params=None, digest_kind="ragged"):
+        """Composition field + a sibling digest field, for the attrs cross-checks."""
+        return PipelineConfig(
+            data_source={"variables": {"h_li": "/path"}},
+            aggregation={
+                "variables": {
+                    "h_tdigest_signal": {
+                        "kind": digest_kind,
+                        "function": "zagg.stats.tdigest.build_tdigest",
+                        "source": "h_li",
+                        "inner_shape": [2],
+                        "dtype": "float32",
+                    },
+                    "composition": {
+                        "function": "zagg.stats.composition.pack_composition",
+                        "source": "h_li",
+                        "dtype": "uint64",
+                        "params": {"threshold": 2} if params is None else params,
+                        "attrs": {"composition": block},
+                    },
+                }
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+
+    def test_composition_attrs_accepted(self):
+        validate_config(
+            self._config_with_composition({"of": "h_tdigest_signal", "threshold": 2})
+        )  # should not raise
+
+    def test_composition_of_must_name_a_declared_field(self):
+        with pytest.raises(ValueError, match="of 'h_tdigest_sginal' is not a declared"):
+            validate_config(self._config_with_composition({"of": "h_tdigest_sginal"}))
+
+    def test_composition_of_must_be_ragged(self):
+        with pytest.raises(ValueError, match="must be a 'kind: ragged' digest field"):
+            validate_config(
+                self._config_with_composition({"of": "h_tdigest_signal"}, digest_kind="scalar")
+            )
+
+    def test_composition_of_cannot_be_itself(self):
+        with pytest.raises(ValueError, match="names the composition field itself"):
+            validate_config(self._config_with_composition({"of": "composition"}))
+
+    def test_composition_threshold_must_match_params(self):
+        with pytest.raises(ValueError, match="disagrees with params.threshold"):
+            validate_config(
+                self._config_with_composition({"of": "h_tdigest_signal", "threshold": 3})
+            )
+
+    def test_composition_attrs_without_block_is_inert(self):
+        # A non-composition attrs block (or a non-mapping one) skips the checks.
+        validate_config(self._config_with_field_attrs({"composition": "zagg-composition/1"}))
+
     def test_shipped_strata_config_validates(self):
         from importlib import resources
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -461,6 +461,43 @@ class TestValidation:
         # Should not raise
         validate_config(atl06_config)
 
+    def _config_with_variables(self, variables):
+        return PipelineConfig(
+            data_source={"variables": variables},
+            aggregation={
+                "variables": {
+                    "n": {"function": "len", "source": "h_li", "dtype": "int32"},
+                }
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+
+    def test_variable_column_form_accepted(self):
+        cfg = self._config_with_variables(
+            {"h_li": "/path", "conf_land": {"path": "/conf", "column": 0}}
+        )
+        validate_config(cfg)  # should not raise
+
+    def test_variable_column_form_unknown_key_rejected(self):
+        cfg = self._config_with_variables(
+            {"h_li": "/path", "c": {"path": "/conf", "column": 0, "slice": 1}}
+        )
+        with pytest.raises(ValueError, match="unknown keys.*slice"):
+            validate_config(cfg)
+
+    def test_variable_column_form_bad_column_rejected(self):
+        for column in (-1, "0", None, True):
+            cfg = self._config_with_variables(
+                {"h_li": "/path", "c": {"path": "/conf", "column": column}}
+            )
+            with pytest.raises(ValueError, match="column must be an integer"):
+                validate_config(cfg)
+
+    def test_variable_non_str_non_dict_rejected(self):
+        cfg = self._config_with_variables({"h_li": "/path", "c": 7})
+        with pytest.raises(ValueError, match="path string or a"):
+            validate_config(cfg)
+
     def test_missing_source(self):
         cfg = PipelineConfig(
             data_source={"variables": {"h_li": "/path"}},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -498,6 +498,44 @@ class TestValidation:
         with pytest.raises(ValueError, match="path string or a"):
             validate_config(cfg)
 
+    def _config_with_field_attrs(self, attrs):
+        return PipelineConfig(
+            data_source={"variables": {"h_li": "/path"}},
+            aggregation={
+                "variables": {
+                    "n": {"function": "len", "source": "h_li", "dtype": "int32", "attrs": attrs},
+                }
+            },
+            output={"grid": {"type": "healpix", "parent_order": 6, "child_order": 12}},
+        )
+
+    def test_field_attrs_accepted(self):
+        validate_config(self._config_with_field_attrs({"stratum": "signal", "signal_threshold": 2}))
+
+    def test_field_attrs_reserved_ragged_key_rejected(self):
+        with pytest.raises(ValueError, match="reserved"):
+            validate_config(self._config_with_field_attrs({"ragged": {}}))
+
+    def test_field_attrs_non_str_key_rejected(self):
+        with pytest.raises(ValueError, match="string keys"):
+            validate_config(self._config_with_field_attrs({1: "x"}))
+
+    def test_field_attrs_non_json_rejected(self):
+        import numpy as np
+
+        with pytest.raises(ValueError, match="JSON-serializable"):
+            validate_config(self._config_with_field_attrs({"arr": np.zeros(2)}))
+
+    def test_shipped_strata_config_validates(self):
+        from importlib import resources
+
+        from zagg.config import load_config
+
+        cfg = load_config(
+            str(resources.files("zagg.configs").joinpath("atl03_tdigest_strata_healpix.yaml"))
+        )
+        validate_config(cfg)
+
     def test_missing_source(self):
         cfg = PipelineConfig(
             data_source={"variables": {"h_li": "/path"}},

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1505,3 +1505,53 @@ class TestSharded:
         g0 = HealpixGrid(4, 8, layout="fullsphere", config=cfg, chunk_inner=6)
         g1 = HealpixGrid(4, 8, layout="fullsphere", config=cfg, chunk_inner=6, sharded=True)
         assert g0.signature() == g1.signature()
+
+
+class TestFieldAttrsTemplate:
+    """Config-declared field attrs land on the template arrays (issue #321)."""
+
+    def _grid(self):
+        from zagg.config import PipelineConfig
+
+        cfg = PipelineConfig(
+            aggregation={
+                "variables": {
+                    "count": {"function": "len", "source": "h_li", "dtype": "int32"},
+                    "h_sig": {
+                        "kind": "ragged",
+                        "function": "zagg.stats.tdigest.build_tdigest_where",
+                        "source": "h_li",
+                        "inner_shape": [2],
+                        "dtype": "float32",
+                        "params": {"delta": 64, "where": "h_li > 0"},
+                        "attrs": {"stratum": "signal", "signal_threshold": 2},
+                    },
+                    "composition": {
+                        "function": "zagg.stats.composition.pack_composition",
+                        "source": "h_li",
+                        "dtype": "uint64",
+                        "fill_value": 0,
+                        "attrs": {"composition": {"spec": "zagg-composition/1", "threshold": 2}},
+                    },
+                }
+            }
+        )
+        return HealpixGrid(parent_order=4, child_order=8, chunk_inner=6, sharded=True, config=cfg)
+
+    def test_scalar_field_attrs(self):
+        m = self._grid().spec().members
+        assert dict(m["composition"].attributes) == {
+            "composition": {"spec": "zagg-composition/1", "threshold": 2}
+        }
+
+    def test_ragged_field_attrs_merge_with_ragged_block(self):
+        m = self._grid().spec().members
+        attrs = dict(m["h_sig"].attributes)
+        # The layout block survives; the declared attrs ride alongside.
+        assert attrs["ragged"]["spec"] == "zagg-ragged/1"
+        assert attrs["stratum"] == "signal"
+        assert attrs["signal_threshold"] == 2
+
+    def test_undeclared_fields_unchanged(self):
+        m = self._grid().spec().members
+        assert dict(m["count"].attributes) == {}

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -1063,6 +1063,36 @@ class TestWindowedCellConfig:
         # The original config is untouched (per-unit copy).
         assert "filters" not in cfg.data_source
 
+    def test_mapping_form_time_field_carries_its_column(self, cfg):
+        # A ``time_field`` declared in the ``{path, column}`` variables form
+        # (issue #321) must filter on that column, not blow up on the "should
+        # have been rejected" guard (review finding: the mapping form reached a
+        # consumer that assumed a bare path string).
+        from zagg.config import windowed_cell_config
+
+        cfg.data_source["variables"]["delta_time"] = {
+            "path": "/{group}/land_ice_segments/packed_time",
+            "column": 2,
+        }
+        _windowed(cfg)
+        unit_cfg, _ = windowed_cell_config(cfg, {"label": "2019", "start": 1.5, "end": 9.5})
+        assert unit_cfg.data_source["filters"][-2:] == [
+            {
+                "level": None,
+                "dataset": "/{group}/land_ice_segments/packed_time",
+                "column": 2,
+                "op": "ge",
+                "value": 1.5,
+            },
+            {
+                "level": None,
+                "dataset": "/{group}/land_ice_segments/packed_time",
+                "column": 2,
+                "op": "lt",
+                "value": 9.5,
+            },
+        ]
+
     def test_unwindowed_config_refuses(self, cfg):
         from zagg.config import windowed_cell_config
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -649,6 +649,33 @@ class TestInlineReadGroup:
         assert "compiled decode unavailable" not in caplog.text
         assert "no chunk map" not in caplog.text
 
+    @pytest.mark.parametrize("write_back", [False, True])
+    def test_mapping_form_variables_read(self, write_back):
+        # The ``{path, column}`` variable form (issue #321, the strata config's
+        # five signal_conf surfaces) must survive BOTH inline arms. Under
+        # ``write_back`` the manifest prebuild assumed every variables value was
+        # a path-template string, so a mapping entry died in
+        # ``_prebuild_group_maps`` before the first byte was read (review
+        # finding); the two columns also share one dataset, so the prebuild
+        # must dedup them to a single chunk map.
+        ds = _fixture_data_source(
+            variables={
+                "h_ph": "/{group}/heights/h_ph",
+                "conf_land": {"path": "/{group}/heights/signal_conf_ph", "column": 0},
+                "conf_ocean": {"path": "/{group}/heights/signal_conf_ph", "column": 1},
+            }
+        )
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        idx = InlineIndex(write_back=write_back)
+        df_i = idx.read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        df_h = HierarchicalIndex().read_group(_open_fixture(), "gt1l", ds, 1, grid)
+        assert df_i is not None and len(df_i) > 0
+        pd.testing.assert_frame_equal(df_i, df_h)
+        assert {"conf_land", "conf_ocean"} <= set(df_i.columns)
+        if write_back:
+            maps = next(iter(idx._pending.values()))
+            assert "/gt1l/heights/signal_conf_ph" in maps  # one map, both columns
+
     def test_falls_back_to_h5coro_on_compiled_failure(self, monkeypatch, caplog):
         # A broken Index reconstruction degrades per dataset (warning, h5coro
         # decode) and never aborts the shard; rows stay identical.

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -532,6 +532,22 @@ class TestStratifiedAggregation:
         assert result["count"] == 0
         assert result["h_sig"] == [] and result["h_noise"] == []
 
+    def test_where_expression_compiles_once_across_cells(self):
+        # The params expression is evaluated per CELL, so it must run against a
+        # cached code object rather than being recompiled every call (review
+        # finding: ~2.5 s/shard of pure compilation at o11/o19 with two ``where``
+        # fields). Pin the mechanism, not the timing.
+        from zagg.processing.aggregate import _compile_param_expr
+
+        _compile_param_expr.cache_clear()
+        cfg = self._config()
+        for seed in range(5):
+            data, _ = self._cell(seed=seed)
+            calculate_cell_statistics(data, config=cfg)
+        info = _compile_param_expr.cache_info()
+        assert info.currsize == 2  # the signal predicate and its negation
+        assert info.misses == 2 and info.hits == 8  # 5 cells x 2 fields
+
 
 class TestVectorOutputs:
     """Issue #29 phase 2: a ``kind: vector`` field yields a per-cell ndarray of

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -442,6 +442,97 @@ class TestCalculateCellStatistics:
         assert result["h_nanmin"] == 1.0
 
 
+class TestStratifiedAggregation:
+    """Signal/noise strata + packed composition through the cell path (issue #321)."""
+
+    _SIGNAL = "(c_land >= 2) | (c_ocean >= 2) | (c_sea >= 2) | (c_ice >= 2) | (c_water >= 2)"
+
+    def _config(self):
+        from zagg.config import PipelineConfig
+
+        return PipelineConfig(
+            aggregation={
+                "variables": {
+                    "count": {"function": "len", "source": "h_li", "dtype": "int32"},
+                    "h_sig": {
+                        "kind": "ragged",
+                        "function": "zagg.stats.tdigest.build_tdigest_where",
+                        "source": "h_li",
+                        "inner_shape": [2],
+                        "dtype": "float32",
+                        "params": {"delta": 64, "where": self._SIGNAL},
+                    },
+                    "h_noise": {
+                        "kind": "ragged",
+                        "function": "zagg.stats.tdigest.build_tdigest_where",
+                        "source": "h_li",
+                        "inner_shape": [2],
+                        "dtype": "float32",
+                        "params": {"delta": 64, "where": f"~({self._SIGNAL})"},
+                    },
+                    "composition": {
+                        "function": "zagg.stats.composition.pack_composition",
+                        "source": "h_li",
+                        "dtype": "uint64",
+                        "fill_value": 0,
+                        "params": {
+                            "conf_land": "c_land",
+                            "conf_ocean": "c_ocean",
+                            "conf_sea_ice": "c_sea",
+                            "conf_land_ice": "c_ice",
+                            "conf_inland_water": "c_water",
+                            "threshold": 2,
+                        },
+                    },
+                }
+            }
+        )
+
+    def _cell(self, n=40, seed=7):
+        rng = np.random.default_rng(seed)
+        conf = rng.integers(-2, 5, size=(n, 5))
+        cols = ("c_land", "c_ocean", "c_sea", "c_ice", "c_water")
+        data = {name: conf[:, i] for i, name in enumerate(cols)}
+        data["h_li"] = rng.standard_normal(n)
+        return data, conf
+
+    def test_strata_are_disjoint_and_exhaustive(self):
+        data, conf = self._cell()
+        result = calculate_cell_statistics(data, config=self._config())
+        n_sig = int(result["h_sig"][:, 1].sum())
+        n_noise = int(result["h_noise"][:, 1].sum())
+        assert n_sig + n_noise == result["count"] == 40
+        assert n_sig == int((conf >= 2).any(axis=1).sum())
+
+    def test_composition_word_survives_above_2_53(self):
+        # A word with a high byte set exceeds float64's exact-integer ceiling;
+        # the integer coercion path must round-trip it exactly.
+        data, conf = self._cell()
+        result = calculate_cell_statistics(data, config=self._config())
+        from zagg.stats.composition import pack_composition
+
+        cols = ("c_land", "c_ocean", "c_sea", "c_ice", "c_water")
+        kw = dict(
+            zip(
+                ("conf_land", "conf_ocean", "conf_sea_ice", "conf_land_ice", "conf_inland_water"),
+                (data[c] for c in cols),
+            )
+        )
+        expected = pack_composition(data["h_li"], **kw, threshold=2)
+        assert result["composition"] == expected
+        assert isinstance(result["composition"], int)
+        assert expected > 2**53  # the regime float() would corrupt
+
+    def test_empty_cell_integer_fill(self):
+        cols = ("c_land", "c_ocean", "c_sea", "c_ice", "c_water")
+        data = {name: np.array([], dtype=np.int64) for name in cols}
+        data["h_li"] = np.array([])
+        result = calculate_cell_statistics(data, config=self._config())
+        assert result["composition"] == 0
+        assert result["count"] == 0
+        assert result["h_sig"] == [] and result["h_noise"] == []
+
+
 class TestVectorOutputs:
     """Issue #29 phase 2: a ``kind: vector`` field yields a per-cell ndarray of
     its declared ``trailing_shape``/``dtype``; scalar fields are unchanged."""

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4018,6 +4018,86 @@ class TestReadGroupFilters:
 # ---------------------------------------------------------------------------
 
 
+class TestVariableColumnSelector:
+    """``data_source.variables`` column-selector mapping form (issue #321)."""
+
+    def _data_source(self, variables):
+        return {
+            "coordinates": {"latitude": "/lat", "longitude": "/lon"},
+            "variables": variables,
+        }
+
+    def test_column_form_selects_scalar_column(self):
+        conf = np.array([[0, 4], [3, 0], [2, 1]])
+        h5 = _FakeH5(
+            {
+                "/lat": np.arange(3.0),
+                "/lon": np.arange(3.0),
+                "/h": np.arange(3.0, dtype=np.float32),
+                "/conf": conf,
+            }
+        )
+        ds = self._data_source(
+            {
+                "h": "/h",
+                "conf_land": {"path": "/conf", "column": 0},
+                "conf_ocean": {"path": "/conf", "column": 1},
+            }
+        )
+        df = _read_group(h5, "gt1l", ds, 0, _ShardGrid())
+        assert df["conf_land"].tolist() == [0, 3, 2]
+        assert df["conf_ocean"].tolist() == [4, 0, 1]
+
+    def test_shared_path_deduped_and_filter_coincides(self):
+        # Five columns off one dataset plus a structured filter on the same
+        # path: values line up after the filter mask, one read for all six uses.
+        conf = np.array([[-2, 9], [0, 8], [4, 7], [-2, 6], [3, 5]])
+        h5 = _FakeH5(
+            {
+                "/lat": np.arange(5.0),
+                "/lon": np.arange(5.0),
+                "/h": np.arange(5.0, dtype=np.float32),
+                "/conf": conf,
+            }
+        )
+        ds = self._data_source(
+            {
+                "h": "/h",
+                "c0": {"path": "/conf", "column": 0},
+                "c1": {"path": "/conf", "column": 1},
+            }
+        )
+        ds["filters"] = [{"dataset": "/conf", "column": 0, "op": "ne", "value": -2}]
+        df = _read_group(h5, "gt1l", ds, 0, _ShardGrid())
+        assert df["c0"].tolist() == [0, 4, 3]
+        assert df["c1"].tolist() == [8, 7, 5]
+
+    def test_column_on_1d_rejected(self):
+        h5 = _FakeH5(
+            {
+                "/lat": np.arange(2.0),
+                "/lon": np.arange(2.0),
+                "/h": np.arange(2.0, dtype=np.float32),
+            }
+        )
+        ds = self._data_source({"h": {"path": "/h", "column": 0}})
+        with pytest.raises(ValueError, match="'column' set but array is 1-D"):
+            _read_group(h5, "gt1l", ds, 0, _ShardGrid())
+
+    def test_2d_without_column_rejected(self):
+        conf = np.zeros((2, 3))
+        h5 = _FakeH5(
+            {
+                "/lat": np.arange(2.0),
+                "/lon": np.arange(2.0),
+                "/conf": conf,
+            }
+        )
+        ds = self._data_source({"conf": "/conf"})
+        with pytest.raises(ValueError, match="requires an integer 'column'"):
+            _read_group(h5, "gt1l", ds, 0, _ShardGrid())
+
+
 class TestExpandMaskToBase:
     def test_single_parent_kept(self):
         # 1 parent keeps base rows 0-2 (3 photons).

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -546,6 +546,25 @@ class TestStratifiedAggregation:
         assert result["count"] == 0
         assert result["h_sig"] == [] and result["h_noise"] == []
 
+    def test_integer_field_rejects_the_nan_sentinel(self):
+        # ``_field_sentinel``'s default sentinel is the string "NaN", which an
+        # integer array cannot hold. Both integer paths (empty scalar cell,
+        # vector padding) must say so naming the config key, not surface as a
+        # stray int('NaN') / np.full(..., nan, dtype=uint64) error (review nit).
+        from zagg.processing.aggregate import _empty_cell_value
+
+        scalar = {"function": "np.max", "source": "h", "dtype": "uint64", "fill_value": "NaN"}
+        with pytest.raises(ValueError, match="cannot hold a non-numeric sentinel"):
+            _empty_cell_value(scalar)
+        vector = {**scalar, "kind": "vector", "trailing_shape": 3}
+        with pytest.raises(ValueError, match="cannot hold a non-numeric sentinel"):
+            _empty_cell_value(vector)
+        # A declared numeric fill still comes through on both paths.
+        assert _empty_cell_value({**scalar, "fill_value": 7}) == 7
+        np.testing.assert_array_equal(
+            _empty_cell_value({**vector, "fill_value": 7}), np.full(3, 7, dtype="uint64")
+        )
+
     def test_where_expression_compiles_once_across_cells(self):
         # The params expression is evaluated per CELL, so it must run against a
         # cached code object rather than being recompiled every call (review

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -546,6 +546,35 @@ class TestStratifiedAggregation:
         assert result["count"] == 0
         assert result["h_sig"] == [] and result["h_noise"] == []
 
+    def test_integer_dtype_is_verified_not_trusted(self):
+        # An integer declaration used to be trusted: bare int() silently
+        # truncated a reducer that returned 2.7. Integral values (including
+        # np.float64(3.0)) still pass; a fractional one names the field.
+        from zagg.config import PipelineConfig
+
+        def _cfg(dtype="int32"):
+            return PipelineConfig(
+                aggregation={
+                    "variables": {"m": {"function": "np.max", "source": "h", "dtype": dtype}}
+                }
+            )
+
+        result = calculate_cell_statistics({"h": np.array([1.0, 3.0])}, config=_cfg())
+        assert result["m"] == 3 and isinstance(result["m"], int)
+        with pytest.raises(ValueError, match=r"'m'.*not integral"):
+            calculate_cell_statistics({"h": np.array([1.0, 2.7])}, config=_cfg())
+        # A float dtype is unchanged: fractional values are exactly what it stores.
+        assert calculate_cell_statistics({"h": np.array([1.0, 2.7])}, config=_cfg("float32"))[
+            "m"
+        ] == pytest.approx(2.7)
+        # The integral check must not route a packed word through float(): a
+        # uint64 above 2**53 stays exact (the issue #321 composition field).
+        word = np.uint64(0xFF000000FF0000FF)
+        big = calculate_cell_statistics(
+            {"h": np.array([word], dtype=np.uint64)}, config=_cfg("uint64")
+        )
+        assert big["m"] == int(word) > 2**53
+
     def test_integer_field_rejects_the_nan_sentinel(self):
         # ``_field_sentinel``'s default sentinel is the string "NaN", which an
         # integer array cannot hold. Both integer paths (empty scalar cell,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -504,6 +504,20 @@ class TestStratifiedAggregation:
         assert n_sig + n_noise == result["count"] == 40
         assert n_sig == int((conf >= 2).any(axis=1).sum())
 
+    def test_non_finite_heights_leave_count_above_the_strata(self):
+        # The strata are keyed to FINITE heights, so ``n_sig + n_noise ==
+        # count`` holds only on all-finite data — the 3-state mask rule in
+        # docs/signal_strata.md is therefore stated against ``count``, not
+        # against "both strata empty" (review finding). Pin the gap here so the
+        # all-finite test above cannot drift into implying the stronger claim.
+        data, _ = self._cell()
+        data["h_li"][[3, 11, 29]] = np.nan
+        result = calculate_cell_statistics(data, config=self._config())
+        n_sig = int(result["h_sig"][:, 1].sum())
+        n_noise = int(result["h_noise"][:, 1].sum())
+        assert result["count"] == 40
+        assert n_sig + n_noise == 37 < result["count"]
+
     def test_composition_word_survives_above_2_53(self):
         # A word with a high byte set exceeds float64's exact-integer ceiling;
         # the integer coercion path must round-trip it exactly.

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -471,6 +471,31 @@ class TestSpillConfig:
         assert not agg._mergeable
         agg.close()
 
+    def test_stratified_config_single_block_only(self):
+        # Signal/noise strata + composition (issue #321): accepted by spill,
+        # pinned non-mergeable (single-block regime, exact via the pooled
+        # replay) — the fold surface would silently drop the ``where`` mask.
+        variables = _base_variables()
+        variables["h_sig"] = {
+            "kind": "ragged",
+            "function": "zagg.stats.tdigest.build_tdigest_where",
+            "source": "h_ph",
+            "inner_shape": [2],
+            "params": {"delta": 64, "where": "h_ph > 0"},
+            "dtype": "float32",
+            "fill_value": 0,
+        }
+        variables["composition"] = {
+            "function": "zagg.stats.composition.pack_composition",
+            "source": "h_ph",
+            "dtype": "uint64",
+            "fill_value": 0,
+        }
+        cfg = _config(streaming={"mode": "spill"}, variables=variables)
+        agg = SpillAggregator(cfg, _grid(cfg), "pandas", 25)
+        assert not agg._mergeable
+        agg.close()
+
     def test_guard_fires_at_construction(self, monkeypatch):
         import os as _os
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -108,6 +108,35 @@ class TestStreamingConfig:
         with pytest.raises(ValueError, match="not.*mergeable|mergeable"):
             validate_streaming(cfg)
 
+    def test_stratified_where_reducer_rejected(self):
+        # Streaming/spill-fold rebuilds digests from the raw source column
+        # ((source, delta) only), so the ``where`` mask would be silently
+        # ignored — the merge surface must reject it until a masked fold law
+        # exists (issue #321).
+        cfg = _config()
+        cfg.aggregation["variables"]["h_sig"] = {
+            "kind": "ragged",
+            "function": "zagg.stats.tdigest.build_tdigest_where",
+            "source": "h_ph",
+            "inner_shape": [2],
+            "params": {"delta": 64, "where": "h_ph > 0"},
+        }
+        with pytest.raises(ValueError, match="h_sig.*no.*merge law"):
+            validate_streaming(cfg)
+
+    def test_composition_scalar_rejected(self):
+        # The packed composition word's fold (digest-weighted lane mean, issue
+        # #321) is not wired into the streaming state — reject, don't corrupt.
+        cfg = _config()
+        cfg.aggregation["variables"]["composition"] = {
+            "function": "zagg.stats.composition.pack_composition",
+            "source": "h_ph",
+            "dtype": "uint64",
+            "fill_value": 0,
+        }
+        with pytest.raises(ValueError, match="composition.*not.*mergeable"):
+            validate_streaming(cfg)
+
     def test_non_tdigest_ragged_rejected(self):
         cfg = _config()
         cfg.aggregation["variables"]["h_raw"] = {


### PR DESCRIPTION
Closes #321. Refs #265 (HHDC parent — the 3-state mask upgrade), #87 (located channel interplay).

## What

Implements the fully ratified #321 design ([rulings](https://github.com/englacial/zagg/issues/321#issuecomment-5123797965), [encoding spec](https://github.com/englacial/zagg/issues/321#issuecomment-5123865321)): per-cell **signal/noise stratification** of ATL03 photons committed at ingest (selection A1 — union `signal_conf > 1` over all five surface columns), as two disjoint t-digest fields whose total weights are exact stratum counts, plus the **packed uint64 composition field** (`zagg-composition/1`: five per-surface + three level lanes as quantized fractions of N_signal, presence-floor quantization), plus the threshold recorded in **store attrs**.

## Phases

- [x] 1. `column:` selector on `data_source.variables` — the mapping form `{path, column}` mirrors the structured-filter `column`, so the five `signal_conf_ph` surfaces become scalar columns off one deduped dataset read (`read.py::_variable_specs`/`_select_column`, both read paths; validated in `config._validate_ds_variables`)
- [x] 2. Reducers — `build_tdigest_where` (mask-stratified digest, delegates to `build_tdigest`, located channel passes through) and `zagg.stats.composition` (`pack_composition`, `unpack/counts_from/merge_composition`; presence floor: nonzero counts never quantize to 0, so presence is exact at every N; counts exact for N ≤ 254; merge = digest-weighted lane mean, re-quantized with the same floor)
- [x] 3. Integer scalar coercion — scalar fields with integer dtypes coerce via `int()` (the old unconditional `float()` corrupts packed words above 2**53) and empty cells take the declared integer `fill_value` (uint64 can't hold NaN); end-to-end cell-path tests including a >2**53 word round-trip. The integer declaration is **verified, not trusted**: a reducer returning a fractional value into an integer field raises naming the field, its dtype, and the value rather than letting `int()` silently truncate it (integral floats like `np.float64(3.0)` still pass); the same fail-fast applies to a non-numeric `fill_value` on an integer field
- [x] 4. Streaming/spill posture — strata + composition are **pooled / single-block-spill only** (exact via the pooled replay); the merge surface's existing gates reject both loudly, now pinned by tests. Deliberate: the streaming fold rebuilds digests from the raw source column (`(source, delta)` only), so whitelisting `build_tdigest_where` would have silently produced *unstratified* digests; the composition fold needs paired-N state that isn't wired. Fold-law follow-up flagged below.
- [x] 5. Field-level store attrs — `aggregation.variables.{name}.attrs` merges config-declared provenance onto the field's array spec in both grids (reserved `ragged` key rejected; JSON-serializability validated), plus the shipped `atl03_tdigest_strata_healpix.yaml` template
- [x] 6. Narrative doc — `docs/signal_strata.md` (+ mkdocs nav)

## How it was tested

- New: `tests/test_composition.py` (16 — exact recovery below the knee, presence floor through 20-deep merge chains, merge-vs-pooled bounded error + exact presence, strata disjointness/exhaustiveness, NaN alignment with digest weights, threshold knob); `TestStratifiedAggregation`, `TestVariableColumnSelector` (test_processing), `TestFieldAttrsTemplate` (test_grids), config validation + shipped-config tests (test_config), streaming/spill rejection pins (test_streaming/test_spill).
- Full suite: **2,680+ passed; the only 3 failures are the known pre-existing ones** (`TestConsolidationGate` ×2, `TestFunctionBuild::test_function_build_succeeds` — all reproduce on clean `main` at `d104dbb`, flagged not fixed per §4).
- `ruff check` / `ruff format --check` clean on all touched files.

## Notes for review

- The merged composition word can sit 1 LSB off the pooled word (re-quantization); the contract is bounded count error + exact presence, and the tests assert exactly that, not word equality.
- A signal photon's level lane is its **strongest** per-surface confidence — the union-consistent choice; documented in the module and doc.
- Any new aggregation key shifts `semantic_hash` — intended (new product identity).
- `config.py` was already ~2.4× the 1000-line ceiling before this PR; additions were kept minimal rather than splitting (pre-existing, flagged).

## Questions for review

1. **Fold-law follow-up scope**: multi-block spill for strata needs a masked per-block fold (re-evaluating the `where` expression over spilled columns) and the composition fold needs per-block N from the signal digest parts. Worth its own issue now, or wait until a stratified product actually hits a multi-block shard? (The located config is single-block anyway, and the ratified plan is one schema epoch = located + strata.)
2. The shipped template is **unlocated** strata; the epoch config (located + strata) composes by adding `location: leaf_id` to both digest fields. Ship that variant too, or leave composition to the epoch-flip decision?

