### PR TITLE
Spatially faithful tensor emission: rank_to_xy deinterleave, block assembly, mask channel

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -173,8 +173,10 @@ for customization examples.
 ## Reading the output
 
 For products with per-cell t-digest fields, the `zagg.readers` package
-reconstructs dense `(64, 64, n_bins)` tensors (or lossless raw value vectors)
-from the stored digests. The
+reconstructs dense, spatially faithful `(64, 64, n_bins)` tensors — with an
+occupancy mask and a shared `(offset, gain)` z-window per block (the
+[reader contract](ragged_layout.md#spatially-faithful-tensors-deinterleave-blocks-mask))
+— or lossless raw value vectors from the stored digests. The
 [t-digest reader notebook](https://github.com/englacial/zagg/blob/main/notebooks/tdigest_reader_example.ipynb)
 walks through `read_tensors` and `read_raw_values` end to end on a self-contained
 synthetic store.

--- a/docs/ragged_layout.md
+++ b/docs/ragged_layout.md
@@ -213,7 +213,13 @@ for tensor, mask, (offset, gain), morton in read_tensors(store, field):
   frozen `hive.decode_coverage_bitmap` convention, one small sidecar object,
   no digest bytes). A store without exact occupancy (every flat store, or a
   box-only/`full`-less missing sidecar) degrades to the 2-state `{0, 2}`
-  populated/not mask. Today occupancy equals digest coverage, so state `1`
+  populated/not mask, where `0` means only "no stored digest" and asserts
+  nothing about whether the cell was observed. **The mask does not carry which
+  regime it is in** — a degraded mask and a 3-state mask over a block with no
+  observed-but-empty cell are both `{0, 2}` — so check
+  `has_exact_occupancy(store)` before keying on `mask == 1`; without it, an
+  empty noise stratum on a degraded store reads as a genuine absence. Today
+  occupancy equals digest coverage, so state `1`
   does not occur; once the
   [issue #334](https://github.com/englacial/zagg/issues/334) signal strata
   land, noise-occupied cells appear as `1` automatically — the 3-state

--- a/docs/ragged_layout.md
+++ b/docs/ragged_layout.md
@@ -157,13 +157,64 @@ cannot drift.
   not re-fetched per inner chunk). Each read chunk is a square `(side, side)`
   block of cells (`side = isqrt(cells_per_chunk)`, 64 for the production
   `chunk_inner` configs), and its coverage-cell morton id is derived from the
-  sibling `morton` coordinate coarsened to the chunk order.
+  sibling `morton` coordinate coarsened to the chunk order. Cell placement
+  within the block is the spec-pinned bit deinterleave — see
+  [the tensor section below](#spatially-faithful-tensors-deinterleave-blocks-mask).
 - **Single-cell random access** (`read_cell`) — indexes the vlen array directly.
   On a sharded store that is exactly **2 ranged GETs** (the shard-index suffix,
   then the one inner chunk holding the cell), never the whole shard object. An
   out-of-range index raises `IndexError` naming the valid range (no negative-index
   wrap); an absent cell returns the zero-length `(0, *inner_shape)` array. Works
   on the `{field}_locations` sibling too.
+
+## Spatially faithful tensors (deinterleave, blocks, mask)
+
+The nested cells axis traces a **Z-order curve** within each chunk subtree, so
+a row-major reshape of the 1-D axis scrambles the 2-D block spatially beyond
+2-cell runs. The readers instead place each cell at the **bit deinterleave**
+of its chunk-local nested rank
+([issue #336](https://github.com/englacial/zagg/issues/336)):
+`mortie.rank_to_xy` / `xy_to_rank` (mortie ≥ 0.9.3), whose contract is
+normative in mortie's `docs/specification.md` **§8** and frozen for mortie 1.x
+— `x` gathers the rank's even bits, `y` its odd bits, origin `(0, 0)` at the
+subtree's south corner, equal to healpy's face-local `pix2xyf` (nest)
+convention. zagg pins **row = y, col = x** (`readers/_layout.py`), matching
+gridlook's `bit_combine(j, i)` texture convention
+(`gridlook/src/ui/grids/Healpix.vue`), so an emitted tensor uploads to a
+gridlook texture with no further shuffle. The golden placement vectors in
+`tests/test_reader_layout.py` are imported from mortie's spec-pinned test
+suite, never re-derived.
+
+`read_tensors` yields the full reader contract per block:
+
+```python
+for tensor, mask, (offset, gain), morton in read_tensors(store, field):
+    ...  # tensor: (side, side, n_bins); mask: (side, side) uint8
+```
+
+- **Blocks** — by default one block per read chunk; `block_order=` assembles
+  the `4**(chunk_order - block_order)` chunks of one block-order subtree into
+  a single `(2**d, 2**d, n_bins)` tensor (`d = cell_order - block_order`; an
+  order-12 block on production geometry is 128×128 from 4 inner chunks). The
+  z-window and `fit` policy are reconciled **block-wide**: one shared
+  `(offset, gain) = (z_lo, resolution)` per block, so bin `i` covers
+  `[offset + i*gain, offset + (i+1)*gain)` for every cell in the block.
+- **Mask** — the block's occupancy channel on the same deinterleaved layout:
+  `0` unobserved, `1` observed with no stored digest, `2` observed with data.
+  States 1/2 come from the hive leaf's `coverage.moc` occupancy sidecar
+  ([issue #200](https://github.com/englacial/zagg/issues/200); decoded by the
+  frozen `hive.decode_coverage_bitmap` convention, one small sidecar object,
+  no digest bytes). A store without exact occupancy (every flat store, or a
+  box-only/`full`-less missing sidecar) degrades to the 2-state `{0, 2}`
+  populated/not mask. Today occupancy equals digest coverage, so state `1`
+  does not occur; once the
+  [issue #334](https://github.com/englacial/zagg/issues/334) signal strata
+  land, noise-occupied cells appear as `1` automatically — the 3-state
+  upgrade is data-driven, not a reader flag.
+
+`read_raw_values` / `read_locations` report the same deinterleaved
+`(row, col)` per cell (invert with `readers._layout.rowcol_to_rank` to get a
+cells-axis index for `read_cell`).
 
 ## Issue #210 typed-dtype migration
 

--- a/docs/ragged_layout.md
+++ b/docs/ragged_layout.md
@@ -199,6 +199,13 @@ for tensor, mask, (offset, gain), morton in read_tensors(store, field):
   z-window and `fit` policy are reconciled **block-wide**: one shared
   `(offset, gain) = (z_lo, resolution)` per block, so bin `i` covers
   `[offset + i*gain, offset + (i+1)*gain)` for every cell in the block.
+  Coarser than the stored shard assembles too (the block-local index is still
+  the nested rank), but the memory bound is then per *block*: the block's
+  decoded digests are all held for the block-wide window, and the emitted
+  tensor grows 4× per coarser order (an order-6 block on the production
+  order-19 geometry would be 34 TB). `max_block_bytes=` (2 GiB default)
+  refuses that allocation with a pointed error instead of a bare
+  `MemoryError`.
 - **Mask** — the block's occupancy channel on the same deinterleaved layout:
   `0` unobserved, `1` observed with no stored digest, `2` observed with data.
   States 1/2 come from the hive leaf's `coverage.moc` occupancy sidecar

--- a/docs/ragged_layout.md
+++ b/docs/ragged_layout.md
@@ -213,8 +213,22 @@ for tensor, mask, (offset, gain), morton in read_tensors(store, field):
   upgrade is data-driven, not a reader flag.
 
 `read_raw_values` / `read_locations` report the same deinterleaved
-`(row, col)` per cell (invert with `readers._layout.rowcol_to_rank` to get a
-cells-axis index for `read_cell`).
+`(row, col)` per cell. `readers._layout.rowcol_to_rank` inverts that to the
+**chunk-local** nested rank (`0..4**depth - 1`) — *not* a `read_cell` key,
+which is a **global** cells-axis index; the chunk's start offset is the
+missing term, and a bare rank is always in range so `read_cell` would read
+the wrong cell without raising. `cell_index` composes the two:
+
+```python
+for morton, (row, col), values in read_raw_values(store, field):
+    cell = cell_index(store, field, morton, row, col)  # chunk_start + rank
+    assert (read_cell(store, field, cell)[:, 0] == values).all()
+```
+
+It resolves the offset from the sibling `morton` coordinate, searching only
+the array's stored spans (the populated chunks the sweep readers yield from)
+and no digest bytes. `morton_index` must be a read-chunk id — a coarser
+`block_order` block id names no single chunk and raises.
 
 ## Issue #210 typed-dtype migration
 

--- a/notebooks/tdigest_reader_example.ipynb
+++ b/notebooks/tdigest_reader_example.ipynb
@@ -22,9 +22,12 @@
     "A downstream client usually wants something denser and fixed-size. The\n",
     "`zagg.readers` package (issue #79) reconstructs that from the stored digests:\n",
     "\n",
-    "- **`read_tensors`** -- a generator yielding `(tensor, morton_index)` per chunk,\n",
-    "  where `tensor` has shape `(64, 64, n_bins)`: each cell's digest rasterized into\n",
-    "  `n_bins` evenly-spaced z-bins.\n",
+    "- **`read_tensors`** -- a generator yielding the reader contract\n",
+    "  `(tensor, mask, (offset, gain), morton_index)` per block (one read chunk by\n",
+    "  default), where `tensor` has shape `(64, 64, n_bins)`: each cell's digest\n",
+    "  rasterized into `n_bins` evenly-spaced z-bins, placed at the **spatially\n",
+    "  faithful** deinterleave of its nested rank (issue #336; mortie spec §8), with\n",
+    "  a uint8 occupancy `mask` and the block's shared z-window `(z_lo, resolution)`.\n",
     "- **`read_raw_values`** -- the lossless companion: when a cell's digest was built\n",
     "  with no merges, its centroid means *are* the original samples, so the raw value\n",
     "  vector is recovered exactly (and it raises when that is not possible).\n",
@@ -200,13 +203,19 @@
    "source": [
     "## 2. `read_tensors`: dense fixed-size tensors\n",
     "\n",
-    "`read_tensors` yields `(tensor, morton_index)` per chunk. For each chunk it:\n",
+    "`read_tensors` yields `(tensor, mask, (offset, gain), morton_index)` per block\n",
+    "(one read chunk by default; `block_order=` assembles whole chunks into larger\n",
+    "blocks). For each block it:\n",
     "\n",
     "1. trims each cell's tails to the `bottom`/`top` quantiles (default 5%/95%),\n",
     "2. anchors a fixed `n_bins * resolution` z-window at the floor of the trimmed\n",
-    "   range,\n",
+    "   range -- the emitted `(offset, gain)` pair, shared by every cell in the block,\n",
     "3. rasterizes every cell's digest into `n_bins` per-bin counts over that window,\n",
-    "4. emits the `(64, 64, n_bins)` tensor plus the chunk's morton id (recovered\n",
+    "   placing cell rank `r` at `rank_to_rowcol(r, depth)` -- the bit deinterleave\n",
+    "   pinned to mortie spec §8 (row = y, col = x, gridlook's texture convention),\n",
+    "4. emits the `(64, 64, n_bins)` tensor, the `(64, 64)` uint8 occupancy `mask`\n",
+    "   (0 unobserved / 1 observed-no-digest / 2 observed-with-data; a flat store\n",
+    "   like this one degrades to `{0, 2}`), and the block's morton id (recovered\n",
     "   from the store).\n",
     "\n",
     "Defaults: `n_bins=128`, `resolution=0.5` m (a 64 m window), `dtype=\"uint32\"`."
@@ -228,7 +237,7 @@
    "source": [
     "from zagg.readers import read_tensors\n",
     "\n",
-    "tensors = {morton: tensor for tensor, morton in read_tensors(store, FIELD)}\n",
+    "tensors = {morton: tensor for tensor, _mask, _scale, morton in read_tensors(store, FIELD)}\n",
     "\n",
     "for morton, tensor in sorted(tensors.items()):\n",
     "    nonzero_cells = int((tensor.sum(axis=2) > 0).sum())\n",
@@ -242,7 +251,13 @@
    "cell_type": "markdown",
    "id": "79a77921",
    "metadata": {},
-   "source": "The morton id is the chunk's coverage cell, recovered from the sibling\n`morton` coordinate array (`{group}/morton`, alongside the field under the same\ngroup — the per-cell morton word coarsened to the chunk's order). Populated\ncells land at their row-major position; everything else is zero."
+   "source": [
+    "The morton id is the chunk's coverage cell, recovered from the sibling\n",
+    "`morton` coordinate array (`{group}/morton`, alongside the field under the same\n",
+    "group — the per-cell morton word coarsened to the chunk's order). Populated\n",
+    "cells land at the deinterleaved `(row, col)` of their nested rank (never a\n",
+    "row-major reshape -- nested order is a Z-order curve); everything else is zero."
+   ]
   },
   {
    "cell_type": "code",
@@ -258,11 +273,15 @@
    },
    "outputs": [],
    "source": [
+    "from zagg.readers import rank_to_rowcol\n",
+    "\n",
     "tensor = tensors[word_a]\n",
-    "# cell 5 -> (row 0, col 5); cell 4095 -> (row 63, col 63); cell 10 unpopulated.\n",
-    "print(\"cell 5   (0, 5)  count sum:\", int(tensor[0, 5].sum()))\n",
-    "print(\"cell 4095 (63,63) count sum:\", int(tensor[63, 63].sum()))\n",
-    "print(\"cell 10  (0,10) count sum:\", int(tensor[0, 10].sum()), \"(unpopulated)\")"
+    "# A cell's position is the bit deinterleave of its nested rank within the\n",
+    "# 64x64 (depth-6) chunk: rank 5 -> (0, 3); rank 4095 -> (63, 63).\n",
+    "for rank, note in [(5, \"populated\"), (4095, \"populated\"), (10, \"unpopulated\")]:\n",
+    "    row, col = rank_to_rowcol(rank, 6)\n",
+    "    print(f\"cell rank {rank:4d} -> (row {row:2d}, col {col:2d}) count sum:\",\n",
+    "          int(tensor[row, col].sum()), f\"({note})\")"
    ]
   },
   {
@@ -297,7 +316,7 @@
     "\n",
     "n_bins, resolution = 128, 0.5\n",
     "tensor = tensors[word_a]\n",
-    "vec = tensor[0, 5]  # the digest histogram for cell 5 of chunk A\n",
+    "vec = tensor[0, 3]  # cell rank 5 of chunk A -- deinterleaved position (0, 3)\n",
     "\n",
     "# Reconstruct the window the reader used: floor of the chunk's trimmed minimum.\n",
     "# We recompute the floor here only to label the x-axis; the reader sets it internally.\n",
@@ -345,7 +364,7 @@
    "outputs": [],
    "source": [
     "for dtype in (\"uint16\", \"uint32\", \"float32\"):\n",
-    "    t, _ = next(read_tensors(store, FIELD, dtype=dtype))\n",
+    "    t, *_rest = next(read_tensors(store, FIELD, dtype=dtype))\n",
     "    print(f\"dtype={dtype:8s} -> tensor.dtype={t.dtype}, peak bin count={t.max()}\")"
    ]
   },
@@ -408,14 +427,14 @@
    "outputs": [],
    "source": [
     "# degrade_resolution: coarsen the bins until the full span fits in 128 bins.\n",
-    "t, _ = next(read_tensors(wide, FIELD, bottom=0.0, top=1.0, fit=\"degrade_resolution\"))\n",
+    "t, *_rest = next(read_tensors(wide, FIELD, bottom=0.0, top=1.0, fit=\"degrade_resolution\"))\n",
     "print(\"fit='degrade_resolution' -> tensor\", t.shape, \"dtype\", t.dtype)\n",
     "\n",
     "# collapse_bins on a *narrow* chunk: shrink n_bins to the smallest pow2 that fits.\n",
     "narrow = MemoryStore()\n",
     "grid.emit_template(narrow)\n",
     "write_chunk(narrow, \"1121121\", {0: rng.uniform(100.0, 110.0, 4_000)})\n",
-    "t2, _ = next(read_tensors(narrow, FIELD, bottom=0.0, top=1.0, fit=\"collapse_bins\"))\n",
+    "t2, *_rest = next(read_tensors(narrow, FIELD, bottom=0.0, top=1.0, fit=\"collapse_bins\"))\n",
     "print(\"fit='collapse_bins' -> tensor\", t2.shape, \"(n_bins collapsed to fit ~10 m span)\")"
    ]
   },
@@ -429,8 +448,10 @@
     "When a cell's digest was built with **no merges** -- every centroid weight is 1,\n",
     "which happens whenever a cell has at most `delta` samples -- the centroid means\n",
     "are exactly the original observations. `read_raw_values` yields\n",
-    "`(morton_index, cell_id, values)` for each such cell, with `values` the recovered\n",
-    "sample vector (sorted ascending, as the digest stores centroids by mean).\n",
+    "`(morton_index, (row, col), values)` for each such cell, with `values` the\n",
+    "recovered sample vector (sorted ascending, as the digest stores centroids by\n",
+    "mean) and `(row, col)` the same deinterleaved position `read_tensors` places\n",
+    "the cell at.\n",
     "\n",
     "If any cell carries a merged centroid (weight > 1), exact recovery is impossible\n",
     "and the reader raises -- the same `raise`-by-default contract as `read_tensors`."
@@ -457,8 +478,8 @@
     "samples = np.array([3.0, 1.0, 2.0, 5.0, 4.0])  # 5 values, well under delta -> no merges\n",
     "write_chunk(lossless, \"1121121\", {7: samples}, delta=512)\n",
     "\n",
-    "for morton, cell_id, values in read_raw_values(lossless, FIELD):\n",
-    "    print(f\"chunk {morton}, cell {cell_id}: recovered {values}\")\n",
+    "for morton, (row, col), values in read_raw_values(lossless, FIELD):\n",
+    "    print(f\"chunk {morton}, cell at (row {row}, col {col}): recovered {values}\")\n",
     "    print(\"matches sorted input:\", np.allclose(values, np.sort(samples)))"
    ]
   },
@@ -493,9 +514,13 @@
    "source": [
     "## Summary\n",
     "\n",
-    "- `read_tensors(store, field, ...)` -> dense `(64, 64, n_bins)` tensors per chunk,\n",
-    "  with `bottom`/`top` tail-trim, a `fit` policy for wide chunks, and a `dtype`\n",
-    "  flag (`uint16`/`uint32`/`float32`).\n",
+    "- `read_tensors(store, field, ...)` -> `(tensor, mask, (offset, gain), morton)`\n",
+    "  per block: dense, spatially faithful `(64, 64, n_bins)` tensors (deinterleaved\n",
+    "  per mortie spec §8) with a uint8 occupancy mask and the block's shared\n",
+    "  z-window, plus `bottom`/`top` tail-trim, a `fit` policy for wide blocks, a\n",
+    "  `dtype` flag (`uint16`/`uint32`/`float32`), and `block_order=` to assemble\n",
+    "  whole chunks into larger blocks (with hive leaves, the mask decodes the\n",
+    "  `coverage.moc` occupancy sidecar).\n",
     "- `read_raw_values(store, field)` -> exact samples per cell when the digest is\n",
     "  merge-free, raising otherwise.\n",
     "- `read_cell(store, field, cell)` -> one cell's digest by global position.\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,11 @@ dependencies = [
     # register from it). 0.2.0 is not on PyPI yet — resolution fails until
     # upstream publishes it.
     "h5coro-hidefix>=0.3.1",
-    # 0.9.0 ships the decimal-emit surface shard ids route through (issue #199):
+    # Floor 0.9.3 for the reader deinterleave (issue #336): rank_to_xy /
+    # xy_to_rank, the nested-rank ↔ face-local (x, y) pair the tensor readers
+    # place cells by (espg/mortie#150; normative convention in mortie's
+    # docs/specification.md §8, frozen for mortie 1.x). Earlier floors: 0.9.0
+    # ships the decimal-emit surface shard ids route through (issue #199) —
     # decimal_repr / to_decimal, the _decimal_to_word parse-back, hive_path, and
     # the MortonIndexScalar decimal display.
     "mortie>=0.9.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     # 0.9.0 ships the decimal-emit surface shard ids route through (issue #199):
     # decimal_repr / to_decimal, the _decimal_to_word parse-back, hive_path, and
     # the MortonIndexScalar decimal display.
-    "mortie>=0.9.1",
+    "mortie>=0.9.3",
     "earthaccess",
     "boto3",
     "fastparquet",

--- a/src/zagg/readers/__init__.py
+++ b/src/zagg/readers/__init__.py
@@ -11,6 +11,7 @@ from zagg.readers._layout import rank_to_rowcol, rowcol_to_rank
 from zagg.readers.tdigest_tensor import (
     cell_index,
     chunk_z_range,
+    has_exact_occupancy,
     rasterize_cell,
     read_cell,
     read_locations,
@@ -21,6 +22,7 @@ from zagg.readers.tdigest_tensor import (
 __all__ = [
     "cell_index",
     "chunk_z_range",
+    "has_exact_occupancy",
     "rank_to_rowcol",
     "rasterize_cell",
     "read_cell",

--- a/src/zagg/readers/__init__.py
+++ b/src/zagg/readers/__init__.py
@@ -7,6 +7,7 @@ writes.  Pure-numpy + zarr (both already core deps); no new dependency.
 
 from __future__ import annotations
 
+from zagg.readers._layout import rank_to_rowcol, rowcol_to_rank
 from zagg.readers.tdigest_tensor import (
     chunk_z_range,
     rasterize_cell,
@@ -18,9 +19,11 @@ from zagg.readers.tdigest_tensor import (
 
 __all__ = [
     "chunk_z_range",
+    "rank_to_rowcol",
     "rasterize_cell",
     "read_cell",
     "read_locations",
     "read_raw_values",
     "read_tensors",
+    "rowcol_to_rank",
 ]

--- a/src/zagg/readers/__init__.py
+++ b/src/zagg/readers/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from zagg.readers._layout import rank_to_rowcol, rowcol_to_rank
 from zagg.readers.tdigest_tensor import (
+    cell_index,
     chunk_z_range,
     rasterize_cell,
     read_cell,
@@ -18,6 +19,7 @@ from zagg.readers.tdigest_tensor import (
 )
 
 __all__ = [
+    "cell_index",
     "chunk_z_range",
     "rank_to_rowcol",
     "rasterize_cell",

--- a/src/zagg/readers/_layout.py
+++ b/src/zagg/readers/_layout.py
@@ -1,0 +1,51 @@
+"""Chunk-local nested rank ↔ 2-D ``(row, col)`` tensor layout (issue #336).
+
+A depth-``d`` HEALPix subtree holds ``4**d`` cells whose ascending nested
+(morton) order traces a Z-order curve over a ``2**d × 2**d`` block — so a
+row-major reshape of the 1-D cells axis scrambles the block spatially beyond
+2-cell runs. The faithful mapping is the pure bit deinterleave that mortie
+0.9.3 ships as ``rank_to_xy``/``xy_to_rank`` (espg/mortie#150; normative
+contract in mortie's ``docs/specification.md`` §8, frozen for mortie 1.x):
+``x`` gathers the rank's even bits, ``y`` its odd bits, with ``(0, 0)`` at the
+subtree's **south corner**, ``x`` increasing toward the north-east edge and
+``y`` toward the north-west edge — exactly healpy's face-local
+``pix2xyf``/``xyf2pix`` (nest) convention.
+
+Row/col orientation (pinned here, once)
+---------------------------------------
+Tensor axis 0 (row) is ``y`` and axis 1 (col) is ``x``. This matches
+gridlook's texture convention (``src/ui/grids/Healpix.vue``,
+``getUnshuffleIndex``): ``texture[i*size + j] = data[bit_combine(j, i)]``,
+i.e. the texture's slow axis ``i`` feeds ``bit_combine``'s second (odd-bit,
+``y``) argument and the fast axis ``j`` its first (even-bit, ``x``) argument
+— so a zagg tensor uploads to a gridlook texture with no further shuffle.
+``tensor[0, 0]`` is the subtree's south corner; rows advance toward the
+north-west edge, columns toward the north-east edge.
+"""
+
+from __future__ import annotations
+
+from mortie import rank_to_xy, xy_to_rank
+
+__all__ = ["rank_to_rowcol", "rowcol_to_rank"]
+
+
+def rank_to_rowcol(rank, depth: int):
+    """``(row, col)`` tensor position of a chunk-local nested rank.
+
+    ``rank`` is the cell's position ``0..4**depth - 1`` within its depth-
+    ``depth`` subtree (scalar or array; the same position the ragged writers
+    use on the cells axis). Returns ``(row, col) = (y, x)`` per the module
+    orientation contract (mortie spec §8 / gridlook ``bit_combine(j, i)``).
+    """
+    x, y = rank_to_xy(rank, depth)
+    return y, x
+
+
+def rowcol_to_rank(row, col, depth: int):
+    """Chunk-local nested rank at a ``(row, col)`` tensor position.
+
+    Inverse of :func:`rank_to_rowcol`: ``row`` is ``y``, ``col`` is ``x``
+    (scalars or arrays; values must be ``< 2**depth``).
+    """
+    return xy_to_rank(col, row, depth)

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -536,7 +536,7 @@ def read_tensors(
     the block's coverage-cell morton id (``side`` is 64 for the production
     ``chunk_inner`` configs at the default per-chunk block). Cell placement is
     the spatially faithful bit deinterleave of the cell's nested rank
-    (issue #336): ``tensor[row, col] = rank_to_rowcol(rank, depth)`` per the
+    (issue #336): ``row, col = rank_to_rowcol(rank, depth)`` per the
     :mod:`zagg.readers._layout` orientation contract (mortie spec §8; row 0 /
     col 0 at the block subtree's south corner, gridlook texture convention).
 

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -62,6 +62,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Iterator
+from itertools import chain, groupby
 from typing import Literal
 
 import numpy as np
@@ -350,17 +351,12 @@ def _open_morton(store: Store, field: str, zarr_format):
         ) from e
 
 
-def _chunk_word(words: np.ndarray, field: str, start: int) -> int:
-    """A read chunk's coverage-cell morton id from its cells' morton words.
+def _cells_order(words: np.ndarray, field: str, start: int) -> int:
+    """HEALPix order of a chunk's written cell words (the cells-axis order).
 
-    ``words`` are the chunk's per-cell morton coordinates (packed uint64 area
-    words at the cell order; ``0`` is the unwritten fill). The chunk id is any
-    written cell's word coarsened to the chunk order — ``cell_order -
-    log4(cells_per_chunk)`` — the same parent cell the CSR layout named its
-    subgroups by.
+    ``words`` are per-cell morton coordinates (packed uint64 area words at the
+    cell order; ``0`` is the unwritten fill).
     """
-    from mortie import clip2order
-
     from zagg.grids.morton import morton_decimal
 
     written = words[words != 0]
@@ -370,9 +366,33 @@ def _chunk_word(words: np.ndarray, field: str, start: int) -> int:
             f"'morton' coordinate — the dense coordinate write did not cover it"
         )
     decimal = morton_decimal(int(written[0]))
-    cell_order = len(decimal) - (2 if decimal.startswith("-") else 1)
-    depth = (int(len(words)).bit_length() - 1) // 2  # log4(cells_per_chunk)
-    return int(clip2order(cell_order - depth, written[:1])[0])
+    return len(decimal) - (2 if decimal.startswith("-") else 1)
+
+
+def _chunk_word(words: np.ndarray, field: str, start: int) -> int:
+    """A read chunk's/block's coverage-cell morton id from its cells' words.
+
+    The id is the written cells' common ancestor at ``cell_order -
+    log4(len(words))`` — the same parent cell the CSR layout named its
+    subgroups by. Raises when the written cells do NOT share that ancestor:
+    the cells axis is then not nested-aligned over this span (a dense
+    multi-shard axis assembled at a block order coarser than the shard
+    order), and index arithmetic would place cells in the wrong subtree.
+    """
+    from mortie import clip2order
+
+    written = words[words != 0]
+    cell_order = _cells_order(words, field, start)
+    order = cell_order - (int(len(words)).bit_length() - 1) // 2  # log4(len)
+    ancestors = clip2order(order, written)
+    if np.any(ancestors != ancestors[0]):
+        raise ValueError(
+            f"cells of the block at {start} of {field!r} span more than one "
+            f"order-{order} ancestor — the cells axis is not nested-aligned over "
+            f"this span (a dense multi-shard axis assembles only at block orders "
+            f"at or finer than the shard order)"
+        )
+    return int(ancestors[0])
 
 
 def _tensor_side(arr, field: str) -> tuple[int, int]:
@@ -407,21 +427,31 @@ def read_tensors(
     top: float = 0.95,
     fit: FitMode = "raise",
     dtype: TensorDtype = "uint32",
+    block_order: int | None = None,
     zarr_format: Literal[2, 3] = 3,
 ) -> Iterator[tuple[np.ndarray, int]]:
-    """Yield ``(tensor, morton_index)`` per coverage chunk of a t-digest field.
+    """Yield ``(tensor, morton_index)`` per coverage block of a t-digest field.
 
     Sweeps the field's vlen array one read chunk (one square cell block) at a
-    time, visiting only the STORED objects. For each populated chunk it trims
+    time, visiting only the STORED objects. For each populated block it trims
     the per-cell tails, derives a fixed z-window (see :func:`chunk_z_range`),
     rasterizes every populated cell's digest into ``n_bins`` counts (see
     :func:`rasterize_cell`), and emits the ``(side, side, n_bins)`` tensor with
-    the chunk's coverage-cell morton id (``side`` is 64 for the production
-    ``chunk_inner`` configs). Cell placement is the spatially faithful bit
-    deinterleave of the cell's nested rank (issue #336):
-    ``tensor[row, col] = rank_to_rowcol(rank, depth)`` per the
+    the block's coverage-cell morton id (``side`` is 64 for the production
+    ``chunk_inner`` configs at the default per-chunk block). Cell placement is
+    the spatially faithful bit deinterleave of the cell's nested rank
+    (issue #336): ``tensor[row, col] = rank_to_rowcol(rank, depth)`` per the
     :mod:`zagg.readers._layout` orientation contract (mortie spec §8; row 0 /
-    col 0 at the chunk subtree's south corner, gridlook texture convention).
+    col 0 at the block subtree's south corner, gridlook texture convention).
+
+    ``block_order`` assembles the ``4**(chunk_order - block_order)`` read
+    chunks of one block-order subtree into a single
+    ``(2**d, 2**d, n_bins)`` tensor (``d = cell_order - block_order``) — e.g.
+    an order-12 block on the production geometry (order-19 cells, 64×64
+    chunks) is a 128×128 tensor assembled from 4 inner chunks. The z-window
+    and the ``fit`` policy are reconciled **block-wide**: one shared
+    offset/gain per block, with degrade/collapse decisions made over all of
+    the block's populated cells, not per chunk.
 
     Parameters
     ----------
@@ -444,6 +474,10 @@ def read_tensors(
         counts to the nearest integer; ``float32`` keeps fractional counts.  A
         per-bin count exceeding the dtype's max (65535 for ``uint16``) wraps on
         cast — keep ``uint32`` for dense cells with many observations per bin.
+    block_order : int, optional
+        HEALPix order of the emitted blocks (default ``None`` — one block per
+        read chunk). Must be at or coarser than the chunk order; a block is
+        assembled from whole read chunks with one shared z-window.
     zarr_format : int, optional
         Zarr format version (default 3).
 
@@ -451,14 +485,15 @@ def read_tensors(
     ------
     (tensor, morton_index) : (ndarray, int)
         ``tensor`` has shape ``(side, side, n_bins_out)`` and the requested
-        dtype; ``morton_index`` is the chunk's coverage-cell morton id.
+        dtype; ``morton_index`` is the block's coverage-cell morton id.
 
     Raises
     ------
     ValueError
         On an unknown ``dtype``/``fit``, a store missing the ragged element
-        attrs or the ``morton`` sibling, or (with ``fit="raise"``) a chunk
-        whose trimmed range overflows the fixed window.
+        attrs or the ``morton`` sibling, an out-of-range ``block_order``, or
+        (with ``fit="raise"``) a block whose trimmed range overflows the
+        fixed window.
     """
     if dtype not in _TENSOR_DTYPES:
         raise ValueError(f"unknown dtype {dtype!r}; expected one of {sorted(_TENSOR_DTYPES)}")
@@ -468,11 +503,44 @@ def read_tensors(
     arr, elem_dtype, elem_shape, _meta = _open_ragged(store, field, zarr_format)
     morton = _open_morton(store, field, zarr_format)
     side, depth = _tensor_side(arr, field)
+    cells_per_chunk = side * side
 
-    for start, populated in _iter_populated_chunks(arr):
-        cells = [(pos, _decode_cell(raw, elem_dtype, elem_shape)) for pos, raw in populated]
+    chunks = _iter_populated_chunks(arr)
+    first = next(chunks, None)
+    if first is None:
+        return
+    if block_order is None:
+        block_cells, block_depth = cells_per_chunk, depth
+    else:
+        # The cells-axis order comes from the first populated chunk's words;
+        # the block subtree must be whole read chunks (coarser or equal).
+        cell_order = _cells_order(morton[first[0] : first[0] + cells_per_chunk], field, first[0])
+        chunk_order = cell_order - depth
+        if not 0 <= int(block_order) <= chunk_order:
+            raise ValueError(
+                f"block_order {block_order} is out of range: a block assembles whole "
+                f"read chunks, so it must be between 0 and the chunk order "
+                f"{chunk_order} (block_order=None reads per chunk)"
+            )
+        block_depth = cell_order - int(block_order)
+        block_cells = 4**block_depth
+        if int(arr.shape[0]) % block_cells:
+            raise ValueError(
+                f"{field!r} has {int(arr.shape[0])} cells — not a whole number of "
+                f"order-{block_order} blocks ({block_cells} cells each), so the cells "
+                f"axis cannot assemble at this block order"
+            )
+    block_side = 1 << block_depth
+
+    for block, group in groupby(chain([first], chunks), key=lambda c: c[0] // block_cells):
+        bstart = block * block_cells
+        cells = [
+            (start - bstart + pos, _decode_cell(raw, elem_dtype, elem_shape))
+            for start, populated in group
+            for pos, raw in populated
+        ]
         z_lo, n_bins_c, resolution_c = chunk_z_range(
-            [digest for _pos, digest in cells],
+            [digest for _rank, digest in cells],
             n_bins=n_bins,
             resolution=resolution,
             bottom=bottom,
@@ -480,15 +548,15 @@ def read_tensors(
             fit=fit,
         )
 
-        tensor = np.zeros((side, side, n_bins_c), dtype=out_dtype)
+        tensor = np.zeros((block_side, block_side, n_bins_c), dtype=out_dtype)
         for rank, digest in cells:
             counts = rasterize_cell(digest, z_lo, resolution_c, n_bins_c)
             if not is_float:
                 counts = np.rint(counts)
-            row, col = rank_to_rowcol(rank, depth)
+            row, col = rank_to_rowcol(rank, block_depth)
             tensor[row, col, :] = counts.astype(out_dtype)
 
-        yield tensor, _chunk_word(morton[start : start + side * side], field, start)
+        yield tensor, _chunk_word(morton[bstart : bstart + block_cells], field, bstart)
 
 
 def read_raw_values(

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -966,9 +966,7 @@ def cell_index(
     side, depth = _tensor_side(arr, field)
     cells_per_chunk = side * side
     if not (0 <= int(row) < side and 0 <= int(col) < side):
-        raise ValueError(
-            f"({row}, {col}) is outside {field!r}'s ({side}, {side}) read-chunk block"
-        )
+        raise ValueError(f"({row}, {col}) is outside {field!r}'s ({side}, {side}) read-chunk block")
     rank = int(rowcol_to_rank(int(row), int(col), depth))
     target = int(morton_index)
     for span_start, span_stop in _stored_chunk_spans(arr):

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -82,6 +82,7 @@ __all__ = [
     "rasterize_cell",
     "chunk_z_range",
     "read_tensors",
+    "has_exact_occupancy",
     "read_raw_values",
     "read_locations",
     "read_cell",
@@ -419,6 +420,31 @@ def _read_store_object(store: Store, key: str) -> bytes | None:
     return None if buf is None else buf.to_bytes()
 
 
+def _coverage_occupancy(store: Store) -> tuple[str, dict, bytes] | None:
+    """``(encoding, coverage, sidecar_bytes)`` when the store has EXACT occupancy.
+
+    ``None`` for every store whose mask must degrade to the 2-state
+    populated/not channel (the D9 degrade): no commit stamp (every flat
+    store), a box-only envelope, or a bitmap envelope whose sidecar object is
+    gone. Shared by :func:`_load_occupancy` and :func:`has_exact_occupancy`,
+    so the public predicate cannot drift from the mask the reader builds.
+    """
+    from zagg import hive
+
+    coverage = hive.read_coverage(store)
+    if not coverage:
+        return None
+    encoding = coverage.get("encoding")
+    if encoding == "full":
+        return "full", coverage, b""  # a full subtree needs no sidecar (D14)
+    if encoding != "bitmap" or not coverage.get("sidecar"):
+        return None
+    payload = _read_store_object(store, str(coverage["sidecar"]))
+    if payload is None:
+        return None
+    return "bitmap", coverage, payload
+
+
 def _load_occupancy(store: Store, arr, words: np.ndarray, field: str) -> tuple | None:
     """The leaf's exact cell occupancy for the mask channel, or ``None``.
 
@@ -439,17 +465,12 @@ def _load_occupancy(store: Store, arr, words: np.ndarray, field: str) -> tuple |
     """
     from zagg import hive
 
-    coverage = hive.read_coverage(store)
-    if not coverage:
+    found = _coverage_occupancy(store)
+    if found is None:
         return None
-    encoding = coverage.get("encoding")
+    encoding, coverage, payload = found
     if encoding == "full":
         return "full", None
-    if encoding != "bitmap" or not coverage.get("sidecar"):
-        return None
-    payload = _read_store_object(store, str(coverage["sidecar"]))
-    if payload is None:
-        return None
     cell_order = _cells_order(words, field, 0)
     if int(coverage.get("cell_order", -1)) != cell_order:
         raise ValueError(
@@ -476,9 +497,11 @@ def _block_mask(words: np.ndarray, occupancy: tuple | None, block_depth: int) ->
     """The block's ``(side, side)`` uint8 occupancy base (values 0/1).
 
     ``1`` marks a cell the leaf's occupancy sidecar records as observed;
-    the caller upgrades digest-bearing cells to ``2``. Without occupancy
-    truth the base stays ``0`` everywhere (mask degrades to the 2-state
-    populated/not — never a wrong answer).
+    the caller upgrades digest-bearing cells to ``2``. Without occupancy truth
+    the base stays ``0`` everywhere: the mask degrades to the 2-state
+    populated/not channel, where ``0`` means "no stored digest" and asserts
+    NOTHING about whether the cell was observed. That degrade is not visible
+    in the mask itself — :func:`has_exact_occupancy` is the discriminator.
     """
     side = 1 << block_depth
     mask = np.zeros((side, side), dtype=np.uint8)
@@ -613,11 +636,18 @@ def read_tensors(
         rasterizes). The observed states come from the hive leaf's
         ``coverage.moc`` occupancy sidecar (issue #200), read WITHOUT
         touching digest bytes; a store without one (every flat store)
-        degrades to the 2-state ``{0, 2}`` populated/not mask. Today a
-        pre-#334 leaf's occupancy equals its digest coverage, so ``1`` does
-        not occur; once the issue #334 signal strata land, noise-occupied
-        cells (observed, no signal digest) appear as ``1`` automatically —
-        the upgrade is data-driven, not a reader flag. ``(offset, gain)`` is
+        degrades to the 2-state ``{0, 2}`` populated/not mask, where ``0``
+        means only "no stored digest" and does NOT assert that the cell was
+        unobserved. **The yielded mask does not say which regime it is in** —
+        a degraded mask and a 3-state mask over a block with no
+        observed-but-empty cell are both ``{0, 2}`` — so a consumer keying on
+        the 3-state semantics (``mask == 1``, the issue #334 noise stratum)
+        must check :func:`has_exact_occupancy` first, or it reads an empty
+        stratum on a degraded store as a genuine absence. Today a pre-#334
+        leaf's occupancy equals its digest coverage, so ``1`` does not occur;
+        once the issue #334 signal strata land, noise-occupied cells
+        (observed, no signal digest) appear as ``1`` automatically — the
+        upgrade is data-driven, not a reader flag. ``(offset, gain)`` is
         the block's shared z-window ``(z_lo, resolution)``: bin ``i`` of
         every cell in the block covers ``[offset + i*gain, offset +
         (i+1)*gain)``. ``morton_index`` is the block's coverage-cell morton
@@ -715,6 +745,30 @@ def read_tensors(
             mask[row, col] = 2
 
         yield tensor, mask, (float(z_lo), float(resolution_c)), _chunk_word(words, field, bstart)
+
+
+def has_exact_occupancy(store: Store) -> bool:
+    """Whether this store's :func:`read_tensors` mask is the 3-state channel.
+
+    The mask's two regimes are indistinguishable from the yielded array (a
+    degraded mask is ``{0, 2}``, and so is a 3-state mask over a block with no
+    observed-but-empty cell), so this is the discriminator — call it once per
+    store before keying on the mask's semantics:
+
+    - ``True`` — the leaf carries exact ``coverage.moc`` occupancy (issue
+      #200), so ``0`` really means *unobserved* and ``1`` (observed, no stored
+      digest — the issue #334 noise stratum) is reported wherever it occurs.
+    - ``False`` — no exact occupancy (no commit stamp, i.e. every flat store;
+      a box-only envelope; or a bitmap envelope whose sidecar is gone), the
+      mask degrades to 2-state populated/not, and ``0`` means only "no stored
+      digest here". Reading ``mask == 1`` as "no noise-occupied cells" would
+      be a false negative.
+
+    One attrs read plus (for a bitmap envelope) the small sidecar object; no
+    digest bytes. Shares :func:`_coverage_occupancy` with the mask build, so
+    it cannot report a regime the reader does not produce.
+    """
+    return _coverage_occupancy(store) is not None
 
 
 def read_raw_values(

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -37,9 +37,10 @@ configs); its coverage-cell morton id is derived from the sibling ``morton``
 coordinate. A cell's 2-D position is the **bit deinterleave** of its nested
 rank within the chunk (``readers._layout.rank_to_rowcol`` — mortie spec §8 /
 gridlook orientation; issue #336), never a row-major reshape: nested order is
-a Z-order curve, so ``divmod(rank, side)`` would scramble the block spatially. Random access to one cell
-(:func:`read_cell`) indexes the vlen array directly — 2 ranged GETs on a
-sharded store (index suffix + one inner chunk), never the whole shard.
+a Z-order curve, so ``divmod(rank, side)`` would scramble the block spatially.
+Random access to one cell (:func:`read_cell`) indexes the vlen array directly
+— 2 ranged GETs on a sharded store (index suffix + one inner chunk), never the
+whole shard.
 
 **Hive products are read one leaf at a time**: a leaf zarr (issue #199) is
 exactly this layout scoped to one shard — the same ``{group}`` path, the
@@ -328,8 +329,10 @@ def _iter_populated_chunks(arr) -> Iterator[tuple[int, list]]:
     ~141 MB at the o8 t-digest scale, the same bound the hive write side
     documents and accepts (``process_and_write_hive``), and this is the
     client-side bulk reader. Chunks whose cells are all absent (the ``b""``
-    fill) are skipped; ``cell_pos`` is the cell's row-major position within
-    the chunk — the same index the writer placed it at.
+    fill) are skipped; ``cell_pos`` is the cell's chunk-local NESTED RANK —
+    the same index the writer placed it at, and the index the readers
+    deinterleave to a tensor position (``rank_to_rowcol``, issue #336); it is
+    never a row-major position (nested order is a Z-order curve).
     """
     cells_per_chunk = int(arr.chunks[0])
     for span_start, span_stop in _stored_chunk_spans(arr):

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -326,10 +326,12 @@ def _iter_populated_chunks(arr) -> Iterator[tuple[int, list]]:
     index suffix on every ``__getitem__`` (~K redundant GETs per shard at the
     production K=256 — review, PR #211), while the full-span slice fetches
     the stored object ONCE (zarr reads a whole outer chunk in a single GET
-    and splits it locally). The held cost is one span's decoded payload —
-    ~141 MB at the o8 t-digest scale, the same bound the hive write side
-    documents and accepts (``process_and_write_hive``), and this is the
-    client-side bulk reader. Chunks whose cells are all absent (the ``b""``
+    and splits it locally). THIS generator's held cost is one span's decoded
+    payload — ~141 MB at the o8 t-digest scale, the same bound the hive write
+    side documents and accepts (``process_and_write_hive``), and this is the
+    client-side bulk reader. Callers that group the yielded chunks into a
+    coarser block hold one BLOCK's payload instead, which is that bound times
+    the number of spans the block covers (see :func:`read_tensors`). Chunks whose cells are all absent (the ``b""``
     fill) are skipped; ``cell_pos`` is the cell's chunk-local NESTED RANK —
     the same index the writer placed it at, and the index the readers
     deinterleave to a tensor position (``rank_to_rowcol``, issue #336); it is
@@ -527,6 +529,7 @@ def read_tensors(
     fit: FitMode = "raise",
     dtype: TensorDtype = "uint32",
     block_order: int | None = None,
+    max_block_bytes: int = 2 * 1024**3,
     zarr_format: Literal[2, 3] = 3,
 ) -> Iterator[tuple[np.ndarray, np.ndarray, tuple[float, float], int]]:
     """Yield ``(tensor, mask, (offset, gain), morton_index)`` per coverage block.
@@ -555,6 +558,19 @@ def read_tensors(
     offset/gain per block, with degrade/collapse decisions made over all of
     the block's populated cells, not per chunk.
 
+    **The memory bound is per BLOCK, not per stored object.** Two terms are
+    held while a block is assembled: (1) the block's decoded digests — the
+    block-wide z-window needs all of them before any cell can be rasterized —
+    which is ``4**(span_order - block_order)`` times one span's payload
+    (~141 MB at the o8 t-digest scale, :func:`_iter_populated_chunks`); and
+    (2) the emitted ``4**block_depth * n_bins`` tensor, which grows 4× per
+    coarser order — an order-6 block on the production order-19 geometry is a
+    34 TB allocation. ``max_block_bytes`` (2 GiB default) refuses term (2)
+    with a pointed error naming the size instead of dying in the allocator;
+    it is checked against the REQUESTED ``n_bins`` (``fit`` only ever shrinks
+    it) and bounds the tensor only — term (1) follows the block order asked
+    for. Raise it deliberately when a large block really is intended.
+
     Parameters
     ----------
     store : Store
@@ -580,6 +596,10 @@ def read_tensors(
         HEALPix order of the emitted blocks (default ``None`` — one block per
         read chunk). Must be at or coarser than the chunk order; a block is
         assembled from whole read chunks with one shared z-window.
+    max_block_bytes : int, optional
+        Refuse a block whose emitted tensor would exceed this many bytes
+        (default 2 GiB) — the guard on the ``block_order`` footgun. Raise it
+        explicitly to allow a bigger block.
     zarr_format : int, optional
         Zarr format version (default 3).
 
@@ -608,8 +628,9 @@ def read_tensors(
     ValueError
         On an unknown ``dtype``/``fit``, a store missing the ragged element
         attrs or the ``morton`` sibling, an out-of-range ``block_order``, a
-        corrupt/misaligned occupancy sidecar, or (with ``fit="raise"``) a
-        block whose trimmed range overflows the fixed window.
+        block tensor over ``max_block_bytes``, a corrupt/misaligned occupancy
+        sidecar, or (with ``fit="raise"``) a block whose trimmed range
+        overflows the fixed window.
     """
     if dtype not in _TENSOR_DTYPES:
         raise ValueError(f"unknown dtype {dtype!r}; expected one of {sorted(_TENSOR_DTYPES)}")
@@ -649,6 +670,22 @@ def read_tensors(
                 f"axis cannot assemble at this block order"
             )
     block_side = 1 << block_depth
+    # Bound the emitted tensor BEFORE allocating it: 4**block_depth grows 4× per
+    # coarser block order, so an unbounded block_order dies in the allocator
+    # (34 TB at order 6 on the production order-19 geometry) with a bare
+    # MemoryError instead of naming its cause. n_bins is the requested count —
+    # the fit policy only ever shrinks it, so this is the upper bound.
+    block_bytes = 4**block_depth * int(n_bins) * out_dtype.itemsize
+    if block_bytes > int(max_block_bytes):
+        asked = (
+            f"block_order={block_order}" if block_order is not None else "the read chunk geometry"
+        )
+        raise ValueError(
+            f"{asked} emits a {block_side}×{block_side}×{n_bins} {dtype} block tensor "
+            f"= {block_bytes} bytes ({block_bytes / 1024**3:.2f} GiB), over the "
+            f"{int(max_block_bytes)}-byte max_block_bytes limit; use a finer "
+            f"block_order, fewer n_bins, or raise max_block_bytes deliberately"
+        )
 
     for block, group in groupby(chain([first], chunks), key=lambda c: c[0] // block_cells):
         bstart = block * block_cells

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -75,7 +75,7 @@ import zarr
 from zarr.abc.store import Store
 
 from zagg.grids.base import RAGGED_ELEMENT_ATTR, RAGGED_SPEC
-from zagg.readers._layout import rank_to_rowcol
+from zagg.readers._layout import rank_to_rowcol, rowcol_to_rank
 from zagg.stats.tdigest import cdf_from_tdigest, quantile_from_tdigest
 
 __all__ = [
@@ -85,6 +85,7 @@ __all__ = [
     "read_raw_values",
     "read_locations",
     "read_cell",
+    "cell_index",
 ]
 
 FitMode = Literal["raise", "degrade_resolution", "collapse_bins"]
@@ -703,8 +704,11 @@ def read_raw_values(
         ``values`` is the cell's recovered 1-D sample vector (sorted ascending,
         as the digest stores centroids by mean); ``(row, col)`` its
         deinterleaved 2-D position within the chunk — the same tensor position
-        :func:`read_tensors` places the cell at (issue #336; invert with
-        :func:`zagg.readers._layout.rowcol_to_rank`).
+        :func:`read_tensors` places the cell at (issue #336).
+        :func:`zagg.readers._layout.rowcol_to_rank` inverts it to the
+        **chunk-local** rank; for a :func:`read_cell` key (a GLOBAL cells-axis
+        index) compose through :func:`cell_index`, which adds the chunk's
+        start offset.
 
     Raises
     ------
@@ -826,3 +830,61 @@ def read_cell(
         )
     (raw,) = arr[cell : cell + 1]
     return _decode_cell(raw, elem_dtype, elem_shape)
+
+
+def cell_index(
+    store: Store,
+    field: str,
+    morton_index: int,
+    row: int,
+    col: int,
+    *,
+    zarr_format: Literal[2, 3] = 3,
+) -> int:
+    """Global cells-axis index of a reported ``(row, col)`` — the :func:`read_cell` key.
+
+    The sweep readers report a chunk-local position:
+    :func:`zagg.readers._layout.rowcol_to_rank` inverts the deinterleave back
+    to a rank ``0..4**depth - 1`` **within the chunk**, while
+    :func:`read_cell` addresses the array's GLOBAL cells axis — so the
+    chunk's own start offset is the missing term, and feeding a bare rank to
+    :func:`read_cell` silently reads the wrong cell (it is always in range).
+    This resolves the offset from the sibling ``morton`` coordinate and
+    returns ``chunk_start + rowcol_to_rank(row, col, depth)``.
+
+    ``morton_index`` is a READ-CHUNK id — the id :func:`read_raw_values`,
+    :func:`read_locations`, and the default (per-chunk) :func:`read_tensors`
+    report. A coarser ``block_order`` block id names no single chunk and
+    raises. Only the array's STORED spans are searched (the populated chunks
+    the sweep readers yield from), one small slice of the ``morton``
+    coordinate per span — never the whole axis, and no digest bytes.
+
+    Raises
+    ------
+    ValueError
+        If ``row``/``col`` are outside the chunk's ``(side, side)`` block, or
+        no stored chunk carries ``morton_index``.
+    """
+    arr, _dt, _sh, _meta = _open_ragged(store, field, zarr_format)
+    morton = _open_morton(store, field, zarr_format)
+    side, depth = _tensor_side(arr, field)
+    cells_per_chunk = side * side
+    if not (0 <= int(row) < side and 0 <= int(col) < side):
+        raise ValueError(
+            f"({row}, {col}) is outside {field!r}'s ({side}, {side}) read-chunk block"
+        )
+    rank = int(rowcol_to_rank(int(row), int(col), depth))
+    target = int(morton_index)
+    for span_start, span_stop in _stored_chunk_spans(arr):
+        span_words = morton[span_start:span_stop]
+        for offset in range(0, span_stop - span_start, cells_per_chunk):
+            words = span_words[offset : offset + cells_per_chunk]
+            start = span_start + offset
+            if not np.any(words) or _chunk_word(words, field, start) != target:
+                continue
+            return start + rank
+    raise ValueError(
+        f"no stored read chunk of {field!r} carries morton id {target} — "
+        f"cell_index resolves the READ-CHUNK ids the sweep readers report "
+        f"(a coarser block_order block id names no single chunk)"
+    )

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -382,10 +382,15 @@ def _chunk_word(words: np.ndarray, field: str, start: int) -> int:
 
     The id is the written cells' common ancestor at ``cell_order -
     log4(len(words))`` — the same parent cell the CSR layout named its
-    subgroups by. Raises when the written cells do NOT share that ancestor:
-    the cells axis is then not nested-aligned over this span (a dense
-    multi-shard axis assembled at a block order coarser than the shard
-    order), and index arithmetic would place cells in the wrong subtree.
+    subgroups by. Any span of a nested-ordered cells axis shares that
+    ancestor by construction, INCLUDING a block coarser than the stored
+    shard: the block-local index is then still the nested rank
+    (``rank_to_xy(R*4**d2 + r, d1+d2) == (X*2**d2 + x, Y*2**d2 + y)``), and
+    the axis-length check in :func:`read_tensors` is what rejects a block
+    order the axis cannot tile. This raises only when the written cells do
+    NOT share the ancestor — the span's ``morton`` coordinate is not
+    nested-ordered (not a zagg-written axis), where index arithmetic would
+    place cells in the wrong subtree.
     """
     from mortie import clip2order
 
@@ -396,9 +401,9 @@ def _chunk_word(words: np.ndarray, field: str, start: int) -> int:
     if np.any(ancestors != ancestors[0]):
         raise ValueError(
             f"cells of the block at {start} of {field!r} span more than one "
-            f"order-{order} ancestor — the cells axis is not nested-aligned over "
-            f"this span (a dense multi-shard axis assembles only at block orders "
-            f"at or finer than the shard order)"
+            f"order-{order} ancestor — the 'morton' coordinate is not in nested "
+            f"order over this span, so a cells-axis index does not name a "
+            f"position in the block's subtree"
         )
     return int(ancestors[0])
 

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -31,10 +31,13 @@ The read plan honors the layout the writer chose: a whole-store sweep LISTs the
 array's stored chunk objects (one object per shard under the ShardingCodec, or
 one per inner chunk on the unsharded flat layout — both self-describing in the
 array metadata, so one code path reads either), then decodes per read chunk.
-Each read chunk is a square ``(side, side)`` block of cells (row-major
-``cell_id`` within the chunk, ``side = isqrt(cells_per_chunk)`` — 64 for the
-production ``chunk_inner`` configs); its coverage-cell morton id is derived
-from the sibling ``morton`` coordinate. Random access to one cell
+Each read chunk is a square ``(side, side)`` block of cells
+(``side = isqrt(cells_per_chunk)`` — 64 for the production ``chunk_inner``
+configs); its coverage-cell morton id is derived from the sibling ``morton``
+coordinate. A cell's 2-D position is the **bit deinterleave** of its nested
+rank within the chunk (``readers._layout.rank_to_rowcol`` — mortie spec §8 /
+gridlook orientation; issue #336), never a row-major reshape: nested order is
+a Z-order curve, so ``divmod(rank, side)`` would scramble the block spatially. Random access to one cell
 (:func:`read_cell`) indexes the vlen array directly — 2 ranged GETs on a
 sharded store (index suffix + one inner chunk), never the whole shard.
 
@@ -66,6 +69,7 @@ import zarr
 from zarr.abc.store import Store
 
 from zagg.grids.base import RAGGED_ELEMENT_ATTR, RAGGED_SPEC
+from zagg.readers._layout import rank_to_rowcol
 from zagg.stats.tdigest import cdf_from_tdigest, quantile_from_tdigest
 
 __all__ = [
@@ -371,16 +375,21 @@ def _chunk_word(words: np.ndarray, field: str, start: int) -> int:
     return int(clip2order(cell_order - depth, written[:1])[0])
 
 
-def _tensor_side(arr, field: str) -> int:
-    """Row-major square side of one read chunk (64 for the production configs)."""
+def _tensor_side(arr, field: str) -> tuple[int, int]:
+    """``(side, depth)`` of one read chunk's square block (64, 6 in production).
+
+    ``side = 2**depth``: the deinterleave (mortie spec §8) is defined over
+    power-of-four subtrees, so a chunk that is not one cannot form a spatially
+    faithful ``(side, side)`` block.
+    """
     cells_per_chunk = int(arr.chunks[0])
     side = math.isqrt(cells_per_chunk)
-    if side * side != cells_per_chunk:
+    if side * side != cells_per_chunk or side & (side - 1):
         raise ValueError(
-            f"{field!r} read chunk holds {cells_per_chunk} cells — not a square "
-            f"block, so it cannot rasterize to a (side, side, n_bins) tensor"
+            f"{field!r} read chunk holds {cells_per_chunk} cells — not a power-of-"
+            f"four subtree, so it cannot deinterleave to a (side, side, n_bins) tensor"
         )
-    return side
+    return side, side.bit_length() - 1
 
 
 # --------------------------------------------------------------------------- #
@@ -408,7 +417,11 @@ def read_tensors(
     rasterizes every populated cell's digest into ``n_bins`` counts (see
     :func:`rasterize_cell`), and emits the ``(side, side, n_bins)`` tensor with
     the chunk's coverage-cell morton id (``side`` is 64 for the production
-    ``chunk_inner`` configs).
+    ``chunk_inner`` configs). Cell placement is the spatially faithful bit
+    deinterleave of the cell's nested rank (issue #336):
+    ``tensor[row, col] = rank_to_rowcol(rank, depth)`` per the
+    :mod:`zagg.readers._layout` orientation contract (mortie spec §8; row 0 /
+    col 0 at the chunk subtree's south corner, gridlook texture convention).
 
     Parameters
     ----------
@@ -454,7 +467,7 @@ def read_tensors(
 
     arr, elem_dtype, elem_shape, _meta = _open_ragged(store, field, zarr_format)
     morton = _open_morton(store, field, zarr_format)
-    side = _tensor_side(arr, field)
+    side, depth = _tensor_side(arr, field)
 
     for start, populated in _iter_populated_chunks(arr):
         cells = [(pos, _decode_cell(raw, elem_dtype, elem_shape)) for pos, raw in populated]
@@ -468,11 +481,11 @@ def read_tensors(
         )
 
         tensor = np.zeros((side, side, n_bins_c), dtype=out_dtype)
-        for cell_id, digest in cells:
+        for rank, digest in cells:
             counts = rasterize_cell(digest, z_lo, resolution_c, n_bins_c)
             if not is_float:
                 counts = np.rint(counts)
-            row, col = divmod(cell_id, side)
+            row, col = rank_to_rowcol(rank, depth)
             tensor[row, col, :] = counts.astype(out_dtype)
 
         yield tensor, _chunk_word(morton[start : start + side * side], field, start)
@@ -483,8 +496,8 @@ def read_raw_values(
     field: str,
     *,
     zarr_format: Literal[2, 3] = 3,
-) -> Iterator[tuple[int, int, np.ndarray]]:
-    """Yield ``(morton_index, cell_id, values)`` raw samples per populated cell.
+) -> Iterator[tuple[int, tuple[int, int], np.ndarray]]:
+    """Yield ``(morton_index, (row, col), values)`` raw samples per populated cell.
 
     The companion lossless reader (issue #79 follow-up): when a digest was built
     with no merges (every centroid weight 1) its centroid means *are* the
@@ -503,10 +516,12 @@ def read_raw_values(
 
     Yields
     ------
-    (morton_index, cell_id, values) : (int, int, ndarray)
+    (morton_index, (row, col), values) : (int, (int, int), ndarray)
         ``values`` is the cell's recovered 1-D sample vector (sorted ascending,
-        as the digest stores centroids by mean); ``cell_id`` its row-major
-        position within the chunk.
+        as the digest stores centroids by mean); ``(row, col)`` its
+        deinterleaved 2-D position within the chunk — the same tensor position
+        :func:`read_tensors` places the cell at (issue #336; invert with
+        :func:`zagg.readers._layout.rowcol_to_rank`).
 
     Raises
     ------
@@ -516,19 +531,21 @@ def read_raw_values(
     """
     arr, elem_dtype, elem_shape, _meta = _open_ragged(store, field, zarr_format)
     morton = _open_morton(store, field, zarr_format)
-    cells_per_chunk = int(arr.chunks[0])
+    side, depth = _tensor_side(arr, field)
+    cells_per_chunk = side * side
 
     for start, populated in _iter_populated_chunks(arr):
         word = _chunk_word(morton[start : start + cells_per_chunk], field, start)
-        for cell_id, raw in populated:
+        for rank, raw in populated:
             digest = _decode_cell(raw, elem_dtype, elem_shape)
             weights = np.asarray(digest[:, 1], dtype=np.float64)
             if np.any(weights > 1.0):
                 raise ValueError(
-                    f"cell {cell_id} (chunk {word}) has merged centroids "
+                    f"cell rank {rank} (chunk {word}) has merged centroids "
                     "(weight > 1); raw values are not losslessly recoverable"
                 )
-            yield word, int(cell_id), np.asarray(digest[:, 0], dtype=np.float64)
+            row, col = rank_to_rowcol(rank, depth)
+            yield word, (int(row), int(col)), np.asarray(digest[:, 0], dtype=np.float64)
 
 
 def read_locations(
@@ -536,8 +553,8 @@ def read_locations(
     field: str,
     *,
     zarr_format: Literal[2, 3] = 3,
-) -> Iterator[tuple[int, int, np.ndarray]]:
-    """Yield ``(morton_index, cell_id, locations)`` per populated cell.
+) -> Iterator[tuple[int, tuple[int, int], np.ndarray]]:
+    """Yield ``(morton_index, (row, col), locations)`` per populated cell.
 
     The location-channel reader (issue #87): a located ragged field stores a
     per-centroid ``uint64`` morton location vector in a sibling vlen array,
@@ -561,10 +578,12 @@ def read_locations(
 
     Yields
     ------
-    (morton_index, cell_id, locations) : (int, int, ndarray)
+    (morton_index, (row, col), locations) : (int, (int, int), ndarray)
         ``locations`` is the cell's ``(k,)`` uint64 per-centroid location
         vector, aligned with the digest rows :func:`read_tensors` /
-        :func:`read_raw_values` see for the same cell.
+        :func:`read_raw_values` see for the same cell; ``(row, col)`` is the
+        cell's deinterleaved 2-D position within the chunk (issue #336),
+        matching the other readers' reporting.
 
     Raises
     ------
@@ -586,12 +605,14 @@ def read_locations(
     # read for a locations-only pass (the digest payload is not consumed here).
     loc_arr, loc_dtype, loc_shape, _loc_meta = _open_ragged(store, loc_field, zarr_format)
     morton = _open_morton(store, field, zarr_format)
-    cells_per_chunk = int(loc_arr.chunks[0])
+    side, depth = _tensor_side(loc_arr, loc_field)
+    cells_per_chunk = side * side
 
     for start, populated in _iter_populated_chunks(loc_arr):
         word = _chunk_word(morton[start : start + cells_per_chunk], loc_field, start)
-        for cell_id, raw in populated:
-            yield word, int(cell_id), _decode_cell(raw, loc_dtype, loc_shape)
+        for rank, raw in populated:
+            row, col = rank_to_rowcol(rank, depth)
+            yield word, (int(row), int(col)), _decode_cell(raw, loc_dtype, loc_shape)
 
 
 def read_cell(

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -51,11 +51,15 @@ walker's/coverage MOC's job, issue #200).
 
 The reader (generator)
 ----------------------
-:func:`read_tensors` yields ``(tensor, morton_index)`` one chunk at a time.
-Per chunk it derives a tail-trimmed z-range from the cells' ``bottom``/``top``
-quantiles, anchors a fixed ``n_bins * resolution`` window at the floor of that
-range, and rasterizes each cell's digest into per-bin counts via
-:func:`zagg.stats.tdigest.cdf_from_tdigest`.
+:func:`read_tensors` yields ``(tensor, mask, (offset, gain), morton_index)``
+— the issue #336 reader contract — one block at a time (a block is one read
+chunk by default, or a ``block_order`` subtree of whole chunks). Per block it
+derives a tail-trimmed z-range from the cells' ``bottom``/``top`` quantiles,
+anchors a fixed ``n_bins * resolution`` window at the floor of that range
+(the shared ``(offset, gain)``), rasterizes each cell's digest into per-bin
+counts via :func:`zagg.stats.tdigest.cdf_from_tdigest`, and decodes the hive
+leaf's ``coverage.moc`` occupancy sidecar (when present) into the uint8
+``mask`` channel on the same deinterleaved layout.
 """
 
 from __future__ import annotations
@@ -395,6 +399,92 @@ def _chunk_word(words: np.ndarray, field: str, start: int) -> int:
     return int(ancestors[0])
 
 
+def _read_store_object(store: Store, key: str) -> bytes | None:
+    """Raw bytes of one store object (e.g. the ``coverage.moc`` sidecar), or None."""
+    from zarr.core.buffer import default_buffer_prototype
+    from zarr.core.sync import sync
+
+    buf = sync(store.get(key, prototype=default_buffer_prototype()))
+    return None if buf is None else buf.to_bytes()
+
+
+def _load_occupancy(store: Store, arr, words: np.ndarray, field: str) -> tuple | None:
+    """The leaf's exact cell occupancy for the mask channel, or ``None``.
+
+    Reads the hive leaf's coverage envelope (the commit stamp) and its
+    ``coverage.moc`` occupancy sidecar (issue #200) — one small GET, no digest
+    bytes. Returns ``("full", None)`` for a fully occupied subtree (issue
+    #246, D14), ``("bitmap", sorted_words)`` with the decoded occupied cell
+    words (:func:`zagg.hive.decode_coverage_bitmap` — the frozen bitmap
+    convention is reused, never reimplemented), or ``None`` when the store
+    carries no exact occupancy (no stamp — every flat store — or a box-only
+    envelope, or a missing sidecar; the D9 degrade). A PRESENT-but-corrupt
+    sidecar raises (see ``decode_coverage_bitmap``).
+
+    ``words`` are a populated chunk's written morton words: the shard id is
+    their ancestor at ``cell_order - log4(n_cells)`` — a leaf's cells axis is
+    exactly one shard subtree, which is also what binds the bitmap's bit
+    positions to the axis.
+    """
+    from zagg import hive
+
+    coverage = hive.read_coverage(store)
+    if not coverage:
+        return None
+    encoding = coverage.get("encoding")
+    if encoding == "full":
+        return "full", None
+    if encoding != "bitmap" or not coverage.get("sidecar"):
+        return None
+    payload = _read_store_object(store, str(coverage["sidecar"]))
+    if payload is None:
+        return None
+    cell_order = _cells_order(words, field, 0)
+    if int(coverage.get("cell_order", -1)) != cell_order:
+        raise ValueError(
+            f"{field!r} coverage envelope measured occupancy at order "
+            f"{coverage.get('cell_order')} but the cells axis is order {cell_order} — "
+            f"the occupancy bitmap cannot be aligned to the tensor cells"
+        )
+    n = int(arr.shape[0])
+    depth = (n.bit_length() - 1) // 2
+    if 4**depth != n:
+        raise ValueError(
+            f"{field!r} carries a leaf coverage stamp but its {n}-cell axis is not a "
+            f"power-of-four shard subtree — the occupancy bitmap cannot be bound to "
+            f"a shard"
+        )
+    from mortie import clip2order
+
+    written = words[words != 0]
+    shard = int(clip2order(cell_order - depth, written[:1])[0])
+    return "bitmap", hive.decode_coverage_bitmap(payload, shard, cell_order)
+
+
+def _block_mask(words: np.ndarray, occupancy: tuple | None, block_depth: int) -> np.ndarray:
+    """The block's ``(side, side)`` uint8 occupancy base (values 0/1).
+
+    ``1`` marks a cell the leaf's occupancy sidecar records as observed;
+    the caller upgrades digest-bearing cells to ``2``. Without occupancy
+    truth the base stays ``0`` everywhere (mask degrades to the 2-state
+    populated/not — never a wrong answer).
+    """
+    side = 1 << block_depth
+    mask = np.zeros((side, side), dtype=np.uint8)
+    if occupancy is None:
+        return mask
+    kind, occupied = occupancy
+    if kind == "full":
+        mask[:] = 1
+        return mask
+    if occupied.size:
+        idx = np.searchsorted(occupied, words)
+        hit = (occupied[np.minimum(idx, occupied.size - 1)] == words) & (words != 0)
+        rows, cols = rank_to_rowcol(np.flatnonzero(hit), block_depth)
+        mask[rows, cols] = 1
+    return mask
+
+
 def _tensor_side(arr, field: str) -> tuple[int, int]:
     """``(side, depth)`` of one read chunk's square block (64, 6 in production).
 
@@ -429,8 +519,11 @@ def read_tensors(
     dtype: TensorDtype = "uint32",
     block_order: int | None = None,
     zarr_format: Literal[2, 3] = 3,
-) -> Iterator[tuple[np.ndarray, int]]:
-    """Yield ``(tensor, morton_index)`` per coverage block of a t-digest field.
+) -> Iterator[tuple[np.ndarray, np.ndarray, tuple[float, float], int]]:
+    """Yield ``(tensor, mask, (offset, gain), morton_index)`` per coverage block.
+
+    The ratified reader contract (issue #336): one tuple per populated block
+    of a t-digest field.
 
     Sweeps the field's vlen array one read chunk (one square cell block) at a
     time, visiting only the STORED objects. For each populated block it trims
@@ -483,17 +576,31 @@ def read_tensors(
 
     Yields
     ------
-    (tensor, morton_index) : (ndarray, int)
+    (tensor, mask, (offset, gain), morton_index) : (ndarray, ndarray, tuple, int)
         ``tensor`` has shape ``(side, side, n_bins_out)`` and the requested
-        dtype; ``morton_index`` is the block's coverage-cell morton id.
+        dtype. ``mask`` is the block's ``(side, side)`` uint8 occupancy
+        channel: ``0`` = unobserved, ``1`` = observed but no stored digest,
+        ``2`` = observed with data (a stored digest — the cells the tensor
+        rasterizes). The observed states come from the hive leaf's
+        ``coverage.moc`` occupancy sidecar (issue #200), read WITHOUT
+        touching digest bytes; a store without one (every flat store)
+        degrades to the 2-state ``{0, 2}`` populated/not mask. Today a
+        pre-#334 leaf's occupancy equals its digest coverage, so ``1`` does
+        not occur; once the issue #334 signal strata land, noise-occupied
+        cells (observed, no signal digest) appear as ``1`` automatically —
+        the upgrade is data-driven, not a reader flag. ``(offset, gain)`` is
+        the block's shared z-window ``(z_lo, resolution)``: bin ``i`` of
+        every cell in the block covers ``[offset + i*gain, offset +
+        (i+1)*gain)``. ``morton_index`` is the block's coverage-cell morton
+        id.
 
     Raises
     ------
     ValueError
         On an unknown ``dtype``/``fit``, a store missing the ragged element
-        attrs or the ``morton`` sibling, an out-of-range ``block_order``, or
-        (with ``fit="raise"``) a block whose trimmed range overflows the
-        fixed window.
+        attrs or the ``morton`` sibling, an out-of-range ``block_order``, a
+        corrupt/misaligned occupancy sidecar, or (with ``fit="raise"``) a
+        block whose trimmed range overflows the fixed window.
     """
     if dtype not in _TENSOR_DTYPES:
         raise ValueError(f"unknown dtype {dtype!r}; expected one of {sorted(_TENSOR_DTYPES)}")
@@ -509,12 +616,14 @@ def read_tensors(
     first = next(chunks, None)
     if first is None:
         return
+    first_words = morton[first[0] : first[0] + cells_per_chunk]
+    occupancy = _load_occupancy(store, arr, first_words, field)
     if block_order is None:
         block_cells, block_depth = cells_per_chunk, depth
     else:
         # The cells-axis order comes from the first populated chunk's words;
         # the block subtree must be whole read chunks (coarser or equal).
-        cell_order = _cells_order(morton[first[0] : first[0] + cells_per_chunk], field, first[0])
+        cell_order = _cells_order(first_words, field, first[0])
         chunk_order = cell_order - depth
         if not 0 <= int(block_order) <= chunk_order:
             raise ValueError(
@@ -548,15 +657,18 @@ def read_tensors(
             fit=fit,
         )
 
+        words = morton[bstart : bstart + block_cells]
         tensor = np.zeros((block_side, block_side, n_bins_c), dtype=out_dtype)
+        mask = _block_mask(words, occupancy, block_depth)
         for rank, digest in cells:
             counts = rasterize_cell(digest, z_lo, resolution_c, n_bins_c)
             if not is_float:
                 counts = np.rint(counts)
             row, col = rank_to_rowcol(rank, block_depth)
             tensor[row, col, :] = counts.astype(out_dtype)
+            mask[row, col] = 2
 
-        yield tensor, _chunk_word(morton[bstart : bstart + block_cells], field, bstart)
+        yield tensor, mask, (float(z_lo), float(resolution_c)), _chunk_word(words, field, bstart)
 
 
 def read_raw_values(

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -504,3 +504,115 @@ class TestMaskChannel:
         store = self._leaf([0], cell_order=11)
         with pytest.raises(ValueError, match="cannot be aligned"):
             list(read_tensors(store, "12/h_tdigest"))
+
+
+class TestMaskBlockCrossing:
+    """The mask channel (phase 4) crossed with ``block_order`` (phase 3) — the
+    one seam where ``_block_mask`` slices a leaf-wide bitmap against a
+    MULTI-CHUNK window and deinterleaves at ``block_depth != depth`` (fold
+    review). A stamped 16-chunk leaf: order-6 shard, order-12 cells, order-8
+    read chunks (16×16), digests at leaf ranks 11/300/1000/4000 and extra
+    occupancy at 12/301/2500."""
+
+    DIGESTS = [11, 300, 1000, 4000]
+    EXTRA = [12, 301, 2500]
+
+    @staticmethod
+    def _leaf(digest_ranks, extra_occupied):
+        """A committed 16-chunk leaf (``chunk_inner=8``, ShardingCodec'd)."""
+        import zarr
+        from test_readers import _cfg
+
+        from zagg import hive
+        from zagg.grids import HealpixGrid
+        from zagg.processing import write_ragged_leaf_to_zarr
+        from zagg.stats.tdigest import build_tdigest
+
+        cfg = _cfg()
+        cfg.output["grid"]["chunk_inner"] = 8
+        cfg.output["grid"]["sharded"] = True
+        grid = HealpixGrid(6, 12, layout="fullsphere", config=cfg, chunk_inner=8, sharded=True)
+        word = morton_word(_KEY_A)
+        store = MemoryStore()
+        grid.emit_shard_template(store)
+        children = np.asarray(grid.children(word), dtype=np.uint64)
+        zarr.open_array(store, path="12/morton", mode="r+")[:] = children
+        # Digests go in at leaf-LOCAL chunk blocks with chunk-local ranks.
+        rng = np.random.default_rng(9)
+        per_chunk: dict[int, list[int]] = {}
+        for rank in sorted(digest_ranks):
+            per_chunk.setdefault(rank // grid.cells_per_chunk, []).append(
+                rank % grid.cells_per_chunk
+            )
+        entries = [
+            (
+                (block,),
+                {
+                    "h_tdigest": (
+                        [build_tdigest(rng.uniform(10.0, 30.0, 50), delta=512) for _ in local],
+                        local,
+                    )
+                },
+            )
+            for block, local in sorted(per_chunk.items())
+        ]
+        write_ragged_leaf_to_zarr(entries, store, grid=grid)
+        occupied = np.sort(children[sorted(set(digest_ranks) | set(extra_occupied))])
+        bitmap = hive.encode_coverage_bitmap(word, occupied, 12)
+        _put_object(store, hive.COVERAGE_SIDECAR, bitmap)
+        hive.stamp_commit(
+            store,
+            cells_with_data=len(digest_ranks),
+            granule_count=1,
+            coverage=hive.build_coverage(word, occupied, 12, bitmap=bitmap),
+        )
+        return store
+
+    @staticmethod
+    def _states(mask):
+        return tuple(
+            sorted(tuple(map(int, p)) for p in zip(*np.nonzero(mask == state))) for state in (1, 2)
+        )
+
+    @pytest.mark.parametrize(
+        "block_order,side,expected",
+        [
+            # Per chunk (block_depth == depth == 4): ranks are chunk-local.
+            (8, 16, [([(2, 2)], [(3, 1)]), ([(6, 3)], [(6, 2)]), ([], [(14, 8)]), ([], [(12, 0)])]),
+            # 4-chunk blocks (block_depth 5): only POPULATED blocks are yielded,
+            # so leaf block 2 (occupancy 2500 but no digest) is not emitted.
+            (7, 32, [([(2, 2), (6, 19)], [(3, 1), (6, 18), (30, 24)]), ([], [(28, 16)])]),
+            # The whole leaf (block_depth 6): every rank at its leaf-local
+            # deinterleave — 12→(2,2), 301→(6,19), 2500→(40,26) observed-only;
+            # 11→(3,1), 300→(6,18), 1000→(30,24), 4000→(60,48) with data.
+            (
+                6,
+                64,
+                [
+                    (
+                        [(2, 2), (6, 19), (40, 26)],
+                        [(3, 1), (6, 18), (30, 24), (60, 48)],
+                    )
+                ],
+            ),
+        ],
+    )
+    def test_mask_deinterleaves_at_the_block_depth(self, block_order, side, expected):
+        store = self._leaf(self.DIGESTS, self.EXTRA)
+        out = list(read_tensors(store, "12/h_tdigest", block_order=block_order))
+        assert [o[1].shape for o in out] == [(side, side)] * len(expected)
+        for (_t, mask, _s, _w), (ones, twos) in zip(out, expected):
+            assert self._states(mask) == (ones, twos)
+
+    def test_block_mask_states_agree_with_the_per_chunk_read(self):
+        """Assembling the mask must not invent or lose occupancy: the leaf
+        block's state counts equal the per-chunk reads' totals."""
+        store = self._leaf(self.DIGESTS, self.EXTRA)
+        chunk_masks = [mask for _t, mask, _s, _w in read_tensors(store, "12/h_tdigest")]
+        ((tensor, block_mask, _s, _w),) = read_tensors(store, "12/h_tdigest", block_order=6)
+        assert int((block_mask == 2).sum()) == sum(int((m == 2).sum()) for m in chunk_masks)
+        # Cell 2500 is occupancy-only in a chunk with no digest at all, so the
+        # per-chunk sweep never yields it — the whole-leaf block does.
+        assert int((block_mask == 1).sum()) == sum(int((m == 1).sum()) for m in chunk_masks) + 1
+        # And the digest-bearing cells still match the tensor's mass exactly.
+        np.testing.assert_array_equal(block_mask == 2, tensor.sum(axis=2) > 0)

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -306,6 +306,47 @@ class TestBlockAssembly:
             with pytest.raises(ValueError, match="block_order .* out of range"):
                 list(read_tensors(store, "12/h_tdigest", block_order=bad))
 
+    @pytest.mark.parametrize("block_order,side", [(5, 128), (4, 256)])
+    def test_block_coarser_than_the_shard_assembles(self, block_order, side):
+        """A block COARSER than the stored shard assembles too (fold review):
+        on a nested-ordered cells axis the block-local index is still the
+        nested rank, so the shard's 64×64 tensor lands whole at the
+        deinterleave of the shard's rank within the coarser parent. The
+        axis-length check is what rejects an untileable block order."""
+        from mortie import clip2order, generate_morton_children
+
+        populate = {0, 3, 7, 12}
+        store, shard6 = self._store(populate)
+        ((block, _mask, _scale, word),) = read_tensors(
+            store, "12/h_tdigest", block_order=block_order
+        )
+        assert block.shape == (side, side, 128)
+        parent = int(clip2order(block_order, np.array([shard6], dtype=np.uint64))[0])
+        assert word == parent
+        # The whole order-6 shard tensor, placed at its rank within `parent`.
+        ((shard_tensor, *_rest),) = read_tensors(store, "12/h_tdigest", block_order=6)
+        kids = [int(k) for k in np.asarray(generate_morton_children(parent, 6))]
+        assert len(kids) == 4 ** (6 - block_order)
+        row, col = (int(v) * 64 for v in rank_to_rowcol(kids.index(shard6), 6 - block_order))
+        np.testing.assert_array_equal(block[row : row + 64, col : col + 64, :], shard_tensor)
+        # Nothing outside the shard's tile (every other order-6 child is empty).
+        assert block.sum() == shard_tensor.sum()
+
+    def test_morton_not_in_nested_order_raises(self):
+        """The corrected guard in ``_chunk_word``: a span whose ``morton``
+        coordinate is NOT nested-ordered (cells from two subtrees) cannot be
+        indexed by cells-axis arithmetic, so it raises."""
+        import zarr
+
+        vals = np.random.default_rng(8).uniform(5.0, 25.0, 100)
+        store, grid, words = _build_store({_KEY_A: {0: vals, 1: vals}})
+        morton = zarr.open_array(store, path="12/morton", mode="r+")
+        base = grid.block_index(words[_KEY_A])[0] * grid.cells_per_chunk
+        # Graft a cell from the OTHER shard's subtree over a written cell.
+        morton[base + 1] = np.asarray(grid.children(morton_word(_KEY_B)))[1]
+        with pytest.raises(ValueError, match="not in nested order"):
+            list(read_tensors(store, "12/h_tdigest"))
+
     def test_chunk_order_block_matches_default(self):
         store, _shard6 = self._store({0, 5})
         default = list(read_tensors(store, "12/h_tdigest"))

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -332,6 +332,18 @@ class TestBlockAssembly:
         # Nothing outside the shard's tile (every other order-6 child is empty).
         assert block.sum() == shard_tensor.sum()
 
+    def test_block_tensor_over_max_block_bytes_raises(self):
+        """The ``block_order`` memory footgun fails with a pointed error naming
+        the size and the limit, not a bare ``MemoryError`` from the allocator."""
+        store, _shard6 = self._store({0})
+        with pytest.raises(ValueError) as exc:
+            list(read_tensors(store, "12/h_tdigest", block_order=4, max_block_bytes=1024))
+        msg = str(exc.value)
+        assert "block_order=4" in msg and "256×256×128 uint32" in msg
+        assert "33554432 bytes" in msg and "1024-byte max_block_bytes limit" in msg
+        # The same block is admitted under the (generous) default cap.
+        assert len(list(read_tensors(store, "12/h_tdigest", block_order=4))) == 1
+
     def test_morton_not_in_nested_order_raises(self):
         """The corrected guard in ``_chunk_word``: a span whose ``morton``
         coordinate is NOT nested-ordered (cells from two subtrees) cannot be

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -1,0 +1,161 @@
+"""Spatial-fidelity goldens for the reader deinterleave — issue #336.
+
+The tensor readers place a cell at the bit deinterleave of its chunk-local
+nested rank (``readers._layout``), pinned to the normative convention in
+mortie's ``docs/specification.md`` §8 (healpy ``pix2xyf`` face-local frame;
+gridlook ``bit_combine(j, i)`` texture orientation: row = y, col = x). The
+golden vectors are IMPORTED from mortie's merged test suite
+(``mortie/tests/test_rank_xy.py``, espg/mortie#150) rather than re-derived,
+so zagg cannot drift from the spec by construction.
+"""
+
+import numpy as np
+import pytest
+from test_readers import _KEY_A, _build_store
+
+from zagg.grids.morton import morton_word
+from zagg.readers._layout import rank_to_rowcol, rowcol_to_rank
+from zagg.readers.tdigest_tensor import read_tensors
+
+# Golden (rank, x, y) triples copied verbatim from mortie's merged test file
+# mortie/tests/test_rank_xy.py (espg/mortie#150) — provenance: healpy 1.20.0
+# `pix2xyf(2**depth, rank, nest=True)` (face 0), rng seed 149; the normative
+# convention pinned by mortie docs/specification.md §8. Depth 6 = the 64x64
+# inner chunk, depth 8 = the 256x256 shard.
+GOLDEN_DEPTH6 = [
+    (0, 0, 0),
+    (1, 1, 0),
+    (2, 0, 1),
+    (3, 1, 1),
+    (335, 27, 3),
+    (907, 17, 27),
+    (1069, 35, 6),
+    (1265, 45, 12),
+    (1873, 61, 16),
+    (2048, 0, 32),
+    (2135, 15, 33),
+    (2511, 27, 43),
+    (3024, 28, 56),
+    (3369, 49, 38),
+    (3592, 32, 50),
+    (4095, 63, 63),
+]
+GOLDEN_DEPTH8 = [
+    (0, 0, 0),
+    (1, 1, 0),
+    (2, 0, 1),
+    (3, 1, 1),
+    (3149, 43, 34),
+    (13006, 74, 91),
+    (30094, 242, 75),
+    (32094, 254, 99),
+    (32768, 0, 128),
+    (35193, 29, 166),
+    (36422, 42, 177),
+    (45487, 83, 207),
+    (58565, 171, 200),
+    (61371, 181, 255),
+    (65052, 230, 242),
+    (65535, 255, 255),
+]
+
+
+class TestLayoutGoldens:
+    """The helper pair matches the mortie spec §8 golden vectors exactly."""
+
+    @pytest.mark.parametrize("depth,golden", [(6, GOLDEN_DEPTH6), (8, GOLDEN_DEPTH8)])
+    def test_rank_to_rowcol_golden(self, depth, golden):
+        ranks, xs, ys = (np.array(col, dtype=np.uint64) for col in zip(*golden))
+        row, col = rank_to_rowcol(ranks, depth)
+        # Orientation contract: row = y, col = x (gridlook bit_combine(j, i)).
+        np.testing.assert_array_equal(row, ys)
+        np.testing.assert_array_equal(col, xs)
+
+    @pytest.mark.parametrize("depth,golden", [(6, GOLDEN_DEPTH6), (8, GOLDEN_DEPTH8)])
+    def test_rowcol_to_rank_golden(self, depth, golden):
+        ranks, xs, ys = (np.array(col, dtype=np.uint64) for col in zip(*golden))
+        np.testing.assert_array_equal(rowcol_to_rank(ys, xs, depth), ranks)
+
+    @pytest.mark.parametrize("depth", [1, 2, 6, 8, 13])
+    def test_round_trip(self, depth):
+        rng = np.random.default_rng(336 + depth)
+        n = int(min(4**depth, 2048))
+        ranks = rng.integers(0, 4**depth, size=n, dtype=np.uint64)
+        row, col = rank_to_rowcol(ranks, depth)
+        assert row.max() < 2**depth and col.max() < 2**depth
+        np.testing.assert_array_equal(rowcol_to_rank(row, col, depth), ranks)
+        row2, col2 = rank_to_rowcol(rowcol_to_rank(row, col, depth), depth)
+        np.testing.assert_array_equal(row2, row)
+        np.testing.assert_array_equal(col2, col)
+
+
+def _tensor_for(cell_to_values, **kwargs):
+    """One 64x64 chunk's float32 tensor from a real store write of _KEY_A."""
+    store, _grid, _words = _build_store({_KEY_A: cell_to_values})
+    out = list(read_tensors(store, "12/h_tdigest", dtype="float32", **kwargs))
+    assert len(out) == 1
+    tensor, morton = out[0]
+    assert morton == morton_word(_KEY_A)
+    return tensor
+
+
+class TestTensorPlacement:
+    """Golden-driven placement through the production write + read path."""
+
+    def test_golden_ranks_land_at_golden_xy(self):
+        # One distinguishable digest per golden rank: cell i holds 10*(i+1)
+        # samples, so the per-cell tensor mass identifies which digest landed
+        # where. All cells share one value range → one shared z-window.
+        rng = np.random.default_rng(1)
+        counts = {rank: 10 * (i + 1) for i, (rank, _x, _y) in enumerate(GOLDEN_DEPTH6)}
+        cells = {rank: rng.uniform(10.0, 30.0, n) for rank, n in counts.items()}
+        t = _tensor_for(cells, bottom=0.0, top=1.0)
+        mass = t.sum(axis=2)
+        for rank, x, y in GOLDEN_DEPTH6:
+            assert mass[y, x] == pytest.approx(counts[rank], rel=0.01)
+        # Exactly the golden positions are populated.
+        rows, cols = np.nonzero(mass)
+        assert {(int(r), int(c)) for r, c in zip(rows, cols)} == {
+            (y, x) for _rank, x, y in GOLDEN_DEPTH6
+        }
+
+    def test_sphere_adjacent_cells_land_tensor_adjacent(self):
+        """The case the row-major reshape fails (issue #336): ranks 0..3 are
+        one nested quad — a 2x2 block of mutually adjacent cells on the
+        sphere (mortie spec §8.1: child tuples order (x, y) = (0,0), (1,0),
+        (0,1), (1,1)) — so they must land as a 2x2 block in the tensor.
+        ``divmod(rank, side)`` strung them along row 0 as (0,0)..(0,3),
+        tearing the quad's two sphere-adjacent rows 64 columns apart."""
+        rng = np.random.default_rng(2)
+        counts = {rank: 10 * (rank + 1) for rank in range(4)}
+        cells = {rank: rng.uniform(10.0, 30.0, n) for rank, n in counts.items()}
+        mass = _tensor_for(cells, bottom=0.0, top=1.0).sum(axis=2)
+        rows, cols = np.nonzero(mass)
+        assert {(int(r), int(c)) for r, c in zip(rows, cols)} == {
+            (0, 0),
+            (0, 1),
+            (1, 0),
+            (1, 1),
+        }
+        # And in the spec-§8.1 order: rank 1 east of rank 0, rank 2 north.
+        for rank, (row, col) in [(0, (0, 0)), (1, (0, 1)), (2, (1, 0)), (3, (1, 1))]:
+            assert mass[row, col] == pytest.approx(counts[rank], rel=0.01)
+
+    def test_reported_rowcol_matches_tensor_position(self):
+        """read_raw_values / read_locations report the SAME (row, col) the
+        tensor places the cell at — one convention across the readers."""
+        from conftest import point_words
+
+        from zagg.readers.tdigest_tensor import read_locations, read_raw_values
+
+        ranks = [rank for rank, _x, _y in GOLDEN_DEPTH6]
+        vals = {rank: np.array([float(rank), float(rank) + 1.0]) for rank in ranks}
+        locs = {rank: point_words(2, rank + 1) for rank in ranks}
+        store, _grid, _words = _build_store({_KEY_A: vals}, located_locs={_KEY_A: locs})
+        expected = {(y, x) for _rank, x, y in GOLDEN_DEPTH6}
+        raw_positions = {rc for _m, rc, _v in read_raw_values(store, "12/h_tdigest")}
+        loc_positions = {rc for _m, rc, _v in read_locations(store, "12/h_tdigest")}
+        assert raw_positions == loc_positions == expected
+        # Values identify the cell: rank recovered from (row, col) round-trips.
+        for _m, (row, col), v in read_raw_values(store, "12/h_tdigest"):
+            assert v[0] == float(rowcol_to_rank(row, col, 6))

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -11,12 +11,12 @@ so zagg cannot drift from the spec by construction.
 
 import numpy as np
 import pytest
-from test_readers import _KEY_A, _build_store, _sharded_store
+from test_readers import _KEY_A, _KEY_B, _build_store, _sharded_store
 from zarr.storage import MemoryStore
 
 from zagg.grids.morton import morton_word
 from zagg.readers._layout import rank_to_rowcol, rowcol_to_rank
-from zagg.readers.tdigest_tensor import read_tensors
+from zagg.readers.tdigest_tensor import cell_index, read_cell, read_raw_values, read_tensors
 
 # Golden (rank, x, y) triples copied verbatim from mortie's merged test file
 # mortie/tests/test_rank_xy.py (espg/mortie#150) — provenance: healpy 1.20.0
@@ -160,6 +160,56 @@ class TestTensorPlacement:
         # Values identify the cell: rank recovered from (row, col) round-trips.
         for _m, (row, col), v in read_raw_values(store, "12/h_tdigest"):
             assert v[0] == float(rowcol_to_rank(row, col, 6))
+
+
+class TestCellIndexComposition:
+    """A reported ``(row, col)`` composes all the way to :func:`read_cell`.
+
+    ``rowcol_to_rank`` inverts to the CHUNK-LOCAL rank; ``read_cell`` keys on
+    the global cells axis, so ``cell_index`` supplies the chunk start."""
+
+    _FIELD = "12/h_tdigest"
+
+    def _store(self):
+        rng = np.random.default_rng(7)
+        # 3 samples per cell → no merged centroids, so read_raw_values recovers
+        # the exact means and read_cell's payload can be compared to them.
+        vals = {rank: np.sort(rng.uniform(10.0, 30.0, 3)) for rank in (0, 5, 11, 4095)}
+        store, _grid, _words = _build_store({_KEY_A: vals, _KEY_B: vals})
+        return store
+
+    def test_reported_rowcol_round_trips_to_read_cell(self):
+        store = self._store()
+        seen = 0
+        for morton, (row, col), values in read_raw_values(store, self._FIELD):
+            cell = cell_index(store, self._FIELD, morton, row, col)
+            digest = read_cell(store, self._FIELD, cell)
+            np.testing.assert_allclose(digest[:, 0], values, rtol=1e-6)
+            seen += 1
+        assert seen == 8  # 4 cells × 2 shards
+
+    def test_bare_chunk_local_rank_reads_the_wrong_cell(self):
+        # The composition the docs used to claim: a chunk-local rank is always
+        # in range, so read_cell(rank) picks a different cell and does NOT
+        # raise — which is why cell_index exists.
+        store = self._store()
+        for morton, (row, col), _values in read_raw_values(store, self._FIELD):
+            rank = int(rowcol_to_rank(row, col, 6))
+            cell = cell_index(store, self._FIELD, morton, row, col)
+            assert cell != rank
+            assert len(read_cell(store, self._FIELD, rank)) == 0  # silently empty
+
+    def test_block_id_and_out_of_block_position_raise(self):
+        store = MemoryStore()
+        _grid, shard6, targets = _sharded_store(store, populate={0, 1})
+        # The order-8 read chunks report order-8 ids; the order-6 shard id
+        # (what block_order=6 would yield) names no single chunk.
+        with pytest.raises(ValueError, match="no stored read chunk"):
+            cell_index(store, self._FIELD, shard6, 3, 1)
+        chunk_word = next(m for m, _rc, _v in read_raw_values(store, self._FIELD))
+        assert cell_index(store, self._FIELD, chunk_word, 3, 1) == targets[0]
+        with pytest.raises(ValueError, match="outside"):
+            cell_index(store, self._FIELD, chunk_word, 16, 0)  # 16×16 read chunk
 
 
 class TestBlockAssembly:

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -11,7 +11,8 @@ so zagg cannot drift from the spec by construction.
 
 import numpy as np
 import pytest
-from test_readers import _KEY_A, _build_store
+from test_readers import _KEY_A, _build_store, _sharded_store
+from zarr.storage import MemoryStore
 
 from zagg.grids.morton import morton_word
 from zagg.readers._layout import rank_to_rowcol, rowcol_to_rank
@@ -159,3 +160,104 @@ class TestTensorPlacement:
         # Values identify the cell: rank recovered from (row, col) round-trips.
         for _m, (row, col), v in read_raw_values(store, "12/h_tdigest"):
             assert v[0] == float(rowcol_to_rank(row, col, 6))
+
+
+class TestBlockAssembly:
+    """``block_order=`` assembles inner-chunk tensors into one block tensor
+    (issue #336 phase 3). Geometry: order-6 shard of K=16 order-8 chunks
+    (16×16 cells each, cell order 12), so block_order 7 = 4 chunks (32×32)
+    and block_order 6 = the whole shard (64×64). Each populated chunk holds
+    one digest at cell rank 11 → (row, col) = (3, 1) within its tile."""
+
+    def _store(self, populate, values=None):
+        store = MemoryStore()
+        _grid, shard6, _targets = _sharded_store(store, populate=populate, values=values)
+        return store, shard6
+
+    def test_block_bit_identical_to_per_chunk_tiles(self):
+        # Identical values in every populated chunk → each chunk's window ==
+        # the shared block window → block tiles are bit-identical to the
+        # per-chunk tensors (the acceptance pin for the assembly path).
+        vals = np.random.default_rng(3).uniform(5.0, 25.0, 400)
+        populate = {0, 3, 7, 12}
+        store, shard6 = self._store(populate, values={k: vals for k in populate})
+
+        per_chunk = list(read_tensors(store, "12/h_tdigest"))
+        assert len(per_chunk) == len(populate)
+        ((block, word),) = read_tensors(store, "12/h_tdigest", block_order=6)
+        assert word == shard6
+        assert block.shape == (64, 64, 128)
+
+        seen = np.zeros((4, 4), dtype=bool)
+        for local, (chunk_t, _cw) in zip(sorted(populate), per_chunk):
+            trow, tcol = rank_to_rowcol(local, 2)  # tile position at depth 2
+            tile = block[trow * 16 : (trow + 1) * 16, tcol * 16 : (tcol + 1) * 16, :]
+            np.testing.assert_array_equal(tile, chunk_t)
+            seen[trow, tcol] = True
+        # Every other tile is all zero (unpopulated chunks contribute nothing).
+        for trow in range(4):
+            for tcol in range(4):
+                if not seen[trow, tcol]:
+                    assert (
+                        block[trow * 16 : (trow + 1) * 16, tcol * 16 : (tcol + 1) * 16].sum() == 0
+                    )
+
+    def test_block_order_7_groups_and_coarsens_morton(self):
+        from mortie import generate_morton_children
+
+        store, shard6 = self._store({0, 1, 2, 3, 5})
+        out = list(read_tensors(store, "12/h_tdigest", block_order=7))
+        assert [t.shape for t, _m in out] == [(32, 32, 128)] * 2
+        # Block ids are the order-7 children of the shard, in nested order.
+        kids = [int(k) for k in np.asarray(generate_morton_children(shard6, 7))]
+        assert [m for _t, m in out] == kids[:2]
+        # Block 0: chunks 0..3 populated at cell rank 11 → tile (r, c) of the
+        # 2x2 chunk grid, cell (3, 1) within each 16x16 tile.
+        mass0 = out[0][0].sum(axis=2)
+        assert {tuple(map(int, p)) for p in zip(*np.nonzero(mass0))} == {
+            (3, 1),
+            (3, 17),
+            (19, 1),
+            (19, 17),
+        }
+        # Block 1: only chunk 5 (local rank 1 within the block → tile (0, 1)).
+        mass1 = out[1][0].sum(axis=2)
+        assert {tuple(map(int, p)) for p in zip(*np.nonzero(mass1))} == {(3, 17)}
+
+    def test_window_reconciled_block_wide(self):
+        rng = np.random.default_rng(4)
+        # Two chunks whose ranges only fit ONE 64 m window jointly anchored
+        # at the global floor: [0, 20] and [40, 60].
+        values = {0: rng.uniform(0.0, 20.0, 300), 1: rng.uniform(40.0, 60.0, 300)}
+        store, _shard6 = self._store({0, 1}, values=values)
+        ((block, _w),) = read_tensors(
+            store, "12/h_tdigest", block_order=7, bottom=0.0, top=1.0, dtype="float32"
+        )
+        mass = block.sum(axis=2)
+        # Both cells' full populations are in the one shared window.
+        assert mass[3, 1] == pytest.approx(300, rel=0.01)
+        assert mass[3, 17] == pytest.approx(300, rel=0.01)
+
+    def test_fit_raise_decided_block_wide(self):
+        rng = np.random.default_rng(5)
+        # Each chunk fits a 64 m window alone, but jointly they span ~100 m —
+        # the block-wide decision must raise where per-chunk reads pass.
+        values = {0: rng.uniform(0.0, 20.0, 300), 1: rng.uniform(80.0, 100.0, 300)}
+        store, _shard6 = self._store({0, 1}, values=values)
+        assert len(list(read_tensors(store, "12/h_tdigest", bottom=0.0, top=1.0))) == 2
+        with pytest.raises(ValueError, match="exceeds the fixed window"):
+            list(read_tensors(store, "12/h_tdigest", block_order=7, bottom=0.0, top=1.0))
+
+    def test_block_order_out_of_range_raises(self):
+        store, _shard6 = self._store({0})
+        for bad in (9, -1):  # chunk order is 8
+            with pytest.raises(ValueError, match="block_order .* out of range"):
+                list(read_tensors(store, "12/h_tdigest", block_order=bad))
+
+    def test_chunk_order_block_matches_default(self):
+        store, _shard6 = self._store({0, 5})
+        default = list(read_tensors(store, "12/h_tdigest"))
+        explicit = list(read_tensors(store, "12/h_tdigest", block_order=8))
+        assert [m for _t, m in default] == [m for _t, m in explicit]
+        for (t_d, _m1), (t_e, _m2) in zip(default, explicit):
+            np.testing.assert_array_equal(t_d, t_e)

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -95,7 +95,7 @@ def _tensor_for(cell_to_values, **kwargs):
     store, _grid, _words = _build_store({_KEY_A: cell_to_values})
     out = list(read_tensors(store, "12/h_tdigest", dtype="float32", **kwargs))
     assert len(out) == 1
-    tensor, morton = out[0]
+    tensor, _mask, _scale, morton = out[0]
     assert morton == morton_word(_KEY_A)
     return tensor
 
@@ -184,12 +184,12 @@ class TestBlockAssembly:
 
         per_chunk = list(read_tensors(store, "12/h_tdigest"))
         assert len(per_chunk) == len(populate)
-        ((block, word),) = read_tensors(store, "12/h_tdigest", block_order=6)
+        ((block, _mask, _scale, word),) = read_tensors(store, "12/h_tdigest", block_order=6)
         assert word == shard6
         assert block.shape == (64, 64, 128)
 
         seen = np.zeros((4, 4), dtype=bool)
-        for local, (chunk_t, _cw) in zip(sorted(populate), per_chunk):
+        for local, (chunk_t, _cm, _cs, _cw) in zip(sorted(populate), per_chunk):
             trow, tcol = rank_to_rowcol(local, 2)  # tile position at depth 2
             tile = block[trow * 16 : (trow + 1) * 16, tcol * 16 : (tcol + 1) * 16, :]
             np.testing.assert_array_equal(tile, chunk_t)
@@ -207,10 +207,10 @@ class TestBlockAssembly:
 
         store, shard6 = self._store({0, 1, 2, 3, 5})
         out = list(read_tensors(store, "12/h_tdigest", block_order=7))
-        assert [t.shape for t, _m in out] == [(32, 32, 128)] * 2
+        assert [o[0].shape for o in out] == [(32, 32, 128)] * 2
         # Block ids are the order-7 children of the shard, in nested order.
         kids = [int(k) for k in np.asarray(generate_morton_children(shard6, 7))]
-        assert [m for _t, m in out] == kids[:2]
+        assert [m for *_o, m in out] == kids[:2]
         # Block 0: chunks 0..3 populated at cell rank 11 → tile (r, c) of the
         # 2x2 chunk grid, cell (3, 1) within each 16x16 tile.
         mass0 = out[0][0].sum(axis=2)
@@ -230,9 +230,11 @@ class TestBlockAssembly:
         # at the global floor: [0, 20] and [40, 60].
         values = {0: rng.uniform(0.0, 20.0, 300), 1: rng.uniform(40.0, 60.0, 300)}
         store, _shard6 = self._store({0, 1}, values=values)
-        ((block, _w),) = read_tensors(
+        ((block, _mask, (offset, gain), _w),) = read_tensors(
             store, "12/h_tdigest", block_order=7, bottom=0.0, top=1.0, dtype="float32"
         )
+        # One shared offset/gain for the whole block, anchored at the global floor.
+        assert offset == 0.0 and gain == 0.5
         mass = block.sum(axis=2)
         # Both cells' full populations are in the one shared window.
         assert mass[3, 1] == pytest.approx(300, rel=0.01)
@@ -258,6 +260,115 @@ class TestBlockAssembly:
         store, _shard6 = self._store({0, 5})
         default = list(read_tensors(store, "12/h_tdigest"))
         explicit = list(read_tensors(store, "12/h_tdigest", block_order=8))
-        assert [m for _t, m in default] == [m for _t, m in explicit]
-        for (t_d, _m1), (t_e, _m2) in zip(default, explicit):
+        assert [m for *_o, m in default] == [m for *_o, m in explicit]
+        for (t_d, m_d, s_d, _w1), (t_e, m_e, s_e, _w2) in zip(default, explicit):
             np.testing.assert_array_equal(t_d, t_e)
+            np.testing.assert_array_equal(m_d, m_e)
+            assert s_d == s_e
+
+
+def _put_object(store, key, payload):
+    """PUT raw bytes into a zarr store (the MemoryStore sidecar write)."""
+    from zarr.core.buffer import default_buffer_prototype
+    from zarr.core.sync import sync
+
+    sync(store.set(key, default_buffer_prototype().buffer.from_bytes(payload)))
+
+
+class TestMaskChannel:
+    """Issue #336 phase 4: the leaf's ``coverage.moc`` occupancy sidecar
+    decodes into the deinterleaved mask channel — 0 unobserved, 1 observed
+    with no stored digest, 2 observed with data — reusing the frozen bitmap
+    convention (``hive.decode_coverage_bitmap``), one small sidecar object
+    and no digest bytes."""
+
+    def _leaf(self, digest_ranks, extra_occupied=(), *, full=False, stamp=True, cell_order=12):
+        """A committed hive leaf (K==1 order-6 shard, 64×64 cells) with
+        digests at ``digest_ranks``; occupancy = digests + ``extra_occupied``."""
+        import zarr
+        from test_readers import _cfg
+
+        from zagg import hive
+        from zagg.grids import HealpixGrid
+        from zagg.processing import write_ragged_leaf_to_zarr
+        from zagg.stats.tdigest import build_tdigest
+
+        rng = np.random.default_rng(6)
+        grid = HealpixGrid(6, 12, layout="fullsphere", config=_cfg(), sharded=False)
+        word = morton_word(_KEY_A)
+        store = MemoryStore()
+        grid.emit_shard_template(store)
+        children = np.asarray(grid.children(word), dtype=np.uint64)
+        zarr.open_array(store, path="12/morton", mode="r+")[:] = children
+        ranks = sorted(digest_ranks)
+        payloads = [build_tdigest(rng.uniform(10.0, 30.0, 50), delta=512) for _ in ranks]
+        write_ragged_leaf_to_zarr([((0,), {"h_tdigest": (payloads, ranks)})], store, grid=grid)
+        occupied = np.sort(children[sorted(set(ranks) | set(extra_occupied))])
+        bitmap = None if full else hive.encode_coverage_bitmap(word, occupied, 12)
+        if bitmap is not None:
+            _put_object(store, hive.COVERAGE_SIDECAR, bitmap)
+        if stamp:
+            hive.stamp_commit(
+                store,
+                cells_with_data=len(ranks),
+                granule_count=1,
+                coverage=hive.build_coverage(word, occupied, cell_order, bitmap=bitmap, full=full),
+            )
+        return store
+
+    @staticmethod
+    def _read_one(store):
+        ((tensor, mask, _scale, _word),) = read_tensors(store, "12/h_tdigest")
+        return tensor, mask
+
+    def test_mask_aligns_with_digest_coverage(self):
+        digest_ranks = [0, 5, 11, 4095]
+        tensor, mask = self._read_one(self._leaf(digest_ranks))
+        expected2 = {tuple(map(int, rank_to_rowcol(r, 6))) for r in digest_ranks}
+        assert {tuple(map(int, p)) for p in zip(*np.nonzero(mask == 2))} == expected2
+        # Pre-#334 leaf: occupancy == digest coverage, so no state-1 cells,
+        # and the mask aligns with the tensor's per-cell mass exactly.
+        assert not np.any(mask == 1)
+        np.testing.assert_array_equal(mask == 2, tensor.sum(axis=2) > 0)
+
+    def test_noise_occupied_reads_as_observed_no_signal(self):
+        # An occupied cell WITHOUT a stored digest (the #334 noise stratum
+        # shape) reads as state 1 with no reader change — data-driven upgrade.
+        store = self._leaf([0, 5], extra_occupied=[7, 335])
+        _tensor, mask = self._read_one(store)
+        assert {tuple(map(int, p)) for p in zip(*np.nonzero(mask == 1))} == {
+            tuple(map(int, rank_to_rowcol(r, 6))) for r in (7, 335)
+        }
+        assert {tuple(map(int, p)) for p in zip(*np.nonzero(mask == 2))} == {
+            tuple(map(int, rank_to_rowcol(r, 6))) for r in (0, 5)
+        }
+
+    def test_full_encoding_marks_whole_block_observed(self):
+        _tensor, mask = self._read_one(self._leaf([3], full=True))
+        assert mask.min() == 1  # D14: the shard id IS the exact MOC
+        assert {tuple(map(int, p)) for p in zip(*np.nonzero(mask == 2))} == {
+            tuple(map(int, rank_to_rowcol(3, 6)))
+        }
+
+    def test_unstamped_store_degrades_to_two_state(self):
+        # Sidecar bytes without a commit stamp are debris (D4): the mask
+        # degrades to populated/not, never a half-trusted occupancy.
+        _tensor, mask = self._read_one(self._leaf([0, 5], stamp=False))
+        assert set(np.unique(mask)) == {0, 2}
+
+    def test_corrupt_sidecar_raises(self):
+        # A wrong-size (but valid-zstd) sidecar must raise, not zero-pad — the
+        # decode_coverage_bitmap posture, surfaced through the reader.
+        from numcodecs import Zstd
+
+        from zagg import hive
+
+        store = self._leaf([0])
+        _put_object(store, hive.COVERAGE_SIDECAR, bytes(Zstd().encode(b"\x00")))
+        with pytest.raises(ValueError, match="refusing to zero-pad"):
+            list(read_tensors(store, "12/h_tdigest"))
+
+    def test_cell_order_mismatch_raises_pointed(self):
+        store = self._leaf([0], cell_order=11)
+        with pytest.raises(ValueError, match="cannot be aligned"):
+            list(read_tensors(store, "12/h_tdigest"))

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -378,6 +378,13 @@ def _put_object(store, key, payload):
     sync(store.set(key, default_buffer_prototype().buffer.from_bytes(payload)))
 
 
+def _del_object(store, key):
+    """DELETE one raw store object (a leaf whose sidecar went missing)."""
+    from zarr.core.sync import sync
+
+    sync(store.delete(key))
+
+
 class TestMaskChannel:
     """Issue #336 phase 4: the leaf's ``coverage.moc`` occupancy sidecar
     decodes into the deinterleaved mask channel — 0 unobserved, 1 observed
@@ -458,6 +465,28 @@ class TestMaskChannel:
         # degrades to populated/not, never a half-trusted occupancy.
         _tensor, mask = self._read_one(self._leaf([0, 5], stamp=False))
         assert set(np.unique(mask)) == {0, 2}
+
+    def test_has_exact_occupancy_discriminates_the_two_regimes(self):
+        """The yielded mask cannot tell a degraded 2-state channel from a
+        3-state one with no observed-but-empty cell — both are ``{0, 2}``.
+        ``has_exact_occupancy`` is the discriminator (fold review)."""
+        from zagg import hive
+        from zagg.readers.tdigest_tensor import has_exact_occupancy
+
+        exact = self._leaf([0, 5])
+        degraded = self._leaf([0, 5], stamp=False)
+        # Identical mask value sets, opposite semantics for `0`.
+        assert set(np.unique(self._read_one(exact)[1])) == {0, 2}
+        assert set(np.unique(self._read_one(degraded)[1])) == {0, 2}
+        assert has_exact_occupancy(exact)
+        assert not has_exact_occupancy(degraded)
+        assert has_exact_occupancy(self._leaf([3], full=True))
+        # A stamped leaf whose sidecar object is gone degrades too, and the
+        # predicate tracks the reader (it shares the same resolution path).
+        no_sidecar = self._leaf([0, 5])
+        _del_object(no_sidecar, hive.COVERAGE_SIDECAR)
+        assert not has_exact_occupancy(no_sidecar)
+        assert set(np.unique(self._read_one(no_sidecar)[1])) == {0, 2}
 
     def test_corrupt_sidecar_raises(self):
         # A wrong-size (but valid-zstd) sidecar must raise, not zero-pad — the

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -309,13 +309,16 @@ class TestReadTensors:
         mortons = sorted(m for _, m in read_tensors(self._store(), "12/h_tdigest"))
         assert mortons == sorted(morton_word(k) for k in (_KEY_A, _KEY_B))
 
-    def test_populated_cell_placement_rowmajor(self):
+    def test_populated_cell_placement_deinterleaved(self):
         out = dict((m, t) for t, m in read_tensors(self._store(), "12/h_tdigest"))
         t = out[morton_word(_KEY_A)]
-        # cell 5 → row 0, col 5; cell 4095 → row 63, col 63.
-        assert t[0, 5].sum() > 0
+        # Deinterleave (issue #336): rank 5 = 0b101 → (row, col) = (y, x) =
+        # (0, 3); rank 4095 → (63, 63); rank 0 → (0, 0).
+        assert t[0, 0].sum() > 0
+        assert t[0, 3].sum() > 0
         assert t[63, 63].sum() > 0
-        # An unpopulated cell stays zero.
+        # The old row-major position of rank 5 is now an unpopulated zero.
+        assert t[0, 5].sum() == 0
         assert t[10, 10].sum() == 0
 
     def test_counts_match_population(self):
@@ -483,9 +486,10 @@ class TestReadRawValues:
         store, _g, words = _build_store({_KEY_A: {7: vals}})
         out = list(read_raw_values(store, "12/h_tdigest"))
         assert len(out) == 1
-        morton, cell_id, recovered = out[0]
+        morton, rowcol, recovered = out[0]
         assert morton == words[_KEY_A]
-        assert cell_id == 7
+        # Rank 7 = 0b111 deinterleaves to (row, col) = (y, x) = (1, 3).
+        assert rowcol == (1, 3)
         # Digest stores centroids sorted by mean → sorted samples.
         np.testing.assert_allclose(recovered, np.sort(vals))
 
@@ -521,9 +525,11 @@ class TestReadLocations:
 
     def test_yields_per_cell_uint64_vectors(self):
         store, vals, locs_in, word = self._located_store()
-        out = {(m, c): locs for m, c, locs in read_locations(store, "12/h_tdigest")}
-        assert set(out) == {(word, 3), (word, 9)}
-        for (_, cid), locs in out.items():
+        out = {(m, rc): locs for m, rc, locs in read_locations(store, "12/h_tdigest")}
+        # Cell ranks 3 and 9 deinterleave to (row, col) = (1, 1) and (2, 1).
+        assert set(out) == {(word, (1, 1)), (word, (2, 1))}
+        for cid, rc in [(3, (1, 1)), (9, (2, 1))]:
+            locs = out[(word, rc)]
             assert locs.dtype == np.uint64
             # Loss-free regime: locations are the cell's point words co-sorted
             # with the values (digest rows sort by mean).
@@ -656,10 +662,11 @@ class TestReadParityWithoutConsolidation:
         assert root.metadata.consolidated_metadata is None
 
         tensors_plain, raw_plain, locs_plain = self._read_all(store)
-        # Sanity: the readers actually reached the data.
+        # Sanity: the readers actually reached the data. Ranks 0 and 63
+        # deinterleave to (row, col) = (0, 0) and (7, 7).
         word_a, word_b = morton_word(_KEY_A), morton_word(_KEY_B)
         assert set(tensors_plain) == {word_a, word_b}
-        assert (word_a, 0) in raw_plain and (word_b, 63) in raw_plain
+        assert (word_a, (0, 0)) in raw_plain and (word_b, (7, 7)) in raw_plain
 
         # Consolidate the SAME store and re-read: consolidation only adds a
         # metadata blob no reader consults, so every byte must match.

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -116,10 +116,11 @@ class _CountingStore(MemoryStore):
         return r
 
 
-def _sharded_store(store, *, populate):
+def _sharded_store(store, *, populate, values=None):
     """A K=16 ShardingCodec'd store with one populated cell per chunk in
     ``populate`` (local chunk ordinals); returns ``(grid, shard_word,
-    {local: global_cell})``."""
+    {local: global_cell})``. ``values`` optionally maps a local chunk ordinal
+    to that chunk's sample vector (default: 300 uniform draws per chunk)."""
     rng = np.random.default_rng(21)
     cfg = _cfg()
     cfg.output["grid"]["chunk_inner"] = 8
@@ -137,7 +138,8 @@ def _sharded_store(store, *, populate):
         if local not in populate:
             chunk_results.append((block, pd.DataFrame(), {}))
             continue
-        payloads = [build_tdigest(rng.uniform(0.0, 30.0, 300), delta=512)]
+        vals = rng.uniform(0.0, 30.0, 300) if values is None else np.asarray(values[local])
+        payloads = [build_tdigest(vals, delta=512)]
         chunk_results.append((block, pd.DataFrame(), {"h_tdigest": (payloads, [11])}))
         targets[local] = base + 11
     write_shard_to_zarr(chunk_results, store, grid=grid, shard_key=shard6)

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -299,20 +299,27 @@ class TestReadTensors:
         return store
 
     def test_shape_and_dtype_default(self):
-        out = dict((m, t) for t, m in read_tensors(self._store(), "12/h_tdigest"))
+        out = {
+            m: (t, mask, scale) for t, mask, scale, m in read_tensors(self._store(), "12/h_tdigest")
+        }
         assert set(out) == {morton_word(_KEY_A), morton_word(_KEY_B)}
-        for t in out.values():
+        for t, mask, (offset, gain) in out.values():
             assert t.shape == (64, 64, 128)
             assert t.dtype == np.uint32
+            # The contract's mask + offset/gain channels (issue #336): a flat
+            # store has no occupancy sidecar, so the mask is the 2-state {0, 2}.
+            assert mask.shape == (64, 64) and mask.dtype == np.uint8
+            assert set(np.unique(mask)) <= {0, 2}
+            assert offset == float(math.floor(offset)) and gain == 0.5
 
     def test_morton_derived_from_coordinate(self):
         # Chunk identity round trip: the per-cell morton coordinate coarsens
         # to the chunk's coverage-cell id (the packed shard word at K==1).
-        mortons = sorted(m for _, m in read_tensors(self._store(), "12/h_tdigest"))
+        mortons = sorted(m for *_tms, m in read_tensors(self._store(), "12/h_tdigest"))
         assert mortons == sorted(morton_word(k) for k in (_KEY_A, _KEY_B))
 
     def test_populated_cell_placement_deinterleaved(self):
-        out = dict((m, t) for t, m in read_tensors(self._store(), "12/h_tdigest"))
+        out = {m: t for t, _mask, _scale, m in read_tensors(self._store(), "12/h_tdigest")}
         t = out[morton_word(_KEY_A)]
         # Deinterleave (issue #336): rank 5 = 0b101 → (row, col) = (y, x) =
         # (0, 3); rank 4095 → (63, 63); rank 0 → (0, 0).
@@ -327,7 +334,7 @@ class TestReadTensors:
         rng = np.random.default_rng(11)
         n = 5_000
         store, _g, words = _build_store({_KEY_A: {0: rng.uniform(0.0, 40.0, n)}})
-        t, m = next(read_tensors(store, "12/h_tdigest", n_bins=128, resolution=0.5))
+        t, _mask, _scale, m = next(read_tensors(store, "12/h_tdigest", n_bins=128, resolution=0.5))
         assert m == words[_KEY_A]
         # Most of the population should land in-window (uniform [0,40] in a 64 m
         # window anchored at floor of the 5th pct).
@@ -340,7 +347,7 @@ class TestReadTensors:
     def test_dtype_flag(self, dtype, np_dtype):
         rng = np.random.default_rng(12)
         store, _g, _w = _build_store({_KEY_A: {0: rng.uniform(0.0, 30.0, 2_000)}})
-        t, _ = next(read_tensors(store, "12/h_tdigest", dtype=dtype))
+        t, *_rest = next(read_tensors(store, "12/h_tdigest", dtype=dtype))
         assert t.dtype == np_dtype
 
     def test_raise_when_chunk_too_wide(self):
@@ -352,7 +359,7 @@ class TestReadTensors:
     def test_degrade_resolution_fits(self):
         rng = np.random.default_rng(15)
         store, _g, _w = _build_store({_KEY_A: {0: rng.uniform(0.0, 400.0, 5_000)}})
-        t, _ = next(
+        t, *_rest = next(
             read_tensors(store, "12/h_tdigest", bottom=0.0, top=1.0, fit="degrade_resolution")
         )
         assert t.shape == (64, 64, 128)
@@ -473,12 +480,14 @@ class TestReadTensors:
             chunk_results.append((block, pd.DataFrame(), {"h_tdigest": (payloads, cell_ids)}))
         write_shard_to_zarr(chunk_results, store_b, grid=grid_b, shard_key=shard6)
 
-        out_a = sorted(read_tensors(store_a, "12/h_tdigest"), key=lambda tm: tm[1])
-        out_b = sorted(read_tensors(store_b, "12/h_tdigest"), key=lambda tm: tm[1])
-        assert [m for _t, m in out_a] == [m for _t, m in out_b] == sorted(data)
-        for (t_a, _ma), (t_b, _mb) in zip(out_a, out_b):
+        out_a = sorted(read_tensors(store_a, "12/h_tdigest"), key=lambda o: o[-1])
+        out_b = sorted(read_tensors(store_b, "12/h_tdigest"), key=lambda o: o[-1])
+        assert [m for *_o, m in out_a] == [m for *_o, m in out_b] == sorted(data)
+        for (t_a, mask_a, scale_a, _ma), (t_b, mask_b, scale_b, _mb) in zip(out_a, out_b):
             assert t_a.shape == (16, 16, 128)
             np.testing.assert_array_equal(t_a, t_b)
+            np.testing.assert_array_equal(mask_a, mask_b)
+            assert scale_a == scale_b
 
 
 class TestReadRawValues:
@@ -648,7 +657,12 @@ class TestReadParityWithoutConsolidation:
 
     @staticmethod
     def _read_all(store):
-        tensors = {m: t for t, m in read_tensors(store, "12/h_tdigest", n_bins=64, resolution=0.5)}
+        tensors = {
+            m: t
+            for t, _mask, _scale, m in read_tensors(
+                store, "12/h_tdigest", n_bins=64, resolution=0.5
+            )
+        }
         raw = {(m, c): v for m, c, v in read_raw_values(store, "12/h_tdigest")}
         locs = {(m, c): loc for m, c, loc in read_locations(store, "12/h_tdigest")}
         return tensors, raw, locs


### PR DESCRIPTION
Closes #336. Refs #265 (the "nested→2-D deinterleave / block / mask" follow-up bullet in the [distillation](https://github.com/englacial/zagg/issues/265#issuecomment-5123695622)).

Implements the [plan comment](https://github.com/englacial/zagg/issues/336#issuecomment-5124645379) exactly: the tensor readers stop row-major-reshaping the nested cells axis (a Z-order curve — the old `divmod(cell_id, side)` scrambled every emitted block spatially beyond 2-cell runs) and instead place each cell at the **bit deinterleave of its chunk-local nested rank** via mortie 0.9.3's `rank_to_xy`/`xy_to_rank` (espg/mortie#150; normative contract in mortie `docs/specification.md` §8, frozen for mortie 1.x).

## What changed

- **`src/zagg/readers/_layout.py`** (new): the `rank_to_rowcol` / `rowcol_to_rank` helper pair, pinning the orientation once — **row = y, col = x**, matching gridlook's `bit_combine(j, i)` texture convention (`gridlook/src/ui/grids/Healpix.vue`, `getUnshuffleIndex`: `texture[i*size + j] = data[bit_combine(j, i)]`), so an emitted tensor uploads to a gridlook texture with no further shuffle. The module docstring documents the choice against both mortie spec §8 and the gridlook file.
- **`src/zagg/readers/tdigest_tensor.py`**: every 1-D→2-D seam routes through the helper — `read_tensors` cell placement, and `read_raw_values` / `read_locations` now report the same deinterleaved `(row, col)` instead of a raw 1-D `cell_id` (one convention across the readers; invert with `rowcol_to_rank` for `read_cell`).
- **Block assembly**: `read_tensors(block_order=...)` assembles the `4**(chunk_order − block_order)` inner chunks of one block-order subtree into a single `(2**d, 2**d, n_bins)` tensor (o12 on production geometry → 128×128 from 4 inner chunks). The z-window and `fit` policy are reconciled **block-wide** (one shared offset/gain per block). `_chunk_word` now also validates that a block's written cells share the block-order ancestor, so a dense multi-shard axis cannot silently mis-assemble.
- **Mask channel**: `read_tensors` now yields the full ratified contract **`(tensor, mask, (offset, gain), morton_id)`**. The uint8 mask (same deinterleaved layout) is `0` unobserved / `1` observed-no-digest / `2` observed-with-data; states 1–2 decode the hive leaf's `coverage.moc` occupancy sidecar via the existing frozen `hive.decode_coverage_bitmap` (reused, not reimplemented) — one small sidecar object, no digest bytes. Stores without exact occupancy (every flat store; unstamped/box-only leaves) degrade to the 2-state `{0, 2}` mask, per D9. Today occupancy equals digest coverage so `1` does not occur; once the #334 strata land, noise-occupied cells appear as `1` automatically (data-driven — pinned by `test_noise_occupied_reads_as_observed_no_signal`).
- **`pyproject.toml`**: `mortie>=0.9.1` → `>=0.9.3` (single edit reaches the Lambda layer post-#323).
- **Docs**: new "Spatially faithful tensors (deinterleave, blocks, mask)" section in `docs/ragged_layout.md` cross-linking mortie spec §8 as the normative convention; `docs/quickstart.md` blurb; `notebooks/tdigest_reader_example.ipynb` updated to the new contract (all code cells re-verified to run).

## Phases

- [x] Phase 1 — mortie floor `>=0.9.3` + `readers/_layout.py` helper pair; all `divmod` seams routed through it (8ee6e71)
- [x] Phase 2 — fidelity goldens: spec-§8 vectors copied verbatim from mortie's merged `tests/test_rank_xy.py` (healpy 1.20.0 provenance, depths 6/8), synthetic 4-cell adjacency, rank↔(row,col) round-trips (26cebcb)
- [x] Phase 3 — `block_order=` assembly with block-wide window/fit (7932d4a)
- [x] Phase 4 — `coverage.moc` mask channel; contract `(tensor, mask, (offset, gain), morton_id)` (03430af)
- [x] Phase 5 — docs + notebook (16e4027)

## How it was tested

- New `tests/test_reader_layout.py` (30 tests): golden placement at depths 6 and 8 (vectors imported from mortie's spec-pinned suite, never re-derived), round-trips, store-driven placement through the production template + writers, block assembly (bit-identical tiles vs chunk-at-a-time reads, order-7/6 grouping + morton coarsening, block-wide window + block-wide `fit="raise"`, out-of-range `block_order`), and the mask channel on committed synthetic hive leaves (digest alignment, noise-occupied → state 1, `encoding: "full"`, unstamped degrade, corrupt-sidecar raise, cell-order mismatch raise).
- **Adjacency acceptance pin verified both ways**: `test_sphere_adjacent_cells_land_tensor_adjacent` and `test_golden_ranks_land_at_golden_xy` were run against a temporary local revert to the old `divmod` reshape — both fail there and pass on the new path (the revert was not committed).
- `tests/test_readers.py` updated to the new contract (placement expectations, `(row, col)` reporting, 4-tuple unpacking; sharded/flat parity now also compares masks and scales).
- Full suite locally: **2679 passed, 35 skipped, 1 failed** — the one failure is the known pre-existing `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`, unrelated to this change (the two `TestConsolidationGate` failures previously seen on main did not reproduce). `ruff check` / `ruff format --check` clean on everything this PR touches.
- mortie **0.9.3 resolved from PyPI** (`uv lock --upgrade-package mortie`) — no local-checkout fallback was needed; the goldens run against the released wheel.

## Questions for review

- **Breaking reader API**: `read_tensors` now yields a 4-tuple and `read_raw_values`/`read_locations` report `(row, col)` instead of a 1-D `cell_id`. These are in-repo client read helpers (issue #79) with no other in-tree consumers beyond the example notebook (updated here); the #328 read notebook consumes the new contract downstream. Flagging in case any out-of-tree consumer needs a heads-up.
- **Pre-existing local lint noise, not fixed here** (per the don't-fix-unrelated rule): `ruff check src tests` flags `N818` on `src/zagg/registry.py:64` (`UnknownCapability`), and `ruff format --check` wants to reformat a python snippet inside `tests/data/benchmark/README.md` — both present on current `origin/main` and outside the PR-bot's `E,F,W,I` gate.
- Blocks with occupancy but **zero stored digests** (possible post-#334: all-noise blocks) are skipped by the sweep (there is no z-window to emit); the mask for such blocks is therefore never yielded. Called out in the docstring — happy to add a `yield`-empty-blocks mode later if the #334 consumer needs it.
