### PR TITLE
Guard agg's Lambda finalize: warn, retry once (5 s), run tail, re-raise (issue #335)

### DIFF
--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -998,9 +998,11 @@ def _handle_stats(event: Dict[str, Any]) -> Dict[str, Any]:
     rows, which have no mirrored envelope to read back), and/or ``rows_from``
     — the run's async status prefix, from which the worker assembles the
     success rows (issue #151 envelopes; worker-role read). ``timestamp``
-    pins the D20 key so the dispatcher knows the path it announced. Nobody
-    reads this response on the Event invoke; errors log and fail open — the
-    run record is best-effort telemetry, never load-bearing.
+    pins the D20 key so the dispatcher knows the path it announced.
+    ``finalize_error`` (issue #335) rides the same event and lands as the one
+    run-level column — the durable record of a deferred finalize failure.
+    Nobody reads this response on the Event invoke; errors log and fail open —
+    the run record is best-effort telemetry, never load-bearing.
     """
     from zagg.telemetry import rows_from_status, write_run_parquet
 
@@ -1022,6 +1024,10 @@ def _handle_stats(event: Dict[str, Any]) -> Dict[str, Any]:
             run_id=event["run_id"],
             timestamp=event.get("timestamp"),
             store_kwargs=_output_store_kwargs(event),
+            # Run-level guarded-finalize outcome (issue #335): the dispatcher
+            # defers a finalize failure through its tail, so this is where the
+            # failure becomes durable. Absent on a pre-#335 dispatcher -> None.
+            finalize_error=event.get("finalize_error"),
         )
         return {
             "statusCode": 200,

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -777,10 +777,14 @@ class Run:
         flat only under ``consolidate_metadata``), then the fail-open rollups:
         root ``coverage.moc``, the run-stats record, and the sweep trigger —
         each a fire-and-forget worker invoke (D8), each swallowed on failure
-        exactly like ``_run_lambda``'s tail. A finalize failure warns
-        immediately (``RuntimeWarning`` — notebook-visible while the tail is
-        still running), is recorded on the handle, and re-raises from
-        :meth:`RunHandle.wait` / a drained harvest iterator.
+        exactly like ``_run_lambda``'s tail. A finalize failure goes through the
+        shared :func:`runner._finalize_with_retry` (issue #335 — one contract
+        for the CLI and the facade): it warns immediately (``RuntimeWarning`` —
+        notebook-visible while the tail is still running), retries once after a
+        fixed 5 s backoff, and only a still-failing finalize is recorded on the
+        handle to re-raise from :meth:`RunHandle.wait` / a drained harvest
+        iterator. The backoff costs nothing interactively — the tail already
+        runs on the finisher thread, so it delays the join, not the cell.
 
         Every shard contributes exactly one result dict, so every shard gets a
         run-stats row: a worker envelope, a :class:`ShardError` payload, or —
@@ -812,45 +816,38 @@ class Run:
                     }
                 )
         layout = get_store_layout(self.config)
-        try:
-            if layout == "hive":
-                runner._invoke_lambda_finalize(
+        # ONE warn/retry/record implementation for every dispatch path (issue
+        # #335 phase 1): agg's _run_lambda, the raster driver and this finisher
+        # all route through runner._finalize_with_retry, so the message contract
+        # and the retry cannot drift between the CLI and the facade. It warns AT
+        # the failure (espg ruling on PR #333, middle option) so a notebook sees
+        # it in-stream rather than only at the join, retries once, and RETURNS
+        # the error — the handle keeps this path's re-raise semantics.
+        finalize_kwargs: dict = {}
+        if layout == "hive":
+            finalize_kwargs = {
+                "config_dict": config_dict,
+                "dataset": dataset,
+                "parent_order": self._parent_order,
+                "overwrite": self.overwrite,
+            }
+        if layout == "hive" or get_consolidate_metadata(self.config):
+            error = runner._finalize_with_retry(
+                lambda: runner._invoke_lambda_finalize(
                     client,
                     self.function_name,
                     self.store,
                     output_creds_event=output_creds_event,
-                    config_dict=config_dict,
-                    dataset=dataset,
-                    parent_order=self._parent_order,
-                    overwrite=self.overwrite,
-                )
-            elif get_consolidate_metadata(self.config):
-                runner._invoke_lambda_finalize(
-                    client,
-                    self.function_name,
-                    self.store,
-                    output_creds_event=output_creds_event,
-                )
-        except Exception as e:
-            handle._finalize_error = e
-            logger.warning(f"finalize invoke failed (surfaced via handle.wait()): {e}")
-            # Warn AT THE FAILURE, not only when the harvest loop finally joins
-            # (espg ruling on PR #333, middle option): the tail goes on and the
-            # error still re-raises from wait()/drain, but a notebook shows this
-            # in-stream immediately instead of leaving the window between
-            # finalize and the join silent. Every shard's data is written — only
-            # the root manifest is stale — and the backstop is idempotent, so
-            # the remedy is a re-run, not a re-compute.
-            warnings.warn(
-                f"finalize (manifest backstop) failed for {self.store}: {e}. "
-                f"Shard outputs are written; the store's root manifest may be "
-                f"stale until finalize runs again. It is idempotent — re-run "
-                f"the dispatch (or re-dispatch finalize) to stamp the manifest. "
-                f"This error also re-raises from handle.wait() / draining the "
-                f"harvest iterator.",
-                RuntimeWarning,
-                stacklevel=2,
+                    **finalize_kwargs,
+                ),
+                store_path=self.store,
+                reraise_note=(
+                    "This error also re-raises from handle.wait() / draining the harvest iterator."
+                ),
             )
+            if error is not None:
+                handle._finalize_error = error
+                logger.warning(f"finalize invoke failed (surfaced via handle.wait()): {error}")
 
         ok_results = [r for r in results if r.get("status_code") == 200 and not r.get("error")]
         if layout == "hive" and get_coverage_moc(self.config):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3060,6 +3060,11 @@ def _finalize_with_retry(
     ``reraise_note``, the one clause of the warning that differs between
     callers. The success path is untouched: no sleep, no warning.
 
+    Two warning shapes, one per attempt kind: a retryable failure warns the
+    diagnosis only (the remediation is not yet true — the retry may heal it),
+    and the terminal failure carries the full stale-manifest contract plus
+    ``reraise_note``.
+
     ``finalize`` is any zero-arg callable, so this is the ONE implementation of
     the warn/retry/record contract for every dispatch path: ``_run_lambda``
     (``executor.finalize``, then the full tail with the error recorded in
@@ -3077,15 +3082,29 @@ def _finalize_with_retry(
         except Exception as e:
             error = e
             retrying = attempt < retries
-            warnings.warn(
+            # A retryable attempt gets the DIAGNOSIS ONLY (review finding): the
+            # full stale-manifest remediation would be false the moment the
+            # retry heals a throttle or a cold-start timeout — exactly the case
+            # (d) was approved for — and an operator trained to ignore this
+            # warning ignores the one that matters. The contract text lands on
+            # the terminal failure, where it is true.
+            message = (
                 f"finalize (manifest backstop) failed for {store_path}: {e}. "
+                f"Retrying in {backoff_s} s."
+                if retrying
+                else f"finalize (manifest backstop) failed for {store_path}: {e}. "
                 f"Shard outputs are written; the store's root manifest may be "
                 f"stale until finalize runs again. It is idempotent — re-run "
                 f"the dispatch (or re-dispatch finalize) to stamp the manifest. "
-                + (f"Retrying once in {backoff_s} s." if retrying else reraise_note),
-                RuntimeWarning,
-                stacklevel=2,
+                f"{reraise_note}"
             )
+            # stacklevel=2 attributes this to the dispatch call site inside zagg,
+            # not the user's frame — deliberate: no fixed level can reach user
+            # code from every caller (``agg`` is several frames up, and the
+            # client facade's tail runs on a finisher THREAD whose stack has no
+            # user frame at all), so the message names the store and the remedy
+            # instead of relying on attribution.
+            warnings.warn(message, RuntimeWarning, stacklevel=2)
             if retrying:
                 time.sleep(backoff_s)
     return error

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1418,6 +1418,7 @@ class RasterStrategy:
                     timesteps_written += body["timesteps"]
 
         wall_time = time.time() - t0
+        finalize_error = None
         if store_layout == "hive":
             # Finalize-backstop-before-all-failed-raise, mirroring the local
             # backend (where ensure_manifest + root coverage run ahead of the
@@ -1428,17 +1429,24 @@ class RasterStrategy:
             # fires (natural gating); the finalize backstop still runs.
             #
             # Finalize backstop (issue #252 hybrid): idempotent ensure_manifest
-            # worker-side — required reader-facing schema (D6), so a failure
-            # raises, unlike the fail-open coverage dispatch below.
-            _invoke_lambda_finalize(
-                client,
-                function_name,
-                store_path,
-                output_creds_event=output_creds_event,
-                config_dict=config_dict,
-                dataset=dataset,
-                parent_order=int(grid.parent_order),
-                overwrite=overwrite,
+            # worker-side. Guarded exactly like the aggregation path (issue #335,
+            # same shared helper — raster is not scoped out of store/telemetry
+            # parity): warn, retry once, then DEFER so the tail below (coverage,
+            # the run-stats record that carries the failure, sweep) still runs
+            # and the error re-raises at the end.
+            finalize_error = _finalize_with_retry(
+                lambda: _invoke_lambda_finalize(
+                    client,
+                    function_name,
+                    store_path,
+                    output_creds_event=output_creds_event,
+                    config_dict=config_dict,
+                    dataset=dataset,
+                    parent_order=int(grid.parent_order),
+                    overwrite=overwrite,
+                ),
+                store_path=store_path,
+                reraise_note="This error re-raises after the post-run tail completes.",
             )
             if get_coverage_moc(config):
                 # Root coverage.moc (issue #200 phase 3): one fire-and-forget
@@ -1486,7 +1494,12 @@ class RasterStrategy:
             )
             for key, error, body in stats_failures
         ]
-        # D8 worker-invoke transport (issue #313): mirrors the spatial path.
+        # D8 worker-invoke transport (issue #313): mirrors the spatial path,
+        # deferred finalize failure included (issue #335) — this write is what
+        # makes it durable, and it happens BEFORE the all-failed raise below.
+        finalize_error_str = (
+            None if finalize_error is None else f"{type(finalize_error).__name__}: {finalize_error}"
+        )
         run_stats_path = _dispatch_run_stats(
             client,
             function_name,
@@ -1496,6 +1509,7 @@ class RasterStrategy:
             result_prefix=result_prefix,
             output_creds_event=output_creds_event,
             store_kwargs=_output_store_kwargs(output_creds_event, region),
+            finalize_error=finalize_error_str,
         )
         # End-of-run rollup sweep (issue #300): D8 worker-invoke transport,
         # mirroring the aggregation lambda path — one fire-and-forget
@@ -1516,6 +1530,11 @@ class RasterStrategy:
                     logger.info(f"Dispatched rollup sweep ({len(leaves)} leaves, fire-and-forget)")
             except Exception as e:
                 logger.warning(f"rollup sweep dispatch failed (fail-open, D9): {e}")
+        # Precedence note (issue #335): the all-failed verdict still raises
+        # FIRST — it is the run's own root cause, not a tail crash, and a stale
+        # manifest is moot when no shard wrote anything. The finalize failure is
+        # already durable (the run-stats write above) and is what re-raises when
+        # some shards did land.
         if cells and errors == len(cells):
             raise RuntimeError(f"all {errors} raster shard(s) failed; last error: {last_error}")
         # Worker telemetry rollup (issue #250): billed durations and peak RSS,
@@ -1562,6 +1581,10 @@ class RasterStrategy:
             "store_path": store_path,
             "backend": "lambda",
             "run_stats_path": run_stats_path,
+            # Guarded finalize (issue #335): always present, None on success —
+            # same key and same meaning as the aggregation lambda summary, so
+            # the two paths' summaries keep one shape for this field.
+            "finalize_error": finalize_error_str,
         }
         if profile:
             # Straggler-maxed stage seconds (+ the write bucket) and summed
@@ -1580,6 +1603,11 @@ class RasterStrategy:
             f"Done (lambda): {shards_with_data}/{len(cells)} shards, "
             f"{errors} errors, {wall_time:.1f}s"
         )
+        # Deferred finalize failure (issue #335): the tail ran with the error
+        # recorded in run-stats; re-raise the original so agg still exits
+        # nonzero, exactly as the aggregation lambda path does.
+        if finalize_error is not None:
+            raise finalize_error
         return summary
 
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3013,39 +3013,48 @@ def _run_local(
     return summary
 
 
-def _finalize_with_retry(executor, *, store_path, retries=1, backoff_s=5) -> Exception | None:
-    """Guarded ``executor.finalize()``: warn at failure, retry, return the error.
+#: Fixed backoff between the finalize attempts (issue #335): not a user knob
+#: (espg ruling), a module constant so tests can collapse the wait.
+_FINALIZE_BACKOFF_S = 5
+
+
+def _finalize_with_retry(
+    finalize, *, store_path, reraise_note, retries=1, backoff_s=None
+) -> Exception | None:
+    """Guarded finalize backstop: warn at failure, retry, return the error.
 
     Issue #335 ((d)+(c), espg-ratified): the finalize backstop is an idempotent
     worker invoke — nothing is corrupted on failure (every shard's outputs are
     already written; only the root manifest may be stale), so a failure warns
-    immediately (same message contract as the PR #333 client facade, so the two
-    paths read identically) and retries once after a fixed 5 s backoff —
-    deliberately not knobs (espg ruling on issue #335). Returns ``None`` on
-    success or the last exception; the caller owns failure semantics
-    (``_run_lambda`` runs the full post-run tail with the error recorded in
-    run-stats, then re-raises so ``agg`` still exits nonzero). The success path
-    is untouched: no sleep, no warning.
+    immediately and retries once after a fixed 5 s backoff — deliberately not
+    knobs (espg ruling on issue #335). Returns ``None`` on success or the last
+    exception; the caller owns failure semantics and describes them in
+    ``reraise_note``, the one clause of the warning that differs between
+    callers. The success path is untouched: no sleep, no warning.
+
+    ``finalize`` is any zero-arg callable, so this is the ONE implementation of
+    the warn/retry/record contract for every dispatch path: ``_run_lambda``
+    (``executor.finalize``, then the full tail with the error recorded in
+    run-stats before it re-raises), ``RasterStrategy``'s Lambda driver, and the
+    :class:`zagg.client.Run` facade's finisher thread (records it on the handle
+    for :meth:`~zagg.client.RunHandle.wait`). Sharing it is the issue #335
+    phase-1 acceptance criterion — ``agg`` and the client cannot drift.
     """
     error = None
+    backoff_s = _FINALIZE_BACKOFF_S if backoff_s is None else backoff_s
     for attempt in range(retries + 1):
         try:
-            executor.finalize()
+            finalize()
             return None
         except Exception as e:
             error = e
             retrying = attempt < retries
-            tail = (
-                f"Retrying once in {backoff_s} s."
-                if retrying
-                else "This error re-raises after the post-run tail completes."
-            )
             warnings.warn(
                 f"finalize (manifest backstop) failed for {store_path}: {e}. "
                 f"Shard outputs are written; the store's root manifest may be "
                 f"stale until finalize runs again. It is idempotent — re-run "
                 f"the dispatch (or re-dispatch finalize) to stamp the manifest. "
-                f"{tail}",
+                + (f"Retrying once in {backoff_s} s." if retrying else reraise_note),
                 RuntimeWarning,
                 stacklevel=2,
             )
@@ -3519,7 +3528,11 @@ def _run_lambda(
     # run-stats recording the failure, sweep) runs as on success and the error
     # re-raises at the end so agg still exits nonzero.
     finalize_start = time.time()
-    finalize_error = _finalize_with_retry(executor, store_path=store_path)
+    finalize_error = _finalize_with_retry(
+        executor.finalize,
+        store_path=store_path,
+        reraise_note="This error re-raises after the post-run tail completes.",
+    )
     finalize_s = time.time() - finalize_start
     wall_time = time.time() - start_time
 

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2315,6 +2315,7 @@ def _dispatch_run_stats(
     store_kwargs=None,
     summary=None,
     inline_rows=None,
+    finalize_error=None,
 ) -> str | None:
     """Fire-and-forget worker-invoke run-record write (issue #313, D8).
 
@@ -2334,6 +2335,12 @@ def _dispatch_run_stats(
     ``run_stats_path`` names the real object — best-effort: the invoke is
     fire-and-forget, mirroring the root MOC's semantics. Fail-open
     everywhere: telemetry must never fail a run whose data landed.
+
+    ``finalize_error`` rides the event (always present, ``None`` on success)
+    and lands as a run-level parquet column (issue #335): the guarded finalize
+    defers its failure through the tail, and this is the durable record a
+    postmortem reads — the alternative is a signal that lives only in the
+    orchestrator's ``RuntimeWarning``. The write stays worker-side (D8).
     """
     from datetime import datetime, timezone
 
@@ -2350,6 +2357,10 @@ def _dispatch_run_stats(
             "store_path": store_path,
             "run_id": run_id,
             "timestamp": timestamp,
+            # Always on the wire, None on success (issue #335) — same
+            # determinism rule as summary["run_stats_path"] below, so the
+            # parquet's column set does not vary run to run.
+            "finalize_error": finalize_error,
         }
         if output_creds_event is not None:
             event["output_credentials"] = output_creds_event
@@ -3696,6 +3707,10 @@ def _run_lambda(
         store_kwargs=_output_store_kwargs(output_creds_event, region),
         summary=summary,
         inline_rows=stats_inline_rows,
+        # The deferred finalize failure becomes DURABLE here (issue #335): the
+        # worker stamps it as the run parquet's run-level column, so the
+        # postmortem signal outlives this process's RuntimeWarning + exit code.
+        finalize_error=summary["finalize_error"],
     )
     # End-of-run rollup sweep (issue #300): the Lambda dispatcher never PUTs
     # (D8 standing rule), so the sweep rides ONE fire-and-forget mode="sweep"

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3535,246 +3535,272 @@ def _run_lambda(
     )
     finalize_s = time.time() - finalize_start
     wall_time = time.time() - start_time
+    # The whole post-run tail is inside this try purely for PRECEDENCE (issue
+    # #335 fold): whatever it raises must not displace a finalize failure. The
+    # legs themselves keep their own fail-open guards; this is the blanket that
+    # keeps the unguarded code BETWEEN them (row building, statistics, the log
+    # f-strings) from swallowing the D6 error the next refactor introduces.
+    try:
+        # End-of-run root coverage.moc (issue #200 phase 3; default-on for hive,
+        # O9): the dispatcher cannot PUT to S3, so it builds + serializes the MOC
+        # and posts ONE fire-and-forget worker invoke that GET-unions-PUTs it.
+        # Transport rationale (espg-requested, plan question 3) — serialized
+        # ranges IN the event vs the completion list via the status channel:
+        #   - Ranges (chosen): the dispatcher already holds the completion list
+        #     in memory, so building the MOC costs milliseconds, and the payload
+        #     is bounded by construction — spatially coherent coverage collapses
+        #     to a few-KB range list, far under Lambda's 256 KB async-invoke cap,
+        #     which a raw ~50k-key completion list would break. One hop, and no
+        #     read-back race against status objects still landing from retried
+        #     stragglers.
+        #   - Completion list via .status/ (rejected): payload size would be
+        #     run-independent and the artifact replayable from durable state, but
+        #     it costs the worker a LIST + N GETs, races in-flight status writes,
+        #     and its replayability is already owned by the §7 sweep's
+        #     authoritative rebuild — the leaves are the durable truth (D9).
+        # Fail-open everywhere: a failed build/invoke logs and the run result is
+        # untouched (the root MOC is a regenerable cache).
+        if get_store_layout(config) == "hive" and get_coverage_moc(config):
+            try:
+                from zagg.hive import build_root_coverage
+                from zagg.windows import union_time_range
 
-    # End-of-run root coverage.moc (issue #200 phase 3; default-on for hive,
-    # O9): the dispatcher cannot PUT to S3, so it builds + serializes the MOC
-    # and posts ONE fire-and-forget worker invoke that GET-unions-PUTs it.
-    # Transport rationale (espg-requested, plan question 3) — serialized
-    # ranges IN the event vs the completion list via the status channel:
-    #   - Ranges (chosen): the dispatcher already holds the completion list
-    #     in memory, so building the MOC costs milliseconds, and the payload
-    #     is bounded by construction — spatially coherent coverage collapses
-    #     to a few-KB range list, far under Lambda's 256 KB async-invoke cap,
-    #     which a raw ~50k-key completion list would break. One hop, and no
-    #     read-back race against status objects still landing from retried
-    #     stragglers.
-    #   - Completion list via .status/ (rejected): payload size would be
-    #     run-independent and the artifact replayable from durable state, but
-    #     it costs the worker a LIST + N GETs, races in-flight status writes,
-    #     and its replayability is already owned by the §7 sweep's
-    #     authoritative rebuild — the leaves are the durable truth (D9).
-    # Fail-open everywhere: a failed build/invoke logs and the run result is
-    # untouched (the root MOC is a regenerable cache).
-    if get_store_layout(config) == "hive" and get_coverage_moc(config):
-        try:
-            from zagg.hive import build_root_coverage
-            from zagg.windows import union_time_range
-
-            # Inside the try so the fail-open claim survives result-envelope
-            # refactors (review finding, PR #208 round 3).
-            ok_results = [
-                r for r in report.results if r.get("status_code") == 200 and not r.get("error")
-            ]
-            done = [r["shard_key"] for r in ok_results]
-            if done:
-                # D15: union the windowed workers' stamped time ranges (each
-                # body mirrors its leaf stamp's ISO strings); unwindowed
-                # bodies carry none and the envelope stays byte-identical.
-                envelope = build_root_coverage(
-                    done,
-                    int(parent_order),
-                    time_range=union_time_range(
-                        *(r.get("body", {}).get("time_range") for r in ok_results)
-                    ),
-                )
-                # An OLD deployment has no coverage mode: the event falls
-                # through to its process handler, which returns a LOGGED 400
-                # (missing shard_key/granule_urls...) — no writes, no result
-                # mirror, and no async redelivery (a returned 400 is a
-                # successful invocation to Lambda's Event retry machinery).
-                # Harmless under D9, but the CloudWatch line is an ERROR, not
-                # silence — mirroring the PR #205 deploy-ordering note.
-                logger.info(
-                    f"Dispatching root coverage.moc write ({len(envelope['ranges'])} "
-                    f"ranges, fire-and-forget) — requires a redeployed function; an "
-                    f"older deployment 400s mode=coverage in its process handler "
-                    f"(logged, no writes, no retry — harmless under D9)"
-                )
-                _invoke_lambda_coverage(
-                    state["lambda_client"],
-                    function_name,
-                    store_path,
-                    envelope,
-                    output_creds_event=output_creds_event,
-                )
-        except Exception as e:
-            logger.warning(f"root coverage.moc dispatch failed (fail-open, D9): {e}")
-
-    # Cost estimate: arm64 pricing = $0.0000133334/GB-second. Compute gb_seconds
-    # and cost *once* over the summed Lambda time (the report carries only the
-    # accumulated compute_time_s) so the arithmetic order -- and thus the last
-    # ULP of estimated_cost_usd -- stays byte-identical to the pre-refactor path
-    # (summing per-cell cost_usd would diverge in FP). Runner owns presentation;
-    # the per-cell CellCost.cost_usd is for the report's structured breakdown.
-    # memory_gb resolved pre-fan-out via _worker_memory_gb (issue #298): the
-    # default function keeps 4.0 (byte-identical); a worker: variant now bills
-    # at its actual size instead of the old flat constant.
-    total_lambda_time = report.cost.compute_time_s
-    gb_seconds = total_lambda_time * memory_gb
-    price_per_gb_sec = LAMBDA_PRICE_PER_GB_SEC
-    estimated_cost = gb_seconds * price_per_gb_sec
-
-    # Structured cost block (issue #298): the pre-invoke ceiling, the deferred
-    # prior-history estimate (the estimate_cost_usd stub -- None until issues
-    # #297/#299 land the sidecar history), and the billed-duration rollup. The
-    # legacy flat ``estimated_cost_usd`` summary key keeps its pre-#298
-    # meaning (the actual-cost rollup) for existing consumers.
-    report.max_cost_usd = run_max_cost
-    report.estimated_cost_usd = estimate_cost_usd(catalog_data)
-    report.actual_cost_usd = estimated_cost
-    cost_block = {
-        "max_cost_usd": run_max_cost,
-        "estimated_cost_usd": report.estimated_cost_usd,
-        "actual_cost_usd": estimated_cost,
-    }
-
-    # Worker-runtime distribution (issue #100). Wall time on a parallel fan-out
-    # tracks the *straggler*, not the mean, so surface max / median / pstdev of
-    # the billed per-cell durations plus the max's share of the function
-    # Timeout -- the safety margin that flags a skewed shardmap (one fat cell
-    # dominating wall time). Raw material already lives in report.results.
-    function_timeout_s = state.get("function_timeout_s", _DEFAULT_FUNCTION_TIMEOUT_S)
-    durations = [r["lambda_duration"] for r in report.results if r.get("lambda_duration")]
-    if durations:
-        worker_max_s = max(durations)
-        worker_median_s = statistics.median(durations)
-        worker_pstdev_s = statistics.pstdev(durations)
-        worker_pct_timeout = worker_max_s / function_timeout_s if function_timeout_s else None
-    else:
-        worker_max_s = worker_median_s = worker_pstdev_s = worker_pct_timeout = None
-
-    # Peak worker memory (issue #120). The Lambda handler stamps body[
-    # "max_memory_mb"] (RSS high-water mark, KB->MB) on every successful
-    # invocation; roll the straggler (max) across cells, matching the wall-time
-    # framing. None when no worker reported it (e.g. local backend).
-    worker_memory = [
-        r["body"]["max_memory_mb"]
-        for r in report.results
-        if (r.get("body") or {}).get("max_memory_mb") is not None
-    ]
-    max_memory_mb = max(worker_memory) if worker_memory else None
-
-    # Container-telemetry rollup (issue #171): cold/warm counts + the ratchet
-    # view (max start-RSS per sandbox generation) from the worker envelopes.
-    container_stats = _container_telemetry_summary([r.get("body") or {} for r in report.results])
-
-    # Per-phase worker breakdown (issue #100 phase 2), only when --profile fed
-    # the workers a "profile" event so they emitted body["phase_timings"]. Roll
-    # the straggler (max) per phase across cells, matching the wall-time framing.
-    # Off by default -> no extra summary key, so the default key set is unchanged.
-    worker_phase_max = None
-    if profile:
-        worker_phase_max = {}
-        for r in report.results:
-            for phase, secs in (r.get("body", {}).get("phase_timings") or {}).items():
-                worker_phase_max[phase] = max(worker_phase_max.get(phase, 0.0), secs)
-
-    summary = {
-        "total_cells": len(cells),
-        "cells_with_data": report.cells_with_data,
-        "cells_error": report.cells_error,
-        "total_obs": report.total_obs,
-        "wall_time_s": wall_time,
-        "lambda_time_s": total_lambda_time,
-        "gb_seconds": gb_seconds,
-        "price_per_gb_sec": price_per_gb_sec,
-        "estimated_cost_usd": estimated_cost,
-        "cost": cost_block,
-        "setup_s": setup_s,
-        "fanout_s": fanout_s,
-        "finalize_s": finalize_s,
-        # Always-present, None on success (issue #335): the run-stats record can
-        # finally distinguish "finalize failed" from "run never happened", and
-        # the key set stays deterministic (the run_stats_path precedent).
-        "finalize_error": (
-            None if finalize_error is None else f"{type(finalize_error).__name__}: {finalize_error}"
-        ),
-        "function_timeout_s": function_timeout_s,
-        "worker_max_s": worker_max_s,
-        "worker_median_s": worker_median_s,
-        "worker_pstdev_s": worker_pstdev_s,
-        "worker_pct_timeout": worker_pct_timeout,
-        "max_memory_mb": max_memory_mb,
-        "store_path": store_path,
-        "backend": "lambda",
-        "function_name": function_name,
-        "results": report.results,
-        **container_stats,
-    }
-    if profile:
-        summary["worker_phase_max"] = worker_phase_max
-    # Run-level stats parquet (issue #297 phase 3; D8 worker-invoke transport,
-    # issue #313): success rows straight off the async result envelopes,
-    # failure rows from the dispatch results the RunReport accumulated. The
-    # PUT itself rides a fire-and-forget worker invoke — the dispatcher may
-    # hold an invoke-only role with no S3 write access.
-    stats_rows, stats_inline_rows = _lambda_result_rows(report.results, run_id=run_id)
-    _dispatch_run_stats(
-        state["lambda_client"],
-        function_name,
-        store_path,
-        stats_rows,
-        run_id=run_id,
-        result_prefix=result_prefix,
-        output_creds_event=output_creds_event,
-        store_kwargs=_output_store_kwargs(output_creds_event, region),
-        summary=summary,
-        inline_rows=stats_inline_rows,
-        # The deferred finalize failure becomes DURABLE here (issue #335): the
-        # worker stamps it as the run parquet's run-level column, so the
-        # postmortem signal outlives this process's RuntimeWarning + exit code.
-        finalize_error=summary["finalize_error"],
-    )
-    # End-of-run rollup sweep (issue #300): the Lambda dispatcher never PUTs
-    # (D8 standing rule), so the sweep rides ONE fire-and-forget mode="sweep"
-    # worker Event invoke — async, retries-0, fail-open (D9: rollups are
-    # caches; `python -m zagg.sweep` is the regeneration backstop). Leaves
-    # come from the envelope stats records; a stale deployed worker's
-    # record-less envelope simply contributes no leaf.
-    if get_store_layout(config) == "hive" and get_sweep(config):
-        try:
-            from zagg.sweep import leaves_from_stats_records
-
-            leaves = leaves_from_stats_records(
-                [
-                    (r.get("body") or {}).get("stats")
-                    for r in report.results
-                    if r.get("status_code") == 200 and not r.get("error")
+                # Inside the try so the fail-open claim survives result-envelope
+                # refactors (review finding, PR #208 round 3).
+                ok_results = [
+                    r for r in report.results if r.get("status_code") == 200 and not r.get("error")
                 ]
-            )
-            if leaves:
-                _invoke_lambda_sweep(
-                    state["lambda_client"],
-                    function_name,
-                    store_path,
-                    leaves,
-                    output_creds_event=output_creds_event,
+                done = [r["shard_key"] for r in ok_results]
+                if done:
+                    # D15: union the windowed workers' stamped time ranges (each
+                    # body mirrors its leaf stamp's ISO strings); unwindowed
+                    # bodies carry none and the envelope stays byte-identical.
+                    envelope = build_root_coverage(
+                        done,
+                        int(parent_order),
+                        time_range=union_time_range(
+                            *(r.get("body", {}).get("time_range") for r in ok_results)
+                        ),
+                    )
+                    # An OLD deployment has no coverage mode: the event falls
+                    # through to its process handler, which returns a LOGGED 400
+                    # (missing shard_key/granule_urls...) — no writes, no result
+                    # mirror, and no async redelivery (a returned 400 is a
+                    # successful invocation to Lambda's Event retry machinery).
+                    # Harmless under D9, but the CloudWatch line is an ERROR, not
+                    # silence — mirroring the PR #205 deploy-ordering note.
+                    logger.info(
+                        f"Dispatching root coverage.moc write ({len(envelope['ranges'])} "
+                        f"ranges, fire-and-forget) — requires a redeployed function; an "
+                        f"older deployment 400s mode=coverage in its process handler "
+                        f"(logged, no writes, no retry — harmless under D9)"
+                    )
+                    _invoke_lambda_coverage(
+                        state["lambda_client"],
+                        function_name,
+                        store_path,
+                        envelope,
+                        output_creds_event=output_creds_event,
+                    )
+            except Exception as e:
+                logger.warning(f"root coverage.moc dispatch failed (fail-open, D9): {e}")
+
+        # Cost estimate: arm64 pricing = $0.0000133334/GB-second. Compute gb_seconds
+        # and cost *once* over the summed Lambda time (the report carries only the
+        # accumulated compute_time_s) so the arithmetic order -- and thus the last
+        # ULP of estimated_cost_usd -- stays byte-identical to the pre-refactor path
+        # (summing per-cell cost_usd would diverge in FP). Runner owns presentation;
+        # the per-cell CellCost.cost_usd is for the report's structured breakdown.
+        # memory_gb resolved pre-fan-out via _worker_memory_gb (issue #298): the
+        # default function keeps 4.0 (byte-identical); a worker: variant now bills
+        # at its actual size instead of the old flat constant.
+        total_lambda_time = report.cost.compute_time_s
+        gb_seconds = total_lambda_time * memory_gb
+        price_per_gb_sec = LAMBDA_PRICE_PER_GB_SEC
+        estimated_cost = gb_seconds * price_per_gb_sec
+
+        # Structured cost block (issue #298): the pre-invoke ceiling, the deferred
+        # prior-history estimate (the estimate_cost_usd stub -- None until issues
+        # #297/#299 land the sidecar history), and the billed-duration rollup. The
+        # legacy flat ``estimated_cost_usd`` summary key keeps its pre-#298
+        # meaning (the actual-cost rollup) for existing consumers.
+        report.max_cost_usd = run_max_cost
+        report.estimated_cost_usd = estimate_cost_usd(catalog_data)
+        report.actual_cost_usd = estimated_cost
+        cost_block = {
+            "max_cost_usd": run_max_cost,
+            "estimated_cost_usd": report.estimated_cost_usd,
+            "actual_cost_usd": estimated_cost,
+        }
+
+        # Worker-runtime distribution (issue #100). Wall time on a parallel fan-out
+        # tracks the *straggler*, not the mean, so surface max / median / pstdev of
+        # the billed per-cell durations plus the max's share of the function
+        # Timeout -- the safety margin that flags a skewed shardmap (one fat cell
+        # dominating wall time). Raw material already lives in report.results.
+        function_timeout_s = state.get("function_timeout_s", _DEFAULT_FUNCTION_TIMEOUT_S)
+        durations = [r["lambda_duration"] for r in report.results if r.get("lambda_duration")]
+        if durations:
+            worker_max_s = max(durations)
+            worker_median_s = statistics.median(durations)
+            worker_pstdev_s = statistics.pstdev(durations)
+            worker_pct_timeout = worker_max_s / function_timeout_s if function_timeout_s else None
+        else:
+            worker_max_s = worker_median_s = worker_pstdev_s = worker_pct_timeout = None
+
+        # Peak worker memory (issue #120). The Lambda handler stamps body[
+        # "max_memory_mb"] (RSS high-water mark, KB->MB) on every successful
+        # invocation; roll the straggler (max) across cells, matching the wall-time
+        # framing. None when no worker reported it (e.g. local backend).
+        worker_memory = [
+            r["body"]["max_memory_mb"]
+            for r in report.results
+            if (r.get("body") or {}).get("max_memory_mb") is not None
+        ]
+        max_memory_mb = max(worker_memory) if worker_memory else None
+
+        # Container-telemetry rollup (issue #171): cold/warm counts + the ratchet
+        # view (max start-RSS per sandbox generation) from the worker envelopes.
+        container_stats = _container_telemetry_summary(
+            [r.get("body") or {} for r in report.results]
+        )
+
+        # Per-phase worker breakdown (issue #100 phase 2), only when --profile fed
+        # the workers a "profile" event so they emitted body["phase_timings"]. Roll
+        # the straggler (max) per phase across cells, matching the wall-time framing.
+        # Off by default -> no extra summary key, so the default key set is unchanged.
+        worker_phase_max = None
+        if profile:
+            worker_phase_max = {}
+            for r in report.results:
+                for phase, secs in (r.get("body", {}).get("phase_timings") or {}).items():
+                    worker_phase_max[phase] = max(worker_phase_max.get(phase, 0.0), secs)
+
+        summary = {
+            "total_cells": len(cells),
+            "cells_with_data": report.cells_with_data,
+            "cells_error": report.cells_error,
+            "total_obs": report.total_obs,
+            "wall_time_s": wall_time,
+            "lambda_time_s": total_lambda_time,
+            "gb_seconds": gb_seconds,
+            "price_per_gb_sec": price_per_gb_sec,
+            "estimated_cost_usd": estimated_cost,
+            "cost": cost_block,
+            "setup_s": setup_s,
+            "fanout_s": fanout_s,
+            "finalize_s": finalize_s,
+            # Always-present, None on success (issue #335): the run-stats record can
+            # finally distinguish "finalize failed" from "run never happened", and
+            # the key set stays deterministic (the run_stats_path precedent).
+            "finalize_error": (
+                None
+                if finalize_error is None
+                else f"{type(finalize_error).__name__}: {finalize_error}"
+            ),
+            "function_timeout_s": function_timeout_s,
+            "worker_max_s": worker_max_s,
+            "worker_median_s": worker_median_s,
+            "worker_pstdev_s": worker_pstdev_s,
+            "worker_pct_timeout": worker_pct_timeout,
+            "max_memory_mb": max_memory_mb,
+            "store_path": store_path,
+            "backend": "lambda",
+            "function_name": function_name,
+            "results": report.results,
+            **container_stats,
+        }
+        if profile:
+            summary["worker_phase_max"] = worker_phase_max
+        # Run-level stats parquet (issue #297 phase 3; D8 worker-invoke transport,
+        # issue #313): success rows straight off the async result envelopes,
+        # failure rows from the dispatch results the RunReport accumulated. The
+        # PUT itself rides a fire-and-forget worker invoke — the dispatcher may
+        # hold an invoke-only role with no S3 write access.
+        stats_rows, stats_inline_rows = _lambda_result_rows(report.results, run_id=run_id)
+        _dispatch_run_stats(
+            state["lambda_client"],
+            function_name,
+            store_path,
+            stats_rows,
+            run_id=run_id,
+            result_prefix=result_prefix,
+            output_creds_event=output_creds_event,
+            store_kwargs=_output_store_kwargs(output_creds_event, region),
+            summary=summary,
+            inline_rows=stats_inline_rows,
+            # The deferred finalize failure becomes DURABLE here (issue #335): the
+            # worker stamps it as the run parquet's run-level column, so the
+            # postmortem signal outlives this process's RuntimeWarning + exit code.
+            finalize_error=summary["finalize_error"],
+        )
+        # End-of-run rollup sweep (issue #300): the Lambda dispatcher never PUTs
+        # (D8 standing rule), so the sweep rides ONE fire-and-forget mode="sweep"
+        # worker Event invoke — async, retries-0, fail-open (D9: rollups are
+        # caches; `python -m zagg.sweep` is the regeneration backstop). Leaves
+        # come from the envelope stats records; a stale deployed worker's
+        # record-less envelope simply contributes no leaf.
+        if get_store_layout(config) == "hive" and get_sweep(config):
+            try:
+                from zagg.sweep import leaves_from_stats_records
+
+                leaves = leaves_from_stats_records(
+                    [
+                        (r.get("body") or {}).get("stats")
+                        for r in report.results
+                        if r.get("status_code") == 200 and not r.get("error")
+                    ]
                 )
-                logger.info(f"Dispatched rollup sweep ({len(leaves)} leaves, fire-and-forget)")
-        except Exception as e:
-            logger.warning(f"rollup sweep dispatch failed (fail-open, D9): {e}")
-    logger.info(
-        f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"
-    )
-    logger.info(
-        f"Lambda compute: {total_lambda_time:.0f}s total, {gb_seconds:.0f} GB-s, ~${estimated_cost:.2f}"
-    )
-    if worker_max_s is not None:
-        pct = f"{worker_pct_timeout:.0%}" if worker_pct_timeout is not None else "n/a"
+                if leaves:
+                    _invoke_lambda_sweep(
+                        state["lambda_client"],
+                        function_name,
+                        store_path,
+                        leaves,
+                        output_creds_event=output_creds_event,
+                    )
+                    logger.info(f"Dispatched rollup sweep ({len(leaves)} leaves, fire-and-forget)")
+            except Exception as e:
+                logger.warning(f"rollup sweep dispatch failed (fail-open, D9): {e}")
         logger.info(
-            f"Workers: max {worker_max_s:.0f}s ({pct} of {function_timeout_s:.0f}s timeout), "
-            f"median {worker_median_s:.0f}s, pstdev {worker_pstdev_s:.0f}s"
+            f"Done: {report.cells_with_data} cells, {report.total_obs:,} obs, {report.cells_error} errors, {wall_time:.1f}s"
         )
-    if max_memory_mb is not None:
-        cap_mb = memory_gb * 1024.0
         logger.info(
-            f"Worker peak memory: {max_memory_mb:.0f} MB ({max_memory_mb / cap_mb:.0%} of "
-            f"{cap_mb:.0f} MB cap)"
+            f"Lambda compute: {total_lambda_time:.0f}s total, {gb_seconds:.0f} GB-s, ~${estimated_cost:.2f}"
         )
-    if profile and worker_phase_max:
-        breakdown = ", ".join(f"{phase} {secs:.0f}s" for phase, secs in worker_phase_max.items())
-        logger.info(f"Worker phases (max across cells): {breakdown}")
-    _log_container_stats(container_stats)
+        if worker_max_s is not None:
+            pct = f"{worker_pct_timeout:.0%}" if worker_pct_timeout is not None else "n/a"
+            logger.info(
+                f"Workers: max {worker_max_s:.0f}s ({pct} of {function_timeout_s:.0f}s timeout), "
+                f"median {worker_median_s:.0f}s, pstdev {worker_pstdev_s:.0f}s"
+            )
+        if max_memory_mb is not None:
+            cap_mb = memory_gb * 1024.0
+            logger.info(
+                f"Worker peak memory: {max_memory_mb:.0f} MB ({max_memory_mb / cap_mb:.0%} of "
+                f"{cap_mb:.0f} MB cap)"
+            )
+        if profile and worker_phase_max:
+            breakdown = ", ".join(
+                f"{phase} {secs:.0f}s" for phase, secs in worker_phase_max.items()
+            )
+            logger.info(f"Worker phases (max across cells): {breakdown}")
+        _log_container_stats(container_stats)
+    except Exception as tail_error:
+        # D6 precedence (issue #335 fold), matching the PR #333 client facade:
+        # the manifest-backstop failure is strictly more load-bearing than a
+        # crashed tail leg, so a tail exception raised AFTER a finalize failure
+        # is logged and chained onto it, never allowed to replace it. With
+        # finalize clean the tail error propagates exactly as it always has.
+        if finalize_error is None:
+            raise
+        logger.error(
+            f"post-run tail failed after the guarded finalize failure "
+            f"({type(tail_error).__name__}: {tail_error}); raising the finalize error "
+            f"instead (D6 precedence) — the tail error rides as its __cause__",
+            exc_info=True,
+        )
+        raise finalize_error from tail_error
     # Deferred finalize failure (issue #335): the tail above ran to completion
     # with the error recorded in run-stats; re-raise the original exception
     # (traceback preserved on the stored object) so agg exits nonzero — the

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3073,6 +3073,13 @@ def _finalize_with_retry(
     for :meth:`~zagg.client.RunHandle.wait`). Sharing it is the issue #335
     phase-1 acceptance criterion — ``agg`` and the client cannot drift.
     """
+    # Validated, not clamped (review finding): a negative ``retries`` would make
+    # ``range(0)`` empty — finalize NEVER called and None returned, which every
+    # call site reads as success. The helper is deliberately importable for
+    # other paths to adopt, so a computed value must fail loudly. 0 is legal:
+    # one attempt, no sleep.
+    if retries < 0:
+        raise ValueError(f"retries must be >= 0, got {retries}")
     error = None
     backoff_s = _FINALIZE_BACKOFF_S if backoff_s is None else backoff_s
     for attempt in range(retries + 1):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -19,6 +19,7 @@ import statistics
 import threading
 import time
 import uuid
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import replace
 from datetime import timedelta
@@ -2993,6 +2994,47 @@ def _run_local(
     return summary
 
 
+def _finalize_with_retry(executor, *, store_path, retries=1, backoff_s=5) -> Exception | None:
+    """Guarded ``executor.finalize()``: warn at failure, retry, return the error.
+
+    Issue #335 ((d)+(c), espg-ratified): the finalize backstop is an idempotent
+    worker invoke — nothing is corrupted on failure (every shard's outputs are
+    already written; only the root manifest may be stale), so a failure warns
+    immediately (same message contract as the PR #333 client facade, so the two
+    paths read identically) and retries once after a fixed 5 s backoff —
+    deliberately not knobs (espg ruling on issue #335). Returns ``None`` on
+    success or the last exception; the caller owns failure semantics
+    (``_run_lambda`` runs the full post-run tail with the error recorded in
+    run-stats, then re-raises so ``agg`` still exits nonzero). The success path
+    is untouched: no sleep, no warning.
+    """
+    error = None
+    for attempt in range(retries + 1):
+        try:
+            executor.finalize()
+            return None
+        except Exception as e:
+            error = e
+            retrying = attempt < retries
+            tail = (
+                f"Retrying once in {backoff_s} s."
+                if retrying
+                else "This error re-raises after the post-run tail completes."
+            )
+            warnings.warn(
+                f"finalize (manifest backstop) failed for {store_path}: {e}. "
+                f"Shard outputs are written; the store's root manifest may be "
+                f"stale until finalize runs again. It is idempotent — re-run "
+                f"the dispatch (or re-dispatch finalize) to stamp the manifest. "
+                f"{tail}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            if retrying:
+                time.sleep(backoff_s)
+    return error
+
+
 def _run_lambda(
     config,
     catalog_data,
@@ -3440,9 +3482,12 @@ def _run_lambda(
     fanout_s = time.time() - start_time
 
     # Consolidate metadata via Lambda (same rationale as setup -- avoids
-    # requiring orchestrator-side S3 access).
+    # requiring orchestrator-side S3 access). Guarded (issue #335): a failed
+    # finalize warns + retries once, then DEFERS — the tail below (coverage,
+    # run-stats recording the failure, sweep) runs as on success and the error
+    # re-raises at the end so agg still exits nonzero.
     finalize_start = time.time()
-    executor.finalize()
+    finalize_error = _finalize_with_retry(executor, store_path=store_path)
     finalize_s = time.time() - finalize_start
     wall_time = time.time() - start_time
 
@@ -3593,6 +3638,12 @@ def _run_lambda(
         "setup_s": setup_s,
         "fanout_s": fanout_s,
         "finalize_s": finalize_s,
+        # Always-present, None on success (issue #335): the run-stats record can
+        # finally distinguish "finalize failed" from "run never happened", and
+        # the key set stays deterministic (the run_stats_path precedent).
+        "finalize_error": (
+            None if finalize_error is None else f"{type(finalize_error).__name__}: {finalize_error}"
+        ),
         "function_timeout_s": function_timeout_s,
         "worker_max_s": worker_max_s,
         "worker_median_s": worker_median_s,
@@ -3675,6 +3726,12 @@ def _run_lambda(
         breakdown = ", ".join(f"{phase} {secs:.0f}s" for phase, secs in worker_phase_max.items())
         logger.info(f"Worker phases (max across cells): {breakdown}")
     _log_container_stats(container_stats)
+    # Deferred finalize failure (issue #335): the tail above ran to completion
+    # with the error recorded in run-stats; re-raise the original exception
+    # (traceback preserved on the stored object) so agg exits nonzero — the
+    # CI/cron failure signal is unchanged, only richer in what got written first.
+    if finalize_error is not None:
+        raise finalize_error
     return summary
 
 

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -385,6 +385,7 @@ def write_run_parquet(
     run_id: str,
     timestamp: str | None = None,
     store_kwargs: dict | None = None,
+    finalize_error: str | None = None,
 ) -> str:
     """PUT the run-level stats parquet at the store root (issue #297 phase 3).
 
@@ -400,6 +401,12 @@ def write_run_parquet(
     worker-invoke transport (issue #313): the dispatcher names the object at
     dispatch so ``summary["run_stats_path"]`` is knowable without reading the
     fire-and-forget worker's response.
+
+    ``finalize_error`` is the one RUN-level column (issue #335): the guarded
+    finalize's failure string (``None`` on a clean run), broadcast constant
+    across the rows like ``run_id``/``n_shards`` already are, so a postmortem
+    can tell "finalize failed" from "the run never happened" off the parquet
+    alone. Always written, so the column set is the same every run.
     """
     import tempfile
 
@@ -412,6 +419,8 @@ def write_run_parquet(
         raise ValueError("write_run_parquet requires at least one row")
     key = run_parquet_key(run_id, timestamp)
     df = pd.DataFrame(rows)
+    # Run-level (issue #335): constant down the column, None on a clean run.
+    df["finalize_error"] = finalize_error
     # Packed morton shard keys exceed 2^53 (and int64 for high base cells), so
     # the DataFrame's float64 inference on a column that mixes ints with
     # failure-row ``None``s silently corrupts them (issue #300 — the sweep's

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -643,24 +643,52 @@ class TestFutures:
 
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", _fail)
         monkeypatch.setattr(runner, "_dispatch_run_stats", lambda *a, **k: gate.wait(10))
+        # Shared helper's fixed backoff (issue #335), collapsed for the test.
+        monkeypatch.setattr(runner, "_FINALIZE_BACKOFF_S", 0)
 
         def _finalize_warnings(caught):
-            return [str(w.message) for w in caught if "finalize" in str(w.message)]
+            return [str(w.message) for w in caught if "manifest backstop" in str(w.message)]
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             handle = _run(catalog, client=StubLambdaClient()).dispatch()
             deadline = time.time() + 10
-            while not _finalize_warnings(caught):
+            # Two: one per attempt of the shared retry (issue #335).
+            while len(_finalize_warnings(caught)) < 2:
                 assert time.time() < deadline, "no finalize warning while the tail ran"
                 time.sleep(0.01)
             assert handle._finisher.is_alive()  # warned before the join, not at it
-            (msg,) = _finalize_warnings(caught)
+            msg = _finalize_warnings(caught)[-1]  # the terminal warning
             assert _STORE in msg and "idempotent" in msg
+            assert "handle.wait()" in msg  # this path's re-raise note
             gate.set()
         # Re-raise semantics unchanged.
         with pytest.raises(RuntimeError, match="finalize down"):
             handle.wait(timeout=10)
+
+    def test_finalize_retry_heals_and_stays_clean(self, catalog, monkeypatch):
+        """Issue #335: the facade shares agg's retry, so a transient finalize
+        failure (throttle, cold-start timeout) leaves a CLEAN handle — warned,
+        but nothing recorded and nothing re-raised from wait()."""
+        from zagg import runner
+
+        outcomes = iter([RuntimeError("throttled"), None])
+        real = runner._invoke_lambda_finalize
+
+        def _flaky(*a, **k):
+            e = next(outcomes, None)
+            if e is not None:
+                raise e
+            return real(*a, **k)
+
+        monkeypatch.setattr(runner, "_invoke_lambda_finalize", _flaky)
+        monkeypatch.setattr(runner, "_FINALIZE_BACKOFF_S", 0)
+        stub = StubLambdaClient()
+        with pytest.warns(RuntimeWarning, match=r"finalize \(manifest backstop\) failed"):
+            handle = _run(catalog, client=stub).dispatch()
+            handle.wait(timeout=10)  # no raise: the retry healed it
+        assert handle._finalize_error is None and handle._tail_error is None
+        assert "finalize" in stub.modes()  # the retry's invoke really landed
 
     def test_finalize_failure_wins_over_a_tail_crash(self, catalog, monkeypatch):
         # Two distinct channels: the D6 manifest backstop failure is the one
@@ -675,6 +703,7 @@ class TestFutures:
 
         monkeypatch.setattr(runner, "_invoke_lambda_finalize", _fail)
         monkeypatch.setattr(runner, "_lambda_result_rows", _boom)
+        monkeypatch.setattr(runner, "_FINALIZE_BACKOFF_S", 0)
         handle = _run(catalog, client=StubLambdaClient()).dispatch()
         with pytest.raises(RuntimeError, match="finalize down"):
             handle.wait(timeout=10)

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1517,6 +1517,28 @@ class TestStatsMode:
         df = pd.read_parquet(f"{root}/stats_20260720T010203Z_runid2.parquet", engine="fastparquet")
         assert set(df["shard_key"]) == {2, 11, 12}
 
+    def test_finalize_error_from_event_lands_in_the_parquet(self, handler_mod, tmp_path):
+        """Issue #335: the dispatcher defers a finalize failure through its
+        tail and ships it on this event; the worker write is what makes it
+        durable (D8 — the dispatcher cannot PUT)."""
+        import pandas as pd
+
+        root = str(tmp_path / "out")
+        resp = handler_mod.lambda_handler(
+            {
+                "mode": "stats",
+                "store_path": root,
+                "run_id": "runid3",
+                "timestamp": "20260720T010203Z",
+                "rows": self._rows(),
+                "finalize_error": "RuntimeError: invoke failed",
+            },
+            MagicMock(),
+        )
+        assert resp["statusCode"] == 200, resp["body"]
+        df = pd.read_parquet(json.loads(resp["body"])["path"], engine="fastparquet")
+        assert set(df["finalize_error"]) == {"RuntimeError: invoke failed"}
+
     def test_empty_rows_is_ok_and_writes_nothing(self, handler_mod, tmp_path):
         root = str(tmp_path / "out")
         resp = handler_mod.lambda_handler(

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -1369,6 +1369,80 @@ class TestRasterHiveLambdaBackend:
             assert ma.get(key) == mb.get(key)
 
 
+class TestRasterFinalizeGuard:
+    """Guarded finalize on the raster Lambda path (issue #335 fold): the same
+    warn / retry-once / defer-and-re-raise contract as the aggregation path, via
+    the same shared helper — raster is never scoped out of store/telemetry
+    parity. Failure is a stale root manifest only; every shard already wrote."""
+
+    def _drive(self, manifest, monkeypatch, *, finalize):
+        import boto3
+
+        from zagg import runner
+
+        cfg, sm_path, shard, _data = manifest
+        cfg.output["store_layout"] = "hive"
+        monkeypatch.setattr(runner, "_FINALIZE_BACKOFF_S", 0)
+        stats: dict = {}
+
+        def _stats(*a, **k):
+            stats.update(k)
+            return "s3://bucket/out.zarr/stats_x.parquet"
+
+        monkeypatch.setattr(runner, "_dispatch_run_stats", _stats)
+
+        def responder(event):
+            mode = event["mode"]
+            if mode == "finalize":
+                finalize()
+                return {"statusCode": 200, "body": json.dumps({"ok": True, "mode": "finalize"})}
+            if mode in ("setup", "coverage", "sweep"):
+                return {"statusCode": 200, "body": "{}"}
+            if mode == "ping":
+                body = {"ok": True, "mode": "ping", "zagg_version": "test"}
+                return {"statusCode": 200, "body": json.dumps(body)}
+            assert mode == "process_raster"
+            body = {"shard_key": event["shard_key"], "timesteps": 2, "cells_with_data": 7}
+            return {"statusCode": 200, "body": json.dumps(body)}
+
+        fake = _FakeLambdaClient(responder)
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
+
+        def run():
+            return agg(
+                cfg,
+                catalog=sm_path,
+                store="s3://bucket/out.zarr",
+                backend="lambda",
+                max_workers=2,
+                invocation="sync",
+            )
+
+        return run, fake, stats
+
+    def test_success_path_unchanged(self, manifest, monkeypatch):
+        run, fake, stats = self._drive(manifest, monkeypatch, finalize=lambda: None)
+        summary = run()
+        assert [e["mode"] for e in fake.events].count("finalize") == 1  # no retry
+        assert summary["finalize_error"] is None  # always present, None on success
+        assert stats["finalize_error"] is None
+
+    def test_failure_defers_through_the_tail_then_reraises(self, manifest, monkeypatch):
+        def _fail():
+            raise RuntimeError("finalize down")
+
+        run, fake, stats = self._drive(manifest, monkeypatch, finalize=_fail)
+        with pytest.warns(RuntimeWarning, match=r"finalize \(manifest backstop\) failed"):
+            with pytest.raises(RuntimeError, match="finalize down"):
+                run()
+        modes = [e["mode"] for e in fake.events]
+        assert modes.count("finalize") == 2  # initial + exactly one retry
+        assert "coverage" in modes  # the tail ran despite the failure...
+        # ...and the failure is DURABLE: it rode the run-stats write (which the
+        # dispatcher cannot do itself — D8), before the re-raise.
+        assert stats["finalize_error"] == "RuntimeError: finalize down"
+
+
 class TestRasterHiveIdempotency:
     """Window re-run + backfill (D13) and the flat-raster default pin
     (issue #247 phase 5)."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3753,6 +3753,29 @@ class TestDispatchRunStats:
         assert runner._dispatch_run_stats(client, "fn", "s3://b/x", [], run_id="r") is None
         assert client.events == []
 
+    def test_finalize_error_rides_the_event(self):
+        """Issue #335: the deferred finalize failure goes ON THE WIRE, so the
+        worker can stamp it into the run parquet — always present, None on a
+        clean run (same determinism rule as summary["run_stats_path"])."""
+        from zagg import runner
+
+        client = self._Client()
+        runner._dispatch_run_stats(
+            client,
+            "fn",
+            "s3://b/out.zarr",
+            self._rows(),
+            run_id="rid",
+            finalize_error="RuntimeError: invoke failed",
+        )
+        (event,) = client.events
+        assert event["finalize_error"] == "RuntimeError: invoke failed"
+
+        clean = self._Client()
+        runner._dispatch_run_stats(clean, "fn", "s3://b/out.zarr", self._rows(), run_id="rid")
+        (event,) = clean.events
+        assert event["finalize_error"] is None  # key present, not absent
+
 
 class TestRunStatsRows:
     """Run-parquet row building from lambda dispatch results (issue #297)."""
@@ -4237,6 +4260,7 @@ class TestFinalizeGuard:
         def fake_stats(*a, **k):
             events.append("stats")
             captured["summary"] = k.get("summary")
+            captured["stats_finalize_error"] = k.get("finalize_error")
 
         monkeypatch.setattr(runner, "_dispatch_run_stats", fake_stats)
         monkeypatch.setattr(sweep_mod, "leaves_from_stats_records", lambda *a, **k: [123])
@@ -4262,7 +4286,7 @@ class TestFinalizeGuard:
     _TAIL = ["coverage", "stats", "sweep"]
 
     def test_success_path_unchanged(self, monkeypatch, atl06_config):
-        run, events, sleeps, _captured = self._drive(
+        run, events, sleeps, captured = self._drive(
             monkeypatch, atl06_config, finalize=lambda: None
         )
         with warnings.catch_warnings(record=True) as caught:
@@ -4271,6 +4295,7 @@ class TestFinalizeGuard:
         assert events == ["finalize"] + self._TAIL  # one attempt, tail as before
         assert sleeps == []  # no backoff on the success path
         assert summary["finalize_error"] is None  # always-present, None on success
+        assert captured["stats_finalize_error"] is None  # ... and on the wire too
         assert not [w for w in caught if "finalize" in str(w.message)]
 
     def test_retry_succeeds_warns_sleeps_no_raise(self, monkeypatch, atl06_config):
@@ -4302,6 +4327,10 @@ class TestFinalizeGuard:
         assert events == ["finalize", "finalize"] + self._TAIL  # full tail ran
         assert sleeps == [5]  # exactly one retry, no more
         assert captured["summary"]["finalize_error"] == "RuntimeError: invoke failed"
+        # ...and it is HANDED TO THE RUN-STATS DISPATCH (issue #335 fold): the
+        # worker stamps it into the parquet, which is the durable record a
+        # postmortem reads — this summary dict never leaves the raising call.
+        assert captured["stats_finalize_error"] == "RuntimeError: invoke failed"
         # Message contract mirrors the PR #333 client facade: store path +
         # shard-outputs-written + stale-manifest + idempotent re-invoke.
         msgs = [str(w.message) for w in caught if "manifest backstop" in str(w.message)]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4347,13 +4347,17 @@ class TestFinalizeGuard:
 
         sleeps = []
         monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
-        executor = MagicMock()
-        executor.finalize.side_effect = RuntimeError("nope")
-        with pytest.warns(RuntimeWarning):
-            err = runner._finalize_with_retry(executor, store_path="s3://out/x.zarr")
-        assert executor.finalize.call_count == 2  # initial + exactly one retry
+        finalize = MagicMock(side_effect=RuntimeError("nope"))
+        with pytest.warns(RuntimeWarning) as caught:
+            err = runner._finalize_with_retry(
+                finalize, store_path="s3://out/x.zarr", reraise_note="RE-RAISES LATER."
+            )
+        assert finalize.call_count == 2  # initial + exactly one retry
         assert sleeps == [5]
         assert isinstance(err, RuntimeError)  # returned, not raised: caller defers
+        # The caller's re-raise semantics are the one clause that varies, so the
+        # CLI and the client facade can share the rest verbatim (issue #335).
+        assert "RE-RAISES LATER." in str(caught[-1].message)
 
 
 class TestResolveSourceCredentials:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4409,6 +4409,30 @@ class TestFinalizeGuard:
         # CLI and the client facade can share the rest verbatim (issue #335).
         assert "RE-RAISES LATER." in str(caught[-1].message)
 
+    def test_retries_validated_not_silently_open(self, monkeypatch):
+        """Review finding: a negative ``retries`` would leave ``range(0)`` empty
+        — finalize never called, None returned, read as SUCCESS by every call
+        site. It raises instead; 0 stays legal (one attempt, no sleep)."""
+        from unittest.mock import MagicMock
+
+        from zagg import runner
+
+        finalize = MagicMock(side_effect=RuntimeError("nope"))
+        with pytest.raises(ValueError, match="retries must be >= 0"):
+            runner._finalize_with_retry(
+                finalize, store_path="s3://out/x.zarr", reraise_note="x", retries=-1
+            )
+        assert finalize.call_count == 0
+
+        sleeps = []
+        monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
+        with pytest.warns(RuntimeWarning):
+            err = runner._finalize_with_retry(
+                finalize, store_path="s3://out/x.zarr", reraise_note="x", retries=0
+            )
+        assert finalize.call_count == 1 and sleeps == []  # one attempt, no backoff
+        assert isinstance(err, RuntimeError)  # ...and the error still comes back
+
 
 class TestResolveSourceCredentials:
     """Provider-selected source credentials, both pipelines (issue #213 Phase 6)."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,7 @@
 """Tests for the runner module (Python API)."""
 
 import json
+import warnings
 from datetime import datetime, timezone
 
 import pytest
@@ -1530,6 +1531,8 @@ class TestSummaryKeysByteIdentical:
         "setup_s",
         "fanout_s",
         "finalize_s",
+        # Guarded finalize (issue #335); always present, None on success.
+        "finalize_error",
         "function_timeout_s",
         "worker_max_s",
         "worker_median_s",
@@ -4110,6 +4113,184 @@ class TestManifestChecker:
         # root via the poller's output-store path (issue #274 Fix 2).
         assert captured["predicate"]() is True
         assert seen["root"] == "s3://out/x.zarr"
+
+
+class TestFinalizeGuard:
+    """Guarded finalize on agg's Lambda path (issue #335, (d)+(c)):
+
+    a failed ``executor.finalize()`` warns immediately, retries ONCE after a
+    fixed 5 s backoff, then defers — the full post-run tail (coverage, run-stats
+    with the failure recorded, sweep) runs as on success and the original
+    exception re-raises at the end so ``agg`` still exits nonzero. Success path
+    byte-identical: no sleep, no warning, ``finalize_error: None``.
+    """
+
+    def _drive(self, monkeypatch, atl06_config, *, finalize):
+        """Hive-path drive (mirrors ``TestManifestChecker._hive_finalize_calls``)
+        with the tail invokes stubbed into an ordered ``events`` log; ``finalize``
+        is called once per backstop-invoke attempt (raise from it to fail one)."""
+        import threading
+        from unittest.mock import MagicMock
+
+        import boto3
+
+        import zagg.grids as grids_mod
+        import zagg.hive as hive
+        import zagg.sweep as sweep_mod
+        from zagg import runner
+        from zagg.concurrency import ConcurrencyReport
+
+        events = []
+        sleeps = []
+        captured = {}
+
+        monkeypatch.setattr(
+            runner,
+            "get_nsidc_s3_credentials",
+            lambda: {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"},
+        )
+        monkeypatch.setattr(grids_mod, "from_config", lambda *a, **k: _stub_grid())
+        atl06_config.output["store_layout"] = "hive"
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 720)
+        monkeypatch.setattr(runner, "_invoke_lambda_ping", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_invoke_lambda_setup_async", lambda *a, **k: None)
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(
+            runner,
+            "compute_available_workers",
+            lambda requested, *a, **k: (
+                1,
+                ConcurrencyReport(
+                    account_limit=1000,
+                    current_concurrent=0,
+                    padding=100,
+                    available=900,
+                    function_reserved=None,
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            runner,
+            "_invoke_lambda_cell",
+            lambda client, chunk_idx, shard_key, *a, **k: {
+                "shard_key": shard_key,
+                "status_code": 200,
+                "body": {"total_obs": 1},
+                "error": None,
+                "timeout": False,
+            },
+        )
+        # Manifest absent -> the finalize backstop invoke actually runs.
+        monkeypatch.setattr(
+            runner,
+            "_start_manifest_checker",
+            lambda check_present, **k: (threading.Event(), threading.Event(), MagicMock()),
+        )
+        monkeypatch.setattr(
+            runner,
+            "_invoke_lambda_finalize",
+            lambda *a, **k: (events.append("finalize"), finalize())[-1],
+        )
+        # Fixed 5 s backoff must not slow the test; record it instead.
+        monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
+        # Tail invokes -> ordered event log (coverage envelope stubbed so the
+        # stub grid's shard keys don't have to be valid morton words).
+        monkeypatch.setattr(hive, "build_root_coverage", lambda *a, **k: {"ranges": [1]})
+        monkeypatch.setattr(
+            runner, "_invoke_lambda_coverage", lambda *a, **k: events.append("coverage")
+        )
+
+        def fake_stats(*a, **k):
+            events.append("stats")
+            captured["summary"] = k.get("summary")
+
+        monkeypatch.setattr(runner, "_dispatch_run_stats", fake_stats)
+        monkeypatch.setattr(sweep_mod, "leaves_from_stats_records", lambda *a, **k: [123])
+        monkeypatch.setattr(runner, "_invoke_lambda_sweep", lambda *a, **k: events.append("sweep"))
+
+        def run():
+            return runner._run_lambda(
+                atl06_config,
+                _run_catalog(),
+                "s3://out/x.zarr",
+                12,
+                max_cells=None,
+                morton_cell=None,
+                max_workers=1,
+                overwrite=False,
+                dry_run=False,
+                region="us-west-2",
+                function_name="fn",
+            )
+
+        return run, events, sleeps, captured
+
+    _TAIL = ["coverage", "stats", "sweep"]
+
+    def test_success_path_unchanged(self, monkeypatch, atl06_config):
+        run, events, sleeps, _captured = self._drive(
+            monkeypatch, atl06_config, finalize=lambda: None
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            summary = run()
+        assert events == ["finalize"] + self._TAIL  # one attempt, tail as before
+        assert sleeps == []  # no backoff on the success path
+        assert summary["finalize_error"] is None  # always-present, None on success
+        assert not [w for w in caught if "finalize" in str(w.message)]
+
+    def test_retry_succeeds_warns_sleeps_no_raise(self, monkeypatch, atl06_config):
+        outcomes = iter([RuntimeError("throttled"), None])
+
+        def flaky():
+            e = next(outcomes)
+            if e is not None:
+                raise e
+
+        run, events, sleeps, _captured = self._drive(monkeypatch, atl06_config, finalize=flaky)
+        with pytest.warns(RuntimeWarning, match=r"finalize \(manifest backstop\) failed"):
+            summary = run()  # no raise: the retry healed it
+        assert events == ["finalize", "finalize"] + self._TAIL
+        assert sleeps == [5]  # fixed 5 s backoff, espg-ratified (no knobs)
+        assert summary["finalize_error"] is None  # retry success IS success
+
+    def test_both_attempts_fail_tail_runs_then_reraises(self, monkeypatch, atl06_config):
+        boom = RuntimeError("invoke failed")
+
+        def always_fail():
+            raise boom
+
+        run, events, sleeps, captured = self._drive(monkeypatch, atl06_config, finalize=always_fail)
+        with pytest.warns(RuntimeWarning) as caught:
+            with pytest.raises(RuntimeError) as excinfo:
+                run()
+        assert excinfo.value is boom  # the ORIGINAL exception, after the tail
+        assert events == ["finalize", "finalize"] + self._TAIL  # full tail ran
+        assert sleeps == [5]  # exactly one retry, no more
+        assert captured["summary"]["finalize_error"] == "RuntimeError: invoke failed"
+        # Message contract mirrors the PR #333 client facade: store path +
+        # shard-outputs-written + stale-manifest + idempotent re-invoke.
+        msgs = [str(w.message) for w in caught if "manifest backstop" in str(w.message)]
+        assert len(msgs) == 2  # warned at BOTH failures
+        for m in msgs:
+            assert "s3://out/x.zarr" in m
+            assert "Shard outputs are written" in m
+            assert "idempotent" in m
+
+    def test_helper_makes_exactly_one_retry(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from zagg import runner
+
+        sleeps = []
+        monkeypatch.setattr(runner.time, "sleep", lambda s: sleeps.append(s))
+        executor = MagicMock()
+        executor.finalize.side_effect = RuntimeError("nope")
+        with pytest.warns(RuntimeWarning):
+            err = runner._finalize_with_retry(executor, store_path="s3://out/x.zarr")
+        assert executor.finalize.call_count == 2  # initial + exactly one retry
+        assert sleeps == [5]
+        assert isinstance(err, RuntimeError)  # returned, not raised: caller defers
 
 
 class TestResolveSourceCredentials:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4340,6 +4340,53 @@ class TestFinalizeGuard:
             assert "Shard outputs are written" in m
             assert "idempotent" in m
 
+    def test_finalize_error_wins_over_a_later_tail_crash(self, monkeypatch, atl06_config, caplog):
+        """D6 precedence (fold of the review finding), matching PR #333's
+        ``RunHandle._raise_tail_error``: a tail exception AFTER a finalize
+        failure is logged + chained, never the one that surfaces."""
+        import logging
+
+        from zagg import runner
+
+        boom = RuntimeError("invoke failed")
+
+        def always_fail():
+            raise boom
+
+        run, events, _sleeps, _captured = self._drive(
+            monkeypatch, atl06_config, finalize=always_fail
+        )
+        # Crash the tail's UNGUARDED row building (the reviewer's example), i.e.
+        # after the fold point and before the re-raise.
+        tail_boom = RuntimeError("tail blew up")
+
+        def _boom(*a, **k):
+            raise tail_boom
+
+        monkeypatch.setattr(runner, "_lambda_result_rows", _boom)
+        with caplog.at_level(logging.ERROR, logger="zagg.runner"):
+            with pytest.warns(RuntimeWarning):
+                with pytest.raises(RuntimeError) as excinfo:
+                    run()
+        assert excinfo.value is boom  # the FINALIZE error, not the tail crash
+        assert excinfo.value.__cause__ is tail_boom  # tail error still reachable
+        assert "tail blew up" in caplog.text  # ...and visible in the log
+        assert events == ["finalize", "finalize", "coverage"]  # crashed before stats
+
+    def test_tail_crash_alone_still_propagates(self, monkeypatch, atl06_config):
+        """The other half of the precedence rule: with finalize CLEAN a tail
+        exception propagates exactly as it did before the guard existed."""
+        from zagg import runner
+
+        run, _events, _sleeps, _captured = self._drive(
+            monkeypatch, atl06_config, finalize=lambda: None
+        )
+        monkeypatch.setattr(
+            runner, "_lambda_result_rows", lambda *a, **k: (_ for _ in ()).throw(ValueError("nope"))
+        )
+        with pytest.raises(ValueError, match="nope"):
+            run()
+
     def test_helper_makes_exactly_one_retry(self, monkeypatch):
         from unittest.mock import MagicMock
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4331,14 +4331,17 @@ class TestFinalizeGuard:
         # worker stamps it into the parquet, which is the durable record a
         # postmortem reads — this summary dict never leaves the raising call.
         assert captured["stats_finalize_error"] == "RuntimeError: invoke failed"
-        # Message contract mirrors the PR #333 client facade: store path +
-        # shard-outputs-written + stale-manifest + idempotent re-invoke.
         msgs = [str(w.message) for w in caught if "manifest backstop" in str(w.message)]
         assert len(msgs) == 2  # warned at BOTH failures
         for m in msgs:
-            assert "s3://out/x.zarr" in m
-            assert "Shard outputs are written" in m
-            assert "idempotent" in m
+            assert "s3://out/x.zarr" in m and "invoke failed" in m  # store + diagnosis
+        # The retryable attempt says only that a retry is imminent (review
+        # finding): the stale-manifest contract would be FALSE if the retry
+        # healed it. The terminal warning carries the full remediation.
+        assert msgs[0].endswith("Retrying in 5 s.")
+        assert "Shard outputs are written" not in msgs[0]
+        assert "Shard outputs are written" in msgs[1] and "idempotent" in msgs[1]
+        assert msgs[1].endswith("This error re-raises after the post-run tail completes.")
 
     def test_finalize_error_wins_over_a_later_tail_crash(self, monkeypatch, atl06_config, caplog):
         """D6 precedence (fold of the review finding), matching PR #333's

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -474,6 +474,28 @@ class TestRunParquet:
         with pytest.raises(ValueError, match="at least one"):
             write_run_parquet(str(tmp_path), [], run_id="x")
 
+    def test_finalize_error_is_a_run_level_column(self, tmp_path):
+        """Issue #335: the guarded finalize's failure is DURABLE here — one
+        run-level column, constant down the rows, always present (None on a
+        clean run) so the column set does not vary run to run."""
+        import pandas as pd
+
+        rows = [flatten_record(_record(1)), flatten_record(_record(2))]
+        clean = write_run_parquet(str(tmp_path / "ok"), rows, run_id="aa01")
+        df = pd.read_parquet(clean, engine="fastparquet")
+        assert "finalize_error" in df.columns and df["finalize_error"].isna().all()
+
+        failed = write_run_parquet(
+            str(tmp_path / "bad"),
+            rows,
+            run_id="aa02",
+            finalize_error="RuntimeError: invoke failed",
+        )
+        df = pd.read_parquet(failed, engine="fastparquet")
+        # Every row carries it (the run-level broadcast), so any row answers
+        # "did finalize fail?" without a second object.
+        assert list(df["finalize_error"]) == ["RuntimeError: invoke failed"] * 2
+
 
 class TestWindowColumn:
     """The per-shard record's ``window`` label (issue #300): threaded like


### PR DESCRIPTION
Closes #335

Implements the espg-ratified **(d) + (c)** design ([approval](https://github.com/englacial/zagg/issues/335#issuecomment-5124725663), [plan](https://github.com/englacial/zagg/issues/335#issuecomment-5124735689), [backoff ruling](https://github.com/englacial/zagg/issues/335#issuecomment-5124739854)): `agg`'s Lambda-path `executor.finalize()` is no longer run-fatal pre-tail. On failure it now warns immediately, retries **once** after a **fixed 5 s** backoff (no knobs), runs the full post-run tail (coverage, run-stats — recording the failure — and sweep), then re-raises the original exception so `agg` still exits nonzero.

## What changed

- **`_finalize_with_retry(finalize, *, store_path, reraise_note, retries=1, backoff_s=None)`** (module-level in `runner.py`): guards **any zero-arg finalize callable**, so it is the single implementation for `agg`, the raster driver and the `zagg.client` facade. A retryable failure warns the diagnosis only (`... Retrying in 5 s.`); the terminal failure warns the full contract (store path + "Shard outputs are written; the store's root manifest may be stale until finalize runs again. It is idempotent — re-run the dispatch (or re-dispatch finalize) to stamp the manifest.") plus the caller's `reraise_note`, the one clause that varies. Sleeps `_FINALIZE_BACKOFF_S` (5 s, module constant so tests can collapse it) between attempts, validates `retries >= 0` (a negative value would skip finalize entirely and read as success), and **returns** the last exception instead of raising — the caller owns failure semantics. Success path untouched: no sleep, no warning.
- **Call sites**: `_run_lambda`'s tail (`executor.finalize`), **`RasterStrategy`'s Lambda driver** (`runner.py`'s `_invoke_lambda_finalize`, previously unguarded and run-fatal pre-tail — raster is not scoped out of store/telemetry parity), and **`client._run_tail`**'s finalize block. `finalize_s` still brackets the phase on the aggregation path.
- **Run-stats (durable)**: the summary dict gains **`finalize_error`** — always present, `None` on success, `"{Type}: {msg}"` on failure — on both the aggregation and raster Lambda summaries, **and it now reaches a durable consumer**: `_dispatch_run_stats` puts it on the `mode="stats"` event, the worker's `_handle_stats` forwards it to `write_run_parquet`, and it lands as one run-level parquet column (constant down the rows, like `run_id`). The write stays worker-side, D8 intact. That is what lets a postmortem distinguish "finalize failed" from "run never happened" off the parquet alone.
- **Re-raise after the tail, with D6 precedence**: the stored exception is re-raised (original object, traceback preserved) right before `return summary`, after coverage/stats/sweep dispatched exactly as on success. The whole tail sits in a `try` whose only job is precedence — a tail exception raised after a finalize failure is logged (`exc_info=True`) and chained as `__cause__`, never allowed to displace the finalize error, matching PR #333's ratified `RunHandle._raise_tail_error` behavior. With finalize clean a tail exception propagates exactly as before. CI/cron failure signal unchanged, only richer in what got written first.

## Phases

All landed as one coherent commit (the plan's five phases are one small, interlocking change):

- [x] Retry helper (`_finalize_with_retry`, importable)
- [x] Guard `agg`'s call site (warn → 5 s → one retry → record, don't raise yet)
- [x] Tail runs + run-stats records `finalize_error`
- [x] Re-raise after the tail (nonzero exit preserved)
- [x] Tests (success-path unchanged, retry-heals, both-fail full-tail + re-raise, exactly-one-retry)
- [x] **Adversarial-review fold** (6 findings, one commit each): durable run-stats record, client adoption of the shared helper, D6 tail precedence, raster Lambda parity, retry-imminent warning, `retries` validation

## Reconciliation with PR #333 — resolved here

PR #333 merged three minutes after this branch's first commit, so **#338 is the branch landing second** and adopting the helper in the client is this PR's work, not a follow-up. Done in `ed3fb7b`: `client._run_tail`'s finalize block calls `runner._finalize_with_retry` and the duplicated five-line warning text is deleted, satisfying the plan's phase-1 criterion ("one shared helper; `agg` and the client cannot drift on retry/warn semantics"). The client's recorded-error / `wait()` re-raise semantics and `_raise_tail_error`'s finalize-first precedence are unchanged.

**Integrated `main` by merge, not rebase** (`c810a65`): the phase commit was already pushed, so a rebase would have required a force-push, which CLAUDE.md §1 forbids. The merge was clean — main's `client.py`, `BENIGN_ERRORS` and `driver=` threading all outside the finalize/tail region.

One consequence worth naming: the client path now retries with the shared 5 s backoff. It costs nothing interactively — the tail already runs on the daemon finisher thread, so the backoff delays the *join*, not the notebook cell, and `wait()`'s documented timeout floor is already ~40 s for the run-stats verify window. Tests set `runner._FINALIZE_BACKOFF_S = 0`.

## How it was tested

- New `TestFinalizeGuard` in `tests/test_runner.py` (hive-path drive mirroring `TestManifestChecker._hive_finalize_calls`, tail invokes stubbed into an ordered event log, `time.sleep` patched):
  1. success path: one finalize attempt, tail order unchanged, no sleep, no finalize warning, `finalize_error is None`;
  2. fail-once-retry-succeeds: warning fired, `sleep(5)` observed, no raise, `finalize_error is None`;
  3. both attempts fail: two warnings (store path + message contract asserted), full tail observed (`coverage`/`stats`/`sweep` events), run-stats summary carries `finalize_error == "RuntimeError: invoke failed"`, and the **original** exception object re-raises after the tail;
  4. helper unit test: exactly one retry (`finalize.call_count == 2`), `sleeps == [5]`, error returned not raised.
- `TestSummaryKeysByteIdentical._LAMBDA_KEYS` extended with `finalize_error` (lambda path only).
- **Review-fold tests** (each finding gets its own): `TestDispatchRunStats.test_finalize_error_rides_the_event` (the value on the wire, fake client asserting the JSON payload); `TestStatsMode.test_finalize_error_from_event_lands_in_the_parquet` in `tests/test_lambda_handler.py` (real worker handler → parquet read-back); `TestWriteRunParquet.test_finalize_error_is_a_run_level_column`; `TestFinalizeGuard.test_finalize_error_wins_over_a_later_tail_crash` + `test_tail_crash_alone_still_propagates` (D6 precedence, both directions, `__cause__` and log asserted); `test_retries_validated_not_silently_open`; `TestRasterFinalizeGuard` in `tests/test_raster_runner.py` (success + defer-through-tail-then-re-raise, `_FakeLambdaClient` responder style); `tests/test_client.py::test_finalize_retry_heals_and_stays_clean`, with the existing client finalize tests updated for the two-attempt warning.
- Post-fold: `uv run pytest tests/test_runner.py tests/test_client.py tests/test_telemetry.py tests/test_lambda_handler.py tests/test_raster_runner.py tests/test_sweep.py tests/test_benchmark.py -q` → **621 passed, 17 skipped**. Full suite: **2768 passed, 35 skipped, 1 failed** (the same pre-existing `TestFunctionBuild::test_function_build_succeeds`, which fails locally on a pip/python-version mismatch in the build script's environment, unrelated to this diff). `ruff check` (CI's `--select=E,F,W,I --ignore=E501`) and `ruff format --check` clean on every touched file.
- `uv run pytest tests/test_runner.py -q`: **220 passed**. `pytest tests/test_benchmark.py tests/test_full_aoi_series.py -q`: 98 passed, 22 skipped.
- Full suite (`uv run pytest -q`): **2712 passed, 35 skipped, 1 failed** — the failure is the known pre-existing `TestFunctionBuild::test_function_build_succeeds` (unrelated to this diff; the two known TestConsolidationGate failures did not reproduce in this run).
- `ruff check src tests` and `ruff format --check` on the touched files: clean.
- Consumer check for the new summary key: `.github/scripts/bench_metrics.py` reads the summary via `summary.get(...)` (additive keys ignored), and `.github/scripts/update_series.py` reindexes to `bench_metrics.RECORD_COLUMNS` (`update_series.py:31`), so a new summary key never reaches the parquet series schema.

## Questions for review

1. **Summary-key and parquet-column shape** (judgment call): `finalize_error` is **always present, `None` on success**, in the summary, on the `mode="stats"` event, and as a parquet column — following the `run_stats_path` precedent in `_write_run_stats` ("keep the summary key set deterministic", issue #297), so a `duckdb`/Athena query can filter on the column across every run's parquet without a schema union. If omit-on-success is preferred, it's a small change.
2. **Raster all-failed precedence** (review-fold judgment call): on the raster path the existing all-shards-failed `RuntimeError` still raises **ahead** of the deferred finalize error, on the reasoning that it is the run's own root cause and a stale manifest is moot when no shard wrote anything (the finalize failure is durable regardless — the run-stats write precedes that raise). Say if finalize should win there too.
3. **Not folded, offered as a follow-up**: the review also suggested surfacing `finalize_error` in the bench series (`bench_metrics.build_record` + an appended `RECORD_COLUMNS` entry). Declined for now — `build_record` reads *summary* keys, and the summary never reaches a caller on the failing path, so the column would be null for exactly the runs it describes. The parquet is the postmortem surface; a bench-series column is a separate ask.
4. Pre-existing, unrelated to this diff (flagged, not fixed per conventions): codespell `statics ==> statistics` at `src/zagg/runner.py:1633` (present on `origin/main`); `ruff format --check` reformat of `tests/data/benchmark/README.md`; mypy errors in untouched regions (`runner.py:2126/2131/2212`, `notebook.py:271`, and others across followed imports); and the 3 known test failures (TestConsolidationGate ×2, TestFunctionBuild::test_function_build_succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HW3smGgEzF9LVWhXcbNv5s

