### PR TITLE
v2 Event transport: always-on status objects, polling resolver, reattach, agg event mode (issue #327)

### DIFF
--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -184,6 +184,20 @@ def _is_run_parquet(key: str) -> bool:
     return "/" not in key and key.startswith("stats_") and key.endswith(".parquet")
 
 
+def _is_status_object(key: str) -> bool:
+    """Any key under a ``.status`` prefix segment: the per-run status channel.
+
+    Generalizes the :func:`_is_run_parquet` telemetry filter (ratified on
+    issue #327): ``<store>.status/run-<id>/...`` holds the always-on per-shard
+    status objects, dispatch manifests, and the issue #151 result envelopes —
+    run telemetry, never write-path store objects, so the #215/#240 tripwire
+    must not count them. The prefix is a store SIBLING, which the
+    "/"-delimited prefix join already keeps out of a store-rooted LIST; this
+    explicit exclusion covers a listing taken from a parent prefix.
+    """
+    return any(part.endswith(".status") for part in key.split("/")[:-1])
+
+
 def list_store_keys(store_path: str, **store_kwargs) -> list[str]:
     """All object keys under a store prefix — local path or ``s3://`` alike.
 
@@ -228,7 +242,7 @@ def store_object_counts(
     a stray write is visible rather than silently pooled. ``other_keys`` is a
     capped sample of unclassifiable keys.
     """
-    keys = list_store_keys(store_path, **store_kwargs)
+    keys = [k for k in list_store_keys(store_path, **store_kwargs) if not _is_status_object(k)]
     per_shard: dict[str, int] = {}
     other: list[str] = []
     metadata = 0

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -154,6 +154,10 @@ the dispatcher at end of run, like coverage mode):
     "rows_from": str (optional) -- the run's async status prefix; the worker
         assembles success rows from the mirrored result envelopes when the
         row set exceeds the async payload budget,
+    "tail_status_url": str (optional, issue #327) -- where to ALSO write the
+        run's tail-completion marker on success (the v2 status prefix's
+        tail.json); a reattached handle (Run.attach) then skips a tail that
+        already ran. Fail-open; absent -> no write, byte-identical.
     "output_credentials": dict (optional, same shape as process mode),
 }
 
@@ -645,6 +649,16 @@ def _write_dispatch_manifest(event: Dict[str, Any]) -> None:
         logger.warning(f"dispatch manifest write failed (fail-open, issue #327): {e}")
 
 
+def _write_tail_status(event: Dict[str, Any]) -> None:
+    """Tail-completion marker off the stats event (issue #327), doubly fail-open."""
+    try:
+        from zagg.client_transport import write_tail_status
+
+        write_tail_status(event, _output_store_kwargs(event))
+    except Exception as e:
+        logger.warning(f"tail status write failed (fail-open, issue #327): {e}")
+
+
 def _write_result(result_url: str, response: Dict[str, Any], event: Dict[str, Any]) -> bool:
     """Write the response envelope to ``result_url`` as JSON (issue #151).
 
@@ -1063,6 +1077,7 @@ def _handle_stats(event: Dict[str, Any]) -> Dict[str, Any]:
         if not rows:
             # A pointer prefix that yielded nothing (and no inline rows):
             # nothing to persist — not an error (fail-open telemetry).
+            _write_tail_status(event)
             return {
                 "statusCode": 200,
                 "body": json.dumps({"ok": True, "mode": "stats", "rows": 0}),
@@ -1074,6 +1089,10 @@ def _handle_stats(event: Dict[str, Any]) -> Dict[str, Any]:
             timestamp=event.get("timestamp"),
             store_kwargs=_output_store_kwargs(event),
         )
+        # Tail-completion marker (issue #327): the stats leg is the recorded
+        # end of the post-run tail, so a reattached handle can skip a tail
+        # that already ran. Fail-open; absent url -> no-op.
+        _write_tail_status(event)
         return {
             "statusCode": 200,
             "body": json.dumps({"ok": True, "mode": "stats", "rows": len(rows), "path": path}),

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -568,6 +568,12 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     # setup/finalize/extract bodies stay byte-identical (their consumers don't
     # aggregate container state).
     response = _attach_container_telemetry(response, telemetry)
+    # Per-shard status object (issue #327): always-on for every per-unit
+    # response carrying a run identity, every status branch (200/400/500,
+    # including the caught-error envelope) -- the v2 Event transport resolves
+    # futures from these instead of the invoke response. Fail-open by
+    # ratification: never affects the shard result.
+    _write_shard_status(event, response)
     # Async result channel (issue #151): on an Event invoke the return value is
     # discarded, so mirror the response envelope to the orchestrator-supplied
     # result_url for it to poll. Covers every branch (200 / 400 / 500) of both
@@ -592,6 +598,22 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         if mirrored:
             _maybe_self_recycle()
     return response
+
+
+def _write_shard_status(event: Dict[str, Any], response: Dict[str, Any]) -> None:
+    """Always-on per-shard status object (issue #327), doubly fail-open.
+
+    The body lives in ``zagg.client_transport.write_shard_status`` (itself
+    fail-open); this wrapper additionally swallows an import/lookup failure so
+    a function zip missing the module cannot fail a shard either. Uses the
+    same output-store resolution as every other worker write.
+    """
+    try:
+        from zagg.client_transport import write_shard_status
+
+        write_shard_status(event, response, _output_store_kwargs(event))
+    except Exception as e:
+        logger.warning(f"shard status write failed (fail-open, issue #327): {e}")
 
 
 def _write_result(result_url: str, response: Dict[str, Any], event: Dict[str, Any]) -> bool:

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -84,6 +84,13 @@ writes the raster (time, cells) template instead, from a synchronous invoke):
         time coordinate, int64 microseconds since the epoch; the orchestrator
         owns the global timestep index and threads it here so the template
         write needs no S3 access from the dispatcher.
+    "run_manifest": dict (optional, issue #327) -- {"run_id", "shards"
+        (decimal shard-key strings), "semantic_hash", "dispatched_at",
+        "dataset"} dispatch identity: on a successful setup the worker writes
+        it (plus this event's "config") as
+        "<store>.status/run-<run_id>/manifest.json" -- what Run.attach
+        rebuilds a handle from (D8: the dispatcher never writes). Fail-open;
+        absent -> no write, byte-identical to pre-#327 events.
     "output_credentials": dict (optional, same shape as process mode),
 }
 
@@ -543,7 +550,13 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     telemetry = _container_telemetry()
     mode = event.get("mode", "process")
     if mode == "setup":
-        return _handle_setup(event)
+        response = _handle_setup(event)
+        # Dispatch manifest (issue #327 phase 2): the run's shard set +
+        # identity, recorded by the WORKER off the same setup invoke (D8) so
+        # a run is reattachable by run id. Fail-open; absent block -> no-op.
+        if response.get("statusCode") == 200:
+            _write_dispatch_manifest(event)
+        return response
     if mode == "finalize":
         return _handle_finalize(event)
     if mode == "ping":
@@ -614,6 +627,22 @@ def _write_shard_status(event: Dict[str, Any], response: Dict[str, Any]) -> None
         write_shard_status(event, response, _output_store_kwargs(event))
     except Exception as e:
         logger.warning(f"shard status write failed (fail-open, issue #327): {e}")
+
+
+def _write_dispatch_manifest(event: Dict[str, Any]) -> None:
+    """Run dispatch manifest off the setup event (issue #327), doubly fail-open.
+
+    Mirrors ``_write_shard_status``: the body lives in
+    ``zagg.client_transport.write_dispatch_manifest`` (itself fail-open); this
+    wrapper additionally swallows an import failure so a function zip missing
+    the module cannot fail the setup either.
+    """
+    try:
+        from zagg.client_transport import write_dispatch_manifest
+
+        write_dispatch_manifest(event, _output_store_kwargs(event))
+    except Exception as e:
+        logger.warning(f"dispatch manifest write failed (fail-open, issue #327): {e}")
 
 
 def _write_result(result_url: str, response: Dict[str, Any], event: Dict[str, Any]) -> bool:

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -1045,6 +1045,7 @@ class Run:
         # the failure (espg ruling on PR #333, middle option) so a notebook sees
         # it in-stream rather than only at the join, retries once, and RETURNS
         # the error — the handle keeps this path's re-raise semantics.
+        finalize_error = None
         finalize_kwargs: dict = {}
         if layout == "hive":
             finalize_kwargs = {
@@ -1068,6 +1069,7 @@ class Run:
                 ),
             )
             if error is not None:
+                finalize_error = str(error)
                 handle._finalize_error = error
                 logger.warning(f"finalize invoke failed (surfaced via handle.wait()): {error}")
 
@@ -1117,6 +1119,12 @@ class Run:
             output_creds_event=output_creds_event,
             store_kwargs=runner._output_store_kwargs(output_creds_event, self.region),
             inline_rows=stats_inline,
+            # Same wire contract as runner's tail (issue #335): always present,
+            # None on success, so the parquet's column set does not vary — and
+            # it is what makes the worker WITHHOLD the tail marker on a failed
+            # finalize, so a reattached handle re-runs the idempotent backstop
+            # instead of reading "recorded" as "succeeded" (review, PR #343).
+            finalize_error=finalize_error,
             tail_status_url=f"{run_status_prefix(self.store, run_id)}/{TAIL_NAME}",
         )
         if layout == "hive" and get_sweep(self.config):

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -594,13 +594,25 @@ class Run:
         )
         run_id = uuid.uuid4().hex
 
+        # Dispatch manifest block (issue #327): rides the setup invoke so the
+        # WORKER records the run's shard set + identity at the status prefix
+        # (D8) — what :meth:`Run.attach` rebuilds a handle from.
+        from zagg.client_transport import build_run_manifest_block
+
+        md = self.catalog_data.get("metadata") or {}
+        run_manifest = build_run_manifest_block(
+            run_id,
+            [k for k, _ in cells],
+            self.config,
+            dataset={"short_name": md.get("short_name"), "version": md.get("version")},
+        )
+
         # Setup handshake, synchronous and load-bearing (worker-side writes
         # only — D8). Hive: fail-fast ping + fire-and-forget manifest write;
         # finalize below is the idempotent backstop (issue #252 hybrid). Flat:
         # the template write itself.
         dataset = None
         if get_store_layout(self.config) == "hive":
-            md = self.catalog_data.get("metadata") or {}
             dataset = {"short_name": md.get("short_name"), "version": md.get("version")}
             runner._invoke_lambda_ping(
                 client,
@@ -621,6 +633,7 @@ class Run:
                 parent_order=self._parent_order,
                 overwrite=self.overwrite,
                 output_creds_event=output_creds_event,
+                run_manifest=run_manifest,
             )
         else:
             runner._invoke_lambda_setup(
@@ -632,6 +645,7 @@ class Run:
                 overwrite=self.overwrite,
                 config_dict=config_dict,
                 output_creds_event=output_creds_event,
+                run_manifest=run_manifest,
             )
 
         aoi_by_shard = runner._aoi_payload_map(self.catalog_data)

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -644,9 +644,11 @@ class Run:
             tick — no held connections, and the run survives client exit
             (reattachable via :meth:`attach`). Futures, harvest iterators,
             ``status()``, and the post-run tail behave identically; the retry
-            policy migrates to status-driven re-dispatch (same
-            ``max_retries``), and a shard whose status object never lands
-            resolves ``failed-unknown``. Requires a deployed worker that
+            policy splits by fault class (see
+            :class:`~zagg.client_transport.StatusPoller`) — ``max_retries``
+            still bounds invoke-layer faults, a worker-reported failure is
+            terminal, and a shard whose status object never lands re-fires once
+            then resolves ``failed-unknown``. Requires a deployed worker that
             writes status objects (issue #327) and read access to the status
             prefix for the poll.
         """

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -112,6 +112,26 @@ class ShardError(RuntimeError):
         self.payload = payload
 
 
+def _fail_with_shard_error(entry, result: dict) -> None:
+    """v2 poller ``on_failed``: a terminal failure raises :class:`ShardError`.
+
+    Shared by :meth:`Run.dispatch` (event transport) and :meth:`Run.attach` so
+    a failed status, a spent retry budget, and the ``failed-unknown`` drop
+    outcome all surface from ``future.result()`` exactly like the v1 transport
+    — the payload is the same per-shard result dict, with ``outcome`` marking
+    a drop.
+    """
+    detail = result.get("error") or f"status {result.get('status_code')}"
+    entry.future.set_exception(
+        ShardError(
+            f"shard {entry.label}: {detail}",
+            shard_key=entry.shard_key,
+            label=entry.label,
+            payload=result,
+        )
+    )
+
+
 class RunHandle:
     """Live handle over one dispatched fan-out: per-shard futures + rollup.
 
@@ -461,6 +481,151 @@ class Run:
             source_credentials=source_credentials,
         )
 
+    @classmethod
+    def attach(
+        cls,
+        store: str,
+        run_id: str,
+        *,
+        function_name: str | None = None,
+        region: str = "us-west-2",
+        lambda_client=None,
+        output_credentials: dict | None = None,
+        output_endpoint_url: str | None = None,
+    ) -> RunHandle:
+        """Reattach to a dispatched run by id (issue #327 phase 5).
+
+        Rebuilds a :class:`RunHandle` from the run's dispatch manifest
+        (``<store>.status/run-<run_id>/manifest.json`` — the config, shard
+        set, and identity the setup invoke recorded worker-side) plus the
+        current status objects: shards already settled resolve on the first
+        poll tick, the rest resolve as their statuses land. A notebook kernel
+        restart or a second machine can adopt a running fleet this way — the
+        Event invokes are already in flight and owe the client nothing.
+
+        Observe-only by design: the manifest carries no granule records, so a
+        ``failed`` status resolves that shard's :class:`ShardError`
+        immediately (no re-dispatch), and a shard with no status object by
+        the drop deadline — anchored at the manifest's ``dispatched_at`` —
+        resolves ``failed-unknown``. The post-run tail runs only if not
+        already recorded (the run's ``tail.json`` marker, checked read-only);
+        when it does run it is the same worker-invoke tail as a live handle
+        (D8 intact — this method's own store traffic is reads).
+
+        Parameters
+        ----------
+        store : str
+            The run's effective store root exactly as dispatched
+            (``handle.store_path`` / the summary's ``store_path``).
+        run_id : str
+            The dispatch's run id (``manifest.json`` names it; it is also in
+            every cell event and stats record).
+        function_name, region, lambda_client, output_credentials,
+        output_endpoint_url
+            Same semantics as :meth:`from_config`; the function/client are
+            only used for the tail invokes when the tail is not yet recorded.
+        """
+        from zagg import client_transport, runner
+
+        output_creds_event = runner._build_output_creds_event(
+            output_credentials, output_endpoint_url, region
+        )
+        store_kwargs = runner._output_store_kwargs(output_creds_event, region)
+        prefix = client_transport.run_status_prefix(store, run_id)
+        manifest = client_transport.read_dispatch_manifest(prefix, store_kwargs)
+        if manifest is None:
+            raise ValueError(
+                f"no dispatch manifest at {prefix}/{client_transport.MANIFEST_NAME} — "
+                f"wrong store/run_id, a dispatcher predating issue #327, or a hive "
+                f"setup Event that was dropped (its manifest write is best-effort)"
+            )
+        if not manifest.get("config"):
+            raise ValueError(f"dispatch manifest for run {run_id} carries no config")
+        config = load_config_from_dict(manifest["config"])
+        validate_config(config)
+        if get_windowing(config) is not None:
+            raise NotImplementedError(
+                "Run.attach covers unwindowed spatial runs; windowed units are "
+                "(shard, window) pairs the manifest does not enumerate"
+            )
+        shards = [int(s) for s in manifest.get("shards") or []]
+        if not shards:
+            raise ValueError(f"dispatch manifest for run {run_id} lists no shards")
+
+        grid = grid_from_config(config)
+        catalog_data = {
+            "shard_keys": shards,
+            "granules": [[] for _ in shards],
+            "grid_signature": grid.spatial_signature(),
+            "metadata": manifest.get("dataset"),
+        }
+        run = cls(
+            config,
+            catalog_data,
+            store=store,
+            function_name=runner._resolve_function_name(config, function_name),
+            region=region,
+            lambda_client=lambda_client,
+            driver=get_driver(config),
+            handoff=get_handoff(config),
+            output_credentials=output_credentials,
+            output_endpoint_url=output_endpoint_url or get_output_endpoint_url(config),
+        )
+        client = lambda_client
+        if client is None:
+            import boto3
+            from botocore.config import Config
+
+            client = boto3.Session().client(
+                "lambda",
+                region_name=region,
+                config=Config(read_timeout=960, connect_timeout=10, retries={"max_attempts": 0}),
+            )
+
+        # Drop deadline anchored at the manifest's dispatched_at: attaching
+        # long after the fleet finished classifies status-less shards
+        # immediately instead of waiting a fresh window.
+        dispatched_at = None
+        try:
+            from datetime import datetime
+
+            dispatched_at = datetime.fromisoformat(manifest["dispatched_at"]).timestamp()
+        except (KeyError, TypeError, ValueError):
+            pass
+        timeout_s = runner._get_function_timeout_s(client, run.function_name)
+        poller = client_transport.StatusPoller(
+            lambda: client_transport.open_status_store(prefix, store_kwargs),
+            drop_timeout_s=client_transport.drop_timeout_s(timeout_s),
+            on_failed=_fail_with_shard_error,
+        )
+        futures: dict[int, Future] = {}
+        for key in shards:
+            label = runner._safe_label(run.grid, key)
+            futures[key] = poller.register(key, label, dispatch=None, dispatched_at=dispatched_at)
+        poller.start()
+
+        handle = RunHandle(futures, store_path=store)
+        finisher = threading.Thread(
+            target=run._post_run,
+            args=(
+                handle,
+                client,
+                poller,
+                asdict(config),
+                manifest.get("dataset"),
+                output_creds_event,
+                run_id,
+            ),
+            kwargs={
+                "tail_done_check": lambda: client_transport.tail_recorded(prefix, store_kwargs)
+            },
+            name="zagg-client-finish",
+            daemon=True,
+        )
+        handle._finisher = finisher
+        finisher.start()
+        return handle
+
     # -- shard selection ----------------------------------------------------
 
     def _resolve_key(self, key) -> int:
@@ -758,24 +923,12 @@ class Run:
         # the helper falls back to the template default (an injected stub
         # client need not answer get_function_configuration).
         timeout_s = runner._get_function_timeout_s(client, self.function_name)
-
-        def _failed(entry, result):
-            detail = result.get("error") or f"status {result.get('status_code')}"
-            entry.future.set_exception(
-                ShardError(
-                    f"shard {entry.label}: {detail}",
-                    shard_key=entry.shard_key,
-                    label=entry.label,
-                    payload=result,
-                )
-            )
-
         poller = client_transport.StatusPoller(
             lambda: client_transport.open_status_store(prefix, store_kwargs),
             drop_timeout_s=client_transport.drop_timeout_s(timeout_s),
             max_retries=self.max_retries,
             max_in_flight=workers,
-            on_failed=_failed,
+            on_failed=_fail_with_shard_error,
         )
         futures: dict[int, Future] = {}
         for key, records in cells:
@@ -900,6 +1053,7 @@ class Run:
         dataset: dict | None,
         output_creds_event: dict | None,
         run_id: str,
+        tail_done_check=None,
     ) -> None:
         """Finisher-thread entry point: run the tail, never lose its failure.
 
@@ -909,9 +1063,17 @@ class Run:
         distinct from the D6-load-bearing ``_finalize_error``) and ``closer``
         — the v1 invoke pool or the v2 status poller, both
         ``shutdown(wait=False)``-shaped — is shut down either way (review
-        finding, PR #333).
+        finding, PR #333). ``tail_done_check`` (issue #327, the attach path):
+        a zero-arg read-only predicate consulted AFTER every shard settles —
+        True means the tail was already recorded (the run's ``tail.json``
+        marker), so a reattached handle never re-runs it.
         """
         try:
+            if tail_done_check is not None:
+                futures_wait(list(handle.futures.values()))
+                if tail_done_check():
+                    logger.info(f"post-run tail already recorded for run {run_id}; skipping")
+                    return
             self._run_tail(handle, client, config_dict, dataset, output_creds_event, run_id)
         except BaseException as e:
             handle._tail_error = e
@@ -1035,9 +1197,13 @@ class Run:
             except Exception as e:
                 logger.warning(f"root coverage.moc dispatch failed (fail-open, D9): {e}")
 
-        # Run-record + sweep, both fail-open (issues #297/#313/#300): sync
-        # transport -> no status prefix, so oversized row sets skip inside
-        # _dispatch_run_stats exactly like agg's invocation="sync" path.
+        # Run-record + sweep, both fail-open (issues #297/#313/#300): no #151
+        # envelope-mirror prefix on either transport, so oversized row sets
+        # skip inside _dispatch_run_stats exactly like agg's sync path. The
+        # worker also records the tail-completion marker (issue #327) so a
+        # reattached handle knows this tail ran.
+        from zagg.client_transport import TAIL_NAME, run_status_prefix
+
         stats_rows, stats_inline = runner._lambda_result_rows(results, run_id=run_id)
         runner._dispatch_run_stats(
             client,
@@ -1049,6 +1215,7 @@ class Run:
             output_creds_event=output_creds_event,
             store_kwargs=runner._output_store_kwargs(output_creds_event, self.region),
             inline_rows=stats_inline,
+            tail_status_url=f"{run_status_prefix(self.store, run_id)}/{TAIL_NAME}",
         )
         if layout == "hive" and get_sweep(self.config):
             try:

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -22,14 +22,20 @@ without draining it is the one flow that truncates the tail: the finisher is a
 daemon thread, so an undrained handle cannot wedge interpreter exit (review
 finding, PR #333).
 
-**v1 transport** (ratified on issue #265): a ``ThreadPoolExecutor`` over the
-existing synchronous ``RequestResponse`` invokes — each shard is one
-:func:`zagg.runner._invoke_lambda_cell` call and its pool future is the
-shard's :class:`concurrent.futures.Future`, wrapping exactly what the worker
-returns today (timings, error payloads). Zero worker-side change; the cost is
-one held connection per in-flight shard and the client staying alive. The v2
-transport (``Event`` invoke + status-object resolver, issue #327) swaps the
-resolver under this same public surface.
+**v1 transport** (ratified on issue #265, the default): a
+``ThreadPoolExecutor`` over the existing synchronous ``RequestResponse``
+invokes — each shard is one :func:`zagg.runner._invoke_lambda_cell` call and
+its pool future is the shard's :class:`concurrent.futures.Future`, wrapping
+exactly what the worker returns today (timings, error payloads). Zero
+worker-side change; the cost is one held connection per in-flight shard and
+the client staying alive.
+
+**v2 transport** (issue #327, ``dispatch(transport="event")``): fire-and-forget
+``InvocationType="Event"`` invokes resolved by a single poller thread over the
+run's status-object prefix (:mod:`zagg.client_transport`) — no held
+connections, status-driven retries under the same ``max_retries``, a distinct
+``failed-unknown`` outcome for silently-dropped invokes, and the run is
+reattachable by run id (:meth:`Run.attach`). Same public surface.
 
 The dispatcher-never-writes invariant (D8) is untouched: every store write —
 template setup, shard output, finalize, coverage/stats/sweep rollups — rides a
@@ -524,13 +530,18 @@ class Run:
             )
             return _DEFAULT_MAX_WORKERS
 
-    def dispatch(self, shard_keys=None, max_workers: int | None = None) -> RunHandle:
+    def dispatch(
+        self,
+        shard_keys=None,
+        max_workers: int | None = None,
+        transport: str = "sync",
+    ) -> RunHandle:
         """Fan the shards out; return a :class:`RunHandle` of per-shard futures.
 
         Returns as soon as the setup handshake completes (worker-side template
         / manifest write — one short synchronous invoke; hive additionally
-        fail-fast-pings first): the fan-out itself runs on a background pool
-        and each shard's outcome arrives through its future.
+        fail-fast-pings first): the fan-out itself runs in the background and
+        each shard's outcome arrives through its future.
 
         Parameters
         ----------
@@ -538,13 +549,34 @@ class Run:
             Subset of shards to dispatch — raw int shardmap keys or external
             string labels (decimal morton for HEALPix). Default all shards.
         max_workers : int, optional
-            Pool width, clamped to the shard count. An explicit value wins
+            Fan-out width, clamped to the shard count. An explicit value wins
             verbatim and skips the preflight probe; omitted, the account
-            concurrency probe sizes the pool (see :meth:`_probe_workers`) and
+            concurrency probe sizes it (see :meth:`_probe_workers`) and
             :data:`_DEFAULT_MAX_WORKERS` is the fallback when it cannot run.
+            Under ``transport="sync"`` this is the invoke thread-pool width;
+            under ``"event"`` it is the dispatch **pacing window** — how many
+            shards may be dispatched-but-unresolved at once, load-bearing
+            because the fleet's 60 s ``MaximumEventAgeInSeconds`` silently
+            drops an Event invoke the account has no concurrency to start.
+        transport : str
+            ``"sync"`` (default, the v1 transport): a thread pool over
+            synchronous ``RequestResponse`` invokes — one held connection per
+            in-flight shard. ``"event"`` (the v2 transport, issue #327):
+            fire-and-forget ``InvocationType="Event"`` invokes resolved by a
+            single poller thread from one LIST of the run's status prefix per
+            tick — no held connections, and the run survives client exit
+            (reattachable via :meth:`attach`). Futures, harvest iterators,
+            ``status()``, and the post-run tail behave identically; the retry
+            policy migrates to status-driven re-dispatch (same
+            ``max_retries``), and a shard whose status object never lands
+            resolves ``failed-unknown``. Requires a deployed worker that
+            writes status objects (issue #327) and read access to the status
+            prefix for the poll.
         """
         from zagg import runner
 
+        if transport not in ("sync", "event"):
+            raise ValueError(f'transport must be "sync" or "event", got {transport!r}')
         cells = self._select(shard_keys)
         if not cells:
             raise ValueError("no shards selected")
@@ -649,33 +681,142 @@ class Run:
             )
 
         aoi_by_shard = runner._aoi_payload_map(self.catalog_data)
-        pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="zagg-client")
-        futures: dict[int, Future] = {}
-        for key, records in cells:
-            futures[int(key)] = pool.submit(
-                self._shard_work,
+        if transport == "event":
+            futures, closer = self._dispatch_event(
                 client,
-                int(key),
-                records,
+                cells,
+                run_id=run_id,
+                workers=workers,
                 config_dict=config_dict,
                 s3_creds=s3_creds,
                 output_creds_event=output_creds_event,
-                aoi_payload=aoi_by_shard.get(int(key)),
+                aoi_by_shard=aoi_by_shard,
                 invoked_by=invoked_by,
-                run_id=run_id,
-                max_workers=workers,
             )
+        else:
+            pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="zagg-client")
+            futures = {}
+            for key, records in cells:
+                futures[int(key)] = pool.submit(
+                    self._shard_work,
+                    client,
+                    int(key),
+                    records,
+                    config_dict=config_dict,
+                    s3_creds=s3_creds,
+                    output_creds_event=output_creds_event,
+                    aoi_payload=aoi_by_shard.get(int(key)),
+                    invoked_by=invoked_by,
+                    run_id=run_id,
+                    max_workers=workers,
+                )
+            closer = pool
 
         handle = RunHandle(futures, store_path=self.store)
         finisher = threading.Thread(
             target=self._post_run,
-            args=(handle, client, pool, config_dict, dataset, output_creds_event, run_id),
+            args=(handle, client, closer, config_dict, dataset, output_creds_event, run_id),
             name="zagg-client-finish",
             daemon=True,
         )
         handle._finisher = finisher
         finisher.start()
         return handle
+
+    def _dispatch_event(
+        self,
+        client,
+        cells,
+        *,
+        run_id: str,
+        workers: int,
+        config_dict: dict,
+        s3_creds: dict,
+        output_creds_event: dict | None,
+        aoi_by_shard: dict,
+        invoked_by: dict | None,
+    ) -> tuple[dict[int, Future], Any]:
+        """v2 Event transport (issue #327): fire-and-forget invokes + one poller.
+
+        Builds each shard's event through the SAME construction the sync/agg
+        paths use (``runner._build_cell_event`` — payloads are byte-identical
+        modulo InvocationType), registers it with a
+        :class:`~zagg.client_transport.StatusPoller` that paces dispatch to
+        the ``workers`` window and resolves every future from one LIST of the
+        run's status prefix per tick, and returns ``(futures, poller)`` — the
+        poller is the finisher's ``closer``. D8 audit: this path's only store
+        traffic is the poller's LIST/GETs (reads); every write stays behind a
+        worker invoke. A terminal failure (a ``failed`` status past the retry
+        budget, or the ``failed-unknown`` drop outcome) raises
+        :class:`ShardError` from the shard's future, exactly like v1.
+        """
+        from zagg import client_transport, runner
+
+        prefix = client_transport.run_status_prefix(self.store, run_id)
+        store_kwargs = runner._output_store_kwargs(output_creds_event, self.region)
+        # The drop deadline keys off the live function Timeout when readable;
+        # the helper falls back to the template default (an injected stub
+        # client need not answer get_function_configuration).
+        timeout_s = runner._get_function_timeout_s(client, self.function_name)
+
+        def _failed(entry, result):
+            detail = result.get("error") or f"status {result.get('status_code')}"
+            entry.future.set_exception(
+                ShardError(
+                    f"shard {entry.label}: {detail}",
+                    shard_key=entry.shard_key,
+                    label=entry.label,
+                    payload=result,
+                )
+            )
+
+        poller = client_transport.StatusPoller(
+            lambda: client_transport.open_status_store(prefix, store_kwargs),
+            drop_timeout_s=client_transport.drop_timeout_s(timeout_s),
+            max_retries=self.max_retries,
+            max_in_flight=workers,
+            on_failed=_failed,
+        )
+        futures: dict[int, Future] = {}
+        for key, records in cells:
+            key = int(key)
+            label = runner._safe_label(self.grid, key)
+            granule_urls = runner._resolve_urls(records, self.driver)
+            ds = runner._clamped_data_source(dict(self.config.data_source), len(granule_urls))
+            cell_config = {**config_dict, "data_source": ds} if ds is not None else config_dict
+            event = runner._build_cell_event(
+                self.grid.block_index(key),
+                key,
+                self._parent_order,
+                self._child_order,
+                granule_urls,
+                self.store,
+                s3_creds,
+                config_dict=cell_config,
+                output_creds_event=output_creds_event,
+                handoff=self.handoff,
+                profile=self.profile,
+                aoi_payload=aoi_by_shard.get(key),
+                invoked_by=invoked_by,
+                run_id=run_id,
+            )
+            submap = {
+                "grid_signature": self.catalog_data["grid_signature"],
+                "metadata": self.catalog_data.get("metadata"),
+                "granules": records,
+            }
+            # May raise the payload-cap ValueError — BEFORE anything fires, so
+            # an undispatchable run fails whole rather than mid-fan-out.
+            payload = runner._cell_payload(event, submap=submap, async_invoke=True, label=label)
+
+            def _fire(p=payload):
+                client.invoke(FunctionName=self.function_name, InvocationType="Event", Payload=p)
+
+            futures[key] = poller.register(
+                key, label, dispatch=_fire, granule_count=len(granule_urls)
+            )
+        poller.start()
+        return futures, poller
 
     def _shard_work(
         self,
@@ -754,7 +895,7 @@ class Run:
         self,
         handle: RunHandle,
         client,
-        pool: ThreadPoolExecutor,
+        closer,
         config_dict: dict,
         dataset: dict | None,
         output_creds_event: dict | None,
@@ -765,8 +906,10 @@ class Run:
         Anything the tail raises outside its own fail-open guards would
         otherwise die in ``threading.excepthook`` while ``wait()`` reported a
         clean run, so it is recorded on the handle as ``_tail_error`` (kept
-        distinct from the D6-load-bearing ``_finalize_error``) and the pool is
-        shut down either way (review finding, PR #333).
+        distinct from the D6-load-bearing ``_finalize_error``) and ``closer``
+        — the v1 invoke pool or the v2 status poller, both
+        ``shutdown(wait=False)``-shaped — is shut down either way (review
+        finding, PR #333).
         """
         try:
             self._run_tail(handle, client, config_dict, dataset, output_creds_event, run_id)
@@ -774,7 +917,7 @@ class Run:
             handle._tail_error = e
             logger.warning(f"post-run tail failed (surfaced via handle.wait()): {e}")
         finally:
-            pool.shutdown(wait=False)
+            closer.shutdown(wait=False)
 
     def _run_tail(
         self,

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -525,106 +525,18 @@ class Run:
             Same semantics as :meth:`from_config`; the function/client are
             only used for the tail invokes when the tail is not yet recorded.
         """
-        from zagg import client_transport, runner
+        from zagg.client_transport import attach_run
 
-        output_creds_event = runner._build_output_creds_event(
-            output_credentials, output_endpoint_url, region
-        )
-        store_kwargs = runner._output_store_kwargs(output_creds_event, region)
-        prefix = client_transport.run_status_prefix(store, run_id)
-        manifest = client_transport.read_dispatch_manifest(prefix, store_kwargs)
-        if manifest is None:
-            raise ValueError(
-                f"no dispatch manifest at {prefix}/{client_transport.MANIFEST_NAME} — "
-                f"wrong store/run_id, a dispatcher predating issue #327, or a hive "
-                f"setup Event that was dropped (its manifest write is best-effort)"
-            )
-        if not manifest.get("config"):
-            raise ValueError(f"dispatch manifest for run {run_id} carries no config")
-        config = load_config_from_dict(manifest["config"])
-        validate_config(config)
-        if get_windowing(config) is not None:
-            raise NotImplementedError(
-                "Run.attach covers unwindowed spatial runs; windowed units are "
-                "(shard, window) pairs the manifest does not enumerate"
-            )
-        shards = [int(s) for s in manifest.get("shards") or []]
-        if not shards:
-            raise ValueError(f"dispatch manifest for run {run_id} lists no shards")
-
-        grid = grid_from_config(config)
-        catalog_data = {
-            "shard_keys": shards,
-            "granules": [[] for _ in shards],
-            "grid_signature": grid.spatial_signature(),
-            "metadata": manifest.get("dataset"),
-        }
-        run = cls(
-            config,
-            catalog_data,
-            store=store,
-            function_name=runner._resolve_function_name(config, function_name),
+        return attach_run(
+            cls,
+            store,
+            run_id,
+            function_name=function_name,
             region=region,
             lambda_client=lambda_client,
-            driver=get_driver(config),
-            handoff=get_handoff(config),
             output_credentials=output_credentials,
-            output_endpoint_url=output_endpoint_url or get_output_endpoint_url(config),
+            output_endpoint_url=output_endpoint_url,
         )
-        client = lambda_client
-        if client is None:
-            import boto3
-            from botocore.config import Config
-
-            client = boto3.Session().client(
-                "lambda",
-                region_name=region,
-                config=Config(read_timeout=960, connect_timeout=10, retries={"max_attempts": 0}),
-            )
-
-        # Drop deadline anchored at the manifest's dispatched_at: attaching
-        # long after the fleet finished classifies status-less shards
-        # immediately instead of waiting a fresh window.
-        dispatched_at = None
-        try:
-            from datetime import datetime
-
-            dispatched_at = datetime.fromisoformat(manifest["dispatched_at"]).timestamp()
-        except (KeyError, TypeError, ValueError):
-            pass
-        timeout_s = runner._get_function_timeout_s(client, run.function_name)
-        poller = client_transport.StatusPoller(
-            lambda: client_transport.open_status_store(prefix, store_kwargs),
-            drop_timeout_s=client_transport.drop_timeout_s(timeout_s),
-            on_failed=_fail_with_shard_error,
-        )
-        futures: dict[int, Future] = {}
-        for key in shards:
-            label = runner._safe_label(run.grid, key)
-            futures[key] = poller.register(key, label, dispatch=None, dispatched_at=dispatched_at)
-        poller.start()
-
-        handle = RunHandle(futures, store_path=store)
-        finisher = threading.Thread(
-            target=run._post_run,
-            args=(
-                handle,
-                client,
-                poller,
-                asdict(config),
-                manifest.get("dataset"),
-                output_creds_event,
-                run_id,
-            ),
-            kwargs={
-                "tail_done_check": lambda: client_transport.tail_recorded(prefix, store_kwargs)
-            },
-            name="zagg-client-finish",
-            daemon=True,
-        )
-        handle._finisher = finisher
-        finisher.start()
-        return handle
 
     # -- shard selection ----------------------------------------------------
 
@@ -915,61 +827,21 @@ class Run:
         budget, or the ``failed-unknown`` drop outcome) raises
         :class:`ShardError` from the shard's future, exactly like v1.
         """
-        from zagg import client_transport, runner
+        from zagg.client_transport import dispatch_event_shards
 
-        prefix = client_transport.run_status_prefix(self.store, run_id)
-        store_kwargs = runner._output_store_kwargs(output_creds_event, self.region)
-        # The drop deadline keys off the live function Timeout when readable;
-        # the helper falls back to the template default (an injected stub
-        # client need not answer get_function_configuration).
-        timeout_s = runner._get_function_timeout_s(client, self.function_name)
-        poller = client_transport.StatusPoller(
-            lambda: client_transport.open_status_store(prefix, store_kwargs),
-            drop_timeout_s=client_transport.drop_timeout_s(timeout_s),
-            max_retries=self.max_retries,
-            max_in_flight=workers,
+        return dispatch_event_shards(
+            self,
+            client,
+            cells,
+            run_id=run_id,
+            workers=workers,
+            config_dict=config_dict,
+            s3_creds=s3_creds,
+            output_creds_event=output_creds_event,
+            aoi_by_shard=aoi_by_shard,
+            invoked_by=invoked_by,
             on_failed=_fail_with_shard_error,
         )
-        futures: dict[int, Future] = {}
-        for key, records in cells:
-            key = int(key)
-            label = runner._safe_label(self.grid, key)
-            granule_urls = runner._resolve_urls(records, self.driver)
-            ds = runner._clamped_data_source(dict(self.config.data_source), len(granule_urls))
-            cell_config = {**config_dict, "data_source": ds} if ds is not None else config_dict
-            event = runner._build_cell_event(
-                self.grid.block_index(key),
-                key,
-                self._parent_order,
-                self._child_order,
-                granule_urls,
-                self.store,
-                s3_creds,
-                config_dict=cell_config,
-                output_creds_event=output_creds_event,
-                handoff=self.handoff,
-                profile=self.profile,
-                aoi_payload=aoi_by_shard.get(key),
-                invoked_by=invoked_by,
-                run_id=run_id,
-            )
-            submap = {
-                "grid_signature": self.catalog_data["grid_signature"],
-                "metadata": self.catalog_data.get("metadata"),
-                "granules": records,
-            }
-            # May raise the payload-cap ValueError — BEFORE anything fires, so
-            # an undispatchable run fails whole rather than mid-fan-out.
-            payload = runner._cell_payload(event, submap=submap, async_invoke=True, label=label)
-
-            def _fire(p=payload):
-                client.invoke(FunctionName=self.function_name, InvocationType="Event", Payload=p)
-
-            futures[key] = poller.register(
-                key, label, dispatch=_fire, granule_count=len(granule_urls)
-            )
-        poller.start()
-        return futures, poller
 
     def _shard_work(
         self,

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -758,7 +758,13 @@ class Run:
             )
 
         aoi_by_shard = runner._aoi_payload_map(self.catalog_data)
+        result_prefix = None
         if transport == "event":
+            from zagg.client_transport import run_status_prefix
+
+            # The tail's oversized-run-record pointer (issue #327): only the
+            # event transport has a per-run prefix to point at.
+            result_prefix = run_status_prefix(self.store, run_id)
             futures, closer = self._dispatch_event(
                 client,
                 cells,
@@ -793,6 +799,7 @@ class Run:
         finisher = threading.Thread(
             target=self._post_run,
             args=(handle, client, closer, config_dict, dataset, output_creds_event, run_id),
+            kwargs={"result_prefix": result_prefix},
             name="zagg-client-finish",
             daemon=True,
         )
@@ -823,8 +830,10 @@ class Run:
         run's status prefix per tick, and returns ``(futures, poller)`` — the
         poller is the finisher's ``closer``. D8 audit: this path's only store
         traffic is the poller's LIST/GETs (reads); every write stays behind a
-        worker invoke. A terminal failure (a ``failed`` status past the retry
-        budget, or the ``failed-unknown`` drop outcome) raises
+        worker invoke. A terminal failure (a ``failed`` status, or the
+        ``failed-unknown`` drop outcome past its one re-fire — see the
+        three-class retry policy on
+        :class:`~zagg.client_transport.StatusPoller`) raises
         :class:`ShardError` from the shard's future, exactly like v1.
         """
         from zagg.client_transport import dispatch_event_shards
@@ -926,6 +935,7 @@ class Run:
         output_creds_event: dict | None,
         run_id: str,
         tail_done_check=None,
+        result_prefix=None,
     ) -> None:
         """Finisher-thread entry point: run the tail, never lose its failure.
 
@@ -938,7 +948,9 @@ class Run:
         finding, PR #333). ``tail_done_check`` (issue #327, the attach path):
         a zero-arg read-only predicate consulted AFTER every shard settles —
         True means the tail was already recorded (the run's ``tail.json``
-        marker), so a reattached handle never re-runs it.
+        marker), so a reattached handle never re-runs it. ``result_prefix``
+        (also #327) is the oversized-run-record pointer — see
+        :meth:`_run_tail`.
         """
         try:
             if tail_done_check is not None:
@@ -946,7 +958,15 @@ class Run:
                 if tail_done_check():
                     logger.info(f"post-run tail already recorded for run {run_id}; skipping")
                     return
-            self._run_tail(handle, client, config_dict, dataset, output_creds_event, run_id)
+            self._run_tail(
+                handle,
+                client,
+                config_dict,
+                dataset,
+                output_creds_event,
+                run_id,
+                result_prefix=result_prefix,
+            )
         except BaseException as e:
             handle._tail_error = e
             logger.warning(f"post-run tail failed (surfaced via handle.wait()): {e}")
@@ -961,6 +981,7 @@ class Run:
         dataset: dict | None,
         output_creds_event: dict | None,
         run_id: str,
+        result_prefix=None,
     ) -> None:
         """After every shard settles: the same worker-invoke tail as ``agg``.
 
@@ -984,6 +1005,16 @@ class Run:
         escaping the retry loop) — a synthesized failure dict, which
         ``_lambda_result_rows`` turns into a ``failure_record`` row rather than
         dropping the shard from telemetry (review finding, PR #333).
+
+        ``result_prefix`` is the pointer ``_dispatch_run_stats`` falls back to
+        when the row set exceeds the inline payload cap. The v1 sync transport
+        has none (no #151 envelope mirror), so an oversized sync run skips its
+        record; the v2 event transport DOES — the run's status prefix, which
+        ``telemetry.rows_from_status`` reads (issue #327) — and fleet-scale
+        runs are exactly the ones that hit the cap, so passing it is what keeps
+        ``Run.dispatch(transport="event")`` from silently dropping the run
+        record that the byte-identical ``agg(invocation="event")`` keeps
+        (``runner.py`` does the same fallback at its own stats dispatch).
         """
         from zagg import runner
 
@@ -1066,11 +1097,13 @@ class Run:
             except Exception as e:
                 logger.warning(f"root coverage.moc dispatch failed (fail-open, D9): {e}")
 
-        # Run-record + sweep, both fail-open (issues #297/#313/#300): no #151
-        # envelope-mirror prefix on either transport, so oversized row sets
-        # skip inside _dispatch_run_stats exactly like agg's sync path. The
-        # worker also records the tail-completion marker (issue #327) so a
-        # reattached handle knows this tail ran.
+        # Run-record + sweep, both fail-open (issues #297/#313/#300). The
+        # oversized-rows pointer is the run's v2 status prefix on an event
+        # run (rows_from_status reads that object shape — issue #327) and
+        # None on the sync transport, which has no #151 envelope mirror to
+        # point at; the same fallback runner.py applies. The worker also
+        # records the tail-completion marker (issue #327) so a reattached
+        # handle knows this tail ran.
         from zagg.client_transport import TAIL_NAME, run_status_prefix
 
         stats_rows, stats_inline = runner._lambda_result_rows(results, run_id=run_id)
@@ -1080,7 +1113,7 @@ class Run:
             self.store,
             stats_rows,
             run_id=run_id,
-            result_prefix=None,
+            result_prefix=result_prefix,
             output_creds_event=output_creds_event,
             store_kwargs=runner._output_store_kwargs(output_creds_event, self.region),
             inline_rows=stats_inline,

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -404,8 +404,8 @@ def dispatch_event_shards(
 
 def attach_run(
     run_cls,
-    store: str,
-    run_id: str,
+    store,
+    run_id,
     *,
     function_name=None,
     region="us-west-2",
@@ -610,7 +610,7 @@ class StatusPoller:
         clock: Callable[[], float] = time.time,
     ):
         self._store_factory = store_factory
-        self._store = None
+        self._store: Any = None
         self._drop_timeout_s = drop_timeout_s
         self._max_retries = max(1, int(max_retries))
         self._max_in_flight = max_in_flight
@@ -741,12 +741,15 @@ class StatusPoller:
                 dispatched = True
 
     def _fire(self, entry: _ShardEntry) -> None:
+        dispatch = entry.dispatch
+        if dispatch is None:  # observe-only entries are never queued (attach)
+            return
         entry.attempts += 1
         entry.dispatched_at = self._clock()
         if entry.first_dispatched_at is None:
             entry.first_dispatched_at = entry.dispatched_at
         try:
-            entry.dispatch()
+            dispatch()
         except Exception as e:
             # An invoke fault burns this attempt (throttles included): the
             # retry budget re-fires it on a later tick, mirroring the sync

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -90,6 +90,12 @@ STATUS_SCHEMA_VERSION = 1
 #: Dispatch-manifest object name under the run prefix (issue #327 phase 2).
 MANIFEST_NAME = "manifest.json"
 
+#: Tail-completion marker under the run prefix (issue #327 phase 5): written
+#: by the mode="stats" worker when the post-run tail's record leg completes,
+#: so a reattached handle re-runs the (idempotent / fail-open) tail only when
+#: it was never recorded.
+TAIL_NAME = "tail.json"
+
 
 def run_status_prefix(store_path: str, run_id: str) -> str:
     """The run's status prefix: ``<store>.status/run-<run_id>`` (a store SIBLING)."""
@@ -253,9 +259,66 @@ def write_shard_status(event: dict, response: dict, store_kwargs: dict[str, Any]
         logger.warning(f"shard status write failed (fail-open, issue #327): {e}")
 
 
+def write_tail_status(event: dict, store_kwargs: dict[str, Any]) -> None:
+    """PUT the tail-completion marker named by ``event["tail_status_url"]``.
+
+    Worker-side (the ``mode="stats"`` handler — the last recorded leg of the
+    post-run tail), fail-open like every status write: absent key or any
+    failure logs and never fails the stats invoke.
+    """
+    try:
+        url = event.get("tail_status_url")
+        if not url:
+            return
+        import obstore
+
+        from zagg.store import open_object_store
+
+        prefix, _, key = url.rpartition("/")
+        marker = {
+            "schema_version": STATUS_SCHEMA_VERSION,
+            "status": "tail_done",
+            "run_id": event.get("run_id"),
+        }
+        obstore.put(open_object_store(prefix, **store_kwargs), key, json.dumps(marker).encode())
+        logger.info(f"Wrote tail status to {url}")
+    except Exception as e:
+        logger.warning(f"tail status write failed (fail-open, issue #327): {e}")
+
+
 # ---------------------------------------------------------------------------
-# Client half: the polling resolver (issue #327 phases 3-4).
+# Client half: the polling resolver (issue #327 phases 3-4) + reattach reads
+# (phase 5). The reads below are the D8-safe half: LIST/GET only.
 # ---------------------------------------------------------------------------
+
+
+def read_dispatch_manifest(prefix: str, store_kwargs: dict[str, Any]) -> dict | None:
+    """The run's dispatch manifest, or ``None`` when absent (read-only)."""
+    import obstore
+    from obstore.exceptions import NotFoundError
+
+    try:
+        store = open_status_store(prefix, store_kwargs)
+        return json.loads(bytes(obstore.get(store, MANIFEST_NAME).bytes()))
+    except (FileNotFoundError, NotFoundError):
+        return None
+
+
+def tail_recorded(prefix: str, store_kwargs: dict[str, Any]) -> bool:
+    """Whether the run's post-run tail marker exists (read-only).
+
+    Any read failure counts as "not recorded": the reattached tail then
+    re-runs, which is safe — finalize is idempotent and the rollup legs are
+    fail-open duplicates at worst.
+    """
+    import obstore
+
+    try:
+        store = open_status_store(prefix, store_kwargs)
+        obstore.get(store, TAIL_NAME)
+        return True
+    except Exception:
+        return False
 
 
 def open_status_store(prefix: str, store_kwargs: dict[str, Any]):

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -101,7 +101,9 @@ def drop_timeout_s(function_timeout_s: float) -> float:
     return float(function_timeout_s) + MAX_EVENT_AGE_S + _DROP_MARGIN_S
 
 
-#: Version stamped into every status object; bump on any key change.
+#: Version stamped into every status object; bump on any key change. Read back
+#: in :meth:`StatusPoller._consume`, which warns on a mismatch so a future bump
+#: is loud rather than subtly wrong (review finding, PR #343).
 STATUS_SCHEMA_VERSION = 1
 
 #: Dispatch-manifest object name under the run prefix (issue #327 phase 2).
@@ -905,7 +907,24 @@ class StatusPoller:
         return keys
 
     def _consume(self, entry: _ShardEntry) -> bool:
-        """GET one listed status object; act on it once per attempt_id."""
+        """GET one listed status object; act on it once per attempt_id.
+
+        Two read-side guards on the fields the channel's forward-compat rests
+        on (review findings, PR #343):
+
+        - An unrecognized ``schema_version`` WARNS. A newer worker against an
+          older client is the normal fleet state during a layer roll, so the
+          version is only worth stamping if a bump is loud; the object is still
+          consumed (a shard whose data landed must not fail on telemetry), but
+          the log names the mismatch instead of reading v99 as v1 in silence.
+        - A falsy/absent ``attempt_id`` is treated as always-new. Adding
+          ``None`` to ``consumed`` used to poison the dedupe permanently: every
+          later attempt's object read as ``None`` too and was ignored, so a
+          shard that SUCCEEDED on its re-fire waited out the whole drop window
+          and was reported ``failed-unknown``. ``build_shard_status`` always
+          sets the id, so this needs a foreign or truncated object — but a
+          silent-wrong-answer mode is worth one line to close.
+        """
         import obstore
 
         try:
@@ -913,10 +932,24 @@ class StatusPoller:
         except Exception as e:
             logger.warning(f"shard {entry.label}: status GET failed (retrying): {e}")
             return False
+        version = obj.get("schema_version")
+        if version != STATUS_SCHEMA_VERSION:
+            logger.warning(
+                f"shard {entry.label}: status object schema_version {version!r} != "
+                f"{STATUS_SCHEMA_VERSION} (this client's); reading it as v"
+                f"{STATUS_SCHEMA_VERSION} — a newer worker may carry keys this "
+                f"client ignores (issue #327)"
+            )
         attempt_id = obj.get("attempt_id")
-        if attempt_id in entry.consumed:
+        if not attempt_id:
+            logger.warning(
+                f"shard {entry.label}: status object carries no attempt_id; "
+                f"treating it as a new attempt (issue #327)"
+            )
+        elif attempt_id in entry.consumed:
             return False  # already acted on (a not-yet-overwritten prior attempt)
-        entry.consumed.add(attempt_id)
+        else:
+            entry.consumed.add(attempt_id)
         result = self._result(
             entry,
             status_code=obj.get("status_code"),

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -700,6 +700,17 @@ class StatusPoller:
         ``dispatched_at`` seeds the drop deadline for observe-only entries
         (attach: the manifest's dispatch time); live entries get stamped at
         their own Event invoke.
+
+        A registration that lands AFTER :meth:`shutdown` resolves immediately
+        as a failure. :meth:`_run` is deliberately open-ended on the other side
+        (registration may trail :meth:`start` — agg's pool registers shards as
+        its threads reach them), so without this guard the loop is already gone
+        and nothing would ever resolve the Future: ``runner``'s
+        ``fut.result()`` has no timeout, so a pool thread would block forever
+        and ``executor.shutdown()`` would never return. Today that ordering is
+        safe only because ``_run_lambda``'s ``finally`` drains the executor
+        before shutting the poller down — load-bearing and undocumented
+        (review finding, PR #343).
         """
         entry = _ShardEntry(
             shard_key=int(shard_key),
@@ -715,7 +726,24 @@ class StatusPoller:
             entry.dispatched_at = dispatched_at if dispatched_at is not None else self._clock()
             entry.first_dispatched_at = entry.dispatched_at
         with self._lock:
-            self._entries[entry.key] = entry
+            stopped = self._stop.is_set()
+            if not stopped:
+                self._entries[entry.key] = entry
+        if stopped:
+            entry.queued = False
+            self._resolve_failure(
+                entry,
+                self._result(
+                    entry,
+                    status_code=None,
+                    body={},
+                    error=(
+                        f"shard {entry.label} registered after the status poller shut "
+                        f"down: no loop left to resolve it (issue #327)"
+                    ),
+                    outcome="not-dispatched",
+                ),
+            )
         return entry.future
 
     def start(self) -> "StatusPoller":
@@ -724,8 +752,14 @@ class StatusPoller:
         return self
 
     def shutdown(self, wait: bool = False) -> None:
-        """Stop the poller thread (pool-shaped so the finisher can close it)."""
-        self._stop.set()
+        """Stop the poller thread (pool-shaped so the finisher can close it).
+
+        The flag is set under the entry lock so it cannot interleave with a
+        :meth:`register` that is mid-insert: a registration either lands while
+        the loop is live, or is refused and resolved (see ``register``).
+        """
+        with self._lock:
+            self._stop.set()
         if wait and self._thread is not None:
             self._thread.join()
 

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -461,6 +461,11 @@ class StatusPoller:
     # -- the loop -------------------------------------------------------------
 
     def _run(self) -> None:
+        # Runs until shutdown(), never self-exits on "all done": registration
+        # may TRAIL start() (agg's pool registers shards as its threads reach
+        # them), so an empty/settled entry map is not proof the run is over.
+        # An idle tick with nothing in flight returns before the LIST, so a
+        # drained poller costs zero requests while it waits to be shut down.
         interval = self._initial_interval_s
         while not self._stop.is_set():
             try:
@@ -470,16 +475,10 @@ class StatusPoller:
                 # persistent one surfaces through the drop deadline instead.
                 logger.warning(f"status poll tick failed (retrying): {e}")
                 progressed = False
-            if self._all_done():
-                return
             interval = (
                 self._initial_interval_s if progressed else min(interval * 2, self._max_interval_s)
             )
             self._stop.wait(interval)
-
-    def _all_done(self) -> bool:
-        with self._lock:
-            return all(e.future.done() for e in self._entries.values())
 
     def _pending(self) -> list[_ShardEntry]:
         with self._lock:

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -54,6 +54,9 @@ logger = logging.getLogger(__name__)
 #: Version stamped into every status object; bump on any key change.
 STATUS_SCHEMA_VERSION = 1
 
+#: Dispatch-manifest object name under the run prefix (issue #327 phase 2).
+MANIFEST_NAME = "manifest.json"
+
 
 def run_status_prefix(store_path: str, run_id: str) -> str:
     """The run's status prefix: ``<store>.status/run-<run_id>`` (a store SIBLING)."""
@@ -128,6 +131,64 @@ def build_shard_status(event: dict, response: dict) -> tuple[str, dict] | None:
         "body": body,
     }
     return shard_status_key(shard_key, window=window), obj
+
+
+def build_run_manifest_block(run_id: str, shard_keys, config, *, dataset: dict | None = None) -> dict:
+    """The dispatcher-side ``run_manifest`` block for the worker setup invoke.
+
+    Rides the EXISTING setup invoke (the hive fire-and-forget manifest write /
+    the flat synchronous template write) so the WORKER records the run's
+    dispatch manifest — the dispatcher never writes (D8). ``shards`` is the
+    dispatched shard-key set as decimal strings (deduped, order-preserving —
+    windowed fan-outs repeat a shard per window), ``semantic_hash`` the run
+    config's D19 identity, ``dispatched_at`` the dispatcher's clock at
+    dispatch, and ``dataset`` the ShardMap identity block (``short_name`` /
+    ``version``) a reattached tail needs for the hive finalize backstop. The
+    worker folds the setup event's own ``config`` into the written manifest,
+    so it is not duplicated here on the wire.
+    """
+    from datetime import datetime, timezone
+
+    from zagg.semantics import semantic_hash
+
+    return {
+        "run_id": run_id,
+        "shards": list(dict.fromkeys(str(int(k)) for k in shard_keys)),
+        "semantic_hash": semantic_hash(config),
+        "dispatched_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "dataset": dataset,
+    }
+
+
+def write_dispatch_manifest(event: dict, store_kwargs: dict[str, Any]) -> None:
+    """PUT the run's dispatch manifest from a setup event — fail-open, worker-side.
+
+    Called from the Lambda handler's setup seam on a successful setup. The
+    ``run_manifest`` block (see :func:`build_run_manifest_block`) plus the
+    setup event's ``config`` land at ``<run prefix>/manifest.json`` — what
+    ``Run.attach`` rebuilds a handle from. Absent block (an old dispatcher, or
+    one dropped over the async payload cap) writes nothing, keeping the event
+    byte-identical to pre-#327; any failure logs and never fails the setup.
+    """
+    try:
+        block = event.get("run_manifest")
+        if not block or not block.get("run_id") or not event.get("store_path"):
+            return
+        manifest = {
+            "schema_version": STATUS_SCHEMA_VERSION,
+            **block,
+            "config": event.get("config"),
+        }
+        import obstore
+
+        from zagg.store import open_object_store
+
+        prefix = run_status_prefix(event["store_path"], block["run_id"])
+        store = open_object_store(prefix, **store_kwargs)
+        obstore.put(store, MANIFEST_NAME, json.dumps(manifest).encode())
+        logger.info(f"Wrote dispatch manifest to {prefix}/{MANIFEST_NAME}")
+    except Exception as e:
+        logger.warning(f"dispatch manifest write failed (fail-open, issue #327): {e}")
 
 
 def write_shard_status(event: dict, response: dict, store_kwargs: dict[str, Any]) -> None:

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -73,6 +73,14 @@ MAX_EVENT_AGE_S = 60.0
 #: ``_ASYNC_POLL_MARGIN_S``.
 _DROP_MARGIN_S = 90.0
 
+#: Class-(b) re-fire budget (see :class:`StatusPoller`): a status-less shard
+#: re-fires at most this many times. ONE, so the worst case is 2 executions —
+#: the bounded double-billing the queue-drop class trades for recovering a
+#: silently discarded invoke (issue #151: ``MaximumRetryAttempts: 0`` exists to
+#: stop the fleet re-billing 900 s executions, so the client must not
+#: reintroduce an unbounded version of it from the outside).
+_MAX_DROP_REFIRES = 1
+
 
 def drop_timeout_s(function_timeout_s: float) -> float:
     """Seconds after dispatch with NO status object => ``failed-unknown``.
@@ -561,6 +569,7 @@ class _ShardEntry:
     granule_count: int = 0
     attempts: int = 0  # dispatches so far (the v1 attempt counter)
     queued: bool = True  # awaiting a dispatch slot
+    drop_refires: int = 0  # class-(b) re-fires spent (see StatusPoller)
     dispatched_at: float | None = None  # this attempt's dispatch clock
     first_dispatched_at: float | None = None
     consumed: set = field(default_factory=set)  # attempt_ids already acted on
@@ -574,17 +583,41 @@ class StatusPoller:
     re-attempted) object. Never writes (D8: the LIST/GETs are reads; every
     write stays worker-side).
 
-    The poller also owns Event dispatch and the migrated retry policy (issue
-    #327 amendment (b) — function errors never return to an Event caller, so
-    ``max_retries`` becomes status-driven): shards register with a zero-arg
-    ``dispatch`` closure, at most ``max_in_flight`` are dispatched-unresolved
-    at once (the concurrency preflight's clamp — load-bearing under the
-    fleet's 60 s ``MaximumEventAgeInSeconds``, which silently drops an Event
-    that cannot start in time), and a ``failed`` status re-dispatches until
-    the shard's total attempts reach ``max_retries``. ``attempt_id`` keeps the
-    accounting straight: each status object is acted on at most once, so a
-    duplicate execution's re-write (or a poll catching a stale pre-retry
-    object) never double-counts.
+    The poller also owns Event dispatch: shards register with a zero-arg
+    ``dispatch`` closure and at most ``max_in_flight`` are
+    dispatched-unresolved at once (the concurrency preflight's clamp —
+    load-bearing under the fleet's 60 s ``MaximumEventAgeInSeconds``, which
+    silently drops an Event that cannot start in time).
+
+    **Retry policy — three fault classes** (issue #327 amendment (b) as folded
+    from the PR #343 review; espg's to veto). Function errors never return to
+    an Event caller, so v1's single ``max_retries`` loop has to be split by
+    what actually failed:
+
+    (a) **Deterministic worker failure** — a ``failed`` STATUS object. By
+        construction the worker RAN TO COMPLETION and reported an error, which
+        is the case issue #119 already excludes from retry on the sync
+        transport (*"Every FunctionError on a synchronous invoke is
+        deterministic for a given shard ... so none are retried"*). It resolves
+        immediately; no re-fire, no second billing.
+    (b) **Queue drop** — no status object by the drop deadline
+        (``failed-unknown``). Genuinely worth one more shot, since the invoke
+        may simply have aged out of the async queue under backpressure. Bounded
+        at :data:`_MAX_DROP_REFIRES` = 1 re-fire, so the exposure is at most
+        **2 × function timeout** billed for a shard that may be unrecoverable
+        (a drop and an OOM/timeout death are indistinguishable from the
+        client). That bound is the point: issue #151 pinned
+        ``MaximumRetryAttempts: 0`` precisely so async fan-out is never
+        re-billed at 900 s per service retry, and an unbounded client-side
+        re-dispatch would reintroduce it.
+    (c) **Invoke-layer fault** — the ``client.invoke`` call itself raised
+        (throttle, read timeout, connection reset). This is v1's ``max_retries``
+        in its original meaning, and it retries up to that budget with
+        exponential backoff.
+
+    ``attempt_id`` keeps the accounting straight across all three: each status
+    object is acted on at most once, so a duplicate execution's re-write (or a
+    poll catching a stale pre-retry object) never double-counts.
 
     Resolution policy is the caller's: a terminal success/no-data sets the
     result dict (the exact shape the sync transport returns); a terminal
@@ -751,11 +784,10 @@ class StatusPoller:
         try:
             dispatch()
         except Exception as e:
-            # An invoke fault burns this attempt (throttles included): the
-            # retry budget re-fires it on a later tick, mirroring the sync
-            # transport's bounded transient retry.
+            # Fault class (c): the invoke CALL failed (throttle, read timeout).
+            # Burns this attempt and re-fires within max_retries.
             logger.warning(f"shard {entry.label}: Event invoke failed ({e})")
-            self._attempt_failed(
+            self._invoke_faulted(
                 entry,
                 self._result(entry, status_code=None, body={}, error=f"Event invoke failed: {e}"),
             )
@@ -795,7 +827,7 @@ class StatusPoller:
         if obj.get("status") in ("ok", "no_data"):
             entry.future.set_result(result)
         else:
-            self._attempt_failed(entry, result)
+            self._worker_failed(entry, result)
         return True
 
     def _result(self, entry: _ShardEntry, *, status_code, body, error, outcome=None) -> dict:
@@ -816,8 +848,45 @@ class StatusPoller:
             result["outcome"] = outcome
         return result
 
-    def _attempt_failed(self, entry: _ShardEntry, result: dict) -> None:
-        """Status-driven retry (issue #327 amendment (b)): re-dispatch or resolve."""
+    # -- the three retry classes (see the class docstring) --------------------
+
+    def _worker_failed(self, entry: _ShardEntry, result: dict) -> None:
+        """Class (a): a ``failed`` status object is TERMINAL — never re-fired.
+
+        The object exists, so the worker ran to completion and reported its own
+        error: deterministic for this shard, exactly the case issue #119
+        excludes from retry on the sync transport. Re-firing it would bill a
+        second full execution for a guaranteed second failure.
+        """
+        self._resolve_failure(entry, result)
+
+    def _drop_failed(self, entry: _ShardEntry, result: dict) -> None:
+        """Class (b): a status-less shard re-fires at most :data:`_MAX_DROP_REFIRES`.
+
+        The one class where a re-fire can actually succeed (an invoke aged out
+        of the async queue never ran), bounded at one so the worst case is two
+        billed executions rather than ``max_retries`` of them (issue #151).
+        ``max_retries <= 1`` opts out entirely, keeping the knob's "no retries"
+        meaning.
+        """
+        if (
+            entry.dispatch is not None
+            and entry.drop_refires < _MAX_DROP_REFIRES
+            and entry.attempts < self._max_retries
+        ):
+            logger.warning(
+                f"shard {entry.label}: no status object (attempt {entry.attempts}); "
+                f"re-firing once — a dropped invoke can still succeed, a dead "
+                f"worker will not (bounded at {_MAX_DROP_REFIRES} re-fire, issue #151)"
+            )
+            with self._lock:
+                entry.drop_refires += 1
+                entry.queued = True
+            return
+        self._resolve_failure(entry, result)
+
+    def _invoke_faulted(self, entry: _ShardEntry, result: dict) -> None:
+        """Class (c): the invoke call itself faulted — retry within ``max_retries``."""
         if entry.dispatch is not None and entry.attempts < self._max_retries:
             logger.warning(
                 f"shard {entry.label}: attempt {entry.attempts} failed "
@@ -827,6 +896,10 @@ class StatusPoller:
             with self._lock:
                 entry.queued = True
             return
+        self._resolve_failure(entry, result)
+
+    def _resolve_failure(self, entry: _ShardEntry, result: dict) -> None:
+        """Terminal failure: the caller's policy, defaulting to ``set_result``."""
         if self._on_failed is not None:
             self._on_failed(entry, result)
         else:
@@ -839,8 +912,7 @@ class StatusPoller:
         margin, so a shard reaching it either had its Event invoke silently
         dropped under backpressure (issue #327 amendment (a')) or died before
         its always-on status write — indistinguishable from here, hence the
-        dedicated outcome. Participates in the same re-dispatch budget as a
-        ``failed`` status.
+        dedicated outcome. Fault class (b): one bounded re-fire.
         """
         result = self._result(
             entry,
@@ -854,4 +926,4 @@ class StatusPoller:
             ),
             outcome="failed-unknown",
         )
-        self._attempt_failed(entry, result)
+        self._drop_failed(entry, result)

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -81,6 +81,15 @@ _DROP_MARGIN_S = 90.0
 #: reintroduce an unbounded version of it from the outside).
 _MAX_DROP_REFIRES = 1
 
+#: Class-(c) backoff cap. A faulted invoke is re-armed with a NOT-BEFORE stamp
+#: at ``2**attempts`` seconds out (2, 4, 8, ... capped here) — the sync
+#: transport's ``time.sleep((2**attempt) + jitter)`` schedule expressed as a
+#: timestamp, because this runs on the single poller thread: sleeping there
+#: would stall every other shard's LIST. No jitter is needed since the poller
+#: re-fires serially anyway, so a synchronized throttle can't produce a
+#: simultaneous burst.
+_RETRY_BACKOFF_CAP_S = 30.0
+
 
 def drop_timeout_s(function_timeout_s: float) -> float:
     """Seconds after dispatch with NO status object => ``failed-unknown``.
@@ -570,6 +579,7 @@ class _ShardEntry:
     attempts: int = 0  # dispatches so far (the v1 attempt counter)
     queued: bool = True  # awaiting a dispatch slot
     drop_refires: int = 0  # class-(b) re-fires spent (see StatusPoller)
+    retry_not_before: float = 0.0  # class-(c) backoff: don't re-fire before this
     dispatched_at: float | None = None  # this attempt's dispatch clock
     first_dispatched_at: float | None = None
     consumed: set = field(default_factory=set)  # attempt_ids already acted on
@@ -613,7 +623,15 @@ class StatusPoller:
     (c) **Invoke-layer fault** — the ``client.invoke`` call itself raised
         (throttle, read timeout, connection reset). This is v1's ``max_retries``
         in its original meaning, and it retries up to that budget with
-        exponential backoff.
+        **exponential backoff** — ``2**attempts`` seconds, capped at
+        :data:`_RETRY_BACKOFF_CAP_S`, recorded as a not-before timestamp on the
+        entry rather than a ``time.sleep``. Sleeping is not available here: one
+        thread serves every shard, so a sleep would stall the LISTs. Without a
+        stamp a throttled shard's whole budget burns in the same pass (the
+        ``while True`` in :meth:`_dispatch_up_to_window` re-reads ``queued``
+        immediately), turning a transient ``TooManyRequestsException`` — the
+        canonical fleet-scale fault, and the exact condition the pacing window
+        exists to manage — into a wholesale run failure in milliseconds.
 
     ``attempt_id`` keeps the accounting straight across all three: each status
     object is acted on at most once, so a duplicate execution's re-write (or a
@@ -726,7 +744,22 @@ class StatusPoller:
             interval = (
                 self._initial_interval_s if progressed else min(interval * 2, self._max_interval_s)
             )
+            # Never oversleep a class-(c) backoff: the idle-tick doubling would
+            # otherwise add up to _POLL_MAX_INTERVAL_S to every re-fire.
+            wait = self._next_retry_wait()
+            if wait is not None:
+                interval = min(interval, max(wait, 0.01))
             self._stop.wait(interval)
+
+    def _next_retry_wait(self) -> float | None:
+        """Seconds until the soonest backoff-armed re-fire, or ``None`` if none."""
+        with self._lock:
+            stamps = [
+                e.retry_not_before
+                for e in self._entries.values()
+                if e.queued and e.retry_not_before and not e.future.done()
+            ]
+        return min(stamps) - self._clock() if stamps else None
 
     def _pending(self) -> list[_ShardEntry]:
         with self._lock:
@@ -753,11 +786,22 @@ class StatusPoller:
         return progressed
 
     def _dispatch_up_to_window(self) -> bool:
-        """Fire queued shards while the in-flight window has room (pacing)."""
+        """Fire queued shards while the in-flight window has room (pacing).
+
+        A queued entry still inside its class-(c) backoff is skipped (not
+        counted against the window either — a parked shard holds no slot), so
+        the loop terminates on a faulting dispatch instead of spinning the whole
+        retry budget in one pass.
+        """
         dispatched = False
         while True:
+            now = self._clock()
             with self._lock:
-                queued = [e for e in self._entries.values() if e.queued and not e.future.done()]
+                queued = [
+                    e
+                    for e in self._entries.values()
+                    if e.queued and not e.future.done() and e.retry_not_before <= now
+                ]
                 in_flight = sum(
                     1 for e in self._entries.values() if not e.queued and not e.future.done()
                 )
@@ -778,6 +822,7 @@ class StatusPoller:
         if dispatch is None:  # observe-only entries are never queued (attach)
             return
         entry.attempts += 1
+        entry.retry_not_before = 0.0  # this attempt cleared any armed backoff
         entry.dispatched_at = self._clock()
         if entry.first_dispatched_at is None:
             entry.first_dispatched_at = entry.dispatched_at
@@ -886,14 +931,22 @@ class StatusPoller:
         self._resolve_failure(entry, result)
 
     def _invoke_faulted(self, entry: _ShardEntry, result: dict) -> None:
-        """Class (c): the invoke call itself faulted — retry within ``max_retries``."""
+        """Class (c): the invoke call itself faulted — backed-off retry.
+
+        Re-arms the entry with a not-before stamp ``2**attempts`` seconds out
+        (capped) instead of sleeping: the poller thread has to stay free for
+        LISTs, and an unstamped re-queue would spend the whole budget in the
+        same ``_dispatch_up_to_window`` pass.
+        """
         if entry.dispatch is not None and entry.attempts < self._max_retries:
+            delay = min(2.0**entry.attempts, _RETRY_BACKOFF_CAP_S)
             logger.warning(
                 f"shard {entry.label}: attempt {entry.attempts} failed "
-                f"({result.get('error')}); re-dispatching "
+                f"({result.get('error')}); re-dispatching in {delay:.0f}s "
                 f"({self._max_retries - entry.attempts} left)"
             )
             with self._lock:
+                entry.retry_not_before = self._clock() + delay
                 entry.queued = True
             return
         self._resolve_failure(entry, result)

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -108,9 +108,9 @@ STATUS_SCHEMA_VERSION = 1
 MANIFEST_NAME = "manifest.json"
 
 #: Tail-completion marker under the run prefix (issue #327 phase 5): written
-#: by the mode="stats" worker when the post-run tail's record leg completes,
-#: so a reattached handle re-runs the (idempotent / fail-open) tail only when
-#: it was never recorded.
+#: by the mode="stats" worker when the post-run tail's record leg completes AND
+#: the run's finalize succeeded, so a reattached handle re-runs the (idempotent
+#: / fail-open) tail whenever it was never recorded or its finalize failed.
 TAIL_NAME = "tail.json"
 
 
@@ -282,10 +282,25 @@ def write_tail_status(event: dict, store_kwargs: dict[str, Any]) -> None:
     Worker-side (the ``mode="stats"`` handler — the last recorded leg of the
     post-run tail), fail-open like every status write: absent key or any
     failure logs and never fails the stats invoke.
+
+    NOT written when the stats event carries a ``finalize_error`` (issue #335):
+    :meth:`zagg.client.Run.attach` reads this marker as "the tail ran" and
+    skips the WHOLE tail, including the idempotent hive finalize /
+    ``ensure_manifest`` backstop — and a run whose finalize failed is precisely
+    the one that needs another pass. Leaving the marker unwritten is the safe
+    direction: attach re-runs a tail that is idempotent by construction
+    (review finding, PR #343). The run parquet still records the failure as its
+    run-level column, so the postmortem signal is not lost.
     """
     try:
         url = event.get("tail_status_url")
         if not url:
+            return
+        if event.get("finalize_error"):
+            logger.info(
+                "tail marker withheld: this run's finalize failed, so a reattached "
+                "handle must re-run the (idempotent) tail (issues #327/#335)"
+            )
             return
         import obstore
 

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -321,6 +321,221 @@ def tail_recorded(prefix: str, store_kwargs: dict[str, Any]) -> bool:
         return False
 
 
+def dispatch_event_shards(
+    run,
+    client,
+    cells,
+    *,
+    run_id,
+    workers,
+    config_dict,
+    s3_creds,
+    output_creds_event,
+    aoi_by_shard,
+    invoked_by,
+    on_failed,
+):
+    """The v2 Event fan-out for :meth:`zagg.client.Run.dispatch` (issue #327).
+
+    Split out of ``client.py`` for the §4 module ceiling (the split the PR
+    plan pre-authorized); ``run`` is the :class:`~zagg.client.Run` instance.
+    Builds each shard's event through the SAME construction the sync/agg
+    paths use (``runner._build_cell_event`` — payloads byte-identical modulo
+    InvocationType, asserted by the parity tests), registers it with a
+    :class:`StatusPoller` that paces dispatch to the ``workers`` window, and
+    returns ``(futures, poller)`` — the poller is the finisher's ``closer``.
+    The payload-cap ValueError raises BEFORE anything fires, so an
+    undispatchable run fails whole rather than mid-fan-out. D8 audit: this
+    path's only store traffic is the poller's LIST/GETs (reads).
+    """
+
+    from zagg import runner
+
+    prefix = run_status_prefix(run.store, run_id)
+    store_kwargs = runner._output_store_kwargs(output_creds_event, run.region)
+    # The drop deadline keys off the live function Timeout when readable; the
+    # helper falls back to the template default (an injected stub client need
+    # not answer get_function_configuration).
+    timeout_s = runner._get_function_timeout_s(client, run.function_name)
+    poller = StatusPoller(
+        lambda: open_status_store(prefix, store_kwargs),
+        drop_timeout_s=drop_timeout_s(timeout_s),
+        max_retries=run.max_retries,
+        max_in_flight=workers,
+        on_failed=on_failed,
+    )
+    futures: dict[int, Future] = {}
+    for key, records in cells:
+        key = int(key)
+        label = runner._safe_label(run.grid, key)
+        granule_urls = runner._resolve_urls(records, run.driver)
+        ds = runner._clamped_data_source(dict(run.config.data_source), len(granule_urls))
+        cell_config = {**config_dict, "data_source": ds} if ds is not None else config_dict
+        event = runner._build_cell_event(
+            run.grid.block_index(key),
+            key,
+            run._parent_order,
+            run._child_order,
+            granule_urls,
+            run.store,
+            s3_creds,
+            config_dict=cell_config,
+            output_creds_event=output_creds_event,
+            handoff=run.handoff,
+            profile=run.profile,
+            aoi_payload=aoi_by_shard.get(key),
+            invoked_by=invoked_by,
+            run_id=run_id,
+        )
+        submap = {
+            "grid_signature": run.catalog_data["grid_signature"],
+            "metadata": run.catalog_data.get("metadata"),
+            "granules": records,
+        }
+        payload = runner._cell_payload(event, submap=submap, async_invoke=True, label=label)
+
+        def _fire(p=payload):
+            client.invoke(FunctionName=run.function_name, InvocationType="Event", Payload=p)
+
+        futures[key] = poller.register(key, label, dispatch=_fire, granule_count=len(granule_urls))
+    poller.start()
+    return futures, poller
+
+
+def attach_run(
+    run_cls,
+    store: str,
+    run_id: str,
+    *,
+    function_name=None,
+    region="us-west-2",
+    lambda_client=None,
+    output_credentials=None,
+    output_endpoint_url=None,
+):
+    """The rebuild behind :meth:`zagg.client.Run.attach` (issue #327 phase 5).
+
+    Split out of ``client.py`` for the §4 module ceiling; the public contract
+    (and its full docstring) lives on ``Run.attach``. Reads the dispatch
+    manifest, rebuilds a Run from its embedded config, registers every listed
+    shard observe-only with a :class:`StatusPoller` (drop deadline anchored at
+    the manifest's ``dispatched_at``), and starts the finisher with the
+    read-only ``tail_recorded`` check so an already-recorded tail never
+    re-runs.
+    """
+    import threading
+    from dataclasses import asdict
+
+    from zagg import runner
+    from zagg.client import RunHandle, _fail_with_shard_error
+    from zagg.config import (
+        get_driver,
+        get_handoff,
+        get_output_endpoint_url,
+        get_windowing,
+        load_config_from_dict,
+        validate_config,
+    )
+    from zagg.grids import from_config as grid_from_config
+
+    output_creds_event = runner._build_output_creds_event(
+        output_credentials, output_endpoint_url, region
+    )
+    store_kwargs = runner._output_store_kwargs(output_creds_event, region)
+    prefix = run_status_prefix(store, run_id)
+    manifest = read_dispatch_manifest(prefix, store_kwargs)
+    if manifest is None:
+        raise ValueError(
+            f"no dispatch manifest at {prefix}/{MANIFEST_NAME} — wrong store/run_id, "
+            f"a dispatcher predating issue #327, or a hive setup Event that was "
+            f"dropped (its manifest write is best-effort)"
+        )
+    if not manifest.get("config"):
+        raise ValueError(f"dispatch manifest for run {run_id} carries no config")
+    config = load_config_from_dict(manifest["config"])
+    validate_config(config)
+    if get_windowing(config) is not None:
+        raise NotImplementedError(
+            "Run.attach covers unwindowed spatial runs; windowed units are "
+            "(shard, window) pairs the manifest does not enumerate"
+        )
+    shards = [int(s) for s in manifest.get("shards") or []]
+    if not shards:
+        raise ValueError(f"dispatch manifest for run {run_id} lists no shards")
+
+    grid = grid_from_config(config)
+    catalog_data = {
+        "shard_keys": shards,
+        "granules": [[] for _ in shards],
+        "grid_signature": grid.spatial_signature(),
+        "metadata": manifest.get("dataset"),
+    }
+    run = run_cls(
+        config,
+        catalog_data,
+        store=store,
+        function_name=runner._resolve_function_name(config, function_name),
+        region=region,
+        lambda_client=lambda_client,
+        driver=get_driver(config),
+        handoff=get_handoff(config),
+        output_credentials=output_credentials,
+        output_endpoint_url=output_endpoint_url or get_output_endpoint_url(config),
+    )
+    client = lambda_client
+    if client is None:
+        import boto3
+        from botocore.config import Config
+
+        client = boto3.Session().client(
+            "lambda",
+            region_name=region,
+            config=Config(read_timeout=960, connect_timeout=10, retries={"max_attempts": 0}),
+        )
+
+    # Drop deadline anchored at the manifest's dispatched_at: attaching long
+    # after the fleet finished classifies status-less shards immediately
+    # instead of waiting a fresh window.
+    dispatched_at = None
+    try:
+        from datetime import datetime
+
+        dispatched_at = datetime.fromisoformat(manifest["dispatched_at"]).timestamp()
+    except (KeyError, TypeError, ValueError):
+        pass
+    timeout_s = runner._get_function_timeout_s(client, run.function_name)
+    poller = StatusPoller(
+        lambda: open_status_store(prefix, store_kwargs),
+        drop_timeout_s=drop_timeout_s(timeout_s),
+        on_failed=_fail_with_shard_error,
+    )
+    futures: dict[int, Future] = {}
+    for key in shards:
+        label = runner._safe_label(run.grid, key)
+        futures[key] = poller.register(key, label, dispatch=None, dispatched_at=dispatched_at)
+    poller.start()
+
+    handle = RunHandle(futures, store_path=store)
+    finisher = threading.Thread(
+        target=run._post_run,
+        args=(
+            handle,
+            client,
+            poller,
+            asdict(config),
+            manifest.get("dataset"),
+            output_creds_event,
+            run_id,
+        ),
+        kwargs={"tail_done_check": lambda: tail_recorded(prefix, store_kwargs)},
+        name="zagg-client-finish",
+        daemon=True,
+    )
+    handle._finisher = finisher
+    finisher.start()
+    return handle
+
+
 def open_status_store(prefix: str, store_kwargs: dict[str, Any]):
     """obstore store rooted at a run's status prefix (the poller's seam).
 

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -1,0 +1,157 @@
+"""v2 Event-transport status channel (issue #327): per-shard status objects.
+
+The fleet-scale alternative to holding one synchronous connection per in-flight
+shard: workers record each shard's outcome as a tiny JSON object under a
+per-run prefix SIBLING to the output store::
+
+    <store>.status/run-<run_id>/shard-<decimal-key>.json
+
+and the client resolves futures by polling that prefix instead of reading an
+invoke response. Both halves of the channel live here so the schema has one
+home:
+
+- **Worker half** (:func:`write_shard_status`): called from the Lambda
+  handler's top-level seam on every per-unit response — every status branch,
+  including the caught-error 500 envelope. Always-on (espg ratification on
+  issue #327: every run, regardless of dispatcher) and emphatically
+  **fail-open**: a status PUT failure logs and never affects the shard result.
+  Written through the same ``open_object_store`` factory + output credentials
+  as every other worker write, so the dispatcher-never-writes rule (D8) is
+  preserved by construction.
+- **Client half** (later phases of issue #327): the polling resolver that
+  turns one LIST of the run prefix per tick into future resolutions.
+
+Naming: the shard component is the shard key's plain decimal rendering
+(``str(int(shard_key))``) — derivable on every handler branch including the
+caught-error path, where the grid (and so the issue #199 morton label) may not
+be constructible. Windowed units (issue #246) suffix the window label,
+mirroring the leaf naming, so two windows of one shard cannot clobber each
+other's object. The prefix is a sibling of the store (never inside it): the
+store stays vanilla zarr v3, the benchmark object model never sees telemetry,
+and an S3 lifecycle/delete rule on the store's key prefix string catches the
+status objects with it (espg ruling on issue #327 — accumulation hygiene is
+the existing prefix delete policy, no in-band pruning).
+
+Lambda Event-invoke semantics this channel is built for (issue #327
+amendments): the fleet's ``EventInvokeConfig`` pins ``MaximumRetryAttempts: 0``
+(no service retries — attempt-id dedupe is belt-and-braces, and it also
+dedupes the client's own re-dispatches) and ``MaximumEventAgeInSeconds: 60``
+(an invoke that cannot start within 60 s is silently dropped — the client
+resolves a status-less shard as ``failed-unknown`` after the drop deadline).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from zagg.dispatch import BENIGN_ERRORS
+
+logger = logging.getLogger(__name__)
+
+#: Version stamped into every status object; bump on any key change.
+STATUS_SCHEMA_VERSION = 1
+
+
+def run_status_prefix(store_path: str, run_id: str) -> str:
+    """The run's status prefix: ``<store>.status/run-<run_id>`` (a store SIBLING)."""
+    return f"{store_path.rstrip('/')}.status/run-{run_id}"
+
+
+def shard_status_key(shard_key, window: str | None = None) -> str:
+    """One shard's status object name under the run prefix.
+
+    ``shard-<decimal-key>.json``, with the window label suffixed for windowed
+    units (validated against the frozen window grammar — a label is a path
+    component here, exactly as in the leaf/sidecar names).
+    """
+    base = f"shard-{int(shard_key)}"
+    if window is None:
+        return f"{base}.json"
+    from zagg.windows import validate_label
+
+    validate_label(str(window))
+    return f"{base}_{window}.json"
+
+
+def build_shard_status(event: dict, response: dict) -> tuple[str, dict] | None:
+    """(object key, status object) for one per-unit response, or ``None``.
+
+    ``None`` when the event carries no run identity (``run_id`` /
+    ``store_path`` / ``shard_key``) — an old dispatcher, or a non-spatial
+    unit — so the write is skipped and behavior is byte-identical to
+    pre-#327 for those events.
+
+    Status classification mirrors the dispatch accumulators: a 200 envelope
+    with no error is ``ok``; a benign no-work error (:data:`BENIGN_ERRORS`)
+    is ``no_data``; everything else — including the handler's caught-error
+    500 — is ``failed``. ``timings`` is the same ``phase_timings`` dict the
+    response body carries; ``body`` is the full envelope body so the poller
+    can synthesize the exact per-shard result dict the sync transport returns
+    (stats record, counters, container telemetry). ``attempt_id`` is a fresh
+    uuid per EXECUTION: a duplicate execution (or a client re-dispatch)
+    overwrites the object with a new id, which is what keeps the client's
+    retry accounting straight.
+    """
+    run_id = event.get("run_id")
+    store_path = event.get("store_path")
+    shard_key = event.get("shard_key")
+    if not run_id or not store_path or shard_key is None:
+        return None
+    try:
+        body = json.loads(response.get("body") or "{}")
+    except (json.JSONDecodeError, TypeError):
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+    error = body.get("error")
+    code = response.get("statusCode")
+    if error in BENIGN_ERRORS:
+        status = "no_data"
+    elif code == 200 and not error:
+        status = "ok"
+    else:
+        status = "failed"
+    window = (event.get("window") or {}).get("label")
+    obj = {
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "status": status,
+        "attempt_id": uuid.uuid4().hex,
+        "run_id": run_id,
+        "shard": str(int(shard_key)),
+        "window": window,
+        "timings": body.get("phase_timings"),
+        "error": str(error) if error else None,
+        "status_code": code,
+        "body": body,
+    }
+    return shard_status_key(shard_key, window=window), obj
+
+
+def write_shard_status(event: dict, response: dict, store_kwargs: dict[str, Any]) -> None:
+    """PUT the per-shard status object for one response — fail-open, always.
+
+    The worker-half entry point, called from the Lambda handler's top-level
+    seam on every per-unit response. ANY exception — building the object,
+    opening the store, the PUT itself — is logged and swallowed (espg
+    ratification on issue #327: the status PUT must never fail a shard whose
+    result is otherwise in hand). ``store_kwargs`` is the handler's own
+    output-store resolution, so the write uses exactly the credentials the
+    shard's data writes used.
+    """
+    try:
+        built = build_shard_status(event, response)
+        if built is None:
+            return
+        key, obj = built
+        import obstore
+
+        from zagg.store import open_object_store
+
+        prefix = run_status_prefix(event["store_path"], event["run_id"])
+        obstore.put(open_object_store(prefix, **store_kwargs), key, json.dumps(obj).encode())
+        logger.info(f"Wrote shard status ({obj['status']}) to {prefix}/{key}")
+    except Exception as e:
+        logger.warning(f"shard status write failed (fail-open, issue #327): {e}")

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -44,12 +44,45 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
+import time
 import uuid
-from typing import Any
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from typing import Any, Callable
 
 from zagg.dispatch import BENIGN_ERRORS
 
 logger = logging.getLogger(__name__)
+
+#: Poll cadence (issue #327, ratified fixed — not knobs): the tick interval
+#: starts at the initial value, doubles on an idle tick up to the cap, and
+#: resets on progress (a consumed status), so retries are picked up fast while
+#: a long quiet fan-out costs ~4 LISTs a minute.
+_POLL_INITIAL_INTERVAL_S = 2.0
+_POLL_MAX_INTERVAL_S = 15.0
+
+#: The fleet's ``MaximumEventAgeInSeconds`` (template.yaml EventInvokeConfig,
+#: issue #151): an Event invoke that cannot start within this window is
+#: silently discarded — the backpressure drop the failed-unknown outcome
+#: exists to catch (issue #327 amendment (a')).
+MAX_EVENT_AGE_S = 60.0
+
+#: Margin on the drop deadline past function timeout + max event age: async
+#: queue latency + the worker's status PUT. Mirrors the #151 channel's
+#: ``_ASYNC_POLL_MARGIN_S``.
+_DROP_MARGIN_S = 90.0
+
+
+def drop_timeout_s(function_timeout_s: float) -> float:
+    """Seconds after dispatch with NO status object => ``failed-unknown``.
+
+    Function timeout (the worker may run to the ceiling and still write its
+    status) + the 60 s max event age (the invoke may sit queued that long
+    before starting — or be dropped) + margin for queue/PUT latency.
+    """
+    return float(function_timeout_s) + MAX_EVENT_AGE_S + _DROP_MARGIN_S
+
 
 #: Version stamped into every status object; bump on any key change.
 STATUS_SCHEMA_VERSION = 1
@@ -133,7 +166,9 @@ def build_shard_status(event: dict, response: dict) -> tuple[str, dict] | None:
     return shard_status_key(shard_key, window=window), obj
 
 
-def build_run_manifest_block(run_id: str, shard_keys, config, *, dataset: dict | None = None) -> dict:
+def build_run_manifest_block(
+    run_id: str, shard_keys, config, *, dataset: dict | None = None
+) -> dict:
     """The dispatcher-side ``run_manifest`` block for the worker setup invoke.
 
     Rides the EXISTING setup invoke (the hive fire-and-forget manifest write /
@@ -216,3 +251,327 @@ def write_shard_status(event: dict, response: dict, store_kwargs: dict[str, Any]
         logger.info(f"Wrote shard status ({obj['status']}) to {prefix}/{key}")
     except Exception as e:
         logger.warning(f"shard status write failed (fail-open, issue #327): {e}")
+
+
+# ---------------------------------------------------------------------------
+# Client half: the polling resolver (issue #327 phases 3-4).
+# ---------------------------------------------------------------------------
+
+
+def open_status_store(prefix: str, store_kwargs: dict[str, Any]):
+    """obstore store rooted at a run's status prefix (the poller's seam).
+
+    Module-level so tests can monkeypatch it with an in-memory store; the
+    production path is the same ``open_object_store`` factory the #151 result
+    poller uses, with the runner's short per-request retry policy riding in
+    ``store_kwargs``.
+    """
+    from zagg.store import open_object_store
+
+    return open_object_store(prefix, **store_kwargs)
+
+
+@dataclass
+class _ShardEntry:
+    """One shard's transport state, owned by the poller thread."""
+
+    shard_key: int
+    label: str
+    key: str  # status object name under the run prefix
+    future: Future
+    dispatch: Callable[[], None] | None  # fires one Event invoke; None = observe-only
+    granule_count: int = 0
+    attempts: int = 0  # dispatches so far (the v1 attempt counter)
+    queued: bool = True  # awaiting a dispatch slot
+    dispatched_at: float | None = None  # this attempt's dispatch clock
+    first_dispatched_at: float | None = None
+    consumed: set = field(default_factory=set)  # attempt_ids already acted on
+
+
+class StatusPoller:
+    """Single background thread resolving ALL shard futures from status objects.
+
+    One LIST of the run's status prefix per tick — O(1) requests per tick
+    regardless of shard count — then one GET per newly-landed (or
+    re-attempted) object. Never writes (D8: the LIST/GETs are reads; every
+    write stays worker-side).
+
+    The poller also owns Event dispatch and the migrated retry policy (issue
+    #327 amendment (b) — function errors never return to an Event caller, so
+    ``max_retries`` becomes status-driven): shards register with a zero-arg
+    ``dispatch`` closure, at most ``max_in_flight`` are dispatched-unresolved
+    at once (the concurrency preflight's clamp — load-bearing under the
+    fleet's 60 s ``MaximumEventAgeInSeconds``, which silently drops an Event
+    that cannot start in time), and a ``failed`` status re-dispatches until
+    the shard's total attempts reach ``max_retries``. ``attempt_id`` keeps the
+    accounting straight: each status object is acted on at most once, so a
+    duplicate execution's re-write (or a poll catching a stale pre-retry
+    object) never double-counts.
+
+    Resolution policy is the caller's: a terminal success/no-data sets the
+    result dict (the exact shape the sync transport returns); a terminal
+    failure goes through ``on_failed(entry, result)`` — the client raises
+    :class:`zagg.client.ShardError` there, ``agg`` records the result dict —
+    defaulting to ``set_result``.
+
+    Observe-only entries (``dispatch=None`` — :meth:`zagg.client.Run.attach`)
+    are never re-dispatched: a ``failed`` status resolves immediately and the
+    drop deadline is anchored at the manifest's ``dispatched_at``.
+    """
+
+    def __init__(
+        self,
+        store_factory: Callable[[], Any],
+        *,
+        drop_timeout_s: float,
+        max_retries: int = 3,
+        max_in_flight: int | None = None,
+        on_failed: Callable[[_ShardEntry, dict], None] | None = None,
+        initial_interval_s: float | None = None,
+        max_interval_s: float | None = None,
+        clock: Callable[[], float] = time.time,
+    ):
+        self._store_factory = store_factory
+        self._store = None
+        self._drop_timeout_s = drop_timeout_s
+        self._max_retries = max(1, int(max_retries))
+        self._max_in_flight = max_in_flight
+        self._on_failed = on_failed
+        # None -> the module constants, read at construction so tests can
+        # scale the cadence for every internally-built poller.
+        self._initial_interval_s = (
+            _POLL_INITIAL_INTERVAL_S if initial_interval_s is None else initial_interval_s
+        )
+        self._max_interval_s = _POLL_MAX_INTERVAL_S if max_interval_s is None else max_interval_s
+        self._clock = clock
+        self._entries: dict[str, _ShardEntry] = {}  # status key -> entry
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    # -- registration / lifecycle -------------------------------------------
+
+    def register(
+        self,
+        shard_key,
+        label: str,
+        *,
+        dispatch: Callable[[], None] | None = None,
+        window: str | None = None,
+        granule_count: int = 0,
+        dispatched_at: float | None = None,
+    ) -> Future:
+        """Track one shard; returns the Future the poller will resolve.
+
+        ``dispatched_at`` seeds the drop deadline for observe-only entries
+        (attach: the manifest's dispatch time); live entries get stamped at
+        their own Event invoke.
+        """
+        entry = _ShardEntry(
+            shard_key=int(shard_key),
+            label=label,
+            key=shard_status_key(shard_key, window=window),
+            future=Future(),
+            dispatch=dispatch,
+            granule_count=granule_count,
+        )
+        if dispatch is None:
+            entry.queued = False
+            entry.attempts = 1
+            entry.dispatched_at = dispatched_at if dispatched_at is not None else self._clock()
+            entry.first_dispatched_at = entry.dispatched_at
+        with self._lock:
+            self._entries[entry.key] = entry
+        return entry.future
+
+    def start(self) -> "StatusPoller":
+        self._thread = threading.Thread(target=self._run, name="zagg-status-poller", daemon=True)
+        self._thread.start()
+        return self
+
+    def shutdown(self, wait: bool = False) -> None:
+        """Stop the poller thread (pool-shaped so the finisher can close it)."""
+        self._stop.set()
+        if wait and self._thread is not None:
+            self._thread.join()
+
+    # -- the loop -------------------------------------------------------------
+
+    def _run(self) -> None:
+        interval = self._initial_interval_s
+        while not self._stop.is_set():
+            try:
+                progressed = self._tick()
+            except Exception as e:
+                # A transient LIST/GET fault must not kill the resolver; a
+                # persistent one surfaces through the drop deadline instead.
+                logger.warning(f"status poll tick failed (retrying): {e}")
+                progressed = False
+            if self._all_done():
+                return
+            interval = (
+                self._initial_interval_s if progressed else min(interval * 2, self._max_interval_s)
+            )
+            self._stop.wait(interval)
+
+    def _all_done(self) -> bool:
+        with self._lock:
+            return all(e.future.done() for e in self._entries.values())
+
+    def _pending(self) -> list[_ShardEntry]:
+        with self._lock:
+            return [e for e in self._entries.values() if not e.future.done()]
+
+    def _tick(self) -> bool:
+        progressed = self._dispatch_up_to_window()
+        pending = [e for e in self._pending() if not e.queued]
+        if not pending:
+            return progressed
+        listed = self._list_keys()
+        now = self._clock()
+        for entry in pending:
+            if entry.future.done():
+                continue
+            if entry.key in listed and self._consume(entry):
+                progressed = True
+            elif (
+                entry.dispatched_at is not None
+                and now >= entry.dispatched_at + self._drop_timeout_s
+            ):
+                self._dropped(entry)
+                progressed = True
+        return progressed
+
+    def _dispatch_up_to_window(self) -> bool:
+        """Fire queued shards while the in-flight window has room (pacing)."""
+        dispatched = False
+        while True:
+            with self._lock:
+                queued = [e for e in self._entries.values() if e.queued and not e.future.done()]
+                in_flight = sum(
+                    1 for e in self._entries.values() if not e.queued and not e.future.done()
+                )
+                room = (
+                    len(queued) if self._max_in_flight is None else self._max_in_flight - in_flight
+                )
+                batch = queued[: max(room, 0)]
+                for entry in batch:
+                    entry.queued = False
+            if not batch:
+                return dispatched
+            for entry in batch:
+                self._fire(entry)
+                dispatched = True
+
+    def _fire(self, entry: _ShardEntry) -> None:
+        entry.attempts += 1
+        entry.dispatched_at = self._clock()
+        if entry.first_dispatched_at is None:
+            entry.first_dispatched_at = entry.dispatched_at
+        try:
+            entry.dispatch()
+        except Exception as e:
+            # An invoke fault burns this attempt (throttles included): the
+            # retry budget re-fires it on a later tick, mirroring the sync
+            # transport's bounded transient retry.
+            logger.warning(f"shard {entry.label}: Event invoke failed ({e})")
+            self._attempt_failed(
+                entry,
+                self._result(entry, status_code=None, body={}, error=f"Event invoke failed: {e}"),
+            )
+
+    # -- resolution -----------------------------------------------------------
+
+    def _list_keys(self) -> set:
+        import obstore
+
+        if self._store is None:
+            self._store = self._store_factory()
+        keys: set = set()
+        for batch in obstore.list(self._store):
+            for meta in batch:
+                keys.add(str(meta["path"]))
+        return keys
+
+    def _consume(self, entry: _ShardEntry) -> bool:
+        """GET one listed status object; act on it once per attempt_id."""
+        import obstore
+
+        try:
+            obj = json.loads(bytes(obstore.get(self._store, entry.key).bytes()))
+        except Exception as e:
+            logger.warning(f"shard {entry.label}: status GET failed (retrying): {e}")
+            return False
+        attempt_id = obj.get("attempt_id")
+        if attempt_id in entry.consumed:
+            return False  # already acted on (a not-yet-overwritten prior attempt)
+        entry.consumed.add(attempt_id)
+        result = self._result(
+            entry,
+            status_code=obj.get("status_code"),
+            body=obj.get("body") or {},
+            error=obj.get("error"),
+        )
+        if obj.get("status") in ("ok", "no_data"):
+            entry.future.set_result(result)
+        else:
+            self._attempt_failed(entry, result)
+        return True
+
+    def _result(self, entry: _ShardEntry, *, status_code, body, error, outcome=None) -> dict:
+        """The v1-shaped per-shard result dict (see ``_poll_lambda_result``)."""
+        start = entry.first_dispatched_at or self._clock()
+        result = {
+            "shard_key": entry.shard_key,
+            "status_code": status_code,
+            "body": body,
+            "wall_time": self._clock() - start,
+            "lambda_duration": (body or {}).get("duration_s", 0),
+            "error": error,
+            "retries": entry.attempts - 1,
+            "timeout": False,
+            "granule_count": entry.granule_count,
+        }
+        if outcome is not None:
+            result["outcome"] = outcome
+        return result
+
+    def _attempt_failed(self, entry: _ShardEntry, result: dict) -> None:
+        """Status-driven retry (issue #327 amendment (b)): re-dispatch or resolve."""
+        if entry.dispatch is not None and entry.attempts < self._max_retries:
+            logger.warning(
+                f"shard {entry.label}: attempt {entry.attempts} failed "
+                f"({result.get('error')}); re-dispatching "
+                f"({self._max_retries - entry.attempts} left)"
+            )
+            with self._lock:
+                entry.queued = True
+            return
+        if self._on_failed is not None:
+            self._on_failed(entry, result)
+        else:
+            entry.future.set_result(result)
+
+    def _dropped(self, entry: _ShardEntry) -> None:
+        """No status object by the drop deadline: the distinct failed-unknown outcome.
+
+        The deadline is function timeout + the fleet's 60 s max event age +
+        margin, so a shard reaching it either had its Event invoke silently
+        dropped under backpressure (issue #327 amendment (a')) or died before
+        its always-on status write — indistinguishable from here, hence the
+        dedicated outcome. Participates in the same re-dispatch budget as a
+        ``failed`` status.
+        """
+        result = self._result(
+            entry,
+            status_code=None,
+            body={},
+            error=(
+                f"failed-unknown: no status object within {self._drop_timeout_s:.0f}s "
+                f"(function timeout + 60s max event age + margin) — the Event invoke "
+                f"was dropped under backpressure, or the worker died before its "
+                f"status write (check CloudWatch)"
+            ),
+            outcome="failed-unknown",
+        )
+        self._attempt_failed(entry, result)

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -544,7 +544,12 @@ def attach_run(
             output_creds_event,
             run_id,
         ),
-        kwargs={"tail_done_check": lambda: tail_recorded(prefix, store_kwargs)},
+        kwargs={
+            "tail_done_check": lambda: tail_recorded(prefix, store_kwargs),
+            # An attached run's rows are the same status objects, so an
+            # oversized row set has the same pointer to fall back to.
+            "result_prefix": prefix,
+        },
         name="zagg-client-finish",
         daemon=True,
     )

--- a/src/zagg/client_transport.py
+++ b/src/zagg/client_transport.py
@@ -19,7 +19,9 @@ home:
   as every other worker write, so the dispatcher-never-writes rule (D8) is
   preserved by construction.
 - **Client half** (later phases of issue #327): the polling resolver that
-  turns one LIST of the run prefix per tick into future resolutions.
+  turns one LIST of the run prefix per tick into future resolutions (one LIST
+  *call*, which is O(N/1000) requests — see :class:`StatusPoller` for the real
+  per-tick cost).
 
 Naming: the shard component is the shard key's plain decimal rendering
 (``str(int(shard_key))``) — derivable on every handler branch including the
@@ -610,10 +612,28 @@ class _ShardEntry:
 class StatusPoller:
     """Single background thread resolving ALL shard futures from status objects.
 
-    One LIST of the run's status prefix per tick — O(1) requests per tick
-    regardless of shard count — then one GET per newly-landed (or
-    re-attempted) object. Never writes (D8: the LIST/GETs are reads; every
+    One LIST of the run's status prefix per tick, then one GET per newly-landed
+    (or re-attempted) object. Never writes (D8: the LIST/GETs are reads; every
     write stays worker-side).
+
+    **What "one LIST per tick" actually costs** (review finding, PR #343 —
+    issue #327's acceptance criterion says *O(1) LIST per tick regardless of
+    shard count*, and that is not literally true): :meth:`_list_keys` re-lists
+    the WHOLE run prefix and materializes every key, so a tick is O(N/1000)
+    requests (``obstore.list``'s internal pagination) and O(N) key parsing —
+    ~5 pages and 5k parsed paths per tick at 5k shards, in perpetuity. It is
+    one *call site*, not one request. Trimming it would mean a lexicographic
+    offset past the highest consumed key (``list_with_offset``); at the orders
+    zagg dispatches today the LIST is not the cost that matters, but nobody
+    should size a 50k-shard run off an O(1) claim. Two smaller notes on the
+    same seam: a shard awaiting a re-fire keeps its stale object listed, so it
+    is re-GET and re-parsed every tick until the new attempt lands (bounded by
+    the failed-shard count); and :meth:`_dispatch_up_to_window` fires its whole
+    batch SERIALLY on this thread, where v1 invoked from ``workers`` threads —
+    so a ``max_in_flight``-wide opening burst is one thread's sequential invoke
+    round-trips (order 10 ms each, i.e. tens of seconds at a 1000-wide window)
+    during which no LIST runs. Fine for 900 s shards; it is a real ramp, not a
+    mystery.
 
     The poller also owns Event dispatch: shards register with a zero-arg
     ``dispatch`` closure and at most ``max_in_flight`` are
@@ -822,10 +842,20 @@ class StatusPoller:
             return [e for e in self._entries.values() if not e.future.done()]
 
     def _tick(self) -> bool:
-        progressed = self._dispatch_up_to_window()
+        # Resolve BEFORE dispatching so a slot freed by a resolution refills in
+        # the SAME tick (review finding, PR #343: dispatching first left the
+        # slot idle until the next tick — up to _POLL_MAX_INTERVAL_S of dead
+        # window). Harmless on the opening tick: every entry is still queued, so
+        # _resolve_landed finds no pending entry and skips the LIST entirely.
+        progressed = self._resolve_landed()
+        return self._dispatch_up_to_window() or progressed
+
+    def _resolve_landed(self) -> bool:
+        """Consume newly-landed status objects; classify past-deadline shards."""
         pending = [e for e in self._pending() if not e.queued]
         if not pending:
-            return progressed
+            return False
+        progressed = False
         listed = self._list_keys()
         now = self._clock()
         for entry in pending:

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -260,8 +260,18 @@ def agg(
         caller to have read access to the output bucket for the poll. Note the
         async request payload cap is 256 KB (vs 6 MB synchronous); pass
         ``"sync"`` for older deployed workers or extreme per-cell payloads
-        (granule-dense shards with large AOI masks). Ignored by the
-        ``"local"`` backend.
+        (granule-dense shards with large AOI masks). ``"event"`` (issue #327,
+        spatial point path only) keeps the same blocking call-shape, return
+        value, and exceptions, with the v2 status-object transport
+        underneath: fire-and-forget Event invokes (no ``result_url``),
+        futures resolved from the workers' always-on per-shard status
+        objects by ONE shared poller (one LIST per tick instead of per-shard
+        GETs), status-driven re-dispatch under the same ``max_retries``, a
+        distinct ``failed-unknown`` outcome for silently-dropped invokes,
+        and the run reattachable by run id (``zagg.client.Run.attach``).
+        Requires a worker deployed with the #327 status writes. The
+        benchmark harness and CI stay on ``"sync"`` — their metrics come
+        from invoke responses. Ignored by the ``"local"`` backend.
     force_cold : bool
         Lambda-only (issue #171), default ``False``. The explicit big-hammer
         for certification runs -- benchmark baselines, memory forensics, or
@@ -445,8 +455,10 @@ class SpatialStrategy:
             max_workers = min(max_workers, n_cells)
             if not store_path.startswith("s3://"):
                 raise ValueError(f"Lambda backend requires s3:// store path, got: {store_path}")
-            if invocation not in ("async", "sync"):
-                raise ValueError(f"Unknown invocation: {invocation!r} (expected 'async' or 'sync')")
+            if invocation not in ("async", "sync", "event"):
+                raise ValueError(
+                    f"Unknown invocation: {invocation!r} (expected 'async', 'sync', or 'event')"
+                )
             function_name = _resolve_function_name(config, function_name)
             return _run_lambda(
                 config,
@@ -1195,6 +1207,8 @@ class RasterStrategy:
         from botocore.config import Config
 
         if invocation not in ("async", "sync"):
+            # invocation="event" (issue #327) covers the spatial point path;
+            # the raster fan-out keeps the #286 async envelope channel.
             raise ValueError(f"Unknown invocation: {invocation!r} (expected 'async' or 'sync')")
         function_name = _resolve_function_name(config, function_name)
         max_workers = min(max_workers or 64, len(cells)) or 1
@@ -1681,6 +1695,8 @@ def _run_lambda_events(
             "the config so the collected rows are written"
         )
     if invocation not in ("async", "sync"):
+        # invocation="event" (issue #327) covers the spatial point path; the
+        # temporal fan-out keeps the #151 async envelope channel.
         raise ValueError(f"Unknown invocation: {invocation!r} (expected 'async' or 'sync')")
     function_name = _resolve_function_name(config, function_name)
 
@@ -3129,9 +3145,18 @@ def _run_lambda(
     run_id = uuid.uuid4().hex
     result_prefix = None
     result_box: dict = {}
+    status_prefix = None
     if invocation == "async":
         result_prefix = f"{store_path.rstrip('/')}.status/{run_id}"
         logger.info(f"Async worker results at {result_prefix}")
+    elif invocation == "event":
+        # v2 Event transport (issue #327): no per-shard result_url — futures
+        # resolve from the ALWAYS-ON per-shard status objects, one LIST of
+        # this prefix per poll tick.
+        from zagg.client_transport import run_status_prefix
+
+        status_prefix = run_status_prefix(store_path, run_id)
+        logger.info(f"Event-transport statuses at {status_prefix}")
 
     # Dispatch manifest block (issue #327): rides the setup invoke so the
     # WORKER records the run's shard set + identity at the status prefix (D8)
@@ -3275,6 +3300,47 @@ def _run_lambda(
             "metadata": catalog_data.get("metadata"),
             "granules": records,
         }
+        # v2 Event transport (issue #327): the SAME event construction as the
+        # sync/async paths (no result_url) fired fire-and-forget; the shard's
+        # future resolves from its always-on status object via the run's
+        # shared poller. Blocking on it here keeps the dispatch loop's
+        # call-shape (accumulator, summary, tail all unchanged); the poller
+        # owns the status-driven re-dispatches, and the pool width bounds
+        # dispatched-unresolved shards — the pacing the fleet's 60 s max
+        # event age makes load-bearing.
+        if invocation == "event":
+            cell_event = _build_cell_event(
+                grid.block_index(int(shard_key)),
+                int(shard_key),
+                parent_order,
+                child_order,
+                granule_urls,
+                store_path,
+                s3_creds,
+                config_dict=cell_config_dict,
+                output_creds_event=output_creds_event,
+                handoff=handoff,
+                profile=profile,
+                aoi_payload=extra.get("aoi_payload"),
+                window=window,
+                invoked_by=invoked_by,
+                run_id=run_id,
+            )
+            cell_payload = _cell_payload(cell_event, submap=submap, async_invoke=True, label=label)
+
+            def _fire(p=cell_payload):
+                state["lambda_client"].invoke(
+                    FunctionName=function_name, InvocationType="Event", Payload=p
+                )
+
+            fut = state["event_poller"].register(
+                int(shard_key),
+                label,
+                dispatch=_fire,
+                window=window["label"] if window is not None else None,
+                granule_count=len(granule_urls),
+            )
+            return fut.result()
         return _invoke_lambda_cell(
             state["lambda_client"],
             grid.block_index(int(shard_key)),
@@ -3368,6 +3434,21 @@ def _run_lambda(
     # preflight() runs the probe, builds the sized client, and sizes the pool.
     executor.preflight(len(cells))
     max_workers = state["workers"]
+
+    # v2 status poller (issue #327): one background thread resolving every
+    # in-flight shard from one LIST of the run's status prefix per tick.
+    # Default failure resolution (result dicts, never exceptions) keeps the
+    # accumulator's error counting identical to the sync/async paths; the
+    # drop deadline is function timeout + 60 s max event age + margin.
+    if invocation == "event":
+        from zagg.client_transport import StatusPoller, drop_timeout_s, open_status_store
+
+        _status_kwargs = _output_store_kwargs(output_creds_event, region)
+        state["event_poller"] = StatusPoller(
+            lambda: open_status_store(status_prefix, _status_kwargs),
+            drop_timeout_s=drop_timeout_s(state["function_timeout_s"]),
+            max_retries=max_retries,
+        ).start()
 
     # Create template via Lambda (flat only). The template write happens
     # inside the function so the orchestrator only needs
@@ -3473,6 +3554,8 @@ def _run_lambda(
         )
     finally:
         executor.shutdown()
+        if state.get("event_poller") is not None:
+            state["event_poller"].shutdown()
         # Stop the overlapped manifest checker and read its verdict (#274 Fix 2).
         # It ran the whole fan-out; stopping now wakes it from its interval wait
         # and joins cleanly (a final check already ran), leaving manifest_found
@@ -3664,7 +3747,10 @@ def _run_lambda(
         store_path,
         stats_rows,
         run_id=run_id,
-        result_prefix=result_prefix,
+        # The oversized-rows pointer: the #151 envelope prefix on async runs,
+        # the v2 status prefix on event runs (rows_from_status reads the
+        # ``stats`` record out of either object shape — issue #327).
+        result_prefix=result_prefix if result_prefix is not None else status_prefix,
         output_creds_event=output_creds_event,
         store_kwargs=_output_store_kwargs(output_creds_event, region),
         summary=summary,

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -4842,6 +4842,116 @@ def _invoke_lambda_sweep(lambda_client, function_name, store_path, leaves, outpu
     )
 
 
+def _build_cell_event(
+    chunk_idx,
+    shard_key,
+    parent_order,
+    child_order,
+    granule_urls,
+    store_path,
+    s3_credentials,
+    *,
+    config_dict,
+    output_creds_event=None,
+    handoff="arrow",
+    profile=False,
+    aoi_payload=None,
+    window=None,
+    invoked_by=None,
+    run_id=None,
+    result_url=None,
+) -> dict:
+    """One shard's worker event dict — the single construction site.
+
+    Extracted from :func:`_invoke_lambda_cell` (issue #327) so the v2 Event
+    transport builds byte-identical payloads to the sync/async paths (modulo
+    ``result_url``, which only the issue #151 channel sets). Key-presence
+    rules are load-bearing: optional keys are added only when set, so default
+    runs' events stay byte-identical to their pre-feature shapes (see the
+    per-key notes in ``_invoke_lambda_cell``'s docstring).
+    """
+    event = {
+        "chunk_idx": chunk_idx,
+        "shard_key": shard_key,
+        "parent_order": parent_order,
+        "granule_urls": granule_urls,
+        "store_path": store_path,
+        "s3_credentials": {
+            "accessKeyId": s3_credentials["accessKeyId"],
+            "secretAccessKey": s3_credentials["secretAccessKey"],
+            "sessionToken": s3_credentials["sessionToken"],
+        },
+    }
+    # child_order is HEALPix-specific; only forward it when set (non-HEALPix
+    # grids leave it None and the handler doesn't require it).
+    if child_order is not None:
+        event["child_order"] = child_order
+    if config_dict is not None:
+        event["config"] = config_dict
+    if output_creds_event is not None:
+        event["output_credentials"] = output_creds_event
+    # Only add the key when profiling, so default runs stay byte-identical (#100).
+    if profile:
+        event["profile"] = True
+    # Only add the AOI key when the flag is on; flag-off runs stay byte-identical
+    # to the pre-feature event (issue #101).
+    if aoi_payload is not None:
+        event["aoi_payload"] = aoi_payload
+    # Temporal window unit (issue #246): {"label", "start", "end"} with the
+    # half-open bounds in dataset units, converted once at dispatch. Absent
+    # (schedule none) keeps the event byte-identical to pre-windowing runs.
+    if window is not None:
+        event["window"] = window
+    # Add the key for the arrow carrier (the default); an explicit pandas run omits
+    # it, staying byte-identical to the pre-handoff path (#130).
+    if handoff and handoff != "pandas":
+        event["handoff"] = handoff
+    # Caller identity for the stats record (issue #297); absent when the STS
+    # resolve failed (fail-open), keeping the event key optional.
+    if invoked_by is not None:
+        event["invoked_by"] = invoked_by
+    # Run identity, threaded like invoked_by (issue #297): the worker copies
+    # it verbatim into the stats record so leaf sidecars join the run parquet.
+    if run_id is not None:
+        event["run_id"] = run_id
+    # Async dispatch (issue #151): tell the worker where to mirror its response
+    # envelope. Absent -> the legacy synchronous / v2 status-object invoke.
+    if result_url is not None:
+        event["result_url"] = result_url
+    return event
+
+
+def _cell_payload(event, *, submap=None, async_invoke, label=None) -> str:
+    """Serialize one cell event, size-gating for the 256 KB Event cap.
+
+    json.dumps is ASCII by default, so len() is the request byte size. The
+    leaf sub-map block (issue #300) is attached only when it FITS an async
+    payload — dropped (never fatal) otherwise, since the sub-map is a
+    regenerable D9 artifact; an event still over the cap without it raises
+    with a remedy up front rather than letting every attempt fail on Lambda's
+    raw RequestEntityTooLargeException (issue #151).
+    """
+    shard_key = event.get("shard_key")
+    payload = json.dumps(event)
+    if submap is not None:
+        with_submap = json.dumps({**event, "submap": submap})
+        if not async_invoke or len(with_submap) <= _ASYNC_PAYLOAD_CAP_BYTES:
+            payload = with_submap
+        else:
+            logger.debug(
+                f"cell {label or shard_key}: dropping submap block ({len(with_submap):,} "
+                f"bytes over the async budget); leaf sub-map deferred to the sweep CLI"
+            )
+    if async_invoke and len(payload) > _ASYNC_PAYLOAD_CAP_BYTES:
+        raise ValueError(
+            f"cell {label or shard_key} event payload is {len(payload):,} bytes, over the "
+            f"{_ASYNC_PAYLOAD_CAP_BYTES:,}-byte async dispatch budget (Lambda caps "
+            'Event invokes at 256 KB): pass invocation="sync" for this run, or '
+            "shrink the per-cell payload (e.g. the strict-AOI aoi_payload)"
+        )
+    return payload
+
+
 def _invoke_lambda_cell(
     lambda_client,
     chunk_idx,
@@ -4902,83 +5012,30 @@ def _invoke_lambda_cell(
     """
     wall_start = time.time()
 
-    event = {
-        "chunk_idx": chunk_idx,
-        "shard_key": shard_key,
-        "parent_order": parent_order,
-        "granule_urls": granule_urls,
-        "store_path": store_path,
-        "s3_credentials": {
-            "accessKeyId": s3_credentials["accessKeyId"],
-            "secretAccessKey": s3_credentials["secretAccessKey"],
-            "sessionToken": s3_credentials["sessionToken"],
-        },
-    }
-    # child_order is HEALPix-specific; only forward it when set (non-HEALPix
-    # grids leave it None and the handler doesn't require it).
-    if child_order is not None:
-        event["child_order"] = child_order
-    if config_dict is not None:
-        event["config"] = config_dict
-    if output_creds_event is not None:
-        event["output_credentials"] = output_creds_event
-    # Only add the key when profiling, so default runs stay byte-identical (#100).
-    if profile:
-        event["profile"] = True
-    # Only add the AOI key when the flag is on; flag-off runs stay byte-identical
-    # to the pre-feature event (issue #101).
-    if aoi_payload is not None:
-        event["aoi_payload"] = aoi_payload
-    # Temporal window unit (issue #246): {"label", "start", "end"} with the
-    # half-open bounds in dataset units, converted once at dispatch. Absent
-    # (schedule none) keeps the event byte-identical to pre-windowing runs.
-    if window is not None:
-        event["window"] = window
-    # Add the key for the arrow carrier (the default); an explicit pandas run omits
-    # it, staying byte-identical to the pre-handoff path (#130).
-    if handoff and handoff != "pandas":
-        event["handoff"] = handoff
-    # Caller identity for the stats record (issue #297); absent when the STS
-    # resolve failed (fail-open), keeping the event key optional.
-    if invoked_by is not None:
-        event["invoked_by"] = invoked_by
-    # Run identity, threaded like invoked_by (issue #297): the worker copies
-    # it verbatim into the stats record so leaf sidecars join the run parquet.
-    if run_id is not None:
-        event["run_id"] = run_id
-    # Async dispatch (issue #151): tell the worker where to mirror its response
-    # envelope and fire-and-forget. Absent -> the legacy synchronous invoke.
-    invocation_type = "RequestResponse"
-    if result_url is not None:
-        event["result_url"] = result_url
-        invocation_type = "Event"
-
-    # json.dumps is ASCII by default, so len() is the request byte size. Gate
-    # async payloads against the 256 KB Event cap with a remedy, up front,
-    # rather than letting every attempt fail on Lambda's raw
-    # RequestEntityTooLargeException (issue #151).
-    payload = json.dumps(event)
-    # Leaf sub-map block (issue #300): attached only when it FITS — a unit
-    # whose granule entries would push an async event over the cap keeps its
-    # pre-#300 payload (the sub-map is a regenerable D9 artifact; the manual
-    # sweep CLI is the backstop), so the cap gate below can never start
-    # rejecting a run that dispatched fine before.
-    if submap is not None:
-        with_submap = json.dumps({**event, "submap": submap})
-        if invocation_type != "Event" or len(with_submap) <= _ASYNC_PAYLOAD_CAP_BYTES:
-            payload = with_submap
-        else:
-            logger.debug(
-                f"cell {label or shard_key}: dropping submap block ({len(with_submap):,} "
-                f"bytes over the async budget); leaf sub-map deferred to the sweep CLI"
-            )
-    if invocation_type == "Event" and len(payload) > _ASYNC_PAYLOAD_CAP_BYTES:
-        raise ValueError(
-            f"cell {label or shard_key} event payload is {len(payload):,} bytes, over the "
-            f"{_ASYNC_PAYLOAD_CAP_BYTES:,}-byte async dispatch budget (Lambda caps "
-            'Event invokes at 256 KB): pass invocation="sync" for this run, or '
-            "shrink the per-cell payload (e.g. the strict-AOI aoi_payload)"
-        )
+    event = _build_cell_event(
+        chunk_idx,
+        shard_key,
+        parent_order,
+        child_order,
+        granule_urls,
+        store_path,
+        s3_credentials,
+        config_dict=config_dict,
+        output_creds_event=output_creds_event,
+        handoff=handoff,
+        profile=profile,
+        aoi_payload=aoi_payload,
+        window=window,
+        invoked_by=invoked_by,
+        run_id=run_id,
+        result_url=result_url,
+    )
+    # Async dispatch (issue #151): result_url flips the invoke to
+    # fire-and-forget. Absent -> the legacy synchronous invoke.
+    invocation_type = "RequestResponse" if result_url is None else "Event"
+    payload = _cell_payload(
+        event, submap=submap, async_invoke=invocation_type == "Event", label=label
+    )
 
     last_error = None
     for attempt in range(max_retries):

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2314,6 +2314,7 @@ def _dispatch_run_stats(
     store_kwargs=None,
     summary=None,
     inline_rows=None,
+    tail_status_url=None,
 ) -> str | None:
     """Fire-and-forget worker-invoke run-record write (issue #313, D8).
 
@@ -2333,6 +2334,10 @@ def _dispatch_run_stats(
     ``run_stats_path`` names the real object — best-effort: the invoke is
     fire-and-forget, mirroring the root MOC's semantics. Fail-open
     everywhere: telemetry must never fail a run whose data landed.
+    ``tail_status_url`` (issue #327) has the worker additionally PUT the
+    run's tail-completion marker at that url when the write completes, so a
+    reattached handle knows the tail was recorded; ``None`` keeps the event
+    byte-identical.
     """
     from datetime import datetime, timezone
 
@@ -2350,6 +2355,8 @@ def _dispatch_run_stats(
             "run_id": run_id,
             "timestamp": timestamp,
         }
+        if tail_status_url is not None:
+            event["tail_status_url"] = tail_status_url
         if output_creds_event is not None:
             event["output_credentials"] = output_creds_event
         if len(json.dumps(rows)) <= _RUN_STATS_INLINE_CAP_BYTES:
@@ -3649,6 +3656,8 @@ def _run_lambda(
     # PUT itself rides a fire-and-forget worker invoke — the dispatcher may
     # hold an invoke-only role with no S3 write access.
     stats_rows, stats_inline_rows = _lambda_result_rows(report.results, run_id=run_id)
+    from zagg.client_transport import TAIL_NAME, run_status_prefix
+
     _dispatch_run_stats(
         state["lambda_client"],
         function_name,
@@ -3660,6 +3669,9 @@ def _run_lambda(
         store_kwargs=_output_store_kwargs(output_creds_event, region),
         summary=summary,
         inline_rows=stats_inline_rows,
+        # Tail-completion marker (issue #327): worker-written at the v2 status
+        # prefix so Run.attach knows this run's tail was recorded.
+        tail_status_url=f"{run_status_prefix(store_path, run_id)}/{TAIL_NAME}",
     )
     # End-of-run rollup sweep (issue #300): the Lambda dispatcher never PUTs
     # (D8 standing rule), so the sweep rides ONE fire-and-forget mode="sweep"

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -3126,6 +3126,19 @@ def _run_lambda(
         result_prefix = f"{store_path.rstrip('/')}.status/{run_id}"
         logger.info(f"Async worker results at {result_prefix}")
 
+    # Dispatch manifest block (issue #327): rides the setup invoke so the
+    # WORKER records the run's shard set + identity at the status prefix (D8)
+    # — every lambda run becomes reattachable/observable by run id.
+    from zagg.client_transport import build_run_manifest_block
+
+    _md = catalog_data.get("metadata") or {}
+    run_manifest = build_run_manifest_block(
+        run_id,
+        [c[0] for c in cells],
+        config,
+        dataset={"short_name": _md.get("short_name"), "version": _md.get("version")},
+    )
+
     # The dispatch lambda_client is built inside preflight() (once the probe
     # has clamped the worker count, which sizes its connection pool), so the
     # per-cell / finalize closures read it from this holder rather than closing
@@ -3390,6 +3403,7 @@ def _run_lambda(
             parent_order=parent_order,
             overwrite=overwrite,
             output_creds_event=output_creds_event,
+            run_manifest=run_manifest,
         )
         # Overlap the fan-out with the client-side morton_hive.json check
         # (issue #274 Fix 2): the async setup write above typically lands
@@ -3411,6 +3425,7 @@ def _run_lambda(
             overwrite=overwrite,
             config_dict=config_dict,
             output_creds_event=output_creds_event,
+            run_manifest=run_manifest,
         )
     setup_s = time.time() - setup_start
 
@@ -4442,15 +4457,18 @@ def _invoke_lambda_setup(
     overwrite,
     config_dict,
     output_creds_event=None,
+    run_manifest=None,
 ):
     """Invoke Lambda in setup mode to create the zarr template (flat only).
 
     Hive runs no longer dispatch setup SYNCHRONOUSLY (issue #252 hybrid):
     the morton_hive.json write fires as a fire-and-forget Event invoke of
     the same setup mode instead (``_invoke_lambda_setup_async``), so nothing
-    but the ping runs ahead of the fan-out. The flat setup event is
-    byte-identical to the pre-#199-phase-3 event, so a new dispatcher keeps
-    working against old deployed functions for flat runs.
+    but the ping runs ahead of the fan-out. ``run_manifest`` (issue #327)
+    rides the event so the worker records the run's dispatch manifest at the
+    status prefix (D8); ``None`` keeps the event byte-identical to the
+    pre-#199-phase-3 one, so a new dispatcher keeps working against old
+    deployed functions for flat runs.
     """
     event = {
         "mode": "setup",
@@ -4464,6 +4482,8 @@ def _invoke_lambda_setup(
         "overwrite": overwrite,
         "config": config_dict,
     }
+    if run_manifest is not None:
+        event["run_manifest"] = run_manifest
     if output_creds_event is not None:
         event["output_credentials"] = output_creds_event
     response = lambda_client.invoke(
@@ -4489,6 +4509,7 @@ def _invoke_lambda_setup_async(
     parent_order=None,
     overwrite=False,
     output_creds_event=None,
+    run_manifest=None,
 ):
     """Fire-and-forget hive manifest write at init (issue #252 hybrid).
 
@@ -4506,6 +4527,8 @@ def _invoke_lambda_setup_async(
     synchronous hive setup event's shape). No response is read; a lost Event
     invoke (retries 0, issue #151 hygiene) is self-healed by finalize's
     idempotent ensure_manifest backstop — see ``_invoke_lambda_finalize``.
+    ``run_manifest`` (issue #327) additionally has the worker record the
+    run's dispatch manifest at the status prefix, size-gated below.
     """
     event = {
         "mode": "setup",
@@ -4516,6 +4539,21 @@ def _invoke_lambda_setup_async(
     }
     if dataset is not None:
         event["dataset"] = dataset
+    # Dispatch manifest (issue #327): attached only when it FITS the 256 KB
+    # Event cap — the shard list scales with the run, and this invoke
+    # dispatched fine before the block existed, so the block is dropped (never
+    # fatal) rather than failing the run; Run.attach then degrades to the
+    # status objects alone.
+    if run_manifest is not None:
+        with_block = {**event, "run_manifest": run_manifest}
+        if len(json.dumps(with_block)) <= _ASYNC_PAYLOAD_CAP_BYTES:
+            event = with_block
+        else:
+            logger.warning(
+                f"run_manifest block over the async setup budget "
+                f"({len(run_manifest.get('shards') or [])} shards); dropped — "
+                f"Run.attach for this run degrades to status objects only (issue #327)"
+            )
     if output_creds_event is not None:
         event["output_credentials"] = output_creds_event
     lambda_client.invoke(

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -267,8 +267,11 @@ def agg(
         underneath: fire-and-forget Event invokes (no ``result_url``),
         futures resolved from the workers' always-on per-shard status
         objects by ONE shared poller (one LIST per tick instead of per-shard
-        GETs), status-driven re-dispatch under the same ``max_retries``, a
-        distinct ``failed-unknown`` outcome for silently-dropped invokes,
+        GETs), the three-class retry policy on
+        :class:`~zagg.client_transport.StatusPoller` (a worker-reported
+        failure never re-fires; a drop re-fires once; an invoke fault retries
+        to ``max_retries`` with backoff), a distinct ``failed-unknown``
+        outcome for silently-dropped invokes,
         and the run reattachable by run id (``zagg.client.Run.attach``).
         Requires a worker deployed with the #327 status writes. The
         benchmark harness and CI stay on ``"sync"`` — their metrics come
@@ -3421,7 +3424,7 @@ def _run_lambda(
         # future resolves from its always-on status object via the run's
         # shared poller. Blocking on it here keeps the dispatch loop's
         # call-shape (accumulator, summary, tail all unchanged); the poller
-        # owns the status-driven re-dispatches, and the pool width bounds
+        # owns the fault-class-driven re-dispatches, and the pool width bounds
         # dispatched-unresolved shards — the pacing the fleet's 60 s max
         # event age makes load-bearing.
         if invocation == "event":

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -473,8 +473,15 @@ def rows_from_status(status_prefix: str, *, store_kwargs: dict | None = None) ->
     def _record(key: str) -> dict | None:
         try:
             envelope = _json.loads(bytes(obstore.get(store, key).bytes()))
-            body = _json.loads(envelope.get("body", "{}"))
-            record = body.get("stats")
+            # Two object shapes share the prefix layout: the #151 result
+            # envelope carries the response body as a JSON STRING; the v2
+            # per-shard status object (issue #327) embeds it as a dict. The
+            # run prefix's non-shard objects (dispatch manifest, tail marker)
+            # parse fine and simply carry no ``stats`` record.
+            body = envelope.get("body", "{}")
+            if isinstance(body, str):
+                body = _json.loads(body or "{}")
+            record = (body or {}).get("stats") if isinstance(body, dict) else None
         except Exception as e:
             logger.warning(f"skipping unparsable status envelope {key}: {e}")
             return None

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -349,6 +349,45 @@ def test_hive_misplaced_rollup_counts_into_shard(monkeypatch):
     assert not any(k.endswith("stats.rollup.json") for k in measured["other_keys"])
 
 
+def test_status_prefix_objects_excluded_everywhere(monkeypatch):
+    # Issue #327 (ratified amendment): the per-run status channel — per-shard
+    # status objects, the dispatch manifest, the issue #151 result envelopes —
+    # is run telemetry, never write-path store objects. It must not land in
+    # ANY bucket (total, metadata, per-shard, other), so the #215/#240
+    # tripwire keeps its exact assertions with the channel active.
+    from zagg import hive
+
+    grid = from_config(_cfg())
+    word = int(morton_word(_KEY_A))
+    label = grid.shard_label(word)
+    leaf = hive.shard_leaf_path("", word).lstrip("/")
+    data = [hive.MANIFEST_NAME, f"{leaf}/count/c/0"]
+    telemetry = [
+        "out.zarr.status/run-abc123/shard-42.json",
+        "out.zarr.status/run-abc123/manifest.json",
+        "out.zarr.status/deadbeef/-4211324.json",  # a #151 result envelope
+    ]
+    monkeypatch.setattr(bench_objects, "list_store_keys", lambda *a, **k: data + telemetry)
+    measured = bench_objects.store_object_counts(
+        "unused", grid=grid, shard_keys=[word], store_layout="hive"
+    )
+    assert measured["objects_total"] == 2
+    assert measured["objects_metadata"] == 1
+    assert measured["objects_per_shard"] == {label: 1}
+    assert measured["objects_other"] == 0
+
+
+def test_is_status_object_classification():
+    assert bench_objects._is_status_object("out.zarr.status/run-a/shard-1.json")
+    assert bench_objects._is_status_object("parent/out.zarr.status/run-a/manifest.json")
+    # The run parquet stays store-root METADATA (issue #297), not a status key...
+    assert not bench_objects._is_status_object("stats_20260101T000000Z_ab.parquet")
+    # ...an in-store data object is never telemetry, and a bare file whose NAME
+    # ends in .status is not under a status prefix.
+    assert not bench_objects._is_status_object("0/012/x.zarr/count/c/0")
+    assert not bench_objects._is_status_object("shard-1.status")
+
+
 # --- mismatch helper (pure) --------------------------------------------------
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -455,7 +455,8 @@ class TestRunnerParity:
     """
 
     @staticmethod
-    def _agg_cell_events(catalog_file, monkeypatch, cfg=None, **agg_kwargs):
+    def _agg_stub(catalog_file, monkeypatch, cfg=None, **agg_kwargs):
+        """Drive ``runner.agg(backend="lambda")`` against a fresh stub; return it."""
         from unittest.mock import MagicMock
 
         import boto3
@@ -488,16 +489,21 @@ class TestRunnerParity:
         # The hive manifest checker (issue #274) polls the output store; keep
         # this run read-free rather than reaching for a bucket that isn't there.
         monkeypatch.setattr(hive, "read_manifest", lambda *a, **k: None)
+        agg_kwargs.setdefault("invocation", "sync")
         runner.agg(
             cfg if cfg is not None else default_config("atl06"),
             catalog=catalog_file,
             store=_STORE,
             backend="lambda",
-            invocation="sync",
             function_name="process-shard-test",
             max_workers=3,
             **agg_kwargs,
         )
+        return stub
+
+    @classmethod
+    def _agg_cell_events(cls, catalog_file, monkeypatch, cfg=None, **agg_kwargs):
+        stub = cls._agg_stub(catalog_file, monkeypatch, cfg=cfg, **agg_kwargs)
         return {e["shard_key"]: e for _, _, e in stub.cell_events()}
 
     @pytest.mark.parametrize("driver", ["s3", "https"])
@@ -523,6 +529,91 @@ class TestRunnerParity:
         href = _rec(3)["s3"] if driver == "s3" else _rec(3)["https"]
         assert client_events[_WORDS[1]]["granule_urls"] == [href]
         assert agg_events[_WORDS[1]]["granule_urls"] == [href]
+
+
+# -- dispatch manifest (issue #327 phase 2) ------------------------------------
+
+
+class TestDispatchManifestBlock:
+    """The setup invoke carries the ``run_manifest`` block (issue #327): the
+    worker records the run's shard set + identity at the status prefix, so
+    every lambda run is reattachable by run id — client and agg alike."""
+
+    @staticmethod
+    def _setup_block(stub):
+        (setup,) = [e for _, _, e in stub.events if e.get("mode") == "setup"]
+        return setup["run_manifest"]
+
+    def test_client_setup_carries_the_block(self, catalog):
+        from zagg.semantics import semantic_hash
+
+        stub = StubLambdaClient()
+        run = _run(catalog, client=stub)
+        run.dispatch().wait(timeout=10)
+        block = self._setup_block(stub)
+        assert sorted(block["shards"]) == sorted(str(w) for w in _WORDS)
+        assert block["run_id"] == stub.cell_events()[0][2]["run_id"]
+        assert block["semantic_hash"] == semantic_hash(run.config)
+        assert block["dataset"] == {"short_name": "ATL06", "version": "006"}
+        assert block["dispatched_at"]  # dispatcher clock, worker copies verbatim
+
+    def test_flat_setup_also_carries_the_block(self, catalog):
+        cfg = default_config("atl06")
+        cfg.output["store_layout"] = "flat"
+        stub = StubLambdaClient()
+        _run(catalog, client=stub, config=cfg).dispatch().wait(timeout=10)
+        assert sorted(self._setup_block(stub)["shards"]) == sorted(str(w) for w in _WORDS)
+
+    def test_agg_setup_block_matches_the_client(self, catalog, catalog_file, monkeypatch):
+        agg_stub = TestRunnerParity._agg_stub(catalog_file, monkeypatch)
+        theirs = self._setup_block(agg_stub)
+        stub = StubLambdaClient()
+        _run(catalog, client=stub).dispatch().wait(timeout=10)
+        mine = self._setup_block(stub)
+        # run_id / dispatched_at are per-dispatch by construction.
+        for block in (mine, theirs):
+            assert block.pop("run_id") and block.pop("dispatched_at")
+        assert mine == theirs
+
+    def test_subset_dispatch_lists_only_dispatched_shards(self, catalog):
+        stub = StubLambdaClient()
+        _run(catalog, client=stub).dispatch(shard_keys=[_WORDS[1]]).wait(timeout=10)
+        assert self._setup_block(stub)["shards"] == [str(_WORDS[1])]
+
+    def test_async_setup_size_gate_drops_the_block(self, monkeypatch):
+        # The hive setup invoke is a 256 KB-capped Event; an oversized shard
+        # list drops the block (never fatal) — attach degrades to statuses.
+        from zagg import runner
+
+        stub = StubLambdaClient()
+        monkeypatch.setattr(runner, "_ASYNC_PAYLOAD_CAP_BYTES", 10)
+        runner._invoke_lambda_setup_async(
+            stub,
+            "fn",
+            _STORE,
+            config_dict={},
+            run_manifest={"run_id": "r", "shards": ["1"]},
+        )
+        (_, _, event) = stub.events[0]
+        assert "run_manifest" not in event
+
+    def test_sync_setup_has_no_size_gate(self):
+        # The flat setup invoke is synchronous (6 MB cap): the block always rides.
+        from zagg import runner
+
+        stub = StubLambdaClient()
+        runner._invoke_lambda_setup(
+            stub,
+            "fn",
+            _STORE,
+            parent_order=6,
+            child_order=12,
+            overwrite=False,
+            config_dict={},
+            run_manifest={"run_id": "r", "shards": ["1"]},
+        )
+        (_, _, event) = stub.events[0]
+        assert event["run_manifest"] == {"run_id": "r", "shards": ["1"]}
 
 
 # -- futures -----------------------------------------------------------------

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -374,6 +374,95 @@ class TestStatusPoller:
         poller.shutdown(wait=True)
 
 
+# -- drop detection (issue #327 phase 4) ------------------------------------------
+
+
+class TestDropDetection:
+    """A shard with no status object after (function timeout + 60 s max event
+    age + margin) resolves ``failed-unknown`` — the silent-drop outcome the
+    fleet's ``MaximumEventAgeInSeconds: 60`` makes possible under
+    backpressure — instead of hanging; it spends the same re-dispatch budget."""
+
+    def test_drop_resolves_failed_unknown_after_deadline(self):
+        store = MemoryStore()
+        now = {"t": 1000.0}
+        poller = ct.StatusPoller(
+            lambda: store,
+            drop_timeout_s=100.0,
+            max_retries=1,
+            clock=lambda: now["t"],
+        )
+        fut = poller.register(1, "1", dispatch=lambda: None)
+        poller.start()
+        time.sleep(0.06)  # several ticks inside the deadline
+        assert not fut.done()  # not classified early
+        now["t"] = 1101.0  # past dispatch (t=1000) + drop_timeout (100)
+        result = fut.result(timeout=5)
+        assert result["outcome"] == "failed-unknown"
+        assert "failed-unknown" in result["error"]
+        assert "60s max event age" in result["error"]
+        assert result["status_code"] is None
+        assert result["body"] == {}
+        poller.shutdown(wait=True)
+
+    def test_drop_participates_in_the_redispatch_budget(self):
+        store = MemoryStore()
+        now = {"t": 0.0}
+        fired: list[float] = []
+        poller = ct.StatusPoller(
+            lambda: store,
+            drop_timeout_s=10.0,
+            max_retries=2,
+            clock=lambda: now["t"],
+        )
+        fut = poller.register(5, "5", dispatch=lambda: fired.append(now["t"]))
+        poller.start()
+        deadline = time.time() + 5
+        while len(fired) < 1 and time.time() < deadline:
+            time.sleep(0.005)
+        now["t"] = 11.0  # first attempt drops -> re-dispatch, not resolution
+        deadline = time.time() + 5
+        while len(fired) < 2 and time.time() < deadline:
+            time.sleep(0.005)
+        assert len(fired) == 2 and not fut.done()
+        # The retry's execution lands its status: the shard recovers.
+        self._late_status(store, 5)
+        result = fut.result(timeout=5)
+        assert result["retries"] == 1
+        assert "outcome" not in result
+        poller.shutdown(wait=True)
+
+    @staticmethod
+    def _late_status(store, shard_key):
+        obj = {
+            "schema_version": 1,
+            "status": "ok",
+            "attempt_id": "late",
+            "shard": str(shard_key),
+            "timings": None,
+            "error": None,
+            "status_code": 200,
+            "body": {"duration_s": 2.0},
+        }
+        obstore.put(store, ct.shard_status_key(shard_key), json.dumps(obj).encode())
+
+    def test_client_event_run_counts_a_drop_failed(self, catalog, status_store, monkeypatch):
+        # End-to-end: the invoke is accepted (202) but no status ever lands;
+        # the shard's future raises ShardError with the DISTINCT outcome in
+        # the payload, status() buckets it failed, and the drop burned the
+        # whole re-dispatch budget.
+        monkeypatch.setattr(ct, "drop_timeout_s", lambda timeout_s: 0.05)
+        stub = EventStubLambdaClient(status_store, drop={_WORDS[0]})
+        handle = _run(catalog, client=stub, max_retries=2).dispatch(transport="event")
+        with pytest.raises(ShardError, match="failed-unknown") as excinfo:
+            handle.futures[_WORDS[0]].result(timeout=10)
+        assert excinfo.value.payload["outcome"] == "failed-unknown"
+        handle.results(return_exceptions=True)
+        assert handle.status() == {"pending": 0, "ok": 2, "failed": 1}
+        attempts = [e for _, _, e in stub.cell_events() if e["shard_key"] == _WORDS[0]]
+        assert len(attempts) == 2  # the budget was spent on re-dispatches
+
+
 # -- keys / prefix ---------------------------------------------------------------
 
 

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -95,7 +95,9 @@ class EventStubLambdaClient:
     invokes (ping/setup/finalize/...) answer synchronously like the v1 stub.
     """
 
-    def __init__(self, status_store, *, fail=(), benign=(), drop=(), fail_times=None):
+    def __init__(
+        self, status_store, *, fail=(), benign=(), drop=(), fail_times=None, drop_times=None
+    ):
         self.status_store = status_store
         self.events: list[tuple[str, str, dict]] = []
         self._lock = threading.Lock()
@@ -103,6 +105,7 @@ class EventStubLambdaClient:
         self._benign = set(benign)
         self._drop = set(drop)  # invoke accepted, no status ever lands
         self._fail_times = dict(fail_times or {})  # key -> failures before success
+        self._drop_times = dict(drop_times or {})  # key -> silent drops before success
         self.status_writes = 0
 
     def invoke(self, **kwargs):
@@ -132,6 +135,12 @@ class EventStubLambdaClient:
         assert kwargs["InvocationType"] == "Event", "v2 cell invokes are fire-and-forget"
         key = event["shard_key"]
         if key in self._drop:
+            return {"StatusCode": 202}
+        if self._drop_times.get(key, 0) > 0:
+            # A queue drop: the invoke is accepted (202) and no status ever
+            # lands for this attempt — fault class (b).
+            with self._lock:
+                self._drop_times[key] -= 1
             return {"StatusCode": 202}
         if key in self._fail:
             response = _envelope({"error": "boom"}, status=500)
@@ -246,22 +255,27 @@ class TestEventDispatch:
         assert handle.results()[_WORDS[2]]["error"] == "No granules found"
         assert handle.status() == {"pending": 0, "ok": 3, "failed": 0}
 
-    def test_failed_status_redispatches_then_raises_shard_error(self, catalog, status_store):
+    def test_failed_status_raises_shard_error_without_redispatch(self, catalog, status_store):
+        # Fault class (a): the worker RAN and reported an error, so the status
+        # object is terminal — one execution billed, never max_retries of them
+        # (issue #119's sync-transport rule, folded from the PR #343 review).
         stub = EventStubLambdaClient(status_store, fail={_WORDS[1]})
-        handle = _run(catalog, client=stub, max_retries=2).dispatch(transport="event")
+        handle = _run(catalog, client=stub, max_retries=3).dispatch(transport="event")
         with pytest.raises(_shard_error(), match="boom") as excinfo:
             handle.futures[_WORDS[1]].result(timeout=10)
         err = excinfo.value
         assert err.shard_key == _WORDS[1]
         assert err.label == _LABELS[1]
-        assert err.payload["retries"] == 1  # second (last) attempt
+        assert err.payload["retries"] == 0  # the first and only attempt
         handle.results(return_exceptions=True)
-        # The migrated retry policy actually re-dispatched: two Event invokes.
         attempts = [e for _, _, e in stub.cell_events() if e["shard_key"] == _WORDS[1]]
-        assert len(attempts) == 2
+        assert len(attempts) == 1
 
-    def test_redispatch_recovers_a_transiently_failing_shard(self, catalog, status_store):
-        stub = EventStubLambdaClient(status_store, fail_times={_WORDS[0]: 1})
+    def test_dropped_invoke_refires_once_and_recovers(self, catalog, status_store, monkeypatch):
+        # Fault class (b): the first invoke is accepted but aged out of the
+        # queue (no status object), so the one bounded re-fire recovers it.
+        monkeypatch.setattr(ct, "drop_timeout_s", lambda timeout_s: 0.05)
+        stub = EventStubLambdaClient(status_store, drop_times={_WORDS[0]: 1})
         handle = _run(catalog, client=stub, max_retries=3).dispatch(transport="event")
         result = handle.futures[_WORDS[0]].result(timeout=10)
         assert result["body"]["total_obs"] == 7
@@ -318,22 +332,40 @@ class TestStatusPoller:
         poller.shutdown(wait=True)
 
     def test_attempt_id_dedupe_acts_once_per_execution(self):
-        # A duplicate poll of the SAME attempt's object must not double-count
-        # against the retry budget; only a NEW attempt_id is consumed.
+        # A duplicate poll of the SAME attempt's object is acted on once; only
+        # a NEW attempt_id is consumed. Driven straight through _consume (the
+        # loop skips a settled entry anyway, so the property lives here).
         store = MemoryStore()
-        fired: list[float] = []
         poller = self._poller(store, max_retries=3)
-        fut = poller.register(1, "1", dispatch=lambda: fired.append(time.time()))
+        poller.register(1, "1", dispatch=lambda: None)
+        entry = poller._entries[ct.shard_status_key(1)]
+        poller._store = store
         _put_status(store, 1, status="failed", attempt_id="a1", error="boom")
+        assert poller._consume(entry) is True
+        assert poller._consume(entry) is False  # same attempt_id: not re-acted
+        assert entry.consumed == {"a1"}
+
+    def test_drop_refire_consumes_a_late_status_object(self):
+        # The re-fire of a dropped invoke (class (b)) is the one place a
+        # queued entry can still see an object land; it resolves normally.
+        store = MemoryStore()
+        now = {"t": 0.0}
+        fired: list[float] = []
+        poller = ct.StatusPoller(
+            lambda: store,
+            drop_timeout_s=10.0,
+            max_retries=3,
+            clock=lambda: now["t"],
+        )
+        fut = poller.register(1, "1", dispatch=lambda: fired.append(now["t"]))
         poller.start()
+        deadline = time.time() + 5
+        while len(fired) < 1 and time.time() < deadline:
+            time.sleep(0.005)
+        now["t"] = 11.0  # the first attempt drops -> the single re-fire
         deadline = time.time() + 5
         while len(fired) < 2 and time.time() < deadline:
             time.sleep(0.005)
-        assert len(fired) == 2  # initial dispatch + ONE re-dispatch for a1
-        # Ticks keep seeing the stale a1 object: no further consumption.
-        time.sleep(0.1)
-        assert len(fired) == 2
-        # The retry's execution lands with a fresh id and resolves the future.
         _put_status(store, 1, status="ok", attempt_id="a2")
         assert fut.result(timeout=5)["retries"] == 1
         poller.shutdown(wait=True)
@@ -419,7 +451,8 @@ class TestDropDetection:
     """A shard with no status object after (function timeout + 60 s max event
     age + margin) resolves ``failed-unknown`` — the silent-drop outcome the
     fleet's ``MaximumEventAgeInSeconds: 60`` makes possible under
-    backpressure — instead of hanging; it spends the same re-dispatch budget."""
+    backpressure — instead of hanging. Fault class (b): exactly ONE bounded
+    re-fire, so the worst case is 2 billed executions (issue #151)."""
 
     def test_drop_resolves_failed_unknown_after_deadline(self):
         store = MemoryStore()
@@ -443,7 +476,38 @@ class TestDropDetection:
         assert result["body"] == {}
         poller.shutdown(wait=True)
 
-    def test_drop_participates_in_the_redispatch_budget(self):
+    def test_drop_refires_exactly_once_then_resolves(self):
+        # max_retries=5, but a status-less shard costs at most TWO executions:
+        # the bound that keeps the client from reintroducing the 3 x 900 s
+        # re-billing MaximumRetryAttempts: 0 exists to prevent (issue #151).
+        store = MemoryStore()
+        now = {"t": 0.0}
+        fired: list[float] = []
+        poller = ct.StatusPoller(
+            lambda: store,
+            drop_timeout_s=10.0,
+            max_retries=5,
+            clock=lambda: now["t"],
+        )
+        fut = poller.register(5, "5", dispatch=lambda: fired.append(now["t"]))
+        poller.start()
+        deadline = time.time() + 5
+        while len(fired) < 1 and time.time() < deadline:
+            time.sleep(0.005)
+        now["t"] = 11.0  # first attempt drops -> the single re-fire
+        deadline = time.time() + 5
+        while len(fired) < 2 and time.time() < deadline:
+            time.sleep(0.005)
+        assert len(fired) == 2 and not fut.done()
+        now["t"] = 22.0  # the re-fire drops too: terminal, no third execution
+        result = fut.result(timeout=5)
+        assert result["outcome"] == "failed-unknown"
+        assert result["retries"] == 1
+        time.sleep(0.1)
+        assert len(fired) == 2
+        poller.shutdown(wait=True)
+
+    def test_drop_refire_recovers_the_shard(self):
         store = MemoryStore()
         now = {"t": 0.0}
         fired: list[float] = []
@@ -458,12 +522,12 @@ class TestDropDetection:
         deadline = time.time() + 5
         while len(fired) < 1 and time.time() < deadline:
             time.sleep(0.005)
-        now["t"] = 11.0  # first attempt drops -> re-dispatch, not resolution
+        now["t"] = 11.0  # first attempt drops -> re-fire, not resolution
         deadline = time.time() + 5
         while len(fired) < 2 and time.time() < deadline:
             time.sleep(0.005)
         assert len(fired) == 2 and not fut.done()
-        # The retry's execution lands its status: the shard recovers.
+        # The re-fire's execution lands its status: the shard recovers.
         _put_status(store, 5)
         result = fut.result(timeout=5)
         assert result["retries"] == 1
@@ -473,18 +537,18 @@ class TestDropDetection:
     def test_client_event_run_counts_a_drop_failed(self, catalog, status_store, monkeypatch):
         # End-to-end: the invoke is accepted (202) but no status ever lands;
         # the shard's future raises ShardError with the DISTINCT outcome in
-        # the payload, status() buckets it failed, and the drop burned the
-        # whole re-dispatch budget.
+        # the payload, status() buckets it failed, and the drop cost exactly
+        # one re-fire even at max_retries=5.
         monkeypatch.setattr(ct, "drop_timeout_s", lambda timeout_s: 0.05)
         stub = EventStubLambdaClient(status_store, drop={_WORDS[0]})
-        handle = _run(catalog, client=stub, max_retries=2).dispatch(transport="event")
+        handle = _run(catalog, client=stub, max_retries=5).dispatch(transport="event")
         with pytest.raises(_shard_error(), match="failed-unknown") as excinfo:
             handle.futures[_WORDS[0]].result(timeout=10)
         assert excinfo.value.payload["outcome"] == "failed-unknown"
         handle.results(return_exceptions=True)
         assert handle.status() == {"pending": 0, "ok": 2, "failed": 1}
         attempts = [e for _, _, e in stub.cell_events() if e["shard_key"] == _WORDS[0]]
-        assert len(attempts) == 2  # the budget was spent on re-dispatches
+        assert len(attempts) == 2  # one bounded re-fire, not five
 
 
 # -- agg invocation="event" (issue #327 phase 6) -----------------------------------

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -746,6 +746,56 @@ class TestAttach:
             Run.attach(_STORE, "windowed", lambda_client=EventStubLambdaClient(status_store))
 
 
+# -- D8 audit (issue #327 phase 7) -------------------------------------------------
+
+
+class TestD8Audit:
+    def test_client_event_run_makes_no_store_writes(self, catalog, status_store, monkeypatch):
+        # Dispatcher-never-writes: every PUT observed during a full v2 client
+        # run must be attributable to the (stub) WORKER — the shard statuses,
+        # the dispatch manifest, and the tail marker, each riding a worker
+        # invoke. The client/poller side only LISTs and GETs (reads).
+        puts: list[str] = []
+        real_put = obstore.put
+
+        def counting_put(store, key, data, *a, **k):
+            puts.append(str(key))
+            return real_put(store, key, data, *a, **k)
+
+        monkeypatch.setattr(obstore, "put", counting_put)
+        stub = EventStubLambdaClient(status_store)
+        handle = _run(catalog, client=stub).dispatch(transport="event")
+        handle.results()
+        handle.wait(timeout=10)
+        expected = [ct.MANIFEST_NAME, ct.TAIL_NAME] + [ct.shard_status_key(w) for w in _WORDS]
+        assert sorted(puts) == sorted(expected)
+
+
+def test_rows_from_status_reads_both_object_shapes(tmp_path):
+    # The run-record pointer transport (issue #313) now also serves event runs
+    # (issue #327): the worker assembles rows from the #151 envelope shape
+    # (body as a JSON string) AND the v2 status-object shape (body as a dict);
+    # the prefix's manifest/tail objects parse fine and contribute no rows.
+    from zagg.telemetry import build_record, rows_from_status
+
+    prefix = tmp_path / "out.zarr.status" / "run-r1"
+    prefix.mkdir(parents=True)
+    rec1 = build_record(shard_key=1, metadata={"total_obs": 5, "duration_s": 1.0})
+    (prefix / "11.json").write_text(
+        json.dumps({"statusCode": 200, "body": json.dumps({"stats": rec1})})
+    )
+    rec2 = build_record(shard_key=2, metadata={"total_obs": 3, "duration_s": 2.0})
+    (prefix / "shard-2.json").write_text(
+        json.dumps(
+            {"schema_version": 1, "status": "ok", "attempt_id": "a", "body": {"stats": rec2}}
+        )
+    )
+    (prefix / "manifest.json").write_text(json.dumps({"schema_version": 1, "run_id": "r1"}))
+    (prefix / "tail.json").write_text(json.dumps({"status": "tail_done"}))
+    rows = rows_from_status(str(prefix))
+    assert sorted(r["shard_key"] for r in rows) == [1, 2]
+
+
 # -- keys / prefix ---------------------------------------------------------------
 
 

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -706,7 +706,7 @@ class TestAggEventMode:
     stay on sync — their metrics come from invoke responses."""
 
     @staticmethod
-    def _agg(catalog_file, monkeypatch, stub, invocation, **agg_kwargs):
+    def _agg(catalog_file, monkeypatch, stub, invocation, config=None, **agg_kwargs):
         from unittest.mock import MagicMock
 
         import boto3
@@ -737,7 +737,7 @@ class TestAggEventMode:
         monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: dict(_CREDS))
         monkeypatch.setattr(hive, "read_manifest", lambda *a, **k: None)
         return runner.agg(
-            default_config("atl06"),
+            config if config is not None else default_config("atl06"),
             catalog=catalog_file,
             store=_STORE,
             backend="lambda",
@@ -826,6 +826,40 @@ class TestAggEventMode:
         assert summary["cells_error"] == 1
         (bad,) = [r for r in summary["results"] if r.get("error")]
         assert bad["outcome"] == "failed-unknown"
+
+    def test_windowed_units_resolve_on_both_windows(self, catalog_file, monkeypatch, status_store):
+        # The ONE seam where the channel's two halves derive the same object
+        # name independently: runner registers with window["label"], the worker
+        # half reads it off event["window"]["label"] in build_shard_status. A
+        # disagreement is silent (the client waits out the whole drop window and
+        # reports failed-unknown for a shard that succeeded), and nothing joined
+        # the two before — the helper and worker tests each cover one side
+        # (review finding, PR #343). Locally testable: one event run over a
+        # 2-window explicit schedule.
+        cfg = default_config("atl06")
+        cfg.output["windowing"] = {
+            "schedule": "explicit",
+            "time_field": "h_li",  # a declared column, so validate_config passes
+            "epoch": "2018-01-01T00:00:00Z",
+            "windows": [
+                {"label": "w1", "start": "2020-01-01T00:00:00Z", "end": "2021-01-01T00:00:00Z"},
+                {"label": "w2", "start": "2021-01-01T00:00:00Z", "end": "2022-01-01T00:00:00Z"},
+            ],
+        }
+        stub = EventStubLambdaClient(status_store)
+        summary = self._agg(catalog_file, monkeypatch, stub, "event", config=cfg)
+        # 3 shards x 2 windows, every unit resolved from its own status object.
+        assert summary["total_cells"] == 6
+        assert summary["cells_error"] == 0
+        assert summary["cells_with_data"] == 6
+        cells = stub.cell_events()
+        assert len(cells) == 6
+        assert sorted(e["window"]["label"] for _, _, e in cells) == ["w1"] * 3 + ["w2"] * 3
+        # Both halves agreed on the per-window key: no shard clobbered another.
+        listed = sorted(str(m["path"]) for b in obstore.list(status_store) for m in b)
+        assert [k for k in listed if k.startswith("shard-")] == sorted(
+            ct.shard_status_key(w, window=lbl) for w in _WORDS for lbl in ("w1", "w2")
+        )
 
     def test_bogus_invocation_refused(self, catalog_file, monkeypatch, status_store):
         with pytest.raises(ValueError, match="Unknown invocation"):
@@ -1015,6 +1049,33 @@ class TestD8Audit:
         handle.wait(timeout=10)
         expected = [ct.MANIFEST_NAME, ct.TAIL_NAME] + [ct.shard_status_key(w) for w in _WORDS]
         assert sorted(puts) == sorted(expected)
+
+    def test_attach_makes_no_store_writes(self, status_store, monkeypatch):
+        # The audit above only covers Run.dispatch, but Run.attach is the one
+        # client path that fires a tail from a FRESH process with no dispatch
+        # state — the path most likely to grow a client-side write later
+        # (review finding, PR #343). Same PUT counter, mid-run state so the
+        # whole tail actually runs.
+        _put_manifest(status_store, "d8attach", _WORDS)
+        body = {"total_obs": 7, "duration_s": 1.0, "stats": {"schema_version": 1}}
+        for word in _WORDS:
+            _put_status(status_store, word, body=dict(body))
+        puts: list[str] = []
+        real_put = obstore.put
+
+        def counting_put(store, key, data, *a, **k):
+            puts.append(str(key))
+            return real_put(store, key, data, *a, **k)
+
+        monkeypatch.setattr(obstore, "put", counting_put)
+        stub = EventStubLambdaClient(status_store)
+        handle = Run.attach(_STORE, "d8attach", lambda_client=stub)
+        handle.results()
+        handle.wait(timeout=10)
+        # The tail ran (finalize + rollups) and the ONLY PUT is the worker's
+        # tail marker, riding the stats invoke.
+        assert "finalize" in [m for m in stub.modes() if m]
+        assert puts == [ct.TAIL_NAME]
 
 
 def test_rows_from_status_reads_both_object_shapes(tmp_path):

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -372,6 +372,7 @@ class TestStatusPoller:
 
     def test_invoke_fault_burns_an_attempt_and_retries(self):
         store = MemoryStore()
+        now = {"t": 1000.0}
         calls = {"n": 0}
 
         def flaky():
@@ -379,15 +380,54 @@ class TestStatusPoller:
             if calls["n"] == 1:
                 raise RuntimeError("TooManyRequestsException")
 
-        poller = self._poller(store, max_retries=3)
+        poller = ct.StatusPoller(
+            lambda: store, drop_timeout_s=1e6, max_retries=3, clock=lambda: now["t"]
+        )
         fut = poller.register(1, "1", dispatch=flaky)
         poller.start()
+        deadline = time.time() + 5
+        while calls["n"] < 1 and time.time() < deadline:
+            time.sleep(0.005)
+        now["t"] = 1002.0  # the 2 s class-(c) backoff expires
         deadline = time.time() + 5
         while calls["n"] < 2 and time.time() < deadline:
             time.sleep(0.005)
         assert calls["n"] == 2
         _put_status(store, 1)
         assert fut.result(timeout=5)["retries"] == 1
+        poller.shutdown(wait=True)
+
+    def test_throttled_invoke_backs_off_instead_of_bursting(self):
+        # The medium-high from the PR #343 review: re-queueing without a
+        # not-before stamp spent the WHOLE retry budget in ~0.3 ms, because
+        # _dispatch_up_to_window's `while True` re-reads `queued` in the same
+        # pass. Each re-fire now waits 2**attempts seconds — enforced by the
+        # clock, not by sleeping on the poller thread.
+        store = MemoryStore()
+        now = {"t": 1000.0}
+        fired: list[float] = []
+
+        def always_throttled():
+            fired.append(now["t"])
+            raise RuntimeError("TooManyRequestsException: Rate exceeded")
+
+        poller = ct.StatusPoller(
+            lambda: store, drop_timeout_s=1e6, max_retries=4, clock=lambda: now["t"]
+        )
+        fut = poller.register(1, "1", dispatch=always_throttled)
+        poller.start()
+        # 2 s, then 4 s, then 8 s: no re-fire until the clock passes the stamp.
+        for expected, t in ((1, 1002.0), (2, 1006.0), (3, 1014.0)):
+            deadline = time.time() + 5
+            while len(fired) < expected and time.time() < deadline:
+                time.sleep(0.005)
+            time.sleep(0.05)  # several ticks INSIDE the backoff
+            assert len(fired) == expected, fired
+            now["t"] = t
+        result = fut.result(timeout=5)  # attempt 4 == max_retries: terminal
+        assert "TooManyRequestsException" in result["error"]
+        assert result["retries"] == 3
+        assert fired == [1000.0, 1002.0, 1006.0, 1014.0]
         poller.shutdown(wait=True)
 
     def test_default_failure_resolution_is_a_result_dict(self):

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -972,3 +972,38 @@ def test_register_returns_unresolved_future():
     fut = poller.register(1, "1", dispatch=lambda: None)
     assert isinstance(fut, Future)
     assert not fut.done()
+
+
+def test_register_after_shutdown_resolves_instead_of_hanging():
+    # An unbounded block is the worst failure mode for a blocking API: agg's
+    # `fut.result()` has no timeout, so a Future nothing can resolve would hang
+    # a pool thread — and its executor.shutdown() — forever (review, PR #343).
+    store = MemoryStore()
+    poller = ct.StatusPoller(lambda: store, drop_timeout_s=10.0)
+    poller.start()
+    poller.shutdown(wait=True)
+    fut = poller.register(1, "1", dispatch=lambda: None)
+    result = fut.result(timeout=1)
+    assert result["outcome"] == "not-dispatched"
+    assert "after the status poller shut down" in result["error"]
+    # The refused entry is not tracked, and a late status object cannot revive it.
+    assert poller._entries == {}
+
+
+def test_register_after_shutdown_honors_the_failure_policy():
+    # The client's policy (ShardError) must apply to the refusal too, so a
+    # post-shutdown registration surfaces as a failed shard, not a silent ok.
+    failures: list = []
+    poller = ct.StatusPoller(
+        lambda: MemoryStore(),
+        drop_timeout_s=10.0,
+        on_failed=lambda e, r: (
+            failures.append(r),
+            e.future.set_exception(RuntimeError(r["error"])),
+        ),
+    )
+    poller.shutdown()
+    fut = poller.register(1, "1", dispatch=lambda: None)
+    with pytest.raises(RuntimeError, match="after the status poller shut down"):
+        fut.result(timeout=1)
+    assert len(failures) == 1

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -121,23 +121,17 @@ class EventStubLambdaClient:
         if key in self._drop:
             return {"StatusCode": 202}
         if key in self._fail:
-            response = _envelope({"error": "boom", "shard_key": key}, status=500)
+            response = _envelope({"error": "boom"}, status=500)
         elif self._fail_times.get(key, 0) > 0:
             with self._lock:
                 self._fail_times[key] -= 1
-            response = _envelope({"error": "boom", "shard_key": key}, status=500)
+            response = _envelope({"error": "boom"}, status=500)
         elif key in self._benign:
-            response = _envelope({"error": "No granules found", "shard_key": key}, status=500)
+            response = _envelope({"error": "No granules found"})
         else:
-            response = _envelope(
-                {
-                    "shard_key": key,
-                    "total_obs": 7,
-                    "duration_s": 1.5,
-                    "phase_timings": {"read": 1.0},
-                    "stats": {"schema_version": 1, "shard_key": key, "run_id": event.get("run_id")},
-                }
-            )
+            # Same canned ok body as tests/test_client.py's v1 stub, so agg
+            # sync/event parity compares identical worker outputs.
+            response = _envelope({"total_obs": 7, "duration_s": 1.5})
         self._write_status(event, response)
         return {"StatusCode": 202}
 
@@ -478,6 +472,181 @@ class TestDropDetection:
         assert handle.status() == {"pending": 0, "ok": 2, "failed": 1}
         attempts = [e for _, _, e in stub.cell_events() if e["shard_key"] == _WORDS[0]]
         assert len(attempts) == 2  # the budget was spent on re-dispatches
+
+
+# -- agg invocation="event" (issue #327 phase 6) -----------------------------------
+
+
+class TestAggEventMode:
+    """``agg(..., invocation="event")``: the same blocking call-shape, return
+    value, and tail as sync, with Event dispatch + status-object resolution
+    underneath (espg ruling, session 2026-07-29). The benchmark harness and CI
+    stay on sync — their metrics come from invoke responses."""
+
+    @staticmethod
+    def _agg(catalog_file, monkeypatch, stub, invocation, **agg_kwargs):
+        from unittest.mock import MagicMock
+
+        import boto3
+
+        from zagg import hive, runner
+        from zagg.concurrency import ConcurrencyReport
+
+        session = MagicMock()
+        session.client.side_effect = lambda service, **k: (
+            stub if service == "lambda" else MagicMock()
+        )
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: session)
+        monkeypatch.setattr(runner, "_get_function_timeout_s", lambda *a, **k: 900)
+        monkeypatch.setattr(
+            runner,
+            "compute_available_workers",
+            lambda requested, *a, **k: (
+                3,
+                ConcurrencyReport(
+                    account_limit=1000,
+                    current_concurrent=0,
+                    padding=100,
+                    available=900,
+                    function_reserved=None,
+                ),
+            ),
+        )
+        monkeypatch.setattr(runner, "get_nsidc_s3_credentials", lambda: dict(_CREDS))
+        monkeypatch.setattr(hive, "read_manifest", lambda *a, **k: None)
+        return runner.agg(
+            default_config("atl06"),
+            catalog=catalog_file,
+            store=_STORE,
+            backend="lambda",
+            invocation=invocation,
+            function_name="process-shard-test",
+            max_workers=3,
+            **agg_kwargs,
+        )
+
+    @pytest.fixture
+    def catalog_file(self, catalog, tmp_path):
+        p = tmp_path / "shardmap.json"
+        p.write_text(json.dumps(catalog))
+        return str(p)
+
+    def test_agg_event_parity_with_sync(self, catalog_file, monkeypatch, status_store):
+        from test_client import StubLambdaClient
+
+        sync_stub = StubLambdaClient()
+        sync_summary = self._agg(catalog_file, monkeypatch, sync_stub, "sync")
+        event_stub = EventStubLambdaClient(status_store)
+        event_summary = self._agg(catalog_file, monkeypatch, event_stub, "event")
+
+        # Same return value shape and counts.
+        assert set(event_summary) == set(sync_summary)
+        for key in (
+            "total_cells",
+            "cells_with_data",
+            "cells_error",
+            "total_obs",
+            "backend",
+            "store_path",
+            "function_name",
+        ):
+            assert event_summary[key] == sync_summary[key], key
+
+        # Same cell events modulo InvocationType (+ per-run identity).
+        sync_cells = {e["shard_key"]: e for _, _, e in sync_stub.cell_events()}
+        event_cells = {e["shard_key"]: e for _, _, e in event_stub.cell_events()}
+        assert set(event_cells) == set(sync_cells) == set(_WORDS)
+        for key in _WORDS:
+            mine, theirs = dict(event_cells[key]), dict(sync_cells[key])
+            assert mine.pop("run_id") and theirs.pop("run_id")
+            assert mine == theirs
+        assert all(t == "Event" for _, t, _ in event_stub.cell_events())
+        assert all(t == "RequestResponse" for _, t, _ in sync_stub.cell_events())
+
+        # Same tail: identical worker-invoke mode sequence (ping, setup,
+        # finalize backstop, coverage, stats).
+        assert [m for m in event_stub.modes() if m] == [m for m in sync_stub.modes() if m]
+
+    def test_agg_event_records_a_failed_shard_like_sync(
+        self, catalog_file, monkeypatch, status_store
+    ):
+        from test_client import StubLambdaClient
+
+        sync_summary = self._agg(
+            catalog_file,
+            monkeypatch,
+            StubLambdaClient(fail={_WORDS[1]}),
+            "sync",
+            max_retries=1,
+        )
+        event_summary = self._agg(
+            catalog_file,
+            monkeypatch,
+            EventStubLambdaClient(status_store, fail={_WORDS[1]}),
+            "event",
+            max_retries=1,
+        )
+        for key in ("cells_error", "cells_with_data", "total_obs"):
+            assert event_summary[key] == sync_summary[key], key
+        assert event_summary["cells_error"] == 1
+        (bad,) = [r for r in event_summary["results"] if r.get("error")]
+        assert bad["error"] == "boom" and bad["shard_key"] == _WORDS[1]
+
+    def test_agg_event_drop_is_a_failed_cell(self, catalog_file, monkeypatch, status_store):
+        monkeypatch.setattr(ct, "drop_timeout_s", lambda timeout_s: 0.05)
+        summary = self._agg(
+            catalog_file,
+            monkeypatch,
+            EventStubLambdaClient(status_store, drop={_WORDS[0]}),
+            "event",
+            max_retries=1,
+        )
+        assert summary["cells_error"] == 1
+        (bad,) = [r for r in summary["results"] if r.get("error")]
+        assert bad["outcome"] == "failed-unknown"
+
+    def test_bogus_invocation_refused(self, catalog_file, monkeypatch, status_store):
+        with pytest.raises(ValueError, match="Unknown invocation"):
+            self._agg(
+                catalog_file, monkeypatch, EventStubLambdaClient(status_store), "carrier-pigeon"
+            )
+
+    def test_raster_fanout_refuses_event(self):
+        from zagg import runner
+
+        with pytest.raises(ValueError, match="Unknown invocation"):
+            runner.RasterStrategy()._run_lambda_shards(
+                default_config("atl06"),
+                [],
+                {},
+                None,
+                "s3://b/x.zarr",
+                times_us=[],
+                overwrite=False,
+                max_workers=1,
+                region="us-west-2",
+                function_name="f",
+                max_retries=1,
+                output_credentials=None,
+                output_endpoint_url=None,
+                invocation="event",
+            )
+
+    def test_temporal_fanout_refuses_event(self):
+        from zagg import runner
+
+        cfg = default_config("atl06")
+        cfg.output["format"] = "parquet"
+        with pytest.raises(ValueError, match="Unknown invocation"):
+            runner._run_lambda_events(
+                cfg,
+                [],
+                "s3://b/x.parquet",
+                max_workers=1,
+                region="us-west-2",
+                function_name="f",
+                invocation="event",
+            )
 
 
 # -- reattach (issue #327 phase 5) ------------------------------------------------

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -349,6 +349,53 @@ class TestStatusPoller:
         kwargs.setdefault("drop_timeout_s", 1050.0)
         return ct.StatusPoller(lambda: store, **kwargs)
 
+    def test_unknown_schema_version_warns_and_still_resolves(self, caplog):
+        # A newer worker against an older client is the normal fleet state
+        # during a layer roll: the object is honored (a shard whose data landed
+        # must not fail on telemetry) but the mismatch is LOUD, so a future
+        # bump can't read as v1 in silence (review, PR #343).
+        store = MemoryStore()
+        poller = self._poller(store)
+        poller.register(1, "1", dispatch=lambda: None)
+        entry = poller._entries[ct.shard_status_key(1)]
+        poller._store = store
+        obj = {
+            "schema_version": 99,
+            "status": "ok",
+            "attempt_id": "a1",
+            "status_code": 200,
+            "body": {},
+        }
+        obstore.put(store, entry.key, json.dumps(obj).encode())
+        with caplog.at_level("WARNING"):
+            assert poller._consume(entry) is True
+        assert "schema_version 99" in caplog.text
+        assert entry.future.result(timeout=1)["status_code"] == 200
+
+    def test_missing_attempt_id_does_not_poison_the_dedupe(self):
+        # A falsy attempt_id used to land None in `consumed`, after which EVERY
+        # later object read as None too and was ignored — so a shard that
+        # succeeded on its re-fire was reported failed-unknown. Absent ids are
+        # always-new instead (review, PR #343).
+        store = MemoryStore()
+        poller = self._poller(store, max_retries=3)
+        poller.register(1, "1", dispatch=lambda: None)
+        entry = poller._entries[ct.shard_status_key(1)]
+        poller._store = store
+
+        def _put_idless(status):
+            obj = {"schema_version": 1, "status": status, "status_code": 200, "body": {}}
+            obstore.put(store, entry.key, json.dumps(obj).encode())
+
+        _put_idless("failed")
+        assert poller._consume(entry) is True
+        assert entry.consumed == set()  # nothing poisoned
+        # A second id-less object is consumed again rather than ignored.
+        entry.future = Future()
+        _put_idless("ok")
+        assert poller._consume(entry) is True
+        assert entry.future.result(timeout=1)["status_code"] == 200
+
     def test_pacing_window_bounds_in_flight_dispatch(self):
         # max_in_flight=1: the second shard's Event must not fire until the
         # first resolves — load-bearing under the fleet's 60 s max event age.

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -97,6 +97,19 @@ class EventStubLambdaClient:
         with self._lock:
             self.events.append((kwargs["FunctionName"], kwargs["InvocationType"], event))
         if event.get("mode") is not None:
+            # Simulate the deployed worker's status-prefix writes off the mode
+            # invokes (issue #327): the setup event's dispatch manifest and
+            # the stats event's tail-completion marker.
+            if event["mode"] == "setup" and event.get("run_manifest"):
+                manifest = {
+                    "schema_version": 1,
+                    **event["run_manifest"],
+                    "config": event.get("config"),
+                }
+                obstore.put(self.status_store, ct.MANIFEST_NAME, json.dumps(manifest).encode())
+            if event["mode"] == "stats" and event.get("tail_status_url"):
+                marker = {"status": "tail_done", "run_id": event.get("run_id")}
+                obstore.put(self.status_store, ct.TAIL_NAME, json.dumps(marker).encode())
             return {
                 "Payload": type(
                     "P", (), {"read": lambda self: b'{"statusCode": 200, "body": "{}"}'}
@@ -151,6 +164,38 @@ def _run(catalog, *, client, config=None, **kwargs):
         source_credentials=_CREDS,
         **kwargs,
     )
+
+
+def _put_status(store, shard_key, status="ok", attempt_id=None, **fields):
+    """Hand-craft one status object (the worker-half schema)."""
+    obj = {
+        "schema_version": 1,
+        "status": status,
+        "attempt_id": attempt_id or f"aid-{time.time_ns()}",
+        "shard": str(shard_key),
+        "timings": None,
+        "error": fields.pop("error", None),
+        "status_code": fields.pop("status_code", 200),
+        "body": fields.pop("body", {}),
+    }
+    obstore.put(store, ct.shard_status_key(shard_key), json.dumps(obj).encode())
+
+
+def _put_manifest(store, run_id, shards, dispatched_at=None, config=None):
+    """Hand-craft one dispatch manifest (what the worker writes off setup)."""
+    from dataclasses import asdict
+    from datetime import datetime, timezone
+
+    manifest = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "shards": [str(int(w)) for w in shards],
+        "semantic_hash": "ab" * 32,
+        "dispatched_at": dispatched_at or datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "dataset": {"short_name": "ATL06", "version": "006"},
+        "config": config if config is not None else asdict(default_config("atl06")),
+    }
+    obstore.put(store, ct.MANIFEST_NAME, json.dumps(manifest).encode())
 
 
 # -- Run.dispatch(transport="event") -------------------------------------------
@@ -241,20 +286,6 @@ class TestStatusPoller:
         kwargs.setdefault("drop_timeout_s", 1050.0)
         return ct.StatusPoller(lambda: store, **kwargs)
 
-    @staticmethod
-    def _put_status(store, shard_key, status="ok", attempt_id=None, **fields):
-        obj = {
-            "schema_version": 1,
-            "status": status,
-            "attempt_id": attempt_id or f"aid-{time.time_ns()}",
-            "shard": str(shard_key),
-            "timings": None,
-            "error": fields.pop("error", None),
-            "status_code": fields.pop("status_code", 200),
-            "body": fields.pop("body", {}),
-        }
-        obstore.put(store, ct.shard_status_key(shard_key), json.dumps(obj).encode())
-
     def test_pacing_window_bounds_in_flight_dispatch(self):
         # max_in_flight=1: the second shard's Event must not fire until the
         # first resolves — load-bearing under the fleet's 60 s max event age.
@@ -269,13 +300,13 @@ class TestStatusPoller:
             time.sleep(0.005)
         time.sleep(0.05)  # a few idle ticks: the window must still hold
         assert fired == [1]
-        self._put_status(store, 1)
+        _put_status(store, 1)
         assert f1.result(timeout=5)["status_code"] == 200
         deadline = time.time() + 5
         while len(fired) < 2 and time.time() < deadline:
             time.sleep(0.005)
         assert fired == [1, 2]
-        self._put_status(store, 2)
+        _put_status(store, 2)
         assert f2.result(timeout=5)["status_code"] == 200
         poller.shutdown(wait=True)
 
@@ -286,7 +317,7 @@ class TestStatusPoller:
         fired: list[float] = []
         poller = self._poller(store, max_retries=3)
         fut = poller.register(1, "1", dispatch=lambda: fired.append(time.time()))
-        self._put_status(store, 1, status="failed", attempt_id="a1", error="boom")
+        _put_status(store, 1, status="failed", attempt_id="a1", error="boom")
         poller.start()
         deadline = time.time() + 5
         while len(fired) < 2 and time.time() < deadline:
@@ -296,7 +327,7 @@ class TestStatusPoller:
         time.sleep(0.1)
         assert len(fired) == 2
         # The retry's execution lands with a fresh id and resolves the future.
-        self._put_status(store, 1, status="ok", attempt_id="a2")
+        _put_status(store, 1, status="ok", attempt_id="a2")
         assert fut.result(timeout=5)["retries"] == 1
         poller.shutdown(wait=True)
 
@@ -316,7 +347,7 @@ class TestStatusPoller:
         while calls["n"] < 2 and time.time() < deadline:
             time.sleep(0.005)
         assert calls["n"] == 2
-        self._put_status(store, 1)
+        _put_status(store, 1)
         assert fut.result(timeout=5)["retries"] == 1
         poller.shutdown(wait=True)
 
@@ -326,7 +357,7 @@ class TestStatusPoller:
         store = MemoryStore()
         poller = self._poller(store, max_retries=1)
         fut = poller.register(7, "7", dispatch=lambda: None)
-        self._put_status(store, 7, status="failed", error="boom", status_code=500)
+        _put_status(store, 7, status="failed", error="boom", status_code=500)
         poller.start()
         result = fut.result(timeout=5)
         assert result["error"] == "boom"
@@ -347,7 +378,7 @@ class TestStatusPoller:
 
         poller = self._poller(store)
         fut = poller.register(1, "1", dispatch=lambda: None)
-        self._put_status(store, 1)
+        _put_status(store, 1)
         try:
             obstore.list = flaky_list
             poller.start()
@@ -367,7 +398,7 @@ class TestStatusPoller:
             on_failed=lambda e, r: (failures.append(r), e.future.set_result(r)),
         )
         fut = poller.register(1, "1", dispatch=None)
-        self._put_status(store, 1, status="failed", error="boom")
+        _put_status(store, 1, status="failed", error="boom")
         poller.start()
         assert fut.result(timeout=5)["error"] == "boom"
         assert len(failures) == 1
@@ -426,25 +457,11 @@ class TestDropDetection:
             time.sleep(0.005)
         assert len(fired) == 2 and not fut.done()
         # The retry's execution lands its status: the shard recovers.
-        self._late_status(store, 5)
+        _put_status(store, 5)
         result = fut.result(timeout=5)
         assert result["retries"] == 1
         assert "outcome" not in result
         poller.shutdown(wait=True)
-
-    @staticmethod
-    def _late_status(store, shard_key):
-        obj = {
-            "schema_version": 1,
-            "status": "ok",
-            "attempt_id": "late",
-            "shard": str(shard_key),
-            "timings": None,
-            "error": None,
-            "status_code": 200,
-            "body": {"duration_s": 2.0},
-        }
-        obstore.put(store, ct.shard_status_key(shard_key), json.dumps(obj).encode())
 
     def test_client_event_run_counts_a_drop_failed(self, catalog, status_store, monkeypatch):
         # End-to-end: the invoke is accepted (202) but no status ever lands;
@@ -461,6 +478,103 @@ class TestDropDetection:
         assert handle.status() == {"pending": 0, "ok": 2, "failed": 1}
         attempts = [e for _, _, e in stub.cell_events() if e["shard_key"] == _WORDS[0]]
         assert len(attempts) == 2  # the budget was spent on re-dispatches
+
+
+# -- reattach (issue #327 phase 5) ------------------------------------------------
+
+
+class TestAttach:
+    """``Run.attach(store, run_id)`` rebuilds a handle from the dispatch
+    manifest + current status objects; the post-run tail runs only when not
+    already recorded. Observe-only: reads, no re-dispatch (D8 intact)."""
+
+    def test_attach_post_run_resolves_and_skips_the_tail(self, catalog, status_store):
+        # A completed live run left manifest + statuses + tail marker behind.
+        live = EventStubLambdaClient(status_store)
+        _run(catalog, client=live).dispatch(transport="event").results()
+        run_id = live.cell_events()[0][2]["run_id"]
+
+        fresh = EventStubLambdaClient(status_store)
+        handle = Run.attach(_STORE, run_id, lambda_client=fresh)
+        results = handle.results()
+        assert set(results) == set(_WORDS)
+        assert all(r["body"]["total_obs"] == 7 for r in results.values())
+        assert handle.status() == {"pending": 0, "ok": 3, "failed": 0}
+        # The tail was recorded (tail.json): the reattached handle fires NOTHING.
+        assert fresh.events == []
+
+    def test_attach_mid_run_resolves_late_shards_and_runs_the_tail(self, status_store):
+        # Mid-run state: manifest + two settled shards; the third lands later.
+        _put_manifest(status_store, "midrun", _WORDS)
+        body = {"total_obs": 7, "duration_s": 1.0, "stats": {"schema_version": 1}}
+        _put_status(status_store, _WORDS[0], body=dict(body))
+        _put_status(status_store, _WORDS[1], body=dict(body))
+
+        stub = EventStubLambdaClient(status_store)
+        handle = Run.attach(_STORE, "midrun", lambda_client=stub)
+        assert handle.futures[_WORDS[0]].result(timeout=10)["body"]["total_obs"] == 7
+        assert not handle.futures[_WORDS[2]].done()
+        _put_status(status_store, _WORDS[2], body=dict(body))  # the fleet finishes
+        handle.results()
+        handle.wait(timeout=10)
+        # No tail marker existed, so the SAME worker-invoke tail ran (D8):
+        # finalize backstop + coverage + stats — and zero cell re-dispatches.
+        modes = [m for m in stub.modes() if m]
+        assert "finalize" in modes and "stats" in modes
+        assert stub.cell_events() == []
+        # ... and the stats leg recorded the marker: a second attach skips it.
+        again = EventStubLambdaClient(status_store)
+        Run.attach(_STORE, "midrun", lambda_client=again).results()
+        assert again.events == []
+
+    def test_attach_failed_status_raises_without_redispatch(self, status_store):
+        _put_manifest(status_store, "failedrun", _WORDS)
+        body = {"total_obs": 7, "duration_s": 1.0}
+        _put_status(status_store, _WORDS[0], body=dict(body))
+        _put_status(status_store, _WORDS[1], body=dict(body))
+        _put_status(status_store, _WORDS[2], status="failed", error="boom", status_code=500)
+        stub = EventStubLambdaClient(status_store)
+        handle = Run.attach(_STORE, "failedrun", lambda_client=stub)
+        with pytest.raises(ShardError, match="boom"):
+            handle.futures[_WORDS[2]].result(timeout=10)
+        handle.results(return_exceptions=True)
+        assert handle.status() == {"pending": 0, "ok": 2, "failed": 1}
+        # Observe-only: attach holds no granule records, so no re-dispatch.
+        assert stub.cell_events() == []
+
+    def test_attach_classifies_stale_missing_shard_failed_unknown(self, status_store):
+        # The drop deadline anchors at the manifest's dispatched_at: attaching
+        # LONG after the fleet finished classifies a status-less shard
+        # immediately instead of waiting a fresh window.
+        _put_manifest(status_store, "stale", _WORDS, dispatched_at="2020-01-01T00:00:00+00:00")
+        body = {"total_obs": 7, "duration_s": 1.0}
+        _put_status(status_store, _WORDS[0], body=dict(body))
+        _put_status(status_store, _WORDS[1], body=dict(body))
+        stub = EventStubLambdaClient(status_store)
+        handle = Run.attach(_STORE, "stale", lambda_client=stub)
+        with pytest.raises(ShardError, match="failed-unknown") as excinfo:
+            handle.futures[_WORDS[2]].result(timeout=10)
+        assert excinfo.value.payload["outcome"] == "failed-unknown"
+
+    def test_attach_missing_manifest_raises(self, status_store):
+        with pytest.raises(ValueError, match="no dispatch manifest"):
+            Run.attach(_STORE, "nosuchrun", lambda_client=EventStubLambdaClient(status_store))
+
+    def test_attach_windowed_config_refused(self, status_store):
+        from dataclasses import asdict
+
+        cfg = default_config("atl06")
+        cfg.output["windowing"] = {
+            "schedule": "explicit",
+            "time_field": "h_li",  # a declared column, so validate_config passes
+            "epoch": "2018-01-01T00:00:00Z",
+            "windows": [
+                {"label": "w1", "start": "2020-01-01T00:00:00Z", "end": "2021-01-01T00:00:00Z"}
+            ],
+        }
+        _put_manifest(status_store, "windowed", _WORDS, config=asdict(cfg))
+        with pytest.raises(NotImplementedError, match="windowed"):
+            Run.attach(_STORE, "windowed", lambda_client=EventStubLambdaClient(status_store))
 
 
 # -- keys / prefix ---------------------------------------------------------------

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -96,9 +96,18 @@ class EventStubLambdaClient:
     """
 
     def __init__(
-        self, status_store, *, fail=(), benign=(), drop=(), fail_times=None, drop_times=None
+        self,
+        status_store,
+        *,
+        fail=(),
+        benign=(),
+        drop=(),
+        fail_times=None,
+        drop_times=None,
+        record=False,
     ):
         self.status_store = status_store
+        self._record = record  # deployed workers ride a stats record; stale ones don't
         self.events: list[tuple[str, str, dict]] = []
         self._lock = threading.Lock()
         self._fail = set(fail)  # deterministic failures (every attempt)
@@ -153,7 +162,12 @@ class EventStubLambdaClient:
         else:
             # Same canned ok body as tests/test_client.py's v1 stub, so agg
             # sync/event parity compares identical worker outputs.
-            response = _envelope({"total_obs": 7, "duration_s": 1.5})
+            body = {"total_obs": 7, "duration_s": 1.5}
+            if self._record:
+                from zagg.telemetry import build_record
+
+                body["stats"] = build_record(shard_key=int(key), metadata=dict(body))
+            response = _envelope(body)
         self._write_status(event, response)
         return {"StatusCode": 202}
 
@@ -291,6 +305,24 @@ class TestEventDispatch:
         first_cell = modes.index(None)
         assert modes[:first_cell] == ["ping", "setup"]
         assert "finalize" in modes and "coverage" in modes and "stats" in modes
+
+    def test_oversized_rows_point_at_the_status_prefix(self, catalog, status_store, monkeypatch):
+        # An oversized row set on an EVENT run keeps its run record: the tail
+        # points rows_from at the run's status prefix (which rows_from_status
+        # reads — issue #327). The facade hardcoded result_prefix=None, so a
+        # fleet-scale event run — the only kind that hits the cap — dropped
+        # the record its byte-identical agg(invocation="event") twin keeps.
+        from zagg import runner
+
+        monkeypatch.setattr(runner, "_RUN_STATS_INLINE_CAP_BYTES", 10)
+        stub = EventStubLambdaClient(status_store, record=True)
+        handle = _run(catalog, client=stub).dispatch(transport="event")
+        handle.results()
+        handle.wait(timeout=10)
+        run_id = stub.cell_events()[0][2]["run_id"]
+        (stats,) = [e for _, _, e in stub.events if e.get("mode") == "stats"]
+        assert stats["rows_from"] == ct.run_status_prefix(_STORE, run_id)
+        assert stats["rows"] == []  # every row is re-derivable from the prefix
 
     def test_unknown_transport_refused(self, catalog, status_store):
         run = _run(catalog, client=EventStubLambdaClient(status_store))

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -105,7 +105,9 @@ class EventStubLambdaClient:
         fail_times=None,
         drop_times=None,
         record=False,
+        fail_modes=(),
     ):
+        self._fail_modes = set(fail_modes)  # mode invokes that raise (e.g. finalize)
         self.status_store = status_store
         self._record = record  # deployed workers ride a stats record; stale ones don't
         self.events: list[tuple[str, str, dict]] = []
@@ -122,6 +124,8 @@ class EventStubLambdaClient:
         with self._lock:
             self.events.append((kwargs["FunctionName"], kwargs["InvocationType"], event))
         if event.get("mode") is not None:
+            if event["mode"] in self._fail_modes:
+                raise RuntimeError(f"{event['mode']} down")
             # Simulate the deployed worker's status-prefix writes off the mode
             # invokes (issue #327): the setup event's dispatch manifest and
             # the stats event's tail-completion marker.
@@ -132,7 +136,13 @@ class EventStubLambdaClient:
                     "config": event.get("config"),
                 }
                 obstore.put(self.status_store, ct.MANIFEST_NAME, json.dumps(manifest).encode())
-            if event["mode"] == "stats" and event.get("tail_status_url"):
+            if (
+                event["mode"] == "stats"
+                and event.get("tail_status_url")
+                # Mirrors write_tail_status: a failed finalize withholds the
+                # marker so a reattached handle re-runs the idempotent tail.
+                and not event.get("finalize_error")
+            ):
                 marker = {"status": "tail_done", "run_id": event.get("run_id")}
                 obstore.put(self.status_store, ct.TAIL_NAME, json.dumps(marker).encode())
             return {
@@ -873,6 +883,30 @@ class TestAttach:
         with pytest.raises(_shard_error(), match="failed-unknown") as excinfo:
             handle.futures[_WORDS[2]].result(timeout=10)
         assert excinfo.value.payload["outcome"] == "failed-unknown"
+
+    def test_attach_reruns_the_tail_after_a_failed_finalize(
+        self, catalog, status_store, monkeypatch
+    ):
+        # Reattaching after a failure is the headline Run.attach use case, and a
+        # failed finalize is the case that needs another pass. The stats event
+        # carries #335's finalize_error, so no tail marker is written and the
+        # reattached handle re-fires the idempotent backstop (review, PR #343).
+        from zagg import runner
+
+        monkeypatch.setattr(runner, "_FINALIZE_BACKOFF_S", 0)
+        live = EventStubLambdaClient(status_store, fail_modes={"finalize"})
+        with pytest.warns(RuntimeWarning, match="finalize"):
+            handle = _run(catalog, client=live).dispatch(transport="event")
+            with pytest.raises(RuntimeError, match="finalize down"):
+                handle.results()  # joins the tail, then re-raises (issue #335)
+        run_id = live.cell_events()[0][2]["run_id"]
+        (stats,) = [e for _, _, e in live.events if e.get("mode") == "stats"]
+        assert stats["finalize_error"] == "finalize down"
+        assert not ct.tail_recorded("ignored-by-the-fixture", {})
+
+        fresh = EventStubLambdaClient(status_store)
+        Run.attach(_STORE, run_id, lambda_client=fresh).results()
+        assert "finalize" in [m for m in fresh.modes() if m]
 
     def test_attach_missing_manifest_raises(self, status_store):
         with pytest.raises(ValueError, match="no dispatch manifest"):

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -349,6 +349,22 @@ class TestStatusPoller:
         kwargs.setdefault("drop_timeout_s", 1050.0)
         return ct.StatusPoller(lambda: store, **kwargs)
 
+    def test_a_freed_slot_refills_in_the_same_tick(self):
+        # _tick consumed AFTER dispatching, so a slot freed by a resolution sat
+        # idle until the NEXT tick — up to _POLL_MAX_INTERVAL_S of dead window
+        # (review, PR #343). Driven tick by tick, no threads.
+        store = MemoryStore()
+        fired: list[int] = []
+        poller = self._poller(store, max_in_flight=1)
+        f1 = poller.register(1, "1", dispatch=lambda: fired.append(1))
+        poller.register(2, "2", dispatch=lambda: fired.append(2))
+        poller._tick()
+        assert fired == [1]  # the window holds shard 2 back
+        _put_status(store, 1)
+        poller._tick()  # ONE tick: resolve shard 1 AND fire shard 2
+        assert f1.done()
+        assert fired == [1, 2]
+
     def test_unknown_schema_version_warns_and_still_resolves(self, caplog):
         # A newer worker against an older client is the normal fleet state
         # during a layer roll: the object is honored (a shard whose data landed

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -17,8 +17,21 @@ import pytest
 from obstore.store import MemoryStore
 
 import zagg.client_transport as ct
-from zagg.client import Run, ShardError
+from zagg.client import Run
 from zagg.config import default_config
+
+
+def _shard_error():
+    """The CURRENT ShardError class, resolved at call time.
+
+    tests/test_client.py's tqdm test importlib.reload()s zagg.client, which
+    rebinds the class object mid-suite; an import-time reference here would
+    stop matching the exceptions the (reloaded) transport raises.
+    """
+    import zagg.client
+
+    return zagg.client.ShardError
+
 
 # Mirrors tests/test_client.py: order-6 shardmap over three packed morton words.
 _ATL06_SIG = {
@@ -236,7 +249,7 @@ class TestEventDispatch:
     def test_failed_status_redispatches_then_raises_shard_error(self, catalog, status_store):
         stub = EventStubLambdaClient(status_store, fail={_WORDS[1]})
         handle = _run(catalog, client=stub, max_retries=2).dispatch(transport="event")
-        with pytest.raises(ShardError, match="boom") as excinfo:
+        with pytest.raises(_shard_error(), match="boom") as excinfo:
             handle.futures[_WORDS[1]].result(timeout=10)
         err = excinfo.value
         assert err.shard_key == _WORDS[1]
@@ -465,7 +478,7 @@ class TestDropDetection:
         monkeypatch.setattr(ct, "drop_timeout_s", lambda timeout_s: 0.05)
         stub = EventStubLambdaClient(status_store, drop={_WORDS[0]})
         handle = _run(catalog, client=stub, max_retries=2).dispatch(transport="event")
-        with pytest.raises(ShardError, match="failed-unknown") as excinfo:
+        with pytest.raises(_shard_error(), match="failed-unknown") as excinfo:
             handle.futures[_WORDS[0]].result(timeout=10)
         assert excinfo.value.payload["outcome"] == "failed-unknown"
         handle.results(return_exceptions=True)
@@ -704,7 +717,7 @@ class TestAttach:
         _put_status(status_store, _WORDS[2], status="failed", error="boom", status_code=500)
         stub = EventStubLambdaClient(status_store)
         handle = Run.attach(_STORE, "failedrun", lambda_client=stub)
-        with pytest.raises(ShardError, match="boom"):
+        with pytest.raises(_shard_error(), match="boom"):
             handle.futures[_WORDS[2]].result(timeout=10)
         handle.results(return_exceptions=True)
         assert handle.status() == {"pending": 0, "ok": 2, "failed": 1}
@@ -721,7 +734,7 @@ class TestAttach:
         _put_status(status_store, _WORDS[1], body=dict(body))
         stub = EventStubLambdaClient(status_store)
         handle = Run.attach(_STORE, "stale", lambda_client=stub)
-        with pytest.raises(ShardError, match="failed-unknown") as excinfo:
+        with pytest.raises(_shard_error(), match="failed-unknown") as excinfo:
             handle.futures[_WORDS[2]].result(timeout=10)
         assert excinfo.value.payload["outcome"] == "failed-unknown"
 

--- a/tests/test_client_transport.py
+++ b/tests/test_client_transport.py
@@ -1,0 +1,403 @@
+"""Tests for the v2 Event transport (issue #327): status objects + poller.
+
+No AWS, no network: Lambda traffic goes through a stub client whose Event
+"workers" write status objects into an ``obstore`` MemoryStore — through the
+REAL ``build_shard_status`` (the worker half), so the two halves of the
+channel cannot drift — and the poller reads them back through the same
+obstore functions the production path uses.
+"""
+
+import json
+import threading
+import time
+from concurrent.futures import Future
+
+import obstore
+import pytest
+from obstore.store import MemoryStore
+
+import zagg.client_transport as ct
+from zagg.client import Run, ShardError
+from zagg.config import default_config
+
+# Mirrors tests/test_client.py: order-6 shardmap over three packed morton words.
+_ATL06_SIG = {
+    "type": "healpix",
+    "indexing_scheme": "nested",
+    "parent_order": 6,
+    "child_order": 12,
+    "layout": "fullsphere",
+}
+_WORDS = [11828422946311897094, 11828141471335186438, 11827859996358475782]
+_LABELS = ["-4211324", "-4211323", "-4211322"]
+_CREDS = {"accessKeyId": "AK", "secretAccessKey": "SK", "sessionToken": "TK"}
+_STORE = "s3://test-bucket/out.zarr"
+
+
+def _rec(n):
+    return {"id": f"g{n}", "s3": f"s3://bucket/granule{n}.h5", "https": f"https://h/granule{n}.h5"}
+
+
+@pytest.fixture
+def catalog():
+    return {
+        "metadata": {"short_name": "ATL06", "version": "006"},
+        "grid_signature": dict(_ATL06_SIG),
+        "shard_keys": list(_WORDS),
+        "granules": [[_rec(4), _rec(5), _rec(6)], [_rec(3)], [_rec(1), _rec(2)]],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _fast_poll(monkeypatch):
+    monkeypatch.setattr(ct, "_POLL_INITIAL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(ct, "_POLL_MAX_INTERVAL_S", 0.02)
+
+
+@pytest.fixture(autouse=True)
+def _no_stats_verify(monkeypatch):
+    from zagg import runner
+
+    monkeypatch.setattr(runner, "_RUN_STATS_VERIFY_WINDOW_S", 0)
+
+
+@pytest.fixture
+def status_store(monkeypatch):
+    """One in-memory status store shared by stub workers and the poller."""
+    store = MemoryStore()
+    monkeypatch.setattr(ct, "open_status_store", lambda prefix, kwargs: store)
+    return store
+
+
+def _envelope(body: dict, status=200) -> dict:
+    return {"statusCode": status, "body": json.dumps(body)}
+
+
+class EventStubLambdaClient:
+    """Stub Lambda whose Event 'workers' write status objects (issue #327).
+
+    A per-unit Event invoke computes the worker's canned response envelope and
+    records it as a status object via the REAL worker half
+    (``build_shard_status``), exactly as the deployed handler seam does. Mode
+    invokes (ping/setup/finalize/...) answer synchronously like the v1 stub.
+    """
+
+    def __init__(self, status_store, *, fail=(), benign=(), drop=(), fail_times=None):
+        self.status_store = status_store
+        self.events: list[tuple[str, str, dict]] = []
+        self._lock = threading.Lock()
+        self._fail = set(fail)  # deterministic failures (every attempt)
+        self._benign = set(benign)
+        self._drop = set(drop)  # invoke accepted, no status ever lands
+        self._fail_times = dict(fail_times or {})  # key -> failures before success
+        self.status_writes = 0
+
+    def invoke(self, **kwargs):
+        event = json.loads(kwargs["Payload"])
+        with self._lock:
+            self.events.append((kwargs["FunctionName"], kwargs["InvocationType"], event))
+        if event.get("mode") is not None:
+            return {
+                "Payload": type(
+                    "P", (), {"read": lambda self: b'{"statusCode": 200, "body": "{}"}'}
+                )(),
+                "FunctionError": None,
+            }
+        assert kwargs["InvocationType"] == "Event", "v2 cell invokes are fire-and-forget"
+        key = event["shard_key"]
+        if key in self._drop:
+            return {"StatusCode": 202}
+        if key in self._fail:
+            response = _envelope({"error": "boom", "shard_key": key}, status=500)
+        elif self._fail_times.get(key, 0) > 0:
+            with self._lock:
+                self._fail_times[key] -= 1
+            response = _envelope({"error": "boom", "shard_key": key}, status=500)
+        elif key in self._benign:
+            response = _envelope({"error": "No granules found", "shard_key": key}, status=500)
+        else:
+            response = _envelope(
+                {
+                    "shard_key": key,
+                    "total_obs": 7,
+                    "duration_s": 1.5,
+                    "phase_timings": {"read": 1.0},
+                    "stats": {"schema_version": 1, "shard_key": key, "run_id": event.get("run_id")},
+                }
+            )
+        self._write_status(event, response)
+        return {"StatusCode": 202}
+
+    def _write_status(self, event, response):
+        obj_key, obj = ct.build_shard_status(event, response)
+        with self._lock:
+            self.status_writes += 1
+        obstore.put(self.status_store, obj_key, json.dumps(obj).encode())
+
+    def cell_events(self):
+        return [(n, t, e) for n, t, e in self.events if e.get("mode") is None]
+
+    def modes(self):
+        return [e.get("mode") for _, _, e in self.events]
+
+
+def _run(catalog, *, client, config=None, **kwargs):
+    return Run.from_config(
+        config if config is not None else default_config("atl06"),
+        shardmap=catalog,
+        store=_STORE,
+        function_name="process-shard-test",
+        lambda_client=client,
+        source_credentials=_CREDS,
+        **kwargs,
+    )
+
+
+# -- Run.dispatch(transport="event") -------------------------------------------
+
+
+class TestEventDispatch:
+    def test_all_shards_resolve_from_status_objects(self, catalog, status_store):
+        stub = EventStubLambdaClient(status_store)
+        handle = _run(catalog, client=stub).dispatch(transport="event")
+        results = handle.results()
+        assert set(results) == set(_WORDS)
+        assert all(r["body"]["total_obs"] == 7 for r in results.values())
+        assert all(r["status_code"] == 200 for r in results.values())
+        assert handle.status() == {"pending": 0, "ok": 3, "failed": 0}
+        cells = stub.cell_events()
+        assert len(cells) == 3
+        assert all(t == "Event" for _, t, _ in cells)
+        # v2 needs no per-shard mirror target: statuses are always-on.
+        assert all("result_url" not in e for _, _, e in cells)
+
+    def test_event_payloads_match_sync_modulo_invocation_type(self, catalog, status_store):
+        from test_client import StubLambdaClient
+
+        sync_stub = StubLambdaClient()
+        _run(catalog, client=sync_stub).dispatch(transport="sync").results()
+        sync_events = {e["shard_key"]: e for _, _, e in sync_stub.cell_events()}
+
+        stub = EventStubLambdaClient(status_store)
+        _run(catalog, client=stub).dispatch(transport="event").results()
+        event_events = {e["shard_key"]: e for _, _, e in stub.cell_events()}
+
+        assert set(event_events) == set(sync_events) == set(_WORDS)
+        for key in _WORDS:
+            mine, theirs = dict(event_events[key]), dict(sync_events[key])
+            assert mine.pop("run_id") and theirs.pop("run_id")  # fresh per dispatch
+            assert mine == theirs  # byte-identical construction (issue #327)
+
+    def test_benign_no_data_counts_ok(self, catalog, status_store):
+        stub = EventStubLambdaClient(status_store, benign={_WORDS[2]})
+        handle = _run(catalog, client=stub).dispatch(transport="event")
+        assert handle.results()[_WORDS[2]]["error"] == "No granules found"
+        assert handle.status() == {"pending": 0, "ok": 3, "failed": 0}
+
+    def test_failed_status_redispatches_then_raises_shard_error(self, catalog, status_store):
+        stub = EventStubLambdaClient(status_store, fail={_WORDS[1]})
+        handle = _run(catalog, client=stub, max_retries=2).dispatch(transport="event")
+        with pytest.raises(ShardError, match="boom") as excinfo:
+            handle.futures[_WORDS[1]].result(timeout=10)
+        err = excinfo.value
+        assert err.shard_key == _WORDS[1]
+        assert err.label == _LABELS[1]
+        assert err.payload["retries"] == 1  # second (last) attempt
+        handle.results(return_exceptions=True)
+        # The migrated retry policy actually re-dispatched: two Event invokes.
+        attempts = [e for _, _, e in stub.cell_events() if e["shard_key"] == _WORDS[1]]
+        assert len(attempts) == 2
+
+    def test_redispatch_recovers_a_transiently_failing_shard(self, catalog, status_store):
+        stub = EventStubLambdaClient(status_store, fail_times={_WORDS[0]: 1})
+        handle = _run(catalog, client=stub, max_retries=3).dispatch(transport="event")
+        result = handle.futures[_WORDS[0]].result(timeout=10)
+        assert result["body"]["total_obs"] == 7
+        assert result["retries"] == 1  # succeeded on the second attempt
+        handle.results()
+        assert handle.status() == {"pending": 0, "ok": 3, "failed": 0}
+
+    def test_post_run_tail_matches_v1(self, catalog, status_store):
+        stub = EventStubLambdaClient(status_store)
+        handle = _run(catalog, client=stub).dispatch(transport="event")
+        handle.results()  # drains + joins the tail
+        modes = stub.modes()
+        first_cell = modes.index(None)
+        assert modes[:first_cell] == ["ping", "setup"]
+        assert "finalize" in modes and "coverage" in modes and "stats" in modes
+
+    def test_unknown_transport_refused(self, catalog, status_store):
+        run = _run(catalog, client=EventStubLambdaClient(status_store))
+        with pytest.raises(ValueError, match="transport"):
+            run.dispatch(transport="carrier-pigeon")
+
+
+# -- StatusPoller unit behavior --------------------------------------------------
+
+
+class TestStatusPoller:
+    @staticmethod
+    def _poller(store, **kwargs):
+        kwargs.setdefault("drop_timeout_s", 1050.0)
+        return ct.StatusPoller(lambda: store, **kwargs)
+
+    @staticmethod
+    def _put_status(store, shard_key, status="ok", attempt_id=None, **fields):
+        obj = {
+            "schema_version": 1,
+            "status": status,
+            "attempt_id": attempt_id or f"aid-{time.time_ns()}",
+            "shard": str(shard_key),
+            "timings": None,
+            "error": fields.pop("error", None),
+            "status_code": fields.pop("status_code", 200),
+            "body": fields.pop("body", {}),
+        }
+        obstore.put(store, ct.shard_status_key(shard_key), json.dumps(obj).encode())
+
+    def test_pacing_window_bounds_in_flight_dispatch(self):
+        # max_in_flight=1: the second shard's Event must not fire until the
+        # first resolves — load-bearing under the fleet's 60 s max event age.
+        store = MemoryStore()
+        fired: list[int] = []
+        poller = self._poller(store, max_in_flight=1)
+        f1 = poller.register(1, "1", dispatch=lambda: fired.append(1))
+        f2 = poller.register(2, "2", dispatch=lambda: fired.append(2))
+        poller.start()
+        deadline = time.time() + 5
+        while not fired and time.time() < deadline:
+            time.sleep(0.005)
+        time.sleep(0.05)  # a few idle ticks: the window must still hold
+        assert fired == [1]
+        self._put_status(store, 1)
+        assert f1.result(timeout=5)["status_code"] == 200
+        deadline = time.time() + 5
+        while len(fired) < 2 and time.time() < deadline:
+            time.sleep(0.005)
+        assert fired == [1, 2]
+        self._put_status(store, 2)
+        assert f2.result(timeout=5)["status_code"] == 200
+        poller.shutdown(wait=True)
+
+    def test_attempt_id_dedupe_acts_once_per_execution(self):
+        # A duplicate poll of the SAME attempt's object must not double-count
+        # against the retry budget; only a NEW attempt_id is consumed.
+        store = MemoryStore()
+        fired: list[float] = []
+        poller = self._poller(store, max_retries=3)
+        fut = poller.register(1, "1", dispatch=lambda: fired.append(time.time()))
+        self._put_status(store, 1, status="failed", attempt_id="a1", error="boom")
+        poller.start()
+        deadline = time.time() + 5
+        while len(fired) < 2 and time.time() < deadline:
+            time.sleep(0.005)
+        assert len(fired) == 2  # initial dispatch + ONE re-dispatch for a1
+        # Ticks keep seeing the stale a1 object: no further consumption.
+        time.sleep(0.1)
+        assert len(fired) == 2
+        # The retry's execution lands with a fresh id and resolves the future.
+        self._put_status(store, 1, status="ok", attempt_id="a2")
+        assert fut.result(timeout=5)["retries"] == 1
+        poller.shutdown(wait=True)
+
+    def test_invoke_fault_burns_an_attempt_and_retries(self):
+        store = MemoryStore()
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("TooManyRequestsException")
+
+        poller = self._poller(store, max_retries=3)
+        fut = poller.register(1, "1", dispatch=flaky)
+        poller.start()
+        deadline = time.time() + 5
+        while calls["n"] < 2 and time.time() < deadline:
+            time.sleep(0.005)
+        assert calls["n"] == 2
+        self._put_status(store, 1)
+        assert fut.result(timeout=5)["retries"] == 1
+        poller.shutdown(wait=True)
+
+    def test_default_failure_resolution_is_a_result_dict(self):
+        # agg's mode: no on_failed -> the terminal failure resolves as the
+        # v1-shaped result dict (the accumulator records it), never an exception.
+        store = MemoryStore()
+        poller = self._poller(store, max_retries=1)
+        fut = poller.register(7, "7", dispatch=lambda: None)
+        self._put_status(store, 7, status="failed", error="boom", status_code=500)
+        poller.start()
+        result = fut.result(timeout=5)
+        assert result["error"] == "boom"
+        assert result["status_code"] == 500
+        assert result["shard_key"] == 7
+        poller.shutdown(wait=True)
+
+    def test_transient_list_fault_does_not_kill_the_poller(self):
+        store = MemoryStore()
+        calls = {"n": 0}
+        real_list = obstore.list
+
+        def flaky_list(s, *a, **k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("503 slow down")
+            return real_list(s, *a, **k)
+
+        poller = self._poller(store)
+        fut = poller.register(1, "1", dispatch=lambda: None)
+        self._put_status(store, 1)
+        try:
+            obstore.list = flaky_list
+            poller.start()
+            assert fut.result(timeout=5)["status_code"] == 200
+        finally:
+            obstore.list = real_list
+        poller.shutdown(wait=True)
+
+    def test_observe_only_entry_never_redispatches(self):
+        # attach's mode (issue #327 phase 5): dispatch=None -> a failed status
+        # resolves immediately through on_failed, no retry budget to spend.
+        store = MemoryStore()
+        failures: list = []
+        poller = self._poller(
+            store,
+            max_retries=3,
+            on_failed=lambda e, r: (failures.append(r), e.future.set_result(r)),
+        )
+        fut = poller.register(1, "1", dispatch=None)
+        self._put_status(store, 1, status="failed", error="boom")
+        poller.start()
+        assert fut.result(timeout=5)["error"] == "boom"
+        assert len(failures) == 1
+        poller.shutdown(wait=True)
+
+
+# -- keys / prefix ---------------------------------------------------------------
+
+
+class TestKeys:
+    def test_run_status_prefix_is_a_store_sibling(self):
+        assert ct.run_status_prefix("s3://b/out.zarr", "abc") == "s3://b/out.zarr.status/run-abc"
+        assert ct.run_status_prefix("s3://b/out.zarr/", "abc").endswith("out.zarr.status/run-abc")
+
+    def test_shard_status_key_decimal_and_window(self):
+        assert ct.shard_status_key(12345) == "shard-12345.json"
+        assert ct.shard_status_key(12345, window="2020") == "shard-12345_2020.json"
+        with pytest.raises(ValueError, match="grammar"):
+            ct.shard_status_key(1, window="../escape")
+
+    def test_drop_timeout_formula(self):
+        # function timeout + 60 s max event age + margin (issue #327 (a')).
+        assert ct.drop_timeout_s(900) == 900 + 60 + 90
+
+
+# -- Future plumbing -------------------------------------------------------------
+
+
+def test_register_returns_unresolved_future():
+    poller = ct.StatusPoller(lambda: MemoryStore(), drop_timeout_s=10.0)
+    fut = poller.register(1, "1", dispatch=lambda: None)
+    assert isinstance(fut, Future)
+    assert not fut.done()

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1366,6 +1366,83 @@ class TestSetupHive:
         assert json.loads(resp["body"]) == {"ok": True, "mode": "setup", "layout": "hive"}
 
 
+class TestDispatchManifest:
+    """Issue #327 phase 2: a setup event carrying ``run_manifest`` has the
+    WORKER write ``<store>.status/run-<id>/manifest.json`` (D8 intact) —
+    fail-open, and only on a successful setup."""
+
+    _BLOCK = {
+        "run_id": "runid2",
+        "shards": ["12345", "67890"],
+        "semantic_hash": "ab" * 32,
+        "dispatched_at": "2026-07-30T00:00:00+00:00",
+        "dataset": {"short_name": "ATL06", "version": "007"},
+    }
+
+    def _event(self, tmp_path, **extra):
+        return {
+            "mode": "setup",
+            "store_path": str(tmp_path / "hive-out"),
+            "parent_order": 6,
+            "overwrite": False,
+            "config": TestProcessHive._hive_config_dict(),
+            "dataset": {"short_name": "ATL06", "version": "007"},
+            "run_manifest": dict(self._BLOCK),
+            **extra,
+        }
+
+    @staticmethod
+    def _read_manifest(tmp_path):
+        p = tmp_path / "hive-out.status" / "run-runid2" / "manifest.json"
+        return json.loads(p.read_text()) if p.exists() else None
+
+    def test_setup_writes_dispatch_manifest_with_config(self, handler_mod, tmp_path):
+        event = self._event(tmp_path)
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200, resp["body"]
+        manifest = self._read_manifest(tmp_path)
+        assert manifest["schema_version"] == 1
+        assert manifest["run_id"] == "runid2"
+        assert manifest["shards"] == ["12345", "67890"]
+        assert manifest["semantic_hash"] == "ab" * 32
+        assert manifest["dispatched_at"] == "2026-07-30T00:00:00+00:00"
+        assert manifest["dataset"] == {"short_name": "ATL06", "version": "007"}
+        # The worker folds the setup event's own config in, so attach can
+        # rebuild the Run without the dispatcher duplicating it on the wire.
+        assert manifest["config"] == event["config"]
+
+    def test_absent_block_writes_nothing(self, handler_mod, tmp_path):
+        event = self._event(tmp_path)
+        del event["run_manifest"]
+        assert handler_mod.lambda_handler(event, _context())["statusCode"] == 200
+        assert not (tmp_path / "hive-out.status").exists()
+
+    def test_failed_setup_writes_no_manifest(self, handler_mod, tmp_path):
+        # Same frozen-key refusal as TestSetupHive: the 500 must not leave a
+        # dispatch manifest claiming a run that never set up.
+        assert handler_mod.lambda_handler(self._event(tmp_path), _context())["statusCode"] == 200
+        other = TestProcessHive._hive_config_dict()
+        other["output"]["grid"]["parent_order"] = 5
+        event = self._event(tmp_path, config=other, run_manifest={**self._BLOCK, "run_id": "bad"})
+        assert handler_mod.lambda_handler(event, _context())["statusCode"] == 500
+        assert not (tmp_path / "hive-out.status" / "run-bad").exists()
+
+    def test_manifest_write_failure_never_fails_setup(self, handler_mod, monkeypatch, tmp_path):
+        import zagg.store
+
+        real = zagg.store.open_object_store
+
+        def boom(prefix, **kwargs):
+            if ".status" in prefix:
+                raise RuntimeError("status channel down")
+            return real(prefix, **kwargs)
+
+        monkeypatch.setattr(zagg.store, "open_object_store", boom)
+        resp = handler_mod.lambda_handler(self._event(tmp_path), _context())
+        assert resp["statusCode"] == 200
+        assert self._read_manifest(tmp_path) is None
+
+
 class TestFinalizeHive:
     """Issue #252 (hybrid): for a hive config, finalize mode re-ensures the
     root ``morton_hive.json`` — the idempotent backstop for the async

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1611,6 +1611,64 @@ class TestStatsMode:
         )
         assert resp["statusCode"] == 500
 
+    def test_tail_status_url_writes_the_marker(self, handler_mod, tmp_path):
+        # Issue #327 phase 5: the stats leg is the recorded end of the
+        # post-run tail; the marker lets Run.attach skip a tail that ran.
+        root = str(tmp_path / "out")
+        url = str(tmp_path / "out.zarr.status" / "run-runid1" / "tail.json")
+        event = {
+            "mode": "stats",
+            "store_path": root,
+            "run_id": "runid1",
+            "timestamp": "20260720T010203Z",
+            "rows": self._rows(),
+            "tail_status_url": url,
+        }
+        assert handler_mod.lambda_handler(event, MagicMock())["statusCode"] == 200
+        marker = json.loads(Path(url).read_text())
+        assert marker["status"] == "tail_done"
+        assert marker["run_id"] == "runid1"
+        # The 0-row path records the marker too (nothing to persist != no tail).
+        url2 = str(tmp_path / "out.zarr.status" / "run-runid2" / "tail.json")
+        resp = handler_mod.lambda_handler(
+            {"mode": "stats", "store_path": root, "run_id": "runid2", "tail_status_url": url2},
+            MagicMock(),
+        )
+        assert resp["statusCode"] == 200
+        assert json.loads(Path(url2).read_text())["run_id"] == "runid2"
+
+    def test_marker_failure_never_fails_the_stats_write(self, handler_mod, monkeypatch, tmp_path):
+        import zagg.client_transport
+
+        def boom(*a, **k):
+            raise RuntimeError("marker down")
+
+        monkeypatch.setattr(zagg.client_transport, "write_tail_status", boom)
+        root = str(tmp_path / "out")
+        event = {
+            "mode": "stats",
+            "store_path": root,
+            "run_id": "runid1",
+            "timestamp": "20260720T010203Z",
+            "rows": self._rows(),
+            "tail_status_url": str(tmp_path / "t.json"),
+        }
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200
+        assert json.loads(resp["body"])["rows"] == 2
+
+    def test_no_tail_status_url_writes_no_marker(self, handler_mod, tmp_path):
+        root = str(tmp_path / "out")
+        event = {
+            "mode": "stats",
+            "store_path": root,
+            "run_id": "runid1",
+            "timestamp": "20260720T010203Z",
+            "rows": self._rows(),
+        }
+        assert handler_mod.lambda_handler(event, MagicMock())["statusCode"] == 200
+        assert not (tmp_path / "out.zarr.status").exists()
+
 
 class TestPingMode:
     """Issue #252: the hive pre-fan-out preflight. Answering 200 at all gates

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1679,6 +1679,32 @@ class TestStatsMode:
         assert resp["statusCode"] == 200
         assert json.loads(resp["body"])["rows"] == 2
 
+    def test_finalize_error_withholds_the_marker(self, handler_mod, tmp_path):
+        # Review finding, PR #343: the marker means "the tail RAN", and
+        # Run.attach reads it as "skip the whole tail" — including the
+        # idempotent finalize backstop a failed-finalize run is exactly the one
+        # that needs. So a stats event carrying #335's finalize_error writes
+        # the run parquet (the durable failure column) but NOT the marker.
+        root = str(tmp_path / "out")
+        url = str(tmp_path / "out.zarr.status" / "run-runid1" / "tail.json")
+        event = {
+            "mode": "stats",
+            "store_path": root,
+            "run_id": "runid1",
+            "timestamp": "20260720T010203Z",
+            "rows": self._rows(),
+            "tail_status_url": url,
+            "finalize_error": "finalize down",
+        }
+        resp = handler_mod.lambda_handler(event, MagicMock())
+        assert resp["statusCode"] == 200
+        assert json.loads(resp["body"])["rows"] == 2  # the record still lands
+        assert not Path(url).exists()
+        # ... and a successful finalize (None on the wire) still writes it.
+        event["finalize_error"] = None
+        assert handler_mod.lambda_handler(event, MagicMock())["statusCode"] == 200
+        assert json.loads(Path(url).read_text())["status"] == "tail_done"
+
     def test_no_tail_status_url_writes_no_marker(self, handler_mod, tmp_path):
         root = str(tmp_path / "out")
         event = {

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -2636,3 +2636,155 @@ class TestAsyncResultWrite:
         resp = handler_mod.lambda_handler({"mode": "extract", "result_url": url}, _context())
         assert resp["statusCode"] == 200
         assert not Path(url).exists()
+
+
+class TestShardStatusObject:
+    """Per-shard status objects (issue #327): always-on, every per-unit status
+    branch, written through the worker's own store factory to the run's
+    ``<store>.status/run-<id>/shard-<key>.json`` — and emphatically fail-open:
+    a status write failure never affects the shard result."""
+
+    def _event(self, monkeypatch, tmp_path, *, meta_error=None, run_id="runid1", **extra):
+        import zagg.grids as grids
+        import zagg.processing as processing
+
+        def fake_process_shard(grid, shard_key, granule_urls, **kwargs):
+            meta = {
+                "shard_key": shard_key,
+                "cells_with_data": 3,
+                "total_obs": 7,
+                "granule_count": len(granule_urls),
+                "files_processed": 1,
+                "duration_s": 0.5,
+                "error": meta_error,
+                "phase_timings": {"read": 1.0, "aggregate": 0.5},
+            }
+            return pd.DataFrame(), meta
+
+        monkeypatch.setattr(processing, "process_shard", fake_process_shard)
+        monkeypatch.setattr(grids, "from_config", lambda *a, **k: MagicMock())
+        event = _base_event(_healpix_config_dict())
+        event["child_order"] = 12
+        event["store_path"] = str(tmp_path / "x.zarr")
+        if run_id is not None:
+            event["run_id"] = run_id
+        event.update(extra)
+        return event
+
+    @staticmethod
+    def _read_status(tmp_path, key="shard-12345.json", run_id="runid1"):
+        p = tmp_path / "x.zarr.status" / f"run-{run_id}" / key
+        return json.loads(p.read_text()) if p.exists() else None
+
+    def test_ok_shard_writes_ok_status(self, handler_mod, monkeypatch, tmp_path):
+        event = self._event(monkeypatch, tmp_path)
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200
+        obj = self._read_status(tmp_path)
+        assert obj["status"] == "ok"
+        assert obj["schema_version"] == 1
+        assert obj["run_id"] == "runid1"
+        assert obj["shard"] == "12345"
+        assert obj["window"] is None
+        assert obj["error"] is None
+        assert obj["status_code"] == 200
+        assert len(obj["attempt_id"]) == 32  # a fresh uuid per execution
+        # The phase dict is the SAME one the response envelope carries.
+        assert obj["timings"] == json.loads(resp["body"])["phase_timings"]
+        # ... and the full body rides along so the poller can synthesize the
+        # sync transport's result dict (stats record, counters).
+        assert obj["body"]["total_obs"] == 7
+        assert obj["body"]["stats"]["run_id"] == "runid1"
+
+    def test_benign_no_work_is_no_data(self, handler_mod, monkeypatch, tmp_path):
+        event = self._event(monkeypatch, tmp_path, meta_error="No granules found")
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 500  # the envelope shape is unchanged
+        obj = self._read_status(tmp_path)
+        assert obj["status"] == "no_data"
+        assert obj["error"] == "No granules found"
+
+    def test_gate_400_writes_failed_status(self, handler_mod, monkeypatch, tmp_path):
+        # The caught-error path: a 400/500 envelope still records a status, so
+        # the poller learns fast instead of waiting out the drop deadline.
+        event = self._event(monkeypatch, tmp_path)
+        del event["granule_urls"]
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 400
+        obj = self._read_status(tmp_path)
+        assert obj["status"] == "failed"
+        assert "granule_urls" in obj["error"]
+        assert obj["status_code"] == 400
+
+    def test_unhandled_exception_writes_failed_status(self, handler_mod, monkeypatch, tmp_path):
+        import zagg.processing as processing
+
+        event = self._event(monkeypatch, tmp_path)
+
+        def boom(*a, **k):
+            raise RuntimeError("worker blew up")
+
+        monkeypatch.setattr(processing, "process_shard", boom)
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 500
+        obj = self._read_status(tmp_path)
+        assert obj["status"] == "failed"
+        assert "worker blew up" in obj["error"]
+
+    def test_windowed_unit_suffixes_the_window_label(self, handler_mod, monkeypatch, tmp_path):
+        event = self._event(
+            monkeypatch, tmp_path, window={"label": "2020", "start": 0.0, "end": 1.0}
+        )
+        handler_mod.lambda_handler(event, _context())
+        obj = self._read_status(tmp_path, key="shard-12345_2020.json")
+        assert obj["status"] == "ok"
+        assert obj["window"] == "2020"
+
+    def test_no_run_id_writes_nothing(self, handler_mod, monkeypatch, tmp_path):
+        # Old dispatcher: no run identity -> no status prefix to name, and the
+        # event/behavior stay byte-identical to pre-#327.
+        event = self._event(monkeypatch, tmp_path, run_id=None)
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200
+        assert not (tmp_path / "x.zarr.status").exists()
+
+    def test_raising_store_never_affects_the_shard_result(self, handler_mod, monkeypatch, tmp_path):
+        # The espg-ratified fail-open contract (issue #327): ANY exception in
+        # the status write logs and the shard's normal result stands.
+        import zagg.store
+
+        def boom(*a, **k):
+            raise RuntimeError("status channel down")
+
+        monkeypatch.setattr(zagg.store, "open_object_store", boom)
+        event = self._event(monkeypatch, tmp_path)
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200
+        assert json.loads(resp["body"])["total_obs"] == 7
+        assert not (tmp_path / "x.zarr.status").exists()
+
+    def test_transport_module_failure_is_also_swallowed(self, handler_mod, monkeypatch, tmp_path):
+        # Belt-and-braces: even the transport helper itself raising (or a
+        # function zip missing the module) must not fail the shard.
+        import zagg.client_transport
+
+        def boom(*a, **k):
+            raise RuntimeError("no transport")
+
+        monkeypatch.setattr(zagg.client_transport, "write_shard_status", boom)
+        event = self._event(monkeypatch, tmp_path)
+        resp = handler_mod.lambda_handler(event, _context())
+        assert resp["statusCode"] == 200
+
+    def test_duplicate_execution_overwrites_with_fresh_attempt_id(
+        self, handler_mod, monkeypatch, tmp_path
+    ):
+        # MaximumRetryAttempts is 0 fleet-wide, so a duplicate execution is a
+        # client re-dispatch; last-writer-wins with a NEW attempt_id is what
+        # keeps the poller's retry accounting straight (issue #327).
+        event = self._event(monkeypatch, tmp_path)
+        handler_mod.lambda_handler(event, _context())
+        first = self._read_status(tmp_path)["attempt_id"]
+        handler_mod.lambda_handler(event, _context())
+        second = self._read_status(tmp_path)["attempt_id"]
+        assert first != second


### PR DESCRIPTION
Closes #327. Refs #326 (built directly on the merged #333 client facade).

Implements the v2 Event transport per the ratified plan on #327 — the [implementation plan](https://github.com/englacial/zagg/issues/327#issuecomment-5124738952) plus its three amendments ([EventInvokeConfig correction](https://github.com/englacial/zagg/issues/327#issuecomment-5124759868), [always-on ratification](https://github.com/englacial/zagg/issues/327#issuecomment-5124783802), [prefix-delete hygiene + fail-open](https://github.com/englacial/zagg/issues/327#issuecomment-5124806827)) — and the session ruling that `agg` grows `invocation="event"` (2026-07-29).

## What this does

Workers now record every per-unit outcome as a small JSON **status object** at `<store>.status/run-<run_id>/shard-<decimal-key>.json` — always-on (every run, every dispatcher, every status branch including the caught-error 500) and **fail-open** (a status PUT failure logs and never affects the shard result). On top of that channel:

- **`Run.dispatch(transport="event")`** — fire-and-forget `InvocationType="Event"` invokes (202), all futures resolved by **one poller thread doing one LIST of the run prefix per tick** (backoff 2 s → 15 s cap, reset on progress). No held connections; `as_completed`/`status()`/`progress()`/`wait()`/tail semantics identical to v1. `max_retries` migrates to the **three-class retry policy** below (amendment (b) as folded from review); dispatch is **paced** to the concurrency window because the fleet's `MaximumEventAgeInSeconds: 60` silently drops invokes under backpressure (amendment (a′)).
- **Drop detection** — a shard with no status object after `function timeout + 60 s max event age + 90 s margin` resolves the distinct **`failed-unknown`** outcome (`payload["outcome"]`, counted failed by `status()`); a drop re-fires exactly once (class (b) below).
- **Dispatch manifest** — the existing setup invoke (hive fire-and-forget setup / flat sync setup) carries a `run_manifest` block; the **worker** writes `run-<id>/manifest.json` (run_id, shard keys as decimal strings, `semantic_hash`, `dispatched_at`, dataset identity, and the setup event's own config folded in). Size-gated on the hive async setup (dropped over the 256 KB cap, never fatal).
- **`Run.attach(store, run_id, ...)`** — rebuilds a `RunHandle` from manifest + current statuses; observe-only (no granule records → no re-dispatch); drop deadline anchored at the manifest's `dispatched_at`; the post-run tail runs **only if not already recorded** — the `mode="stats"` worker writes a `tail.json` marker when the tail's record leg completes **and** finalize succeeded (a run carrying #335's `finalize_error` withholds it, so a reattached handle re-runs the idempotent backstop), checked read-only.
- **`agg(..., invocation="event")`** — same blocking call-shape, summary shape, and exceptions as sync; Event dispatch + the same shared poller underneath (`_cell_work` blocks on the shard's future, so the accumulator/summary/tail are untouched and the pool width provides the pacing). Raster/temporal keep refusing anything but async/sync. **The benchmark harness and CI stay on sync** (their metrics come from invoke responses; `run_benchmark.py` untouched).
- **Tripwire** — `bench_objects` gains `_is_status_object` (generalizing the `_is_run_parquet` telemetry filter, ratified amendment): anything under a `.status` prefix segment is excluded from every bucket of the #215/#240 object model.

D8 is intact end to end: every write (status objects, manifest, tail marker) is worker-side off an invoke; the client/poller side only LISTs and GETs — asserted by an explicit audit test that counts every PUT during a full v2 run.

## Status object schema (as implemented)

```json
{
  "schema_version": 1,
  "status": "ok" | "failed" | "no_data",
  "attempt_id": "<uuid4 hex, fresh per execution>",
  "run_id": "<dispatcher run id>",
  "shard": "<decimal shard key>",
  "window": null | "<window label>",
  "timings": { "read": 1.0, "aggregate": 0.5, "write": 0.2 },
  "error": null | "<error string>",
  "status_code": 200,
  "body": { "...": "the full response envelope body" }
}
```

`body` is one field beyond the ratified minimum — see Questions.

## Retry policy (three fault classes)

Folded from the PR review, which found that re-dispatching on **any** non-ok status diverged
from a recorded decision and could bill `max_retries` full executions for an unrecoverable
shard. Function errors never return to an Event caller, so v1's single `max_retries` loop is
split by what actually failed:

| class | trigger | behavior |
|---|---|---|
| (a) deterministic worker failure | a `failed` **status object** | never re-fires; resolves immediately |
| (b) queue drop | no status object by the drop deadline (`failed-unknown`) | re-fires **exactly once** (`_MAX_DROP_REFIRES = 1`) |
| (c) invoke-layer fault | `client.invoke` itself raised (throttle, read timeout) | retries to `max_retries` with `2**attempts` s backoff |

- **(a)** A status object exists ⇒ the worker ran to completion and reported its own error ⇒
  deterministic for that shard. This is the rule the sync transport already follows: *"Every
  `FunctionError` on a synchronous invoke is deterministic for a given shard … so none are
  retried"* (#119). Re-firing buys a guaranteed second failure at full cost.
- **(b)** The one class where a re-fire can actually succeed, since an invoke that aged out of
  the async queue never ran. Bounded at one re-fire because a drop and an OOM/timeout death are
  indistinguishable from the client, so the exposure is **at most 2 × function timeout** billed
  for a shard that may be unrecoverable. That bound is the point: #151 pinned
  `MaximumRetryAttempts: 0` precisely so async fan-out is never re-billed at 900 s per service
  retry, and an unbounded client-side re-dispatch would reintroduce it from the outside.
  `max_retries <= 1` opts out entirely, keeping the knob's "no retries" meaning.
- **(c)** `max_retries` in its original v1 meaning. Backoff is a **not-before timestamp** on the
  entry, not a `time.sleep` — one thread serves every shard, so sleeping would stall the LISTs,
  and an unstamped re-queue burned the whole budget in the same dispatch pass (measured: 5
  invokes in 0.3 ms), turning a transient `TooManyRequestsException` into a wholesale run
  failure. Throttling is the canonical fleet-scale fault, so this is the class that most needed
  the fix.

**@espg's to veto** — this is a policy choice, not a bug fix, and it changes what a `max_retries`
value means on the event transport (it no longer governs worker-reported failures at all). Say
the word and any of the three classes can move; the code keeps them in three separate methods
(`_worker_failed` / `_drop_failed` / `_invoke_faulted`) so a change is one method deep.

## Phases

- [x] Phase 1 — worker-side status objects (always-on, fail-open) + tripwire exclusion (`4688c17`)
- [x] Phase 2 — dispatch manifest via the setup invoke (`95ef221`)
- [x] Phase 3 — client Event transport + `StatusPoller` + `_build_cell_event`/`_cell_payload` extraction (`007f89c`)
- [x] Phase 4 — drop detection: `failed-unknown` + budget participation, fake-clock tests (`2194771`)
- [x] Phase 5 — `Run.attach` + tail-completion marker (`fc0267f`)
- [x] Phase 6 — `agg(invocation="event")` + `rows_from_status` dual-shape (`324f9e1`)
- [x] Phase 7 — cross-cutting tests: D8 write audit, dual-shape rows (`65025b8`)
- [x] Module-ceiling split + typing hygiene + a test-ordering fix (`ab411f4`, `f06a506`, `3851a2a` — the tqdm test in `test_client.py` reload()s `zagg.client` mid-suite, so the transport tests resolve `ShardError` at call time)
- [x] Merge of `origin/main` (`142c4d7` — main advanced with the issue #335 guarded-finalize tail mid-implementation; the `_dispatch_run_stats` overlaps keep BOTH sides: `finalize_error` (#335) and `tail_status_url` + the event-run stats pointer (#327), applied inside #335's new tail `try:` structure)
- [x] Adversarial-review fold — 8 findings, one commit each (`862e23a`, `009a0f6`, `a8dd7b1`, `7ce6c5a`, `3818c81`, `5f448d5`, `7876f4b`, `de583d8`): the retry-policy split above, the throttle backoff, the event-run run-record pointer, the post-shutdown `register` guard, the withheld tail marker on a failed finalize, the schema/attempt-id read guards, the corrected per-tick LIST cost + same-tick slot refill, and the windowed-key + attach-D8 coverage

## How it was tested

New `tests/test_client_transport.py` (46 tests): a stub Lambda whose Event "workers" write status objects into an obstore `MemoryStore` **through the real `build_shard_status`**, so the worker and client halves cannot drift. Covers: poller resolution, event/sync payload parity (byte-identical modulo InvocationType), each retry class (a `failed` status resolving with zero re-dispatches, a drop re-firing exactly once at `max_retries=5`, a throttle backing off on an asserted 2/4/8 s schedule), attempt-id dedupe (a duplicate execution's object is acted on once) and its falsy-id guard, an unknown `schema_version` warning, post-shutdown `register` refusal, same-tick slot refill, pacing window (`max_in_flight=1` provably holds), drop classification with a fake clock + budget participation, attach mid-run/post-run/failed/stale/missing-manifest/windowed-refusal, agg event↔sync parity (same events modulo InvocationType, same tail mode sequence, same summary counts), a windowed 2-window event run pinning the per-window status key across both halves of the channel, the D8 PUT audit on **both** the dispatch and attach paths, and `rows_from_status` over both object shapes.

Plus: 9 handler tests for the status write (every branch incl. caught-error 400/500, window suffix, no-run-id no-op, raising store → shard result unaffected — the ratified fail-open test), 4 for the dispatch manifest, 4 for the tail marker; 6 client tests for the `run_manifest` block (client/agg block equality, size gate); 2 tripwire tests.

Local gates: `pytest tests/test_client.py tests/test_runner.py tests/test_processing.py tests/test_benchmark_objects.py tests/test_lambda_handler.py tests/test_client_transport.py` green; `ruff check` + `ruff format --check` clean on every touched file; mypy clean on the new module. Full suite green except pre-existing/environmental failures: `TestFunctionBuild::test_function_build_succeeds` (known), and `test_full_aoi_benchmark`/`test_raster_benchmark`/`test_shardmap`/`test_sources`/`test_viz` items that need `pyarrow` (catalog extra absent in this env). The known `TestConsolidationGate` pair passes locally.

## Questions for review

1. **Status objects carry the full envelope `body`** — one field beyond the ratified `{status, attempt_id, run_id, shard, timings, error}` schema. Without it the event transport cannot reproduce sync's results (`total_obs`/`cells_with_data` in the summary, `body["stats"]` for the run parquet and sweep leaves, `time_range` for coverage). The body is a few KB (granule ids ride as `granules_sha256`, never as lists). Flag if you'd rather enumerate fields.
2. **Shard naming uses the raw decimal key** (`shard-<int>`), not the issue #199 morton label — the caught-error handler path must name the object without constructing a grid. The manifest lists the same decimal strings, so the join is consistent; labels remain in messages/`ShardError`.
3. **Drop margin** is 90 s (`_DROP_MARGIN_S`, mirroring `_ASYNC_POLL_MARGIN_S`), so the deadline is `timeout + 60 + 90`. Poll-tick LIST pagination rides `obstore.list`'s internal pagination (one logical LIST per tick).
4. **Manifest size gate**: on the hive async setup the `run_manifest` block is dropped when it would push the event over the 256 KB cap (roughly 10k+ shards) — attach then degrades to statuses only. Keeping it would need a different transport for the manifest (another worker invoke); deferred.
5. **Both modules are over the §4 ~1000-line ceiling** and I am raising it rather than splitting further on my own. `client.py` is 1148 lines (912 pre-#327; the poller/transport/attach machinery already lives in the new `src/zagg/client_transport.py` — the split the plan pre-authorized), and `client_transport.py` is now **1099** lines, up from 854 because the review fold added the retry-policy rationale, the corrected per-tick cost paragraph, and the read-guard docstrings. Both overages are prose, not logic: `ruff`'s own count of code lines is well under. Three options — (a) leave it, since the growth is documentation of ratified decisions; (b) split the worker half (`build_shard_status`/`write_*`, ~250 lines) into `zagg/status_objects.py`, leaving the poller and reattach in `client_transport.py`; (c) move the retry-policy prose to a docs page and cross-reference it. Your call — I did not want a module split to ride in on a review fold.
6. **Payload-cap behavior differs slightly on the event transport**: the 256 KB check runs for ALL shards before anything fires (fail-whole-run early) instead of mid-fan-out per shard.
7. **Scope notes**: local-backend runs write no status objects (no worker handler in that path); `Run.attach` covers unwindowed spatial runs (windowed units are (shard, window) pairs the manifest does not enumerate) — `agg(invocation="event")` does handle windowed configs (status keys carry the window suffix; a 2-window run is now covered locally per the review, still untested at fleet scale).
8. **`deployment/aws/lambda_handler.py` was modified** — the issue's phase 1 explicitly requires the worker-side status write, and the additions are three thin, doubly-fail-open delegations into `zagg.client_transport` (the #297/#300/#313 precedent for handler changes). No infra files (template.yaml, build/standup scripts) touched, nothing run against live AWS.


