### PR TITLE
Overview-zarr sweep family: pyramid generation at ancestor nodes (issue #201)

### DIFF
--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -46,9 +46,18 @@ through).
 
 from __future__ import annotations
 
+import re
+
 # Per-shard attribution on the flat layout assumes the 1-D fullsphere HEALPix
 # layout the benchmark manifests use (block index arithmetic on the cells
 # axis); the hive layout attributes by leaf prefix and is layout-agnostic.
+
+#: A leaf zarr basename's morton-id stem (D1 grammar: sign + base 1-6, then
+#: digits 1-4). Sweep overview basenames (issue #201, D23 window naming:
+#: ``{window}.zarr`` / ``all.zarr``) can never match it — window labels carry
+#: 0/5-9 digits or letters and ``all`` is the reserved token — which is what
+#: lets the hive walk tell an overview zarr from a stray source leaf.
+_MORTON_ID_RE = re.compile(r"-?[1-6][1-4]*")
 
 
 def _require_fullsphere(grid) -> None:
@@ -233,6 +242,7 @@ def store_object_counts(
     other: list[str] = []
     metadata = 0
     rollups = 0
+    overviews = 0
 
     if store_layout == "flat":
         _require_fullsphere(grid)
@@ -303,6 +313,20 @@ def store_object_counts(
                 if key.endswith(".rollup.json"):
                     rollups += 1
                     continue
+                # Sweep overview zarrs (issue #201): `{window}.zarr/...` at a
+                # digit node. The window-token basename can never parse as a
+                # morton id (see _MORTON_ID_RE), while a source leaf's stem
+                # before the first `_` always does — so an overview classifies
+                # into its own D9 second-pass bucket (like the rollups above,
+                # excluded from the audited write-path total) while a stray
+                # id-named `.zarr` outside the dispatched leaf set stays a
+                # loud ``other`` finding.
+                seg = next((p for p in key.split("/") if p.endswith(".zarr")), None)
+                if seg is not None and not _MORTON_ID_RE.fullmatch(
+                    seg.removesuffix(".zarr").split("_", 1)[0]
+                ):
+                    overviews += 1
+                    continue
                 node, _, name = key.rpartition("/")
                 is_sibling = any(
                     name == f"{stem}.json"
@@ -321,6 +345,7 @@ def store_object_counts(
         "objects_metadata": metadata,
         "objects_per_shard": per_shard,
         "objects_rollups": rollups,
+        "objects_overviews": overviews,
         "objects_other": len(other),
         "other_keys": other[:20],
     }
@@ -377,13 +402,17 @@ def object_count_mismatch(measured: dict, expected: dict) -> str | None:
     know every object the run writes.
     """
     problems = []
-    # Sweep rollups (issue #300) are second-pass D9 caches, not write-path
-    # objects: the end-of-run sweep may or may not have landed them by
-    # measurement time (fire-and-forget on Lambda), so they are tallied in
-    # their own bucket and excluded from the write-path total this model
-    # audits (the #215 bypass guard below is untouched — rollups never live
-    # inside a leaf prefix).
-    total = measured["objects_total"] - measured.get("objects_rollups", 0)
+    # Sweep rollups (issue #300) and overview zarrs (issue #201) are
+    # second-pass D9 caches, not write-path objects: the end-of-run sweep may
+    # or may not have landed them by measurement time (fire-and-forget on
+    # Lambda), so they are tallied in their own buckets and excluded from the
+    # write-path total this model audits (the #215 bypass guard below is
+    # untouched — neither ever lives inside a leaf prefix).
+    total = (
+        measured["objects_total"]
+        - measured.get("objects_rollups", 0)
+        - measured.get("objects_overviews", 0)
+    )
     meta = measured["objects_metadata"]
     meta_lo, meta_hi = expected["metadata_min"], expected["metadata"]
     if not (meta_lo <= meta <= meta_hi):

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -2339,7 +2339,7 @@ def _validate_pyramid(config: PipelineConfig) -> None:
     raw = config.output.get("pyramid")
     if raw is None or raw is False:
         return
-    knob = get_pyramid(config)  # raises on a non-mapping
+    knob = get_pyramid(config) or {}  # raises on a non-mapping
     if get_store_layout(config) != "hive":
         raise ValueError(
             "output.pyramid requires output.store_layout: hive (overviews live at "

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -856,6 +856,10 @@ def _validate_store_layout_keys(config: PipelineConfig) -> None:
             "output.sweep requires output.store_layout: hive (the rollup sweep "
             "folds hive-tree leaf artifacts; flat stores have no digit tree)"
         )
+    # Overview pyramid declaration (issue #201): explicit blocks are grammar-
+    # checked here; the D24 none-field warning fires at manifest build time
+    # (template time for the store), not per config validation.
+    _validate_pyramid(config)
 
 
 def _validate_windowing(config: PipelineConfig) -> None:
@@ -2298,6 +2302,88 @@ def get_sweep(config: PipelineConfig) -> bool:
     if flag is None:
         return get_store_layout(config) == "hive"
     return bool(flag)
+
+
+def get_pyramid(config: PipelineConfig) -> dict | None:
+    """The overview pyramid declaration knob, or ``None`` when disabled (#201).
+
+    ``output.pyramid`` shapes the manifest's template-time pyramid block
+    (``zagg.sweep_overview.build_pyramid_block``): absent/null returns ``{}``
+    — the defaults apply (an every-2-orders overview schedule below the shard
+    order, the espg-ratified display default; no all-time fold) — and
+    ``false`` returns ``None``, declaring the overview family OFF for the
+    store. An explicit mapping may carry ``spacing`` (int >= 1), ``orders``
+    (explicit ancestor orders, winning over ``spacing``), ``all_time``
+    (bool: also maintain the ``all.zarr`` cross-window fold on windowed
+    stores), and ``summarize`` (the D24 opt-in derived-summary declarations,
+    ``{source_field: {"as": name, ...}}`` — recorded in the pyramid block,
+    never the semantic core).
+    """
+    raw = config.output.get("pyramid")
+    if raw is False:
+        return None
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"output.pyramid must be a mapping or false (got {raw!r})")
+    return dict(raw)
+
+
+def _validate_pyramid(config: PipelineConfig) -> None:
+    """Validate the ``output.pyramid`` knob's grammar (issue #201).
+
+    Only an EXPLICIT block is checked (absent/false are always legal); an
+    explicit block requires the hive store layout, like ``sweep`` — the
+    pyramid materializes through the hive manifest.
+    """
+    raw = config.output.get("pyramid")
+    if raw is None or raw is False:
+        return
+    knob = get_pyramid(config)  # raises on a non-mapping
+    if get_store_layout(config) != "hive":
+        raise ValueError(
+            "output.pyramid requires output.store_layout: hive (overviews live at "
+            "hive-tree ancestor nodes; flat stores have no digit tree)"
+        )
+    unknown = set(knob) - {"spacing", "orders", "all_time", "summarize"}
+    if unknown:
+        raise ValueError(f"output.pyramid has unknown keys {sorted(unknown)}")
+    spacing = knob.get("spacing")
+    if spacing is not None and (not isinstance(spacing, int) or spacing < 1):
+        raise ValueError(f"output.pyramid.spacing must be an int >= 1 (got {spacing!r})")
+    parent_order = int((config.output.get("grid") or {}).get("parent_order", 0))
+    orders = knob.get("orders")
+    if orders is not None:
+        ok = isinstance(orders, list) and all(isinstance(k, int) for k in orders)
+        if not ok or any(not (0 <= k < parent_order) for k in orders):
+            raise ValueError(
+                f"output.pyramid.orders must be a list of ancestor orders in "
+                f"[0, parent_order) = [0, {parent_order}) (got {orders!r})"
+            )
+    all_time = knob.get("all_time")
+    if all_time is not None and not isinstance(all_time, bool):
+        raise ValueError(f"output.pyramid.all_time must be a boolean (got {all_time!r})")
+    summarize = knob.get("summarize")
+    if summarize is None:
+        return
+    if not isinstance(summarize, dict):
+        raise ValueError(f"output.pyramid.summarize must be a mapping (got {summarize!r})")
+    fields = get_agg_fields(config)
+    for source, decl in summarize.items():
+        if source not in fields:
+            raise ValueError(
+                f"output.pyramid.summarize names unknown field {source!r} "
+                f"(declared: {sorted(fields)})"
+            )
+        target = (decl or {}).get("as")
+        if not isinstance(target, str) or not target:
+            raise ValueError(f"output.pyramid.summarize.{source} requires 'as': <new field name>")
+        if target in fields:
+            raise ValueError(
+                f"output.pyramid.summarize.{source}.as = {target!r} collides with a "
+                f"declared field: derived summaries must use a DIFFERENT name so overview "
+                f"schema never silently differs from source (D24)"
+            )
 
 
 def get_windowing(config: PipelineConfig) -> dict | None:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1042,6 +1042,17 @@ def _validate_windowing_windows(block: dict, schedule: str) -> None:
             start, end = _windows.parse_utc(entry["start"]), _windows.parse_utc(entry["end"])
         except ValueError as e:
             raise ValueError(f"output.windowing.windows: {e}") from e
+        if label == _windows.SCHEDULE_NONE_TOKEN:
+            # The opaque grammar admits it, but the token names the unwindowed
+            # / all-time artifact everywhere (leaf_name_v3, the D23 overview
+            # basename and its envelope key), so an explicit window by this
+            # name would ALIAS the all-time fold — the per-window overview gets
+            # overwritten and never regenerates (review finding, issue #201).
+            raise ValueError(
+                f"explicit window label {label!r} is the reserved schedule:none token "
+                f"(SCHEDULE_NONE_TOKEN, D23) — it would alias the all-time artifact; "
+                f"declare a different explicit label"
+            )
         if not start < end:
             raise ValueError(
                 f"explicit window {label!r} is not half-open: start "

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -2,6 +2,7 @@
 
 import importlib
 import inspect
+import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -12,6 +13,8 @@ import numpy as np
 import yaml
 
 import zagg.configs
+
+logger = logging.getLogger(__name__)
 
 
 class LinkDict(TypedDict):
@@ -858,8 +861,11 @@ def _validate_store_layout_keys(config: PipelineConfig) -> None:
         )
     # Overview pyramid declaration (issue #201): explicit blocks are grammar-
     # checked here; the D24 none-field warning fires at manifest build time
-    # (template time for the store), not per config validation.
+    # (template time for the store), not per config validation. The NaN-fill
+    # reduction warning below IS per config validation (espg ruling on the
+    # PR #344 nan-policy finding): it concerns the store encoding itself.
     _validate_pyramid(config)
+    _warn_nan_ambiguous_reductions(config)
 
 
 def _validate_windowing(config: PipelineConfig) -> None:
@@ -2395,6 +2401,55 @@ def _validate_pyramid(config: PipelineConfig) -> None:
                 f"declared field: derived summaries must use a DIFFERENT name so overview "
                 f"schema never silently differs from source (D24)"
             )
+
+
+#: Exact-law reductions whose plain (NaN-propagating) forms cannot round-trip
+#: through a NaN fill: at read, a NaN datum and the fill are the same bytes.
+_NAN_AMBIGUOUS_REDUCTIONS = ("min", "max", "sum")
+
+
+def _warn_nan_ambiguous_reductions(config: PipelineConfig) -> None:
+    """Warn when a plain ``min``/``max``/``sum`` pairs with a NaN fill (#201).
+
+    Warning, not error — the pairing is legal (the shipped atl06 config uses
+    it by design), but the store encoding has a consequence the author should
+    have chosen knowingly: a NaN datum and the fill sentinel are the same
+    bytes, so downstream the reduction behaves as its nan-skipping form (the
+    pyramid block declares this as ``nan_policy: "skip"``) and a
+    NaN-propagating result is unrecoverable. Declaring ``nanmin``/``nanmax``/
+    ``nansum`` states the same semantics explicitly and silences this.
+    """
+    from zagg.semantics import _fold_function_name, field_composability
+
+    for name, meta in get_agg_fields(config).items():
+        fn = _fold_function_name(meta.get("function"))
+        if fn not in _NAN_AMBIGUOUS_REDUCTIONS or not _is_nan_fill(meta):
+            continue
+        try:
+            if field_composability(meta) != "exact":
+                continue
+        except Exception:
+            continue  # malformed meta: the kind/shape validators own the error
+        logger.warning(
+            f"aggregation.variables.{name}: {meta.get('function')!r} with a NaN fill_value — "
+            f"NaN data is indistinguishable from fill at read; the reduction behaves as "
+            f'nan{fn} in overviews (declared in the pyramid block as nan_policy: "skip") '
+            f"and any NaN-carrying result is unrecoverable — use nan{fn} explicitly to "
+            f"silence this (issue #201)"
+        )
+
+
+def _is_nan_fill(meta: dict) -> bool:
+    """Whether a field's fill sentinel is NaN (explicitly, or by float default)."""
+    fill = meta.get("fill_value")
+    if fill is None:
+        try:
+            return np.issubdtype(np.dtype(meta.get("dtype", "float32")), np.floating)
+        except TypeError:
+            return False
+    if isinstance(fill, str):
+        return fill.strip().lower() == "nan"
+    return isinstance(fill, float) and np.isnan(fill)
 
 
 def get_windowing(config: PipelineConfig) -> dict | None:

--- a/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
+++ b/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
@@ -148,3 +148,4 @@ output:
     sharded: true
     child_order: 19              # leaf cell resolution (~10 m)
   store_layout: hive
+  pyramid: false                 # overview sweep opted out pending Phase E fleet sizing (issue #201)

--- a/src/zagg/coverage.py
+++ b/src/zagg/coverage.py
@@ -198,6 +198,39 @@ def warn_if_stale(store_root: str, shard_key, envelope: dict | None) -> bool:
     return True
 
 
+def _is_decimal_id(decimal: str) -> bool:
+    """Whether ``decimal`` is a well-formed D1 id: ``{sign+base}`` + ``[1-4]`` digits.
+
+    The guard that keeps ``morton_words_from_decimals`` from raising out of the
+    repair walk: a foreign basename can satisfy the leaf-name grammar AND
+    :func:`~zagg.hive._decimal_order` without being a morton id at all
+    (``all.zarr`` — ``_decimal_order("all") == 2``).
+    """
+    base = _decimal_base(decimal)
+    return _is_base_component(base) and all(ch in "1234" for ch in decimal[len(base) :])
+
+
+def _is_derived_zarr(zarr_root: str, store_kwargs: dict) -> bool:
+    """Whether a ``.zarr``'s root attrs declare a D11 ``role`` (derived artifact).
+
+    Overview pyramid zarrs (issue #201) sit at ANCESTOR digit nodes under
+    ``{window}.zarr`` basenames, so the walker's leaf grammar can match them
+    (``all.zarr``, or a digits-only window label that parses as a decimal); the
+    ``role`` attr is the sanctioned discriminator — D11 forbids inferring the
+    role from tree position. One small GET of the root group metadata, gated by
+    the caller on a non-shard-order depth so source leaves never pay it.
+    """
+    from zagg.hive import _read_json
+    from zagg.sweep_overview import ROLE_ATTR
+
+    try:
+        meta = _read_json(open_object_store(zarr_root, **store_kwargs), "zarr.json")
+    except ValueError:
+        return False
+    attrs = (meta or {}).get("attributes")
+    return isinstance(attrs, dict) and ROLE_ATTR in attrs
+
+
 def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     """Rebuild the root MOC from a full tree walk — the explicit escape hatch.
 
@@ -215,6 +248,10 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     shards whose commit stamp is present — unstamped debris is excluded,
     exactly as the D4 model demands. The fresh envelope carries
     ``source: "refresh"`` and REPLACES the root object (no union: the walk
+    supersedes it). DERIVED zarrs at ancestor nodes — the overview pyramid
+    family, issue #201 — are stamped and can wear leaf-shaped basenames, so a
+    ``.zarr`` off the shard-order depth is checked for the D11 ``role`` attr and
+    skipped when it carries one (never classified by position). A
     supersedes it). A successful refresh also re-arms the
     :func:`warn_if_stale` once-per-episode latch for this store. Returns the
     envelope written, or ``None`` — deleting any existing root object — when
@@ -258,6 +295,13 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
                 stamp = read_commit(open_store(f"{root}/{rel}", **store_kwargs))
                 if stamp is None:
                     continue  # unstamped debris (D4)
+                if rel.count("/") - 1 != order and _is_derived_zarr(f"{root}/{rel}", store_kwargs):
+                    # A DERIVED artifact at an ancestor node, not source data:
+                    # overview pyramid zarrs are stamped and their basenames can
+                    # collide with the leaf grammar (issue #201). Silent like all
+                    # non-data children — the role attr is authoritative (D11).
+                    logger.debug(f"refresh: skipping derived zarr {rel!r} (D11 role attr)")
+                    continue
                 # Windowed leaves (issue #246, D13): `{full_id}_{window}.zarr`
                 # names split on the first `_` (frozen parse rule); several
                 # windows of one shard collapse to one coverage entry below.
@@ -271,6 +315,17 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
                     logger.warning(
                         f"refresh: skipping STAMPED leaf {name!r} with a malformed "
                         f"window label (frozen grammar, mortie#62) — it will NOT be "
+                        f"listed in {ROOT_COVERAGE_NAME}"
+                    )
+                    continue
+                if not _is_decimal_id(decimal):
+                    # Same posture, one grammar down: the name split succeeded
+                    # but the id is not a morton decimal, so no MOC word exists
+                    # for it. Skipped HERE rather than left to raise out of the
+                    # closing `morton_words_from_decimals` (issue #201 review).
+                    logger.warning(
+                        f"refresh: skipping STAMPED leaf {name!r} whose id {decimal!r} is not "
+                        f"a D1 morton decimal (sign+base then [1-4] digits) — it will NOT be "
                         f"listed in {ROOT_COVERAGE_NAME}"
                     )
                     continue

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -41,9 +41,9 @@ leaf zarr** under a morton digit tree::
   root ``coverage.moc`` (issue #200 phase 3, default-on for hive) is a
   shard-order ranges MOC at the store root — the second root-only object,
   written fail-open by the dispatcher (locally) or a fire-and-forget worker
-  invoke (Lambda), and a regenerable cache under D9. The pyramid sweep (§7)
-  is a follow-on; the manifest's ``pyramid`` block is declared-only in round
-  one (D11/D12).
+  invoke (Lambda), and a regenerable cache under D9. The manifest's
+  ``pyramid`` block declares the overview schedule at template time and the
+  §7 sweep populates its actuals (D11/D22 — issue #201).
 """
 
 from __future__ import annotations
@@ -286,9 +286,13 @@ def build_manifest(grid, dataset: dict | None = None, windowing: dict | None = N
     ``grid`` supplies the orders; ``dataset`` (typically the ShardMap's
     ``metadata``) supplies identity — only ``short_name`` and ``version`` are
     recorded. The split schedule is implicit under D2 (one digit per level down
-    to the shard order) but recorded explicitly for forward compatibility; the
-    ``pyramid`` block is declared-only in round one (D11: overviews are a
-    second-pass sweep, never written at fan-out time).
+    to the shard order) but recorded explicitly for forward compatibility. The
+    ``pyramid`` block carries the template-time overview declaration —
+    per-family order schedule + per-field D24 composability classes
+    (:func:`zagg.sweep_overview.build_pyramid_block`, issue #201); the §7
+    sweep populates ``materialized`` actuals but never rewrites the
+    declaration (overviews are a second-pass sweep, never written at
+    fan-out time — D11).
 
     ``windowing`` (issue #246) is the normalized declaration from
     :func:`zagg.config.get_windowing`; when given, the manifest declares
@@ -300,6 +304,7 @@ def build_manifest(grid, dataset: dict | None = None, windowing: dict | None = N
     manifest byte-identical to pre-windowing runs.
     """
     from zagg.semantics import semantic_hash
+    from zagg.sweep_overview import build_pyramid_block
 
     dataset = dataset or {}
     manifest = {
@@ -319,7 +324,7 @@ def build_manifest(grid, dataset: dict | None = None, windowing: dict | None = N
         # stores are retroactively 1 (the _frozen normalization); new stores
         # declare it explicitly.
         "path_grouping": 1,
-        "pyramid": {"orders": [], "aggregation": {}},
+        "pyramid": build_pyramid_block(grid.config, int(grid.parent_order)),
         "generated_at": _utcnow(),
     }
     if windowing:

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -80,6 +80,15 @@ GRID_SPATIAL_KEYS = ("crs", "resolution", "bounds")
 #: direct aggregation at the coarser order, byte for byte (§8.3). Names are
 #: matched after :func:`_fold_function_name` normalization, so ``min``,
 #: ``np.min`` and ``numpy.min`` all key the same law.
+#:
+#: The plain and nan-aware variants share a law ON PURPOSE, and the exactness
+#: claim is against the **nan-skipping** reduction for both (review finding,
+#: issue #201): a leaf's stored NaN is the same bytes whether it is the fill
+#: sentinel or a NaN datum, so nothing downstream can tell them apart —
+#: :func:`zagg.sweep_overview.fold_dense` skips both, and the overview records
+#: :data:`zagg.sweep_overview.EXACT_NAN_POLICY` per field so a reader knows
+#: which reduction it actually got. A NaN-propagating ``min``/``max``/``sum``
+#: is unrecoverable at this seam, not merely unimplemented.
 EXACT_MERGE_LAWS = {
     "len": "sum",
     "count": "sum",

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -74,6 +74,90 @@ FINGERPRINT_HEX = 12
 GRID_SPATIAL_KEYS = ("crs", "resolution", "bounds")
 
 
+#: D24 exact merge laws: aggregator name -> fold law. These are the reducers
+#: whose per-cell outputs compose EXACTLY across cell orders — count/sum by
+#: addition, min/max by extremum — so an up-tree fold of leaf values equals a
+#: direct aggregation at the coarser order, byte for byte (§8.3). Names are
+#: matched after :func:`_fold_function_name` normalization, so ``min``,
+#: ``np.min`` and ``numpy.min`` all key the same law.
+EXACT_MERGE_LAWS = {
+    "len": "sum",
+    "count": "sum",
+    "sum": "sum",
+    "nansum": "sum",
+    "min": "min",
+    "nanmin": "min",
+    "max": "max",
+    "nanmax": "max",
+}
+
+#: The three D24 composability classes, weakest first. ``exact`` folds byte-
+#: equal; ``approximate`` merges natively but order-dependently (t-digests —
+#: ``np.isclose`` equality, the merge-vs-spill epistemic class); ``none`` has
+#: no merge law and exists only at native resolution (per-field exclusion —
+#: the ruled D24 default, issue #201).
+COMPOSABILITY_CLASSES = ("none", "approximate", "exact")
+
+
+def _fold_function_name(name) -> str | None:
+    """Normalize an aggregator ``function`` name for merge-law lookup.
+
+    ``np.``/``numpy.`` prefixes strip (they resolve to the same callables in
+    :func:`zagg.config.resolve_function`); other dotted paths pass through
+    unchanged (their laws are keyed by full path, e.g. the t-digest builders).
+    """
+    if not isinstance(name, str):
+        return None
+    for prefix in ("np.", "numpy."):
+        if name.startswith(prefix):
+            return name.removeprefix(prefix)
+    return name
+
+
+def field_composability(meta: dict) -> str:
+    """The D24 composability class of one aggregation field's metadata.
+
+    Derived from the field's aggregator via the merge-law flags the #217
+    mergeable-reducer machinery already established (the same set
+    ``validate_streaming`` accepts, widened by the exact sum/min/max laws):
+
+    - ``exact`` — scalar ``function`` in :data:`EXACT_MERGE_LAWS`;
+    - ``approximate`` — an unlocated ragged t-digest field with the standard
+      ``(2,)`` centroid inner shape (merge is order-dependent; ``np.isclose``
+      equality class, cf. D24);
+    - ``none`` — everything else: expressions, vector fields, chunk-resolution
+      companions, located ragged (no streaming merge law for the location
+      channel yet), and any scalar reducer without an exact law (mean, std,
+      median, quantiles, ...).
+    """
+    from zagg.config import get_output_signature
+
+    sig = get_output_signature(meta)
+    if meta.get("expression") is not None or sig["resolution"] != "cell":
+        return "none"
+    function = _fold_function_name(meta.get("function"))
+    if sig["kind"] == "ragged":
+        from zagg.processing.streaming import _TDIGEST_FUNCTIONS
+
+        if (
+            sig["location"] is None
+            and meta.get("function") in _TDIGEST_FUNCTIONS
+            and tuple(sig["inner_shape"]) == (2,)
+        ):
+            return "approximate"
+        return "none"
+    if sig["kind"] == "scalar" and function in EXACT_MERGE_LAWS:
+        return "exact"
+    return "none"
+
+
+def composability_classes(config: PipelineConfig) -> dict[str, str]:
+    """``{field_name: composability class}`` for every aggregation field (D24)."""
+    from zagg.config import get_agg_fields
+
+    return {name: field_composability(meta) for name, meta in get_agg_fields(config).items()}
+
+
 def _without(mapping: dict, keys: tuple[str, ...]) -> dict:
     return {k: v for k, v in (mapping or {}).items() if k not in keys}
 
@@ -160,10 +244,14 @@ def semantic_fingerprint(digest: str) -> str:
 
 __all__ = [
     "AGGREGATION_PACKAGING_KEYS",
+    "COMPOSABILITY_CLASSES",
     "DATA_SOURCE_PACKAGING_KEYS",
+    "EXACT_MERGE_LAWS",
     "FINGERPRINT_HEX",
     "GRID_SPATIAL_KEYS",
     "canonical_semantic_json",
+    "composability_classes",
+    "field_composability",
     "semantic_core",
     "semantic_fingerprint",
     "semantic_hash",

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -4,8 +4,8 @@ One idempotent bottom-up pass over a hive store's digit tree that folds leaf
 artifacts into interior-node rollups, per registered **artifact family**
 (D22): stats sidecars (the :func:`zagg.telemetry.merge` fold), MOC regen,
 sub-shardmap rollups (leaf ShardMap JSON folded via the #294 exact coarsen
-regroup), overview zarrs (reserved for issue #201), and optional debris
-collection (stubbed). Everything the sweep
+regroup), overview zarrs (issue #201; :mod:`zagg.sweep_overview`), and
+optional debris collection (stubbed). Everything the sweep
 writes is a **regenerable cache, never truth** (D9): deleting every rollup
 leaves all leaf reads intact, and the leaf sidecars/stamps remain the durable
 ground truth.
@@ -50,8 +50,11 @@ logger = logging.getLogger(__name__)
 #: Envelope version of every rollup object this module writes.
 SWEEP_SPEC = "zagg-sweep/1"
 
-#: Families swept when the caller does not choose (D22 phases 1-3).
-DEFAULT_FAMILIES = ("stats", "moc", "submap")
+#: Families swept when the caller does not choose (the four D22 families).
+#: ``moc`` deliberately precedes ``overview``: the overview fold discovers
+#: untouched sibling shards through the root ``coverage.moc``, which the MOC
+#: family refreshes earlier in the same pass.
+DEFAULT_FAMILIES = ("stats", "moc", "submap", "overview")
 
 #: Grid types already warned about as unsupported leaf sub-maps (once-ish, so a
 #: raster sweep does not warn-spam per shard). Never security-load-bearing.
@@ -76,8 +79,12 @@ class SweepFamily:
     staleness timestamp) and :meth:`merge` (the associative payload fold);
     :meth:`finish` is an optional post-walk hook fed the top-level (base-node)
     artifacts — the seam the MOC family uses to refresh the store-root
-    ``coverage.moc``. Families registered with ``available = False`` are
-    visible slots that :func:`get_family` refuses with their ``reason``.
+    ``coverage.moc``. A family whose artifact is not a per-node JSON rollup
+    (the overview family's zarrs, issue #201) instead defines ``sweep_store``
+    — the whole-tree hook :func:`run_sweep` dispatches to with the manifest
+    and the normalized dirty work set. Families registered with
+    ``available = False`` are visible slots that :func:`get_family` refuses
+    with their ``reason``.
     """
 
     name = ""
@@ -477,14 +484,21 @@ class _ReprojectTarget:
 
 
 class OverviewFamily(SweepFamily):
-    """Overview zarrs (D11/D22) — the reserved issue #201 slot."""
+    """Overview zarrs at ancestor nodes (D11/D22/D24 — issue #201).
+
+    Unlike the JSON-rollup families, the artifact is a ZARR at manifest-
+    declared orders only, folded from leaf DATA (per-field D24 merge laws),
+    so this family overrides :attr:`sweep_store` — the whole-tree hook the
+    engine dispatches to instead of the generic bottom-up JSON fold. The
+    implementation lives in :mod:`zagg.sweep_overview`.
+    """
 
     name = "overview"
-    available = False
-    reason = (
-        "overview zarr aggregation is issue #201's follow-on PR; this slot "
-        "reserves the family registration (D22)"
-    )
+
+    def sweep_store(self, store_root, manifest, by_shard, store_kwargs) -> dict:
+        from zagg.sweep_overview import sweep_overviews
+
+        return sweep_overviews(store_root, manifest, by_shard, store_kwargs=store_kwargs)
 
 
 class DebrisFamily(SweepFamily):
@@ -552,9 +566,13 @@ def run_sweep(store_root: str, leaves, *, families=None, store_kwargs: dict | No
         "families": {},
     }
     for fam in fams:
-        summary["families"][fam.name] = _sweep_family(
-            store_root, store, fam, by_shard, shard_order, manifest.get("spec"), store_kwargs
-        )
+        runner = getattr(fam, "sweep_store", None)
+        if runner is not None:
+            summary["families"][fam.name] = runner(store_root, manifest, by_shard, store_kwargs)
+        else:
+            summary["families"][fam.name] = _sweep_family(
+                store_root, store, fam, by_shard, shard_order, manifest.get("spec"), store_kwargs
+            )
     return summary
 
 

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -173,6 +173,116 @@ def fold_digests(cell_digests: list, *, delta: int, dtype="float32") -> bytes:
 
 
 # ---------------------------------------------------------------------------
+# The manifest pyramid block: template-time declaration (D22, per-family
+# schedules), sweep-populated actuals.
+# ---------------------------------------------------------------------------
+
+
+def build_pyramid_block(config, shard_order: int) -> dict:
+    """The manifest ``pyramid`` block: the template-time declaration (D22).
+
+    Declares the overview family's order schedule (``output.pyramid`` knob;
+    default every :data:`DEFAULT_SPACING` orders below the shard order —
+    espg-ratified) and each field's composability class + fold method (D24).
+    ``none`` fields are declared with their class ONLY — the recorded absence
+    that gives readers zero-open filtering (option A, the ruled default) —
+    and warned about loudly at template time, per the D24 ruling. The sweep
+    later adds ``materialized`` actuals; it never rewrites the declaration.
+    """
+    from zagg.config import get_agg_fields, get_pyramid
+    from zagg.semantics import EXACT_MERGE_LAWS, _fold_function_name, composability_classes
+
+    knob = get_pyramid(config)
+    if knob is None:  # output.pyramid: false — declared off
+        return {"spec": PYRAMID_SPEC, "overview": {"orders": []}}
+    spacing = int(knob.get("spacing") or DEFAULT_SPACING)
+    if knob.get("orders") is not None:
+        orders = sorted({int(k) for k in knob["orders"]}, reverse=True)
+    else:
+        orders = list(range(int(shard_order) - spacing, -1, -spacing))
+    agg = get_agg_fields(config)
+    fields: dict = {}
+    excluded = []
+    for name, cls in composability_classes(config).items():
+        meta = agg[name]
+        if cls == "exact":
+            fields[name] = {
+                "class": "exact",
+                "method": EXACT_MERGE_LAWS[_fold_function_name(meta.get("function"))],
+                "dtype": meta.get("dtype", "float32"),
+                "fill_value": _json_fill(meta.get("fill_value", "NaN")),
+            }
+        elif cls == "approximate":
+            inner = meta.get("inner_shape") or (2,)
+            fields[name] = {
+                "class": "approximate",
+                "method": TDIGEST_LAW,
+                "dtype": meta.get("dtype", "float32"),
+                "inner_shape": [int(inner)] if isinstance(inner, int) else [int(x) for x in inner],
+                "delta": int((meta.get("params") or {}).get("delta", 512)),
+            }
+        else:
+            fields[name] = {"class": "none"}
+            excluded.append(name)
+    if excluded and orders:
+        logger.warning(
+            f"pyramid: fields {excluded} are non-composable (D24 class 'none') and will "
+            f"exist ONLY at native resolution — excluded from every overview order (the "
+            f"per-field-exclusion default; declare a derived summary to opt in, issue #201)"
+        )
+    overview: dict = {
+        "spacing": spacing,
+        "orders": orders,
+        "all_time": bool(knob.get("all_time", False)),
+        "fields": fields,
+    }
+    if knob.get("summarize"):
+        overview["summarize"] = {str(k): dict(v) for k, v in knob["summarize"].items()}
+    return {"spec": PYRAMID_SPEC, "overview": overview}
+
+
+def _json_fill(fill_value):
+    """A JSON-safe fill token (zarr v3 uses the string ``"NaN"``)."""
+    if isinstance(fill_value, float) and np.isnan(fill_value):
+        return "NaN"
+    return fill_value
+
+
+def _update_manifest_pyramid(store_root, orders, store_kwargs) -> bool:
+    """Record materialized overview orders in the manifest pyramid block.
+
+    The one manifest key the sweep may touch (D11: the block is populated/
+    updated by the §7 sweep; it is excluded from the frozen resume keys, so
+    this RMW can never brick appends). Fail-open — the declaration readers
+    key on is untouched; ``materialized`` is a convenience actual.
+    """
+    import obstore
+
+    from zagg.hive import MANIFEST_NAME, _utcnow, read_manifest
+    from zagg.store import open_object_store
+
+    try:
+        fresh = read_manifest(store_root, **store_kwargs)
+        if fresh is None:
+            return False
+        block = fresh.setdefault("pyramid", {}).setdefault("overview", {})
+        known = set((block.get("materialized") or {}).get("orders") or [])
+        block["materialized"] = {
+            "orders": sorted(known | {int(k) for k in orders}),
+            "generated_at": _utcnow(),
+        }
+        obstore.put(
+            open_object_store(store_root, **store_kwargs),
+            MANIFEST_NAME,
+            json.dumps(fresh, indent=1).encode(),
+        )
+        return True
+    except Exception as e:
+        logger.warning(f"sweep[overview]: manifest pyramid update failed (fail-open): {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Phase B: the overview writer — the family's whole-tree sweep.
 # ---------------------------------------------------------------------------
 
@@ -236,6 +346,7 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
         orders = [k for k in orders if k not in bad]
     candidates = _candidate_decimals(store_root, shard_order, by_shard, store_kwargs)
     store = open_object_store(store_root, **store_kwargs)
+    materialized: set[int] = set()
     for k in orders:
         nodes = sorted({_node_at(d, k) for d in by_shard})
         for node in nodes:
@@ -264,6 +375,8 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
                 )
                 if entry is not None:
                     entries[key] = entry
+            if entries:
+                materialized.add(k)
             fresh = {
                 "spec": _sweep().SWEEP_SPEC,
                 "family": "overview",
@@ -275,8 +388,14 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
                 import obstore
 
                 obstore.put(
-                    store, f"{_node_rel(node)}/{ENVELOPE_NAME}", json.dumps(fresh, indent=1).encode()
+                    store,
+                    f"{_node_rel(node)}/{ENVELOPE_NAME}",
+                    json.dumps(fresh, indent=1).encode(),
                 )
+    if counts["written"]:
+        counts["manifest_updated"] = _update_manifest_pyramid(
+            store_root, sorted(materialized), store_kwargs
+        )
     return counts
 
 
@@ -483,7 +602,9 @@ def _fold_node(
     for name, meta in fields.items():
         if meta["class"] == "exact":
             dtype = np.dtype(meta.get("dtype") or "float32")
-            slabs[name] = np.full(n_cells, _fill_scalar(meta.get("fill_value", "NaN"), dtype), dtype)
+            slabs[name] = np.full(
+                n_cells, _fill_scalar(meta.get("fill_value", "NaN"), dtype), dtype
+            )
         else:
             digests[name] = [[] for _ in range(n_cells)]
     if target_order >= shard_order:

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -691,7 +691,8 @@ def _fold_node(
                     raise ValueError(
                         f"morton shape {morton.shape} is not the manifest cell_order "
                         f"{cell_order} subtree ({leaf_cells} cells); mixed-order source "
-                        f"leaves are unsupported this round (D24 reader gate)"
+                        f"leaves are unsupported this round (issue #347: sweep fold "
+                        f"semantics + the writer-side append guard)"
                     )
                 partials: dict = {}
                 cell_digests: dict = {}

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -493,6 +493,7 @@ def _read_envelope(store, node: str) -> dict | None:
         envelope = None
     usable = (
         isinstance(envelope, dict)
+        and envelope.get("spec") == _sweep().SWEEP_SPEC
         and envelope.get("family") == "overview"
         and isinstance(envelope.get("windows"), dict)
     )

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -1,0 +1,170 @@
+"""Overview-zarr sweep family: pyramid generation at ancestor nodes (issue #201).
+
+The fourth D22 derived-artifact family (``docs/design/sparse_coverage.md`` §7,
+D11/D22/D24): for each manifest-declared overview order *k*, the sweep folds
+committed source leaves into an **overview zarr at the ancestor digit node** —
+the same leaf structure one order family up (dense per-field arrays + the
+``morton`` coordinate + ragged t-digest vlen arrays), at cell order
+``cell_order - (shard_order - k)`` (constant depth: cells coarsen 4x per
+order of ascent, so the pyramid is the store's resolution axis, partially
+materialized — D24).
+
+Field inclusion is gated by the D24 composability class
+(:func:`zagg.semantics.field_composability`): ``exact`` fields fold by their
+merge law (count/sum by addition, min/max by extremum — byte-equal to direct
+aggregation at the coarser order), ``approximate`` fields (t-digests) merge
+via the order-independent k-way fold (``np.isclose`` equality class), and
+``none`` fields are **excluded** — they exist only at native resolution, with
+the absence declared in the manifest's pyramid block (the ruled D24 default;
+declared derived summaries are the opt-in, deferred until a roster-kind
+consumer exists — issue #265).
+
+Naming and attrs are the ratified D23/D11 layout moczarr plans against:
+overviews inherit window naming — ``{window}.zarr`` at the ancestor node,
+``all.zarr`` for the unwindowed / all-time fold (the reserved token) — and
+every overview carries ``role: overview`` plus source orders, per-field
+aggregation methods, and the D22 generation stamp in its root attrs (never
+inferred from tree position: a shallow zarr may equally be coarse source).
+
+Like every sweep artifact, overviews are regenerable caches (D9): deleting
+every one leaves all leaf reads intact. Discovery is from the run-record
+work set plus the root coverage MOC — never a recursive LIST.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+#: Envelope version of the per-node overview attrs payload this module writes.
+OVERVIEW_SPEC = "zagg-overview/1"
+#: Root-group attrs key carrying the overview provenance payload (D11).
+OVERVIEW_ATTR = "zagg_overview"
+#: Root-group attrs key classifying the zarr (D11/D24: never inferred from
+#: position; source leaves carry no role — absence means source).
+ROLE_ATTR = "role"
+#: Version string of the manifest ``pyramid`` block this module declares.
+PYRAMID_SPEC = "zagg-pyramid/1"
+#: Default overview-order spacing (espg-ratified on the issue #201 thread:
+#: display schedule is every 2 orders — 16x per step, ~1/15 extra storage).
+DEFAULT_SPACING = 2
+
+#: Fold law name recorded for approximate (t-digest) fields: the
+#: order-independent k-way merge (issue #279 — deterministic under
+#: permutation, unlike a pairwise left-fold).
+TDIGEST_LAW = "tdigest_kway"
+
+
+# ---------------------------------------------------------------------------
+# Phase A: per-field up-aggregation kernels (the D24 merge laws over arrays).
+# ---------------------------------------------------------------------------
+
+
+def _is_missing(values: np.ndarray, fill_value) -> np.ndarray:
+    """Boolean missing-mask for a dense field slab (fill/NaN sentinel cells)."""
+    if values.dtype.kind == "f":
+        fill = _fill_scalar(fill_value, values.dtype)
+        if np.isnan(fill):
+            return np.isnan(values)
+        return np.isnan(values) | (values == fill)
+    return values == _fill_scalar(fill_value, values.dtype)
+
+
+def _fill_scalar(fill_value, dtype):
+    """The numeric fill sentinel (zarr's ``"NaN"`` JSON token included)."""
+    if isinstance(fill_value, str):
+        return np.array(fill_value, dtype=dtype)[()]  # "NaN"/"Infinity" tokens
+    return np.array(fill_value, dtype=dtype)[()]
+
+
+#: law -> (reduce ufunc, identity kind). The identity replaces missing cells
+#: before the reduce; all-missing groups are restored to the fill afterwards.
+_LAW_REDUCERS = {
+    "sum": np.add,
+    "min": np.minimum,
+    "max": np.maximum,
+}
+
+
+def fold_dense(values: np.ndarray, factor: int, law: str, fill_value) -> np.ndarray:
+    """Fold a dense per-cell slab ``factor``-to-one under an exact merge law.
+
+    ``values`` is a leaf-ordered 1-D array (row i = the i-th subtree cell in
+    ascending packed-word order — the leaf invariant), so ``factor``
+    consecutive rows share one coarser parent: the fold is a pure
+    ``reshape(-1, factor)`` reduce. Missing cells (the field's fill sentinel,
+    NaN for float fields) are excluded from the reduce; an all-missing group
+    folds back to the fill. Exact by construction for the D24 exact class:
+    addition/extremum over the same values in the same ascending order a
+    direct coarser aggregation would visit.
+    """
+    if law not in _LAW_REDUCERS:
+        raise ValueError(f"unknown exact fold law {law!r}; known: {sorted(_LAW_REDUCERS)}")
+    values = np.asarray(values)
+    if factor <= 0 or values.shape[0] % factor:
+        raise ValueError(f"cannot fold {values.shape[0]} cells {factor}-to-one")
+    groups = values.reshape(-1, factor)
+    missing = _is_missing(groups, fill_value)
+    if law == "sum":
+        identity = np.zeros((), dtype=groups.dtype)
+    elif law == "min":
+        ident = np.inf if groups.dtype.kind == "f" else np.iinfo(groups.dtype).max
+        identity = np.array(ident, dtype=groups.dtype)
+    else:  # max
+        ident = -np.inf if groups.dtype.kind == "f" else np.iinfo(groups.dtype).min
+        identity = np.array(ident, dtype=groups.dtype)
+    out = _LAW_REDUCERS[law].reduce(np.where(missing, identity, groups), axis=1)
+    fill = _fill_scalar(fill_value, groups.dtype)
+    return np.where(missing.all(axis=1), fill, out).astype(groups.dtype, copy=False)
+
+
+def combine_dense(a: np.ndarray, b: np.ndarray, law: str, fill_value) -> np.ndarray:
+    """Element-wise combine of two partial folds under one exact law.
+
+    The accumulation form of :func:`fold_dense` (interleave the operands and
+    fold 2-to-one), for overview cells assembled from more than one source
+    leaf: coarser-than-shard overview orders, and the all-time fold's
+    cross-window accumulation.
+    """
+    a, b = np.asarray(a), np.asarray(b)
+    stacked = np.stack([a, b], axis=1).reshape(-1)
+    return fold_dense(stacked, 2, law, fill_value)
+
+
+def decode_digest(raw, dtype, inner_shape=(2,)) -> np.ndarray:
+    """One cell's ragged payload bytes -> its ``(k, *inner_shape)`` array.
+
+    The D18 vlen framing (raw little-endian C-order values at the element
+    dtype); an empty payload decodes to the zero-length array, matching the
+    reader (``zagg.readers.tdigest_tensor._decode_cell``).
+    """
+    dt = np.dtype(dtype).newbyteorder("<")
+    return np.frombuffer(bytes(raw), dtype=dt).reshape((-1, *inner_shape))
+
+
+def encode_digest(digest: np.ndarray, dtype) -> bytes:
+    """The inverse of :func:`decode_digest`: C-order little-endian bytes."""
+    dt = np.dtype(dtype).newbyteorder("<")
+    return np.ascontiguousarray(np.asarray(digest, dtype=dt)).tobytes()
+
+
+def fold_digests(cell_digests: list, *, delta: int, dtype="float32") -> bytes:
+    """Merge one overview cell's accumulated t-digests into its payload bytes.
+
+    The approximate-class fold law (D24): the **order-independent k-way
+    merge** (:func:`zagg.stats.tdigest.merge_tdigests_kway`, issue #279), so
+    the overview digest is permutation-stable — a re-sweep over unchanged
+    leaves reproduces identical bytes. An empty accumulation folds to the
+    empty payload (the ragged fill).
+    """
+    from zagg.stats.tdigest import merge_tdigests_kway
+
+    digests = [d for d in cell_digests if len(d)]
+    if not digests:
+        return b""
+    if len(digests) == 1:
+        return encode_digest(digests[0], dtype)
+    return encode_digest(merge_tdigests_kway(digests, delta=int(delta)), dtype)

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -304,8 +304,10 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
 
     Idempotent: a (node, window) whose stored generation stamp (merged-leaf
     count + max leaf stamp timestamp) AND content hash both match the freshly
-    folded payload is skipped — the hash is the same-second backstop the
-    engine's payload compare provides for JSON families. Returns the standard
+    folded payload — and whose zarr is confirmed present and stamped, since the
+    envelope and the artifact are two objects (D9) — is skipped; the hash is
+    the same-second backstop the engine's payload compare provides for JSON
+    families. Returns the standard
     ``written``/``current``/``empty``/``failed`` counts plus ``declared``.
     """
     from zagg.store import open_object_store
@@ -548,6 +550,7 @@ def _roll_node(
         isinstance(existing_entry, dict)
         and existing_entry.get("generation") == fold["generation"]
         and existing_entry.get("content_hash") == fold["content_hash"]
+        and _overview_committed(store_root, node, existing_entry.get("object"), store_kwargs)
     ):
         counts["current"] += 1
         return existing_entry
@@ -565,6 +568,29 @@ def _roll_node(
         "generation": fold["generation"],
         "content_hash": fold["content_hash"],
     }
+
+
+def _overview_committed(store_root, node, basename, store_kwargs) -> bool:
+    """Whether the entry's overview zarr is really present AND stamped (D9).
+
+    Unlike the JSON families — whose bookkeeping IS the artifact, so they
+    self-heal for free — the overview's envelope entry and its zarr are two
+    objects: a generation+hash match proves nothing about the zarr surviving.
+    One commit-stamp GET makes skip-if-current self-healing (a deleted
+    overview regenerates) and doubles as proof the D4 stamp landed, so a torn
+    prior write no longer reads as ``current`` (review finding, issue #201).
+    """
+    from zagg.hive import read_commit
+    from zagg.store import open_store
+
+    if not basename:
+        return False
+    try:
+        leaf = open_store(f"{store_root}/{_node_rel(node)}/{basename}", **store_kwargs)
+        return read_commit(leaf) is not None
+    except Exception as e:  # an unreadable object is not a current one
+        logger.debug(f"sweep[overview]: cannot confirm {node}/{basename} ({e})")
+        return False
 
 
 def _fold_node(

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -33,6 +33,8 @@ work set plus the root coverage MOC — never a recursive LIST.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 
 import numpy as np
@@ -168,3 +170,541 @@ def fold_digests(cell_digests: list, *, delta: int, dtype="float32") -> bytes:
     if len(digests) == 1:
         return encode_digest(digests[0], dtype)
     return encode_digest(merge_tdigests_kway(digests, delta=int(delta)), dtype)
+
+
+# ---------------------------------------------------------------------------
+# Phase B: the overview writer — the family's whole-tree sweep.
+# ---------------------------------------------------------------------------
+
+#: Per-node overview bookkeeping object (window inventory + skip-if-current
+#: stamps), sibling to the other families' ``{family}.rollup.json`` — the same
+#: closed name grammar, so the §5 walker's child classification is unaffected.
+ENVELOPE_NAME = "overview.rollup.json"
+
+
+def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kwargs=None) -> dict:
+    """Generate/refresh overview zarrs at the manifest-declared orders (D22).
+
+    ``by_shard`` is the engine's normalized dirty work set
+    (``{shard_decimal: {window, ...}}``); the walk visits ONLY ancestor nodes
+    of those shards at each declared order. The full descendant leaf set per
+    node comes from the dirty set unioned with the root ``coverage.moc``
+    (run record + MOC — never a LIST); with the default family order the MOC
+    family has just refreshed that root in the same pass.
+
+    Idempotent: a (node, window) whose stored generation stamp (merged-leaf
+    count + max leaf stamp timestamp) AND content hash both match the freshly
+    folded payload is skipped — the hash is the same-second backstop the
+    engine's payload compare provides for JSON families. Returns the standard
+    ``written``/``current``/``empty``/``failed`` counts plus ``declared``.
+    """
+    from zagg.store import open_object_store
+
+    store_kwargs = dict(store_kwargs or {})
+    counts: dict = {"written": 0, "current": 0, "empty": 0, "failed": 0, "declared": True}
+    decl = (manifest.get("pyramid") or {}).get("overview")
+    if not isinstance(decl, dict) or not decl.get("orders"):
+        counts["declared"] = False
+        logger.info(
+            "sweep[overview]: no pyramid overview declaration in the manifest "
+            "(template-time, D22); nothing to generate"
+        )
+        return counts
+    if decl.get("summarize"):
+        logger.warning(
+            f"sweep[overview]: declared derived summaries {sorted(decl['summarize'])} are not "
+            f"generated yet — no roster-kind ragged field ships (D24 opt-in, issue #265); skipping"
+        )
+    fields = {
+        n: dict(m)
+        for n, m in (decl.get("fields") or {}).items()
+        if isinstance(m, dict) and m.get("class") in ("exact", "approximate")
+    }
+    if not fields:
+        logger.info("sweep[overview]: no composable fields declared; nothing to generate")
+        return counts
+    shard_order = int(manifest["shard_order"])
+    cell_order = int(manifest["cell_order"])
+    windowed = manifest.get("temporal") is not None
+    orders = sorted({int(k) for k in decl["orders"]}, reverse=True)
+    bad = [k for k in orders if not (0 <= k < shard_order)]
+    if bad:
+        logger.warning(
+            f"sweep[overview]: declared orders {bad} are not ancestor orders of "
+            f"shard_order {shard_order}; skipping them"
+        )
+        orders = [k for k in orders if k not in bad]
+    candidates = _candidate_decimals(store_root, shard_order, by_shard, store_kwargs)
+    store = open_object_store(store_root, **store_kwargs)
+    for k in orders:
+        nodes = sorted({_node_at(d, k) for d in by_shard})
+        for node in nodes:
+            node_shards = sorted(d for d in candidates if d.startswith(node))
+            dirty_windows = set()
+            for d in by_shard:
+                if d.startswith(node):
+                    dirty_windows |= by_shard[d]
+            envelope = _read_envelope(store, node)
+            entries = dict((envelope or {}).get("windows") or {})
+            for key, fold_windows in _window_work(decl, windowed, dirty_windows, entries):
+                entry = _roll_node(
+                    store_root,
+                    node,
+                    k,
+                    key,
+                    fold_windows,
+                    node_shards,
+                    fields,
+                    cell_order,
+                    shard_order,
+                    windowed,
+                    entries.get(key),
+                    counts,
+                    store_kwargs,
+                )
+                if entry is not None:
+                    entries[key] = entry
+            fresh = {
+                "spec": _sweep().SWEEP_SPEC,
+                "family": "overview",
+                "node": node,
+                "order": k,
+                "windows": entries,
+            }
+            if entries and fresh != envelope:
+                import obstore
+
+                obstore.put(
+                    store, f"{_node_rel(node)}/{ENVELOPE_NAME}", json.dumps(fresh, indent=1).encode()
+                )
+    return counts
+
+
+def _sweep():
+    """The engine module (lazy: sweep.py registers this module's family)."""
+    import zagg.sweep
+
+    return zagg.sweep
+
+
+def _node_rel(decimal: str) -> str:
+    return _sweep()._node_rel(decimal)
+
+
+def _node_at(decimal: str, order: int) -> str:
+    """The ancestor prefix of a shard decimal at ``order`` (0 = base)."""
+    from zagg.hive import _decimal_base
+
+    return decimal[: len(_decimal_base(decimal)) + order]
+
+
+def _rel_rank(decimal: str, node: str) -> int:
+    """Base-4 rank of ``decimal``'s digit tail beyond the ``node`` prefix."""
+    rank = 0
+    for ch in decimal[len(node) :]:
+        rank = rank * 4 + (int(ch) - 1)
+    return rank
+
+
+def _candidate_decimals(store_root, shard_order, by_shard, store_kwargs) -> set:
+    """Descendant-leaf candidates: the dirty set unioned with the root MOC.
+
+    Discovery stays LIST-free (D22): untouched sibling shards contribute via
+    the root ``coverage.moc`` (default-on for hive; refreshed by the MOC
+    family earlier in the same default pass). A missing/unusable root MOC
+    degrades to the dirty set with a loud warning — the overview then covers
+    only the given leaves until a full sweep repairs it (D9: regenerable).
+    """
+    from zagg.grids.morton import morton_decimal
+    from zagg.hive import read_root_coverage, root_coverage_words
+
+    decimals = set(by_shard)
+    try:
+        env = read_root_coverage(store_root, **store_kwargs)
+    except ValueError:
+        env = None
+    if isinstance(env, dict) and env.get("order") == shard_order:
+        try:
+            decimals |= {morton_decimal(int(w)) for w in root_coverage_words(env)}
+            return decimals
+        except (KeyError, TypeError, ValueError) as e:
+            logger.warning(f"sweep[overview]: unusable root coverage.moc ({e})")
+    if decimals:
+        logger.warning(
+            "sweep[overview]: no usable root coverage.moc — overviews will fold ONLY "
+            "the run's own leaves; sweep the moc family (or the default set) to repair"
+        )
+    return decimals
+
+
+def _window_work(decl, windowed, dirty_windows, entries) -> list:
+    """``(envelope key, [windows to fold])`` work items for one node.
+
+    Per-window overviews inherit window naming (D23); the reserved ``all``
+    token is the unwindowed leaf AND the opt-in all-time fold on a windowed
+    store (``all_time`` in the declaration; a preexisting all-time entry stays
+    maintained even if the declaration later drops the flag).
+    """
+    from zagg.windows import SCHEDULE_NONE_TOKEN
+
+    if not windowed:
+        return [(SCHEDULE_NONE_TOKEN, [None])]
+    labels = sorted(
+        {w for w in dirty_windows if w is not None}
+        | {key for key in entries if key != SCHEDULE_NONE_TOKEN}
+    )
+    work = [(w, [w]) for w in labels]
+    if decl.get("all_time") or SCHEDULE_NONE_TOKEN in entries:
+        work.append((SCHEDULE_NONE_TOKEN, labels))
+    return work
+
+
+def _read_envelope(store, node: str) -> dict | None:
+    """The node's stored overview envelope, or ``None`` (strict, D9 cache)."""
+    import obstore
+    from obstore.exceptions import NotFoundError
+
+    try:
+        data = obstore.get(store, f"{_node_rel(node)}/{ENVELOPE_NAME}").bytes()
+    except (FileNotFoundError, NotFoundError):
+        return None
+    try:
+        envelope = json.loads(bytes(data))
+    except ValueError:
+        envelope = None
+    usable = (
+        isinstance(envelope, dict)
+        and envelope.get("family") == "overview"
+        and isinstance(envelope.get("windows"), dict)
+    )
+    if not usable:
+        logger.debug(f"sweep[overview]: unusable envelope at node {node}; ignoring")
+        return None
+    return envelope
+
+
+def _roll_node(
+    store_root,
+    node,
+    k,
+    key,
+    fold_windows,
+    node_shards,
+    fields,
+    cell_order,
+    shard_order,
+    windowed,
+    existing_entry,
+    counts,
+    store_kwargs,
+):
+    """Fold one (node, window) overview; write its zarr unless current.
+
+    Returns the fresh envelope entry, the existing one when current (or when
+    no leaf contributed — an emptied window keeps its prior overview, the
+    same append-only posture as the engine's interior fallback), or ``None``.
+    """
+    try:
+        fold = _fold_node(
+            store_root,
+            node,
+            k,
+            fold_windows,
+            node_shards,
+            fields,
+            cell_order,
+            shard_order,
+            counts,
+            store_kwargs,
+        )
+    except Exception as e:
+        logger.warning(f"sweep[overview]: fold failed at node {node} window {key!r}; ({e})")
+        counts["failed"] += 1
+        return None
+    if fold is None:
+        counts["empty"] += 1
+        return existing_entry
+    if (
+        isinstance(existing_entry, dict)
+        and existing_entry.get("generation") == fold["generation"]
+        and existing_entry.get("content_hash") == fold["content_hash"]
+    ):
+        counts["current"] += 1
+        return existing_entry
+    try:
+        basename = _write_overview(
+            store_root, node, k, key, fold, fields, cell_order, shard_order, windowed, store_kwargs
+        )
+    except Exception as e:
+        logger.warning(f"sweep[overview]: write failed at node {node} window {key!r}; ({e})")
+        counts["failed"] += 1
+        return None
+    counts["written"] += 1
+    return {
+        "object": basename,
+        "generation": fold["generation"],
+        "content_hash": fold["content_hash"],
+    }
+
+
+def _fold_node(
+    store_root,
+    node,
+    k,
+    fold_windows,
+    node_shards,
+    fields,
+    cell_order,
+    shard_order,
+    counts,
+    store_kwargs,
+):
+    """Fold the node's committed descendant leaves into per-field slabs.
+
+    Reads leaf DATA by declared array name only — never a member enumeration
+    — so orphan array prefixes from schema evolution (issue #341 Bug A) and
+    foreign objects (status prefixes, #327) cannot crash the fold. A leaf
+    missing one declared field contributes fill for it (schema evolution:
+    the field postdates the leaf); a leaf at an unexpected cell order or with
+    an unreadable group is skipped loudly (``failed``), never fatal.
+    """
+    import zarr
+
+    from zagg.grids.morton import morton_word
+    from zagg.hive import read_commit, shard_leaf_path
+    from zagg.store import open_store
+    from zagg.windows import union_time_range
+
+    target_order = cell_order - (shard_order - k)
+    n_cells = 4 ** (target_order - k)
+    leaf_cells = 4 ** (cell_order - shard_order)
+    slabs: dict = {}
+    digests: dict = {}
+    for name, meta in fields.items():
+        if meta["class"] == "exact":
+            dtype = np.dtype(meta.get("dtype") or "float32")
+            slabs[name] = np.full(n_cells, _fill_scalar(meta.get("fill_value", "NaN"), dtype), dtype)
+        else:
+            digests[name] = [[] for _ in range(n_cells)]
+    if target_order >= shard_order:
+        span = 4 ** (target_order - shard_order)
+        fold_factor = 4 ** (shard_order - k)
+    else:
+        span = 1
+        fold_factor = leaf_cells
+    n_leaves, timestamps, granules, ranges = 0, [], 0, []
+    for dec in node_shards:
+        if target_order >= shard_order:
+            start = _rel_rank(dec, node) * span
+        else:
+            start = _rel_rank(_node_at(dec, target_order), node)
+        for window in fold_windows:
+            leaf = shard_leaf_path(store_root, morton_word(dec), window=window)
+            leaf_store = open_store(leaf, **store_kwargs)
+            stamp = read_commit(leaf_store)
+            if stamp is None:
+                continue  # absent leaf or unstamped debris (D4)
+            # Fold the whole leaf's contribution BEFORE touching the slabs, so
+            # a corrupt leaf skips cleanly instead of half-applying.
+            try:
+                group = zarr.open_group(leaf_store, path=str(cell_order), mode="r", zarr_format=3)
+                morton = group["morton"]
+                if morton.shape != (leaf_cells,):
+                    raise ValueError(
+                        f"morton shape {morton.shape} is not the manifest cell_order "
+                        f"{cell_order} subtree ({leaf_cells} cells); mixed-order source "
+                        f"leaves are unsupported this round (D24 reader gate)"
+                    )
+                partials: dict = {}
+                cell_digests: dict = {}
+                for name, meta in fields.items():
+                    try:
+                        values = group[name][:]
+                    except KeyError:
+                        # Schema evolution: the field postdates this leaf — it
+                        # contributes fill, exactly what re-running would write.
+                        logger.debug(f"sweep[overview]: leaf {leaf} lacks field {name!r}")
+                        continue
+                    if meta["class"] == "exact":
+                        partials[name] = fold_dense(
+                            values, fold_factor, meta.get("method"), meta.get("fill_value", "NaN")
+                        )
+                    else:
+                        dtype = meta.get("dtype") or "float32"
+                        inner = tuple(meta.get("inner_shape") or (2,))
+                        cell_digests[name] = [
+                            (start + i // fold_factor, decode_digest(payload, dtype, inner))
+                            for i, payload in enumerate(values)
+                            if payload is not None and len(payload)
+                        ]
+            except Exception as e:
+                logger.warning(f"sweep[overview]: skipping unreadable leaf {leaf} ({e})")
+                counts["failed"] += 1
+                continue
+            seg = slice(start, start + span)
+            for name, partial in partials.items():
+                meta = fields[name]
+                slabs[name][seg] = combine_dense(
+                    slabs[name][seg], partial, meta.get("method"), meta.get("fill_value", "NaN")
+                )
+            for name, decoded in cell_digests.items():
+                for j, digest in decoded:
+                    digests[name][j].append(digest)
+            n_leaves += 1
+            timestamps.append(stamp.get("written_at"))
+            granules += int(stamp.get("granule_count") or 0)
+            if stamp.get("time_range") is not None:
+                ranges.append(stamp["time_range"])
+    if n_leaves == 0:
+        return None
+    for name, acc in digests.items():
+        meta = fields[name]
+        slab = np.full(n_cells, b"", dtype=object)
+        for j, cell in enumerate(acc):
+            if cell:
+                slab[j] = fold_digests(
+                    cell, delta=int(meta.get("delta") or 512), dtype=meta.get("dtype") or "float32"
+                )
+        slabs[name] = slab
+    stamps = [t for t in timestamps if t is not None]
+    return {
+        "slabs": slabs,
+        "generation": {
+            "n_leaves": int(n_leaves),
+            "max_leaf_timestamp": max(stamps) if stamps else None,
+        },
+        "content_hash": _content_hash(node, k, target_order, fields, slabs),
+        "granule_count": granules,
+        "time_range": union_time_range(*ranges) if ranges else None,
+    }
+
+
+def _content_hash(node, k, target_order, fields, slabs) -> str:
+    """sha256 over the folded per-field values (decoded bytes, O11-style).
+
+    The skip-if-current backstop: leaf stamps resolve to whole seconds, so a
+    same-second leaf re-run carries an unchanged generation stamp; the hash
+    catches the content change without re-reading the written overview.
+    """
+    h = hashlib.sha256(f"{OVERVIEW_SPEC}:{node}:{k}:{target_order}".encode())
+    for name in sorted(slabs):
+        h.update(name.encode())
+        slab = slabs[name]
+        if slab.dtype == object:
+            for payload in slab:
+                h.update(len(payload).to_bytes(4, "little"))
+                h.update(payload)
+        else:
+            h.update(np.ascontiguousarray(slab).tobytes())
+    return h.hexdigest()
+
+
+def _overview_config(fields):
+    """A minimal PipelineConfig whose leaf template matches the overview.
+
+    The overview zarr reuses the leaf template machinery
+    (``HealpixGrid.emit_shard_template``) so structure — dtypes, fills, the
+    D18 ragged attrs, the D16 dggs attrs — cannot drift from source leaves.
+    """
+    from zagg.config import PipelineConfig
+
+    variables = {}
+    for name, meta in fields.items():
+        if meta["class"] == "exact":
+            variables[name] = {
+                "function": meta.get("method"),
+                "dtype": meta.get("dtype", "float32"),
+                "fill_value": meta.get("fill_value", "NaN"),
+            }
+        else:
+            variables[name] = {
+                "kind": "ragged",
+                "function": "zagg.stats.tdigest.build_tdigest",
+                "inner_shape": list(meta.get("inner_shape") or [2]),
+                "dtype": meta.get("dtype", "float32"),
+                "fill_value": 0,
+            }
+    return PipelineConfig(
+        aggregation={
+            "coordinates": {"morton": {"dtype": "uint64", "fill_value": 0}},
+            "variables": variables,
+        }
+    )
+
+
+def _write_overview(
+    store_root, node, k, key, fold, fields, cell_order, shard_order, windowed, store_kwargs
+) -> str:
+    """Write one overview zarr at its ancestor node; returns the basename.
+
+    D23 naming: overviews inherit window naming — ``{window}.zarr``, with the
+    reserved ``all`` token for the unwindowed / all-time fold. Write order is
+    pinned like a leaf's: template (wholesale overwrite — a prior overview or
+    torn debris is replaced, D4 retry semantics) -> arrays -> role/provenance
+    attrs -> commit stamp LAST, so an interrupted writer leaves ignorable
+    debris and presence certifies the ``role`` attr landed (D11).
+    """
+    import zarr
+    from mortie import generate_morton_children
+
+    from zagg.grids.healpix import HealpixGrid
+    from zagg.grids.morton import morton_word
+    from zagg.hive import _utcnow, stamp_commit
+    from zagg.store import open_store
+    from zagg.windows import SCHEDULE_NONE_TOKEN, leaf_name_v3
+
+    target_order = cell_order - (shard_order - k)
+    basename = leaf_name_v3(None if key == SCHEDULE_NONE_TOKEN else key)
+    path = f"{store_root}/{_node_rel(node)}/{basename}"
+    grid = HealpixGrid(k, target_order, config=_overview_config(fields), sharded=True)
+    store = open_store(path, **store_kwargs)
+    grid.emit_shard_template(store, overwrite=True)
+    group = zarr.open_group(store, path=str(target_order), mode="r+", zarr_format=3)
+    words = np.asarray(generate_morton_children(morton_word(node), target_order), dtype=np.uint64)
+    group["morton"][:] = words
+    for name, slab in fold["slabs"].items():
+        group[name][:] = slab
+    populated = _populated_mask(fold["slabs"], fields)
+    root = zarr.open_group(store, path="", mode="r+", zarr_format=3)
+    root.attrs.update(
+        {
+            ROLE_ATTR: "overview",
+            OVERVIEW_ATTR: {
+                "spec": OVERVIEW_SPEC,
+                "node": node,
+                "order": int(k),
+                "cell_order": int(target_order),
+                "source_shard_order": int(shard_order),
+                "source_cell_order": int(cell_order),
+                "window": key,
+                "fields": {
+                    n: {"class": m["class"], "method": m.get("method", TDIGEST_LAW)}
+                    for n, m in fields.items()
+                },
+                "generation": fold["generation"],
+                "content_hash": fold["content_hash"],
+                "generated_at": _utcnow(),
+            },
+        }
+    )
+    stamp_window = key if windowed else None
+    stamp_commit(
+        store,
+        cells_with_data=int(populated.sum()),
+        granule_count=int(fold["granule_count"]),
+        window=stamp_window,
+        time_range=fold["time_range"] if stamp_window is not None else None,
+    )
+    return basename
+
+
+def _populated_mask(slabs: dict, fields: dict) -> np.ndarray:
+    """Cells carrying any non-fill value in any included field."""
+    populated = None
+    for name, slab in slabs.items():
+        if slab.dtype == object:
+            mask = np.fromiter((len(p) > 0 for p in slab), dtype=bool, count=len(slab))
+        else:
+            mask = ~_is_missing(slab, fields[name].get("fill_value", "NaN"))
+        populated = mask if populated is None else (populated | mask)
+    return populated if populated is not None else np.zeros(0, dtype=bool)

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -11,8 +11,9 @@ materialized — D24).
 
 Field inclusion is gated by the D24 composability class
 (:func:`zagg.semantics.field_composability`): ``exact`` fields fold by their
-merge law (count/sum by addition, min/max by extremum — byte-equal to direct
-aggregation at the coarser order), ``approximate`` fields (t-digests) merge
+merge law (count/sum by addition, min/max by extremum — byte-equal to a direct
+**nan-skipping** aggregation at the coarser order; see
+:data:`EXACT_NAN_POLICY`), ``approximate`` fields (t-digests) merge
 via the order-independent k-way fold (``np.isclose`` equality class), and
 ``none`` fields are **excluded** — they exist only at native resolution, with
 the absence declared in the manifest's pyramid block (the ruled D24 default;
@@ -53,6 +54,17 @@ PYRAMID_SPEC = "zagg-pyramid/1"
 #: Default overview-order spacing (espg-ratified on the issue #201 thread:
 #: display schedule is every 2 orders — 16x per step, ~1/15 extra storage).
 DEFAULT_SPACING = 2
+
+#: NaN policy the exact fold actually implements, recorded per field in the
+#: pyramid declaration and in every overview's attrs (review finding, issue
+#: #201). A leaf's stored NaN is the same bytes whether it is the fill sentinel
+#: or a NaN datum, so :func:`fold_dense` cannot distinguish them and skips
+#: both: the exact-class fold is byte-equal to a direct ``nansum``/``nanmin``/
+#: ``nanmax`` at the coarser order, NOT to a NaN-propagating ``sum``/``min``/
+#: ``max`` (which the store encoding makes unrecoverable either way — the plain
+#: and nan-aware aggregators share one law in
+#: :data:`zagg.semantics.EXACT_MERGE_LAWS`).
+EXACT_NAN_POLICY = "skip"
 
 #: Fold law name recorded for approximate (t-digest) fields: the
 #: order-independent k-way merge (issue #279 — deterministic under
@@ -101,7 +113,9 @@ def fold_dense(values: np.ndarray, factor: int, law: str, fill_value) -> np.ndar
     NaN for float fields) are excluded from the reduce; an all-missing group
     folds back to the fill. Exact by construction for the D24 exact class:
     addition/extremum over the same values in the same ascending order a
-    direct coarser aggregation would visit.
+    direct coarser aggregation would visit — with the one premise
+    :data:`EXACT_NAN_POLICY` names: NaN is ALWAYS missing (fill and datum are
+    the same bytes), so the match is against the nan-skipping reduction.
     """
     if law not in _LAW_REDUCERS:
         raise ValueError(f"unknown exact fold law {law!r}; known: {sorted(_LAW_REDUCERS)}")
@@ -209,6 +223,7 @@ def build_pyramid_block(config, shard_order: int) -> dict:
             fields[name] = {
                 "class": "exact",
                 "method": EXACT_MERGE_LAWS[_fold_function_name(meta.get("function")) or ""],
+                "nan_policy": EXACT_NAN_POLICY,
                 "dtype": meta.get("dtype", "float32"),
                 "fill_value": _json_fill(meta.get("fill_value", "NaN")),
             }
@@ -842,10 +857,7 @@ def _write_overview(
                 "source_shard_order": int(shard_order),
                 "source_cell_order": int(cell_order),
                 "window": key,
-                "fields": {
-                    n: {"class": m["class"], "method": m.get("method", TDIGEST_LAW)}
-                    for n, m in fields.items()
-                },
+                "fields": {n: _field_provenance(m) for n, m in fields.items()},
                 "generation": fold["generation"],
                 "content_hash": fold["content_hash"],
                 "generated_at": _utcnow(),
@@ -861,6 +873,19 @@ def _write_overview(
         time_range=fold["time_range"] if stamp_window is not None else None,
     )
     return basename
+
+
+def _field_provenance(meta: dict) -> dict:
+    """One field's per-field entry in the overview attrs: class + fold law.
+
+    Exact fields also carry :data:`EXACT_NAN_POLICY`, so a reader of the
+    overview knows the reduction it actually got — nan-skipping, never
+    NaN-propagating (review finding, issue #201).
+    """
+    entry = {"class": meta["class"], "method": meta.get("method", TDIGEST_LAW)}
+    if meta["class"] == "exact":
+        entry["nan_policy"] = EXACT_NAN_POLICY
+    return entry
 
 
 def _populated_mask(slabs: dict, fields: dict) -> np.ndarray:

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -208,7 +208,7 @@ def build_pyramid_block(config, shard_order: int) -> dict:
         if cls == "exact":
             fields[name] = {
                 "class": "exact",
-                "method": EXACT_MERGE_LAWS[_fold_function_name(meta.get("function"))],
+                "method": EXACT_MERGE_LAWS[_fold_function_name(meta.get("function")) or ""],
                 "dtype": meta.get("dtype", "float32"),
                 "fill_value": _json_fill(meta.get("fill_value", "NaN")),
             }
@@ -767,6 +767,7 @@ def _write_overview(
     """
     import zarr
     from mortie import generate_morton_children
+    from zarr import open_array
 
     from zagg.grids.healpix import HealpixGrid
     from zagg.grids.morton import morton_word
@@ -780,11 +781,12 @@ def _write_overview(
     grid = HealpixGrid(k, target_order, config=_overview_config(fields), sharded=True)
     store = open_store(path, **store_kwargs)
     grid.emit_shard_template(store, overwrite=True)
-    group = zarr.open_group(store, path=str(target_order), mode="r+", zarr_format=3)
     words = np.asarray(generate_morton_children(morton_word(node), target_order), dtype=np.uint64)
-    group["morton"][:] = words
+    arr = open_array(store, path=f"{target_order}/morton", zarr_format=3, consolidated=False)
+    arr[:] = words
     for name, slab in fold["slabs"].items():
-        group[name][:] = slab
+        arr = open_array(store, path=f"{target_order}/{name}", zarr_format=3, consolidated=False)
+        arr[:] = slab
     populated = _populated_mask(fold["slabs"], fields)
     root = zarr.open_group(store, path="", mode="r+", zarr_format=3)
     root.attrs.update(

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -464,7 +464,9 @@ def _window_work(decl, windowed, dirty_windows, entries) -> list:
     Per-window overviews inherit window naming (D23); the reserved ``all``
     token is the unwindowed leaf AND the opt-in all-time fold on a windowed
     store (``all_time`` in the declaration; a preexisting all-time entry stays
-    maintained even if the declaration later drops the flag).
+    maintained even if the declaration later drops the flag). A window whose
+    label IS that token can therefore never own a separate overview — same
+    basename, same envelope key — so it yields the all-time item alone.
     """
     from zagg.windows import SCHEDULE_NONE_TOKEN
 
@@ -476,6 +478,19 @@ def _window_work(decl, windowed, dirty_windows, entries) -> list:
     )
     work = [(w, [w]) for w in labels]
     if decl.get("all_time") or SCHEDULE_NONE_TOKEN in entries:
+        if SCHEDULE_NONE_TOKEN in labels:
+            # A window literally labeled with the reserved token (config
+            # validation now rejects it; a hand-edited or pre-guard manifest can
+            # still carry one). Its per-window overview would resolve to the
+            # SAME basename and envelope key as the all-time fold, be
+            # overwritten, and never regenerate — so yield only the all-time
+            # item, which folds this window in anyway (review finding, #201).
+            logger.warning(
+                f"sweep[overview]: window label {SCHEDULE_NONE_TOKEN!r} is the reserved "
+                f"all-time token (D23) — no separate per-window overview is written for "
+                f"it; its leaves fold into the all-time overview instead"
+            )
+            work = [item for item in work if item[0] != SCHEDULE_NONE_TOKEN]
         work.append((SCHEDULE_NONE_TOKEN, labels))
     return work
 

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o9_hive.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o9_hive.yaml
@@ -104,3 +104,4 @@ output:
     sharded: true                # issue #193: sharded output fixed on for the matrix
     child_order: 19              # leaf cell resolution (~10 m)
   store_layout: hive             # issue #240: the hive regression arm (leaf zarr per shard)
+  pyramid: false                 # overview sweep opted out pending Phase E fleet sizing (issue #201)

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o9_hive_located.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o9_hive_located.yaml
@@ -105,3 +105,4 @@ output:
     sharded: true                # issue #193: sharded output fixed on for the matrix
     child_order: 19              # leaf cell resolution (~10 m)
   store_layout: hive             # issue #240: the hive regression arm (leaf zarr per shard)
+  pyramid: false                 # overview sweep opted out pending Phase E fleet sizing (issue #201)

--- a/tests/data/benchmark/configs/atl03_tdigest_healpix_o9_hive_strata.yaml
+++ b/tests/data/benchmark/configs/atl03_tdigest_healpix_o9_hive_strata.yaml
@@ -141,3 +141,4 @@ output:
     sharded: true                # issue #193: sharded output fixed on for the matrix
     child_order: 19              # leaf cell resolution (~10 m)
   store_layout: hive             # issue #240: the hive regression arm (leaf zarr per shard)
+  pyramid: false                 # overview sweep opted out pending Phase E fleet sizing (issue #201)

--- a/tests/data/benchmark/configs/s2_neon_o9.yaml
+++ b/tests/data/benchmark/configs/s2_neon_o9.yaml
@@ -29,6 +29,7 @@ output:
   # Hive: the promoted production default for HEALPix raster (issue #237,
   # ratified issue #272). One leaf zarr object per array per dispatch shard.
   store_layout: hive
+  pyramid: false                 # overview sweep opted out pending Phase E fleet sizing (issue #201)
   grid:
     type: healpix
     indexing_scheme: nested

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -310,10 +310,15 @@ def test_hive_store_matches_model(tmp_path, monkeypatch):
     assert measured["objects_metadata"] == expected["metadata"] == 4
     assert measured["objects_other"] == 0
     assert list(measured["objects_per_shard"]) == [_KEY_A]
-    # The end-of-run sweep (issue #300) lands its rollups in their own bucket
-    # (second-pass D9 caches); the write-path total excludes them.
+    # The end-of-run sweep lands its rollups (issue #300) and overview zarrs
+    # (issue #201) in their own buckets (second-pass D9 caches); the
+    # write-path total excludes both.
     assert measured["objects_rollups"] > 0
-    assert measured["objects_total"] - measured["objects_rollups"] == expected["total_max"]
+    assert measured["objects_overviews"] > 0
+    write_path = (
+        measured["objects_total"] - measured["objects_rollups"] - measured["objects_overviews"]
+    )
+    assert write_path == expected["total_max"]
     assert bench_objects.object_count_mismatch(measured, expected) is None
     # Attribution really is the leaf prefix.
     leaf = hive.shard_leaf_path("", word).lstrip("/")
@@ -347,6 +352,38 @@ def test_hive_misplaced_rollup_counts_into_shard(monkeypatch):
     assert measured["objects_per_shard"] == {label: 2}  # data + misplaced rollup
     assert measured["objects_other"] == 0
     assert not any(k.endswith("stats.rollup.json") for k in measured["other_keys"])
+
+
+def test_hive_overview_zarrs_count_into_their_own_bucket(monkeypatch):
+    # Sweep overview zarrs (issue #201) are `{window}.zarr` / `all.zarr` at a
+    # digit node — window tokens can never parse as morton ids, so they get
+    # their own D9 bucket; a stray *id*-named zarr outside the dispatched leaf
+    # set stays a loud ``other`` finding, and anything inside a leaf prefix
+    # still attributes to that shard (the #215 guard is untouched).
+    from zagg import hive
+
+    grid = from_config(_cfg())
+    word = int(morton_word(_KEY_A))
+    label = grid.shard_label(word)
+    leaf = hive.shard_leaf_path("", word).lstrip("/")
+    node = leaf.rsplit("/", 1)[0]
+    base = node.split("/", 1)[0]
+    keys = [
+        f"{leaf}/count/c/0",  # in-leaf data -> this shard
+        f"{base}/all.zarr/zarr.json",  # all-time overview at the base node
+        f"{node}/2019.zarr/2/count/c/0",  # per-window overview at the node
+        f"{node}/overview.rollup.json",  # the family's envelope -> rollups
+        f"{base}/-311.zarr/zarr.json",  # stray ID-named zarr -> other
+    ]
+    monkeypatch.setattr(bench_objects, "list_store_keys", lambda *a, **k: keys)
+    measured = bench_objects.store_object_counts(
+        "unused", grid=grid, shard_keys=[word], store_layout="hive"
+    )
+    assert measured["objects_overviews"] == 2
+    assert measured["objects_rollups"] == 1
+    assert measured["objects_per_shard"] == {label: 1}
+    assert measured["objects_other"] == 1
+    assert measured["other_keys"] == [f"{base}/-311.zarr/zarr.json"]
 
 
 # --- mismatch helper (pure) --------------------------------------------------
@@ -594,8 +631,11 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     # ... + the stats.json AND shardmap.json siblings (issues #297/#300).
     assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 2
     assert expected["metadata"] == 4
-    # Sweep rollups (issue #300) ride their own bucket, outside the
-    # write-path total this model audits.
-    assert measured["objects_total"] - measured["objects_rollups"] == expected["total_max"]
+    # Sweep rollups (issue #300) and overview zarrs (issue #201) ride their
+    # own buckets, outside the write-path total this model audits.
+    write_path = (
+        measured["objects_total"] - measured["objects_rollups"] - measured["objects_overviews"]
+    )
+    assert write_path == expected["total_max"]
     assert measured["objects_other"] == 0
     assert bench_objects.object_count_mismatch(measured, expected) is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2495,3 +2495,57 @@ class TestWorkerBlock:
         )
         with pytest.raises(ValueError, match=r"worker\.memory must be one of"):
             validate_config(cfg)
+
+
+class TestNanAmbiguousReductionWarning:
+    """Plain min/max/sum + NaN fill warns at validation (espg ruling, issue #201).
+
+    Warning, never error: NaN data is the same bytes as the fill at read, so
+    the reduction behaves as its nan-skipping form downstream (the pyramid
+    block declares ``nan_policy: "skip"``); declaring the ``nan*`` form states
+    that explicitly and silences the warning. The shipped atl06 config trips
+    it by design and must stay valid.
+    """
+
+    def _cfg(self, function, **meta):
+        return {
+            "pipeline": {"type": "spatial"},
+            "data_source": {
+                "reader": "h5coro",
+                "coordinates": {"latitude": "/lat", "longitude": "/lon"},
+                "variables": {"h": "/h"},
+            },
+            "aggregation": {
+                "variables": {
+                    "x": {"source": "h", "function": function, "dtype": "float32", **meta}
+                }
+            },
+            "output": {
+                "store": ".",
+                "grid": {"type": "healpix", "parent_order": 6, "child_order": 12},
+            },
+        }
+
+    def test_min_with_explicit_nan_fill_warns(self, caplog):
+        validate_config(load_config_from_dict(self._cfg("min", fill_value="NaN")))
+        assert "indistinguishable from fill" in caplog.text
+        assert "nanmin" in caplog.text and "issue #201" in caplog.text
+
+    def test_float_default_fill_warns_too(self, caplog):
+        # No fill_value declared: floats default to the NaN sentinel — the
+        # exact posture of the shipped atl06 h_min/h_max declarations.
+        validate_config(load_config_from_dict(self._cfg("max")))
+        assert "nanmax" in caplog.text and "indistinguishable from fill" in caplog.text
+
+    def test_nan_form_is_silent(self, caplog):
+        validate_config(load_config_from_dict(self._cfg("nanmin", fill_value="NaN")))
+        assert "indistinguishable from fill" not in caplog.text
+
+    def test_non_nan_fill_is_silent(self, caplog):
+        validate_config(load_config_from_dict(self._cfg("min", fill_value=0.0)))
+        assert "indistinguishable from fill" not in caplog.text
+
+    def test_shipped_atl06_warns_and_stays_valid(self, caplog):
+        cfg = default_config("atl06")  # h_min/h_max: min/max, float32, NaN default
+        validate_config(cfg)  # must NOT raise
+        assert "h_min" in caplog.text and "h_max" in caplog.text

--- a/tests/test_coverage_root.py
+++ b/tests/test_coverage_root.py
@@ -726,6 +726,33 @@ class TestRefreshRootCoverage:
         assert any("mixed-order stores are unsupported" in r.message for r in caplog.records)
         np.testing.assert_array_equal(hive.root_coverage_words(env), _words(SHARD))
 
+    def test_non_decimal_stamped_leaf_skipped_with_warning(self, tmp_path, caplog):
+        # A stamped `.zarr` whose stem satisfies the leaf grammar but is not a
+        # morton decimal ("all.zarr" — the window-only /3 token, hand-copied or
+        # role-less debris) used to sail past `_decimal_order` and raise
+        # "malformed decimal Morton id 'all'" out of the repair path itself
+        # (review finding, issue #201). It is skipped with a warning instead.
+        import logging
+        import pathlib
+
+        from zagg.coverage import refresh_root_coverage
+        from zagg.grids import HealpixGrid
+        from zagg.store import open_store
+
+        root = self._store_with_leaves(tmp_path, stamped=(SHARD,))
+        node = pathlib.Path(hive.shard_leaf_path(root, morton_word(SHARD))).parent
+        grid = HealpixGrid(
+            parent_order=6, child_order=8, layout="fullsphere", config=default_config("atl06")
+        )
+        store = open_store(str(node / "all.zarr"))
+        grid.emit_shard_template(store, overwrite=True)
+        hive.stamp_commit(store, cells_with_data=1, granule_count=1)
+
+        with caplog.at_level(logging.WARNING, logger="zagg.coverage"):
+            env = refresh_root_coverage(root)
+        assert any("not a D1 morton decimal" in r.message for r in caplog.records)
+        np.testing.assert_array_equal(hive.root_coverage_words(env), _words(SHARD))
+
     def test_not_a_hive_root_raises(self, tmp_path):
         from zagg.coverage import refresh_root_coverage
 

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -194,8 +194,13 @@ class TestManifest:
         assert m["shard_order"] == 6
         # Explicit split schedule: one digit per level down to the shard order.
         assert m["split_schedule"] == [1] * 6
-        # Declared-only in round one (populated by the pyramid sweep, D11).
-        assert m["pyramid"] == {"orders": [], "aggregation": {}}
+        # Template-time overview declaration (issue #201): default every-2
+        # schedule below the shard order, per-field D24 classes; the sweep
+        # adds `materialized` actuals later (D11).
+        overview = m["pyramid"]["overview"]
+        assert overview["orders"] == [4, 2, 0]
+        assert overview["fields"]["count"]["class"] == "exact"
+        assert overview["fields"]["h_mean"] == {"class": "none"}
         assert m["generated_at"]
 
     def test_ensure_write_read_round_trip(self, cfg, tmp_path):

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -261,6 +261,18 @@ class TestWindowingConfig:
         with pytest.raises(ValueError, match="grammar"):
             validate_config(cfg)
 
+    def test_explicit_reserved_all_label(self, cfg):
+        # The opaque grammar admits "all", but the token names the unwindowed /
+        # all-time artifact (leaf_name_v3, the D23 overview basename), so an
+        # explicit window by that name would alias it (issue #201 review).
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[{"label": "all", "start": "2019-01-01", "end": "2020-01-01"}],
+        )
+        with pytest.raises(ValueError, match="reserved schedule:none token"):
+            validate_config(cfg)
+
     def test_explicit_reversed_range(self, cfg):
         _windowed(
             cfg,

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -363,13 +363,17 @@ class TestMocRollup:
         _put_leaf(tmp_path, "-311")
         _stamp_leaf(tmp_path, "-311")
         summary = run_sweep(str(tmp_path), _leaf_refs("-311"))
-        assert set(summary["families"]) == {"stats", "moc", "submap"}
+        assert set(summary["families"]) == {"stats", "moc", "submap", "overview"}
         assert _rollup(tmp_path, "-3", family="stats") is not None
         assert _rollup(tmp_path, "-3", family="moc") is not None
         # No leaf sub-map was written -> the submap family finds nothing and
         # stays empty without failing the pass.
         assert summary["families"]["submap"]["empty"] >= 1
         assert _rollup(tmp_path, "-3", family="submap") is None
+        # The fixture manifest carries no pyramid overview declaration
+        # (template-time, issue #201) -> the overview family no-ops.
+        assert summary["families"]["overview"]["declared"] is False
+        assert summary["families"]["overview"]["written"] == 0
 
 
 SUBMAP_SIG = {
@@ -626,7 +630,7 @@ class TestFamilyRegistry:
 
     @pytest.mark.parametrize(
         ("name", "marker"),
-        [("overview", "issue #201"), ("debris", "not implemented")],
+        [("debris", "not implemented")],
     )
     def test_stub_families_refuse_with_pointer(self, name, marker):
         assert name in sweep_mod.FAMILIES  # registered slot stays visible
@@ -637,8 +641,14 @@ class TestFamilyRegistry:
         except NotImplementedError as e:
             assert marker in str(e)
 
+    def test_overview_family_is_available(self):
+        # Issue #201: the reserved slot is implemented — a whole-tree family
+        # (sweep_store hook), not a per-node JSON fold.
+        fam = get_family("overview")
+        assert callable(fam.sweep_store)
+
     def test_default_families_are_the_implemented_set(self):
-        assert sweep_mod.DEFAULT_FAMILIES == ("stats", "moc", "submap")
+        assert sweep_mod.DEFAULT_FAMILIES == ("stats", "moc", "submap", "overview")
 
 
 def _run_record(root, rows, run_id="r1"):

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -3,24 +3,161 @@
 Phase A covers the composability-class helpers (the D24 derivation from the
 aggregator merge-law set) and the per-field up-aggregation kernels: exact
 folds byte-equal by construction, approximate (t-digest) folds via the
-order-independent k-way merge.
+order-independent k-way merge. Phase B covers the overview writer — real
+leaf zarrs folded into ``{window}.zarr``/``all.zarr`` overviews at declared
+ancestor orders, with the D11 role/provenance attrs.
 """
 
-import numpy as np
-import pytest
+import json
 
+import numpy as np
+import obstore
+import pytest
+import zarr
+
+from zagg.grids.morton import morton_word
+from zagg.hive import MANIFEST_NAME, read_commit, shard_leaf_path, stamp_commit
 from zagg.semantics import (
     EXACT_MERGE_LAWS,
     composability_classes,
     field_composability,
 )
+from zagg.store import open_object_store, open_store
+from zagg.sweep import run_sweep
 from zagg.sweep_overview import (
+    OVERVIEW_ATTR,
+    PYRAMID_SPEC,
+    ROLE_ATTR,
     combine_dense,
     decode_digest,
     encode_digest,
     fold_dense,
     fold_digests,
 )
+
+SHARD_ORDER = 2
+CELL_ORDER = 4
+LEAF_CELLS = 4 ** (CELL_ORDER - SHARD_ORDER)
+
+#: The manifest pyramid declaration the writer consumes (template-time, D22).
+FIELDS_DECL = {
+    "count": {"class": "exact", "method": "sum", "dtype": "int32", "fill_value": 0},
+    "h_min": {"class": "exact", "method": "min", "dtype": "float32", "fill_value": "NaN"},
+    "h_tdigest": {
+        "class": "approximate",
+        "method": "tdigest_kway",
+        "dtype": "float32",
+        "inner_shape": [2],
+        "delta": 64,
+    },
+    "h_mean": {"class": "none"},  # option A: absence declared in the block
+}
+
+
+def _write_manifest(
+    root, *, orders=(1, 0), all_time=False, windowed=False, shard_order=SHARD_ORDER, fields=None
+):
+    manifest = {
+        "spec": "morton-hive/2" if windowed else "morton-hive/1",
+        "dataset": {"short_name": "TEST", "version": "1"},
+        "cell_order": CELL_ORDER,
+        "shard_order": shard_order,
+        "split_schedule": [1] * shard_order,
+        "pyramid": {
+            "spec": PYRAMID_SPEC,
+            "overview": {
+                "spacing": 2,
+                "orders": list(orders),
+                "all_time": all_time,
+                "fields": dict(FIELDS_DECL if fields is None else fields),
+            },
+        },
+        "generated_at": "2026-01-01T00:00:00+00:00",
+    }
+    if windowed:
+        manifest["temporal"] = {"schedule": "yearly", "time_field": "t"}
+    obstore.put(open_object_store(str(root)), MANIFEST_NAME, json.dumps(manifest).encode())
+    return manifest
+
+
+def _leaf_cfg(*, with_h_min=True):
+    from zagg.config import PipelineConfig
+
+    variables = {
+        "count": {"function": "len", "dtype": "int32", "fill_value": 0},
+        "h_mean": {"function": "mean", "dtype": "float32"},
+        "h_tdigest": {
+            "kind": "ragged",
+            "function": "zagg.stats.tdigest.build_tdigest",
+            "inner_shape": [2],
+            "dtype": "float32",
+            "fill_value": 0,
+        },
+    }
+    if with_h_min:
+        variables["h_min"] = {"function": "min", "dtype": "float32"}
+    return PipelineConfig(
+        aggregation={
+            "coordinates": {"morton": {"dtype": "uint64", "fill_value": 0}},
+            "variables": variables,
+        }
+    )
+
+
+def _make_leaf(
+    root,
+    decimal,
+    cells,
+    *,
+    window=None,
+    time_range=None,
+    with_h_min=True,
+    shard_order=SHARD_ORDER,
+):
+    """Write one committed leaf: ``cells`` maps leaf row -> observation values."""
+    from mortie import generate_morton_children
+
+    from zagg.grids.healpix import HealpixGrid
+    from zagg.stats.tdigest import build_tdigest
+
+    grid = HealpixGrid(shard_order, CELL_ORDER, config=_leaf_cfg(with_h_min=with_h_min))
+    word = morton_word(decimal)
+    store = open_store(shard_leaf_path(str(root), word, window=window))
+    grid.emit_shard_template(store, overwrite=True)
+    group = zarr.open_group(store, path=str(CELL_ORDER), mode="r+", zarr_format=3)
+    n = 4 ** (CELL_ORDER - shard_order)
+    group["morton"][:] = np.asarray(generate_morton_children(word, CELL_ORDER), dtype=np.uint64)
+    count = np.zeros(n, np.int32)
+    h_min = np.full(n, np.nan, np.float32)
+    h_mean = np.full(n, np.nan, np.float32)
+    digest = np.full(n, b"", dtype=object)
+    for i, obs in cells.items():
+        obs = np.asarray(obs, dtype=np.float64)
+        count[i] = len(obs)
+        h_min[i] = obs.min()
+        h_mean[i] = obs.mean()
+        digest[i] = encode_digest(build_tdigest(obs, delta=64), "float32")
+    group["count"][:] = count
+    if with_h_min:
+        group["h_min"][:] = h_min
+    group["h_mean"][:] = h_mean
+    group["h_tdigest"][:] = digest
+    stamp_commit(
+        store,
+        cells_with_data=len(cells),
+        granule_count=1,
+        window=window,
+        time_range=time_range,
+    )
+
+
+def _overview_group(root, node_rel, basename, order):
+    store = open_store(f"{root}/{node_rel}/{basename}")
+    return zarr.open_group(store, path=str(order), mode="r", zarr_format=3)
+
+
+def _overview_root(root, node_rel, basename):
+    return zarr.open_group(open_store(f"{root}/{node_rel}/{basename}"), mode="r", zarr_format=3)
 
 
 class TestComposabilityClasses:
@@ -179,3 +316,204 @@ class TestFoldDigests:
         forward = fold_digests(list(digests), delta=64)
         backward = fold_digests(list(reversed(digests)), delta=64)
         assert forward == backward  # the issue #279 order-independent law
+
+
+class TestOverviewWriter:
+    def test_folds_leaves_at_every_declared_order(self, tmp_path):
+        from zagg.stats.tdigest import quantile_from_tdigest
+
+        _write_manifest(tmp_path, orders=(1, 0))
+        _make_leaf(tmp_path, "-311", {0: [1.0, 2.0], 5: [10.0]})
+        _make_leaf(tmp_path, "-312", {0: [3.0]})
+        refs = [(morton_word("-311"), None), (morton_word("-312"), None)]
+        result = run_sweep(str(tmp_path), refs, families=("overview",))
+        counts = result["families"]["overview"]
+        # order 1: node -31; order 0: node -3 -> two overview zarrs.
+        assert counts["written"] == 2 and counts["failed"] == 0
+
+        # Order 1 (cells at order 3, 4 source cells per overview cell):
+        # leaf -311 occupies overview rows 0-3, leaf -312 rows 4-7.
+        g1 = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        np.testing.assert_array_equal(g1["count"][:8], [2, 1, 0, 0, 1, 0, 0, 0])
+        assert g1["h_min"][0] == 1.0 and g1["h_min"][4] == 3.0
+        merged = decode_digest(bytes(g1["h_tdigest"][:][0]), "float32")
+        assert np.isclose(quantile_from_tdigest(merged, 0.5), 2.0, atol=0.6)
+        # morton is the order-3 subtree of -31, ascending.
+        assert g1["morton"].shape == (16,) and g1["morton"].dtype == np.uint64
+
+        # Order 0 (cells at order 2 == the source shard order): each leaf
+        # folds whole into its shard's cell — count 3 for -311, 1 for -312.
+        g0 = _overview_group(tmp_path, "-3", "all.zarr", 2)
+        np.testing.assert_array_equal(g0["count"][:2], [3, 1])
+        assert g0["h_min"][0] == 1.0 and g0["h_min"][1] == 3.0
+
+    def test_role_and_provenance_attrs(self, tmp_path):
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        root = _overview_root(tmp_path, "-3/1", "all.zarr")
+        assert root.attrs[ROLE_ATTR] == "overview"
+        info = root.attrs[OVERVIEW_ATTR]
+        assert info["order"] == 1 and info["cell_order"] == 3
+        assert info["source_shard_order"] == SHARD_ORDER
+        assert info["source_cell_order"] == CELL_ORDER
+        assert info["fields"]["count"] == {"class": "exact", "method": "sum"}
+        assert info["fields"]["h_tdigest"]["method"] == "tdigest_kway"
+        assert info["generation"]["n_leaves"] == 1
+        # The overview is a stamped, committed zarr (D4 semantics apply).
+        stamp = read_commit(open_store(str(tmp_path / "-3" / "1" / "all.zarr")))
+        assert stamp is not None and stamp["granule_count"] == 1
+
+    def test_none_field_is_absent_from_the_overview(self, tmp_path):
+        # Option A (the ruled D24 default): h_mean exists at the leaves but is
+        # excluded from every overview order; the pyramid block declares it.
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0, 5.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        g = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        assert "h_mean" not in g
+        assert "count" in g and "h_tdigest" in g
+
+    def test_no_declaration_is_a_noop(self, tmp_path):
+        manifest = _write_manifest(tmp_path, orders=(1,))
+        manifest["pyramid"] = {"orders": [], "aggregation": {}}  # the legacy block
+        obstore.put(open_object_store(str(tmp_path)), MANIFEST_NAME, json.dumps(manifest).encode())
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        result = run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        assert result["families"]["overview"]["declared"] is False
+        assert result["families"]["overview"]["written"] == 0
+        assert not (tmp_path / "-3" / "1" / "all.zarr").exists()
+
+    def test_unstamped_debris_leaf_is_invisible(self, tmp_path):
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        # A torn worker's leaf: template only, no commit stamp (D4).
+        from zagg.grids.healpix import HealpixGrid
+
+        grid = HealpixGrid(SHARD_ORDER, CELL_ORDER, config=_leaf_cfg())
+        debris = open_store(shard_leaf_path(str(tmp_path), morton_word("-312")))
+        grid.emit_shard_template(debris, overwrite=True)
+        refs = [(morton_word("-311"), None), (morton_word("-312"), None)]
+        run_sweep(str(tmp_path), refs, families=("overview",))
+        g = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        info = _overview_root(tmp_path, "-3/1", "all.zarr").attrs[OVERVIEW_ATTR]
+        assert info["generation"]["n_leaves"] == 1
+        np.testing.assert_array_equal(g["count"][4:8], [0, 0, 0, 0])
+
+    def test_envelope_records_window_inventory(self, tmp_path):
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        envelope = json.loads((tmp_path / "-3" / "1" / "overview.rollup.json").read_text())
+        assert envelope["family"] == "overview" and envelope["node"] == "-31"
+        entry = envelope["windows"]["all"]
+        assert entry["object"] == "all.zarr"
+        assert entry["generation"]["n_leaves"] == 1
+        assert entry["content_hash"]
+
+    def test_windowed_per_window_and_all_time(self, tmp_path):
+        _write_manifest(tmp_path, orders=(1,), windowed=True, all_time=True)
+        _make_leaf(
+            tmp_path,
+            "-311",
+            {0: [1.0, 2.0]},
+            window="2019",
+            time_range=["2019-02-01T00:00:00+00:00", "2019-11-01T00:00:00+00:00"],
+        )
+        _make_leaf(
+            tmp_path,
+            "-311",
+            {0: [10.0]},
+            window="2020",
+            time_range=["2020-01-01T00:00:00+00:00", "2020-06-01T00:00:00+00:00"],
+        )
+        word = morton_word("-311")
+        result = run_sweep(str(tmp_path), [(word, "2019"), (word, "2020")], families=("overview",))
+        assert result["families"]["overview"]["written"] == 3  # 2019, 2020, all
+        g2019 = _overview_group(tmp_path, "-3/1", "2019.zarr", 3)
+        g2020 = _overview_group(tmp_path, "-3/1", "2020.zarr", 3)
+        gall = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        assert g2019["count"][0] == 2 and g2020["count"][0] == 1
+        assert gall["count"][0] == 3  # the all-time fold accumulates windows
+        assert gall["h_min"][0] == 1.0
+        # Stamps: per-window overviews carry their window; the all-time fold
+        # carries the reserved token and the unioned extent (D15/D23).
+        stamp = read_commit(open_store(str(tmp_path / "-3" / "1" / "all.zarr")))
+        assert stamp["window"] == "all"
+        assert stamp["time_range"] == [
+            "2019-02-01T00:00:00+00:00",
+            "2020-06-01T00:00:00+00:00",
+        ]
+        assert read_commit(open_store(str(tmp_path / "-3" / "1" / "2019.zarr")))["window"] == "2019"
+
+    def test_sibling_contribution_via_root_moc(self, tmp_path):
+        # Incremental run: the second sweep names ONLY the new leaf; the
+        # untouched sibling still contributes through the root coverage.moc
+        # the MOC family refreshed (run record + MOC, never a LIST).
+        _write_manifest(tmp_path, orders=(0,))
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("moc", "overview"))
+        _make_leaf(tmp_path, "-312", {0: [5.0]})
+        run_sweep(str(tmp_path), [(morton_word("-312"), None)], families=("moc", "overview"))
+        g = _overview_group(tmp_path, "-3", "all.zarr", 2)
+        np.testing.assert_array_equal(g["count"][:2], [1, 1])
+        assert g["h_min"][0] == 1.0 and g["h_min"][1] == 5.0
+
+    def test_missing_field_reads_as_fill(self, tmp_path):
+        # Schema evolution: a leaf written before h_min existed contributes
+        # fill for it — the walk never dies on the absent array (issue #341).
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0]}, with_h_min=False)
+        result = run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        assert result["families"]["overview"]["written"] == 1
+        g = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        assert g["count"][0] == 1
+        assert np.isnan(g["h_min"][0])
+
+    def test_orphan_objects_in_leaf_are_tolerated(self, tmp_path):
+        # Issue #341 Bug A: schema evolution can leave orphan array prefixes
+        # inside a leaf; the fold opens arrays BY NAME (no member walk), so
+        # junk prefixes and foreign objects cannot crash it.
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [2.0]})
+        leaf = tmp_path / "-3" / "1" / "1" / "-311.zarr"
+        orphan = leaf / str(CELL_ORDER) / "orphan_field" / "c"
+        orphan.mkdir(parents=True)
+        (orphan / "0").write_bytes(b"\x00garbage")
+        (leaf / "stray.status").write_text("worker status debris")
+        result = run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        counts = result["families"]["overview"]
+        assert counts["written"] == 1 and counts["failed"] == 0
+
+    def test_unreadable_leaf_skips_loudly_not_fatally(self, tmp_path, caplog):
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        # A committed leaf whose inner group vanished (torn schema surgery):
+        # stamp present, arrays gone -> skip + log, the node still folds.
+        _make_leaf(tmp_path, "-312", {0: [9.0]})
+        import shutil
+
+        shutil.rmtree(tmp_path / "-3" / "1" / "2" / "-312.zarr" / str(CELL_ORDER))
+        refs = [(morton_word("-311"), None), (morton_word("-312"), None)]
+        result = run_sweep(str(tmp_path), refs, families=("overview",))
+        counts = result["families"]["overview"]
+        assert counts["written"] == 1 and counts["failed"] == 1
+        assert "skipping unreadable leaf" in caplog.text
+        g = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        assert g["count"][0] == 1
+
+    def test_coarser_than_shard_order_accumulates(self, tmp_path):
+        # Overview cells COARSER than the shard order (deep schedule, shallow
+        # depth): whole shards fold into one overview cell, accumulated
+        # across leaves.
+        _write_manifest(tmp_path, orders=(0,), shard_order=3)
+        _make_leaf(tmp_path, "-3111", {0: [1.0]}, shard_order=3)
+        _make_leaf(tmp_path, "-3112", {1: [4.0, 5.0]}, shard_order=3)
+        refs = [(morton_word("-3111"), None), (morton_word("-3112"), None)]
+        result = run_sweep(str(tmp_path), refs, families=("overview",))
+        assert result["families"]["overview"]["written"] == 1
+        # node -3, overview cells at order 1 (= 4 - 3 + 0): both shards live
+        # under -31 -> row 0 accumulates 1 + 2 observations.
+        g = _overview_group(tmp_path, "-3", "all.zarr", 1)
+        np.testing.assert_array_equal(g["count"][:], [3, 0, 0, 0])
+        assert g["h_min"][0] == 1.0

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -255,6 +255,25 @@ class TestFoldDense:
             expect = np.array([direct(vals[i : i + 4]) for i in range(0, 64, 4)], np.float32)
             np.testing.assert_array_equal(out, expect)
 
+    def test_nan_datum_is_skipped_not_propagated(self):
+        # The DECLARED premise behind the §8.3 exactness claim (review finding,
+        # issue #201, EXACT_NAN_POLICY): a stored NaN is the fill sentinel and a
+        # NaN datum at once — same bytes — so the fold is nanmin/nansum, never
+        # the NaN-propagating min/sum a direct coarse aggregation would return.
+        from zagg.sweep_overview import EXACT_NAN_POLICY
+
+        assert EXACT_NAN_POLICY == "skip"
+        vals = np.array([1.0, np.nan, 3.0, 4.0], dtype=np.float32)
+        np.testing.assert_array_equal(fold_dense(vals, 4, "min", "NaN"), [np.nanmin(vals)])
+        np.testing.assert_array_equal(fold_dense(vals, 4, "sum", "NaN"), [np.nansum(vals)])
+        assert np.isnan(np.min(vals)) and np.isnan(np.sum(vals))  # the divergence
+
+    def test_nan_datum_skipped_even_under_a_numeric_fill(self):
+        # Uniform policy: even where the fill is NOT NaN — so a NaN datum could
+        # in principle be told apart — NaN still counts as missing.
+        vals = np.array([2.0, np.nan], dtype=np.float32)
+        np.testing.assert_array_equal(fold_dense(vals, 2, "min", -9999.0), [2.0])
+
     def test_fold_is_composable_two_hops(self):
         # fold(16x) == fold(4x) then fold(4x): the associativity that lets a
         # spacing-2 schedule read leaves directly at every declared order.
@@ -339,12 +358,17 @@ class TestPyramidBlock:
         assert overview["fields"]["count"] == {
             "class": "exact",
             "method": "sum",
+            "nan_policy": "skip",
             "dtype": "int32",
             "fill_value": 0,
         }
         assert overview["fields"]["h_min"] == {
             "class": "exact",
             "method": "min",
+            # The declared premise (issue #201 review): a stored NaN is the fill
+            # sentinel and a NaN datum at once, so the fold skips both — this is
+            # nanmin, not min. h_min's fill IS NaN in the shipped atl06 config.
+            "nan_policy": "skip",
             "dtype": "float32",
             "fill_value": "NaN",  # JSON-safe token, not float nan
         }
@@ -483,8 +507,13 @@ class TestOverviewWriter:
         assert info["order"] == 1 and info["cell_order"] == 3
         assert info["source_shard_order"] == SHARD_ORDER
         assert info["source_cell_order"] == CELL_ORDER
-        assert info["fields"]["count"] == {"class": "exact", "method": "sum"}
+        assert info["fields"]["count"] == {
+            "class": "exact",
+            "method": "sum",
+            "nan_policy": "skip",
+        }
         assert info["fields"]["h_tdigest"]["method"] == "tdigest_kway"
+        assert "nan_policy" not in info["fields"]["h_tdigest"]
         assert info["generation"]["n_leaves"] == 1
         # The overview is a stamped, committed zarr (D4 semantics apply).
         stamp = read_commit(open_store(str(tmp_path / "-3" / "1" / "all.zarr")))

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -795,6 +795,47 @@ class TestSection83Obligations:
                     atol=0.25,
                 )
 
+    @pytest.mark.parametrize("k", [1, 0])
+    def test_morton_labels_address_the_folded_cells(self, tmp_path, k):
+        # Review finding, issue #201: the writer places slabs by base-4 rank
+        # arithmetic but LABELS them with generate_morton_children(), two
+        # orderings that must agree — and `_direct()` above cannot catch a
+        # disagreement because it recomputes the writer's own formula. Resolve
+        # every slot from the overview's OWN morton value instead: a leaf cell
+        # belongs to the overview cell its morton decimal PREFIXES.
+        from mortie import generate_morton_children
+
+        from zagg.grids.morton import morton_decimal
+
+        refs = self._populate(tmp_path, orders=(k,))
+        run_sweep(str(tmp_path), refs, families=("overview",))
+        target_order = CELL_ORDER - (SHARD_ORDER - k)
+        node = {1: "-31", 0: "-3"}[k]
+        base = node[: len(node) - k]
+        g = _overview_group(tmp_path, {1: "-3/1", 0: "-3"}[k], "all.zarr", target_order)
+
+        pooled: dict[str, list] = {}
+        for (dec, row), obs in self.OBS.items():
+            word = generate_morton_children(morton_word(dec), CELL_ORDER)[row]
+            cell = morton_decimal(int(word))  # the order-4 leaf cell's id
+            pooled.setdefault(cell[: len(base) + target_order], []).extend(obs)
+        assert pooled  # every OBS cell resolved to an overview cell
+
+        morton, count, h_min = g["morton"][:], g["count"][:], g["h_min"][:]
+        assert len(set(morton.tolist())) == len(morton)  # labels are distinct
+        seen = set()
+        for j, word in enumerate(morton.tolist()):
+            label = morton_decimal(int(word))
+            assert label.startswith(node) and len(label) == len(base) + target_order
+            if label in pooled:
+                obs = np.asarray(pooled[label], dtype=np.float64)
+                assert count[j] == len(obs)
+                assert h_min[j] == np.float32(obs.min())
+                seen.add(label)
+            else:  # unclaimed slots stay at the fill
+                assert count[j] == 0 and np.isnan(h_min[j])
+        assert seen == set(pooled)  # no populated cell went unlabelled
+
     def test_second_pass_over_unchanged_tree_writes_nothing(self, tmp_path):
         refs = self._populate(tmp_path)
         first = run_sweep(str(tmp_path), refs, families=("moc", "overview"))

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -1,0 +1,181 @@
+"""Overview sweep family (issue #201): D24 kernels, writer, pyramid block.
+
+Phase A covers the composability-class helpers (the D24 derivation from the
+aggregator merge-law set) and the per-field up-aggregation kernels: exact
+folds byte-equal by construction, approximate (t-digest) folds via the
+order-independent k-way merge.
+"""
+
+import numpy as np
+import pytest
+
+from zagg.semantics import (
+    EXACT_MERGE_LAWS,
+    composability_classes,
+    field_composability,
+)
+from zagg.sweep_overview import (
+    combine_dense,
+    decode_digest,
+    encode_digest,
+    fold_dense,
+    fold_digests,
+)
+
+
+class TestComposabilityClasses:
+    def test_default_atl06_config_classes(self):
+        from zagg.config import default_config
+
+        classes = composability_classes(default_config("atl06"))
+        assert classes["count"] == "exact"
+        assert classes["h_min"] == "exact"
+        assert classes["h_max"] == "exact"
+        # average / var / quantile have no exact fold law; the expression
+        # field is never composable.
+        for name in ("h_mean", "h_sigma", "h_variance", "h_q25", "h_q50", "h_q75"):
+            assert classes[name] == "none"
+
+    def test_tdigest_field_is_approximate(self):
+        from zagg.config import default_config
+
+        classes = composability_classes(default_config("atl03_tdigest_healpix"))
+        assert classes["h_tdigest"] == "approximate"
+
+    def test_located_tdigest_is_none(self):
+        # The located channel has no streaming merge law yet -> excluded.
+        meta = {
+            "kind": "ragged",
+            "function": "zagg.stats.tdigest.build_tdigest",
+            "inner_shape": [2],
+            "location": "leaf_id",
+            "dtype": "float32",
+        }
+        assert field_composability(meta) == "none"
+
+    @pytest.mark.parametrize("name", ["min", "np.min", "numpy.min", "nanmax", "np.nansum"])
+    def test_prefix_normalization(self, name):
+        assert field_composability({"function": name, "dtype": "float32"}) == "exact"
+
+    def test_every_exact_law_is_known(self):
+        assert set(EXACT_MERGE_LAWS.values()) == {"sum", "min", "max"}
+
+    @pytest.mark.parametrize(
+        "meta",
+        [
+            {"function": "mean"},
+            {"function": "median"},
+            {"expression": "np.sum(x)"},
+            {"function": "min", "kind": "vector", "trailing_shape": [3]},
+            {"function": "len", "resolution": "chunk"},
+            {"function": "zagg.stats.tdigest.build_tdigest", "kind": "ragged", "inner_shape": [3]},
+            {"function": "somepkg.custom", "kind": "ragged", "inner_shape": [2]},
+        ],
+    )
+    def test_non_composable_metas(self, meta):
+        assert field_composability(meta) == "none"
+
+    def test_pairwise_tdigest_builder_is_approximate(self):
+        meta = {
+            "kind": "ragged",
+            "function": "zagg.stats.tdigest.build_tdigest_pairwise",
+            "inner_shape": [2],
+            "dtype": "float32",
+        }
+        assert field_composability(meta) == "approximate"
+
+
+class TestFoldDense:
+    def test_sum_int_count(self):
+        counts = np.array([1, 2, 0, 0, 3, 0, 4, 5], dtype=np.int32)
+        out = fold_dense(counts, 4, "sum", 0)
+        assert out.dtype == np.int32
+        np.testing.assert_array_equal(out, [3, 12])
+
+    def test_sum_float_nan_fill_skips_missing(self):
+        vals = np.array([1.5, np.nan, 2.5, np.nan], dtype=np.float32)
+        out = fold_dense(vals, 2, "sum", "NaN")
+        np.testing.assert_array_equal(out, np.array([1.5, 2.5], dtype=np.float32))
+
+    def test_all_missing_group_folds_to_fill(self):
+        vals = np.array([np.nan, np.nan, 1.0, 2.0], dtype=np.float32)
+        out = fold_dense(vals, 2, "min", "NaN")
+        assert np.isnan(out[0]) and out[1] == 1.0
+
+    def test_min_max_extrema(self):
+        vals = np.array([3.0, np.nan, -1.0, 7.0], dtype=np.float32)
+        np.testing.assert_array_equal(fold_dense(vals, 4, "min", "NaN"), [-1.0])
+        np.testing.assert_array_equal(fold_dense(vals, 4, "max", "NaN"), [7.0])
+
+    def test_exact_equals_direct(self):
+        # The fold at factor 4 equals a direct order-coarser aggregation over
+        # the same values (the §8.3 exactness claim, in kernel form). Exact
+        # binary floats so equality is byte-for-byte.
+        rng = np.random.default_rng(7)
+        vals = (rng.integers(-64, 64, size=64) / 4.0).astype(np.float32)
+        for law, direct in (("sum", np.sum), ("min", np.min), ("max", np.max)):
+            out = fold_dense(vals, 4, law, "NaN")
+            expect = np.array([direct(vals[i : i + 4]) for i in range(0, 64, 4)], np.float32)
+            np.testing.assert_array_equal(out, expect)
+
+    def test_fold_is_composable_two_hops(self):
+        # fold(16x) == fold(4x) then fold(4x): the associativity that lets a
+        # spacing-2 schedule read leaves directly at every declared order.
+        vals = np.arange(32, dtype=np.float32)
+        one_hop = fold_dense(vals, 16, "sum", "NaN")
+        two_hop = fold_dense(fold_dense(vals, 4, "sum", "NaN"), 4, "sum", "NaN")
+        np.testing.assert_array_equal(one_hop, two_hop)
+
+    def test_int_extrema_identity(self):
+        vals = np.array([5, 0, 0, 2], dtype=np.int32)  # fill 0 = missing
+        np.testing.assert_array_equal(fold_dense(vals, 2, "max", 0), [5, 2])
+        np.testing.assert_array_equal(fold_dense(vals, 2, "min", 0), [5, 2])
+
+    def test_bad_factor_and_unknown_law_raise(self):
+        with pytest.raises(ValueError, match="cannot fold"):
+            fold_dense(np.zeros(3), 2, "sum", 0)
+        with pytest.raises(ValueError, match="unknown exact fold law"):
+            fold_dense(np.zeros(4), 2, "mean", 0)
+
+    def test_combine_accumulates(self):
+        a = np.array([1.0, np.nan], dtype=np.float32)
+        b = np.array([2.0, np.nan], dtype=np.float32)
+        out = combine_dense(a, b, "sum", "NaN")
+        assert out[0] == 3.0 and np.isnan(out[1])
+
+
+class TestFoldDigests:
+    def _digest(self, values):
+        from zagg.stats.tdigest import build_tdigest
+
+        return build_tdigest(np.asarray(values, dtype=np.float64), delta=64)
+
+    def test_roundtrip_encode_decode(self):
+        d = self._digest([1.0, 2.0, 3.0])
+        raw = encode_digest(d, "float32")
+        np.testing.assert_array_equal(decode_digest(raw, "float32"), d.astype(np.float32))
+
+    def test_empty_accumulation_is_empty_payload(self):
+        assert fold_digests([], delta=64) == b""
+        assert decode_digest(b"", "float32").shape == (0, 2)
+
+    def test_single_digest_passes_through(self):
+        d = self._digest([1.0, 5.0])
+        assert fold_digests([d], delta=64) == encode_digest(d, "float32")
+
+    def test_merge_matches_kway_oracle(self):
+        from zagg.stats.tdigest import merge_tdigests_kway, quantile_from_tdigest
+
+        a, b = self._digest(np.arange(100.0)), self._digest(np.arange(100.0, 200.0))
+        raw = fold_digests([a, b], delta=64)
+        merged = decode_digest(raw, "float32")
+        oracle = merge_tdigests_kway([a, b], delta=64)
+        np.testing.assert_array_equal(merged, oracle.astype(np.float32))
+        # And the merged digest is the subtree's distribution (np.isclose class).
+        assert np.isclose(quantile_from_tdigest(merged, 0.5), 99.5, rtol=0.05)
+
+    def test_merge_is_permutation_stable(self):
+        digests = [self._digest(np.arange(i, i + 50.0)) for i in (0, 30, 60)]
+        forward = fold_digests(list(digests), delta=64)
+        backward = fold_digests(list(reversed(digests)), delta=64)
+        assert forward == backward  # the issue #279 order-independent law

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -572,6 +572,24 @@ class TestOverviewWriter:
         ]
         assert read_commit(open_store(str(tmp_path / "-3" / "1" / "2019.zarr")))["window"] == "2019"
 
+    def test_window_named_all_folds_into_the_all_time_overview(self, tmp_path, caplog):
+        # Review finding, issue #201: a window labeled with the reserved token
+        # resolves to the same basename AND envelope key as the all-time fold,
+        # which used to overwrite it and then never regenerate it. Config
+        # validation now rejects the label; a pre-guard manifest folds the
+        # window into the all-time overview with a warning instead.
+        _write_manifest(tmp_path, orders=(1,), windowed=True, all_time=True)
+        _make_leaf(tmp_path, "-311", {0: [1.0, 2.0]}, window="2019")
+        _make_leaf(tmp_path, "-311", {0: [10.0]}, window="all")
+        word = morton_word("-311")
+        result = run_sweep(str(tmp_path), [(word, "2019"), (word, "all")], families=("overview",))
+        assert result["families"]["overview"]["written"] == 2  # 2019 + all-time
+        assert "reserved all-time token" in caplog.text
+        gall = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        assert gall["count"][0] == 3  # both windows' leaves are folded in
+        envelope = json.loads((tmp_path / "-3" / "1" / "overview.rollup.json").read_text())
+        assert sorted(envelope["windows"]) == ["2019", "all"]
+
     def test_sibling_contribution_via_root_moc(self, tmp_path):
         # Incremental run: the second sweep names ONLY the new leaf; the
         # untouched sibling still contributes through the root coverage.moc

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -809,6 +809,40 @@ class TestSection83Obligations:
         for p, digest in hashes.items():
             assert json.loads(p.read_text())["windows"]["all"]["content_hash"] == digest
 
+    def test_deleting_only_the_zarrs_regenerates_them(self, tmp_path):
+        # Review finding, issue #201: the envelope and the zarr are two objects,
+        # so skip-if-current must probe the ARTIFACT — deleting only the zarrs
+        # used to read back as `current` with nothing on disk (no D9 self-heal).
+        import shutil
+
+        refs = self._populate(tmp_path)
+        run_sweep(str(tmp_path), refs, families=("moc", "overview"))
+        hashes = {
+            p: json.loads(p.read_text())["windows"]["all"]["content_hash"]
+            for p in tmp_path.rglob("overview.rollup.json")
+        }
+        zarrs = sorted(tmp_path.rglob("all.zarr"))
+        assert len(zarrs) == 2 and len(hashes) == 2
+        for p in zarrs:
+            shutil.rmtree(p)
+        counts = run_sweep(str(tmp_path), refs, families=("overview",))["families"]["overview"]
+        assert counts["written"] == 2 and counts["current"] == 0
+        for p in zarrs:
+            assert read_commit(open_store(str(p))) is not None
+        # ...and the regenerated folds are byte-identical (same content hashes).
+        for p, digest in hashes.items():
+            assert json.loads(p.read_text())["windows"]["all"]["content_hash"] == digest
+
+    def test_torn_overview_write_is_not_current(self, tmp_path):
+        # The same probe covers a torn prior write: the zarr is there but the
+        # commit stamp never landed, so the entry must not read as `current`.
+        refs = self._populate(tmp_path, orders=(0,))
+        run_sweep(str(tmp_path), refs, families=("moc", "overview"))
+        (tmp_path / "-3" / "all.zarr" / "zarr.json").unlink()
+        counts = run_sweep(str(tmp_path), refs, families=("overview",))["families"]["overview"]
+        assert counts["written"] == 1 and counts["current"] == 0
+        assert read_commit(open_store(str(tmp_path / "-3" / "all.zarr"))) is not None
+
     def test_repair_walk_ignores_overviews(self, tmp_path):
         # Review finding, issue #201: overview basenames collide with the leaf
         # grammar, so the D9 repair walk must classify them out by the D11 role

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -809,6 +809,37 @@ class TestSection83Obligations:
         for p, digest in hashes.items():
             assert json.loads(p.read_text())["windows"]["all"]["content_hash"] == digest
 
+    def test_repair_walk_ignores_overviews(self, tmp_path):
+        # Review finding, issue #201: overview basenames collide with the leaf
+        # grammar, so the D9 repair walk must classify them out by the D11 role
+        # attr. `all.zarr` used to die outright on a shard_order-2 store
+        # (_decimal_order("all") == 2 -> "malformed decimal Morton id 'all'").
+        from zagg.coverage import refresh_root_coverage
+        from zagg.grids.morton import morton_decimal
+        from zagg.hive import root_coverage_words
+
+        refs = self._populate(tmp_path, orders=(1, 0))
+        run_sweep(str(tmp_path), refs, families=("moc", "overview"))
+        assert sorted(p.name for p in tmp_path.rglob("all.zarr")) == ["all.zarr"] * 2
+        env = refresh_root_coverage(str(tmp_path))
+        assert [morton_decimal(int(w)) for w in root_coverage_words(env)] == ["-311", "-312"]
+
+    def test_repair_walk_ignores_digit_labeled_overviews(self, tmp_path):
+        # The windowed half of the same finding: a window label made of [1-4]
+        # digits at length shard_order+1 parses as a VALID decimal, so the
+        # rebuilt root MOC used to gain a phantom positive-base shard ("2411")
+        # that then poisons every root-MOC consumer.
+        from zagg.coverage import refresh_root_coverage
+        from zagg.grids.morton import morton_decimal
+        from zagg.hive import root_coverage_words
+
+        _write_manifest(tmp_path, orders=(1,), windowed=True, shard_order=3)
+        _make_leaf(tmp_path, "-3111", {0: [1.0]}, window="2411", shard_order=3)
+        run_sweep(str(tmp_path), [(morton_word("-3111"), "2411")], families=("moc", "overview"))
+        assert (tmp_path / "-3" / "1" / "2411.zarr").is_dir()
+        env = refresh_root_coverage(str(tmp_path))
+        assert [morton_decimal(int(w)) for w in root_coverage_words(env)] == ["-3111"]
+
     def test_role_never_inferred_from_position(self, tmp_path):
         # D11/D24: an overview is classified by its role attr, never by tree
         # depth — the leaf carries NO role, the overview always does.

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -318,6 +318,132 @@ class TestFoldDigests:
         assert forward == backward  # the issue #279 order-independent law
 
 
+class TestPyramidBlock:
+    """The manifest declaration (Phase C): template time + config grammar."""
+
+    def _cfg(self, **output):
+        from zagg.config import default_config
+
+        cfg = default_config("atl06")
+        cfg.output.update(output)
+        return cfg
+
+    def test_default_declaration_from_atl06(self, caplog):
+        from zagg.sweep_overview import build_pyramid_block
+
+        block = build_pyramid_block(self._cfg(), shard_order=6)
+        overview = block["overview"]
+        assert block["spec"] == PYRAMID_SPEC
+        assert overview["spacing"] == 2 and overview["orders"] == [4, 2, 0]
+        assert overview["all_time"] is False
+        assert overview["fields"]["count"] == {
+            "class": "exact",
+            "method": "sum",
+            "dtype": "int32",
+            "fill_value": 0,
+        }
+        assert overview["fields"]["h_min"] == {
+            "class": "exact",
+            "method": "min",
+            "dtype": "float32",
+            "fill_value": "NaN",  # JSON-safe token, not float nan
+        }
+        assert overview["fields"]["h_mean"] == {"class": "none"}
+        # The D24 loud template-time warning names the excluded fields.
+        assert "non-composable" in caplog.text and "h_mean" in caplog.text
+        json.dumps(block)  # JSON-safe by construction
+
+    def test_tdigest_field_declaration_carries_delta(self):
+        from zagg.config import default_config
+        from zagg.sweep_overview import build_pyramid_block
+
+        cfg = default_config("atl03_tdigest_healpix")
+        block = build_pyramid_block(cfg, shard_order=9)
+        entry = block["overview"]["fields"]["h_tdigest"]
+        assert entry["class"] == "approximate" and entry["method"] == "tdigest_kway"
+        assert entry["inner_shape"] == [2] and entry["delta"] == 256
+
+    def test_explicit_orders_and_all_time(self):
+        from zagg.sweep_overview import build_pyramid_block
+
+        cfg = self._cfg(pyramid={"orders": [5, 1], "all_time": True})
+        overview = build_pyramid_block(cfg, shard_order=6)["overview"]
+        assert overview["orders"] == [5, 1] and overview["all_time"] is True
+
+    def test_spacing_knob(self):
+        from zagg.sweep_overview import build_pyramid_block
+
+        cfg = self._cfg(pyramid={"spacing": 3})
+        assert build_pyramid_block(cfg, shard_order=9)["overview"]["orders"] == [6, 3, 0]
+
+    def test_disabled_declares_off(self):
+        from zagg.sweep_overview import build_pyramid_block
+
+        block = build_pyramid_block(self._cfg(pyramid=False), shard_order=6)
+        assert block["overview"] == {"orders": []}
+
+    def test_build_manifest_carries_the_block(self):
+        from zagg.grids.healpix import HealpixGrid
+        from zagg.hive import build_manifest
+
+        grid = HealpixGrid(6, 8, config=self._cfg())
+        manifest = build_manifest(grid, dataset={"short_name": "ATL06", "version": "007"})
+        assert manifest["pyramid"]["overview"]["orders"] == [4, 2, 0]
+        json.dumps(manifest)
+
+    def test_validate_rejects_bad_grammar(self):
+        from zagg.config import validate_config
+
+        with pytest.raises(ValueError, match="spacing must be an int >= 1"):
+            validate_config(self._cfg(store_layout="hive", pyramid={"spacing": 0}))
+        with pytest.raises(ValueError, match="orders must be a list of ancestor orders"):
+            validate_config(self._cfg(store_layout="hive", pyramid={"orders": [6]}))
+        with pytest.raises(ValueError, match="all_time must be a boolean"):
+            validate_config(self._cfg(store_layout="hive", pyramid={"all_time": "yes"}))
+        with pytest.raises(ValueError, match="unknown keys"):
+            validate_config(self._cfg(store_layout="hive", pyramid={"levels": [1]}))
+        with pytest.raises(ValueError, match="must be a mapping or false"):
+            validate_config(self._cfg(store_layout="hive", pyramid=True))
+
+    def test_validate_rejects_pyramid_on_flat(self):
+        from zagg.config import validate_config
+
+        with pytest.raises(ValueError, match="output.pyramid requires"):
+            validate_config(
+                self._cfg(
+                    store_layout="flat", coverage_moc=False, sweep=False, pyramid={"spacing": 2}
+                )
+            )
+
+    def test_validate_summarize_grammar(self):
+        from zagg.config import validate_config
+
+        ok = self._cfg(store_layout="hive", pyramid={"summarize": {"h_mean": {"as": "h_mean_d"}}})
+        validate_config(ok)
+        with pytest.raises(ValueError, match="unknown field"):
+            validate_config(
+                self._cfg(store_layout="hive", pyramid={"summarize": {"nope": {"as": "x"}}})
+            )
+        with pytest.raises(ValueError, match="collides with a declared field"):
+            validate_config(
+                self._cfg(store_layout="hive", pyramid={"summarize": {"h_mean": {"as": "count"}}})
+            )
+        with pytest.raises(ValueError, match="requires 'as'"):
+            validate_config(self._cfg(store_layout="hive", pyramid={"summarize": {"h_mean": {}}}))
+
+    def test_summarize_recorded_in_block(self):
+        from zagg.sweep_overview import build_pyramid_block
+
+        cfg = self._cfg(pyramid={"summarize": {"h_mean": {"as": "h_mean_digest"}}})
+        overview = build_pyramid_block(cfg, shard_order=6)["overview"]
+        assert overview["summarize"] == {"h_mean": {"as": "h_mean_digest"}}
+
+    def test_default_pyramid_validates_clean(self):
+        from zagg.config import validate_config
+
+        validate_config(self._cfg(store_layout="hive"))  # absent knob is legal
+
+
 class TestOverviewWriter:
     def test_folds_leaves_at_every_declared_order(self, tmp_path):
         from zagg.stats.tdigest import quantile_from_tdigest
@@ -501,6 +627,44 @@ class TestOverviewWriter:
         assert "skipping unreadable leaf" in caplog.text
         g = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
         assert g["count"][0] == 1
+
+    def test_summarize_declaration_warns_and_skips(self, tmp_path, caplog):
+        _write_manifest(tmp_path, orders=(1,))
+        manifest = json.loads((tmp_path / MANIFEST_NAME).read_text())
+        manifest["pyramid"]["overview"]["summarize"] = {"h_mean": {"as": "h_mean_digest"}}
+        obstore.put(open_object_store(str(tmp_path)), MANIFEST_NAME, json.dumps(manifest).encode())
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        result = run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        assert result["families"]["overview"]["written"] == 1
+        assert "derived summaries" in caplog.text and "issue #265" in caplog.text
+        g = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        assert "h_mean_digest" not in g
+
+    def test_sweep_populates_manifest_materialized(self, tmp_path):
+        from zagg.hive import read_manifest
+
+        _write_manifest(tmp_path, orders=(1, 0))
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        result = run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        assert result["families"]["overview"]["manifest_updated"] is True
+        block = read_manifest(str(tmp_path))["pyramid"]["overview"]
+        assert block["materialized"]["orders"] == [0, 1]
+        assert block["materialized"]["generated_at"]
+        # The declaration itself is untouched (the sweep populates, never
+        # rewrites — D11/D22 write-once discipline).
+        assert block["orders"] == [1, 0] and block["fields"] == FIELDS_DECL
+
+    def test_manifest_update_keeps_frozen_keys_resumable(self, tmp_path):
+        # The pyramid block is excluded from the frozen resume keys, so the
+        # sweep's materialized update can never brick an append precheck.
+        from zagg.hive import _frozen_matches, read_manifest
+
+        before = _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        after = read_manifest(str(tmp_path))
+        assert after["pyramid"] != before["pyramid"]
+        assert _frozen_matches(after, before)
 
     def test_coarser_than_shard_order_accumulates(self, tmp_path):
         # Overview cells COARSER than the shard order (deep schedule, shallow

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -681,3 +681,141 @@ class TestOverviewWriter:
         g = _overview_group(tmp_path, "-3", "all.zarr", 1)
         np.testing.assert_array_equal(g["count"][:], [3, 0, 0, 0])
         assert g["h_min"][0] == 1.0
+
+
+class TestSection83Obligations:
+    """The standing D22 test claims for the overview family (§8.3)."""
+
+    #: Two shards' observations, keyed (leaf decimal, leaf row). Exact binary
+    #: floats so exact-class equality asserts are byte-for-byte.
+    OBS = {
+        ("-311", 0): [1.5, 2.5, -3.0],
+        ("-311", 3): [8.0],
+        ("-311", 5): [0.25, 0.75],
+        ("-311", 15): [4.0, 6.0],
+        ("-312", 0): [3.0, -1.0],
+        ("-312", 9): [2.0],
+    }
+
+    def _populate(self, root, orders=(1, 0)):
+        _write_manifest(root, orders=orders)
+        cells: dict = {}
+        for (dec, row), obs in self.OBS.items():
+            cells.setdefault(dec, {})[row] = obs
+        for dec, rows in cells.items():
+            _make_leaf(root, dec, rows)
+        return [(morton_word(d), None) for d in sorted(cells)]
+
+    def _direct(self, k):
+        """Direct aggregation at overview order ``k``: pool raw observations
+        per overview cell (the oracle the fold must match)."""
+        span = 4 ** (CELL_ORDER - SHARD_ORDER - (SHARD_ORDER - k))
+        pooled: dict[int, list] = {}
+        for (dec, row), obs in self.OBS.items():
+            shard_rank = {"-311": 0, "-312": 1}[dec]
+            cell = shard_rank * span + row // 4 ** (SHARD_ORDER - k)
+            pooled.setdefault(cell, []).extend(obs)
+        return pooled
+
+    @pytest.mark.parametrize("k", [1, 0])
+    def test_rollup_equals_direct_at_every_declared_order(self, tmp_path, k):
+        from zagg.stats.tdigest import build_tdigest, quantile_from_tdigest
+
+        refs = self._populate(tmp_path)
+        run_sweep(str(tmp_path), refs, families=("overview",))
+        rel = {1: "-3/1", 0: "-3"}[k]
+        g = _overview_group(tmp_path, rel, "all.zarr", CELL_ORDER - (SHARD_ORDER - k))
+        count, h_min = g["count"][:], g["h_min"][:]
+        digests = g["h_tdigest"][:]
+        direct = self._direct(k)
+        for cell in range(len(count)):
+            if cell not in direct:
+                assert count[cell] == 0 and np.isnan(h_min[cell])
+                assert len(bytes(digests[cell])) == 0
+                continue
+            obs = np.asarray(direct[cell], dtype=np.float64)
+            # Exact class: byte-equal to the direct aggregation (§8.3).
+            assert count[cell] == len(obs)
+            assert h_min[cell] == np.float32(obs.min())
+            # Approximate class: np.isclose against the direct digest (D24).
+            merged = decode_digest(bytes(digests[cell]), "float32")
+            oracle = build_tdigest(obs, delta=64)
+            for q in (0.25, 0.5, 0.75):
+                assert np.isclose(
+                    quantile_from_tdigest(merged, q),
+                    quantile_from_tdigest(oracle, q),
+                    rtol=0.05,
+                    atol=0.25,
+                )
+
+    def test_second_pass_over_unchanged_tree_writes_nothing(self, tmp_path):
+        refs = self._populate(tmp_path)
+        first = run_sweep(str(tmp_path), refs, families=("moc", "overview"))
+        assert first["families"]["overview"]["written"] == 2
+        env_before = (tmp_path / "-3" / "1" / "overview.rollup.json").read_text()
+        second = run_sweep(str(tmp_path), refs, families=("moc", "overview"))
+        counts = second["families"]["overview"]
+        assert counts["written"] == 0 and counts["current"] == 2
+        assert "manifest_updated" not in counts  # no write, no manifest touch
+        assert (tmp_path / "-3" / "1" / "overview.rollup.json").read_text() == env_before
+
+    def test_same_second_leaf_rerun_rewrites_via_content_hash(self, tmp_path, monkeypatch):
+        # Leaf stamps resolve to whole seconds, so a back-to-back re-run
+        # carries an UNCHANGED generation stamp; freeze the clock to force the
+        # collision and prove the content hash is the backstop that rewrites.
+        import zagg.hive as hive_mod
+
+        monkeypatch.setattr(hive_mod, "_utcnow", lambda: "2026-05-01T12:00:00+00:00")
+        refs = self._populate(tmp_path, orders=(0,))
+        run_sweep(str(tmp_path), refs, families=("moc", "overview"))
+        stale = json.loads((tmp_path / "-3" / "overview.rollup.json").read_text())
+        # Same wall-clock second, different content: leaf -311 changes.
+        _make_leaf(tmp_path, "-311", {0: [100.0]})
+        result = run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        assert result["families"]["overview"]["written"] == 1
+        fresh = json.loads((tmp_path / "-3" / "overview.rollup.json").read_text())
+        assert fresh["windows"]["all"]["generation"] == stale["windows"]["all"]["generation"]
+        assert fresh["windows"]["all"]["content_hash"] != stale["windows"]["all"]["content_hash"]
+        g = _overview_group(tmp_path, "-3", "all.zarr", 2)
+        # The re-run leaf's new fold, with the untouched sibling retained
+        # (candidates come from the root MOC, not just the dirty set).
+        assert g["count"][0] == 1 and g["count"][1] == 3
+        assert g["h_min"][0] == 100.0
+
+    def test_deleting_every_overview_leaves_leaf_reads_green(self, tmp_path):
+        import shutil
+
+        from zagg.hive import read_commit as read_stamp
+
+        refs = self._populate(tmp_path)
+        run_sweep(str(tmp_path), refs, families=("moc", "overview"))
+        hashes = {
+            p: json.loads(p.read_text())["windows"]["all"]["content_hash"]
+            for p in tmp_path.rglob("overview.rollup.json")
+        }
+        assert hashes
+        for p in tmp_path.rglob("all.zarr"):
+            shutil.rmtree(p)
+        for p in list(tmp_path.rglob("overview.rollup.json")):
+            p.unlink()
+        # Leaf truth reads back untouched (nothing-load-bearing, D9)...
+        for dec in ("-311", "-312"):
+            leaf = open_store(shard_leaf_path(str(tmp_path), morton_word(dec)))
+            assert read_stamp(leaf) is not None
+            g = zarr.open_group(leaf, path=str(CELL_ORDER), mode="r", zarr_format=3)
+            assert g["count"][0] >= 1
+        # ...and one sweep regenerates byte-identical folds (same hashes).
+        run_sweep(str(tmp_path), refs, families=("overview",))
+        for p, digest in hashes.items():
+            assert json.loads(p.read_text())["windows"]["all"]["content_hash"] == digest
+
+    def test_role_never_inferred_from_position(self, tmp_path):
+        # D11/D24: an overview is classified by its role attr, never by tree
+        # depth — the leaf carries NO role, the overview always does.
+        refs = self._populate(tmp_path, orders=(1,))
+        run_sweep(str(tmp_path), refs, families=("overview",))
+        leaf = zarr.open_group(
+            open_store(shard_leaf_path(str(tmp_path), morton_word("-311"))), mode="r"
+        )
+        assert ROLE_ATTR not in leaf.attrs
+        assert _overview_root(tmp_path, "-3/1", "all.zarr").attrs[ROLE_ATTR] == "overview"


### PR DESCRIPTION
Closes #201

Implements the **overview-zarr family** of the unified second-pass sweep — the fourth D22 derived-artifact family, riding the #300 engine (d104dbb) — against the amended spec (PR #306: D16–D24 + O-resolutions) and the [implementation plan posted on the thread](https://github.com/englacial/zagg/issues/201#issuecomment-5025396182), with the on-thread rulings applied: all-time overviews as `all.zarr` (confirmed), display schedule every 2 orders, and the [ragged roster-field ruling](https://github.com/englacial/zagg/issues/201#issuecomment-5025509889) (option A per-field exclusion as the default, option B declared derived summary as the opt-in, [full option space](https://github.com/englacial/zagg/issues/201#issuecomment-5025519604)).

## What it does

For each **manifest-declared overview order k**, the sweep folds committed source leaves into an overview zarr at the ancestor digit node, at cell order `cell_order − (shard_order − k)` — constant depth, cells coarsen 4× per order of ascent, so the pyramid is the store's resolution axis, partially materialized (D24). Field inclusion is gated by the new **D24 composability-class helpers** (`zagg.semantics.field_composability`, derived from the aggregator merge-law set):

- **exact** (`len/count/sum/nansum/min/nanmin/max/nanmax`, `np.`-prefix normalized) — folds by merge law, byte-equal to direct aggregation at the coarser order;
- **approximate** (unlocated ragged t-digest, `(2,)` centroids) — the order-independent k-way merge (`merge_tdigests_kway`, issue #279), `np.isclose` class;
- **none** (everything else) — **excluded**: exists only at native resolution, absence declared in the pyramid block, loud warning at template time (the ruled D24 default).

Discovery is run-record + root `coverage.moc` — never a LIST; `moc` precedes `overview` in `DEFAULT_FAMILIES` so the root MOC is fresh in the same pass. Idempotence is the D22 generation stamp (merged-leaf count + max leaf stamp timestamp) **plus a content hash** over the folded decoded values (O11-style) — the same-second backstop the JSON families get from the engine's payload compare. Overviews are regenerable caches (D9): deleting every one leaves leaf reads green, and regeneration is byte-stable (the digest merge is permutation-independent).

## Store shape emitted (the moczarr#15 8b seam)

```
{product_root}/
  morton_hive.json                 pyramid block: template-declared schedule + per-field
                                   D24 classes/methods (incl. declared ABSENCE for
                                   class-none fields); sweep-populated `materialized`
  {base}/{d1}/.../{dk}/            ancestor node at a declared overview order k
    {window}.zarr/                 per-window overview (D23: overviews inherit window
                                   naming); `all.zarr` = unwindowed / all-time fold
      zarr.json                    root attrs: `role: "overview"` (never inferred from
                                   position, D11) + `zagg_overview` {spec, node, order,
                                   cell_order, source_shard_order, source_cell_order,
                                   window, per-field {class, method}, generation,
                                   content_hash, generated_at} + the D4 commit stamp
                                   (the FINAL write; window label + time-range union
                                   ride it on windowed stores)
      {cell_order}/                inner group, same structure as a source leaf
                                   (emitted through HealpixGrid.emit_shard_template so
                                   dtypes/fills/D18 ragged attrs/D16 dggs attrs cannot
                                   drift):
        morton                     uint64, full subtree words at the overview cell order
        {exact fields...}          dense arrays, merge-law folded
        {tdigest fields...}        vlen-bytes ragged, k-way merged
    overview.rollup.json           sweep bookkeeping (same closed name grammar as the
                                   other families' rollup objects): window inventory +
                                   per-window generation + content hash
```

Source leaves carry **no** `role` attr (absence = source); analysis readers reject on `role: "overview"`, display readers stop at it.

## Phases (mirroring the thread plan)

- [x] **Phase A — fold kernels + class gating**: `zagg.semantics.{EXACT_MERGE_LAWS, field_composability, composability_classes}`; `zagg.sweep_overview.{fold_dense, combine_dense, fold_digests, encode_digest, decode_digest}` (`phase 1`)
- [x] **Phase B — overview writer**: `sweep_overviews` + `OverviewFamily` (the engine's new whole-tree `sweep_store` hook), D23 naming, D11 attrs, D22 generation stamps, per-node envelope; `DEFAULT_FAMILIES` gains `overview` (`phase 2`)
- [x] **Phase C — manifest pyramid block**: `build_pyramid_block` wired into `build_manifest` (template-time declaration, default every-2 schedule), the `output.pyramid` knob + validation (`get_pyramid`/`_validate_pyramid`, incl. the option-B `summarize` declaration grammar), sweep-populated `materialized` actuals (`phase 3`)
- [x] **Phase D — §8.3 obligations**: rollup == direct at every declared order (byte-equal exact / `np.isclose` approximate), sweep idempotence, same-second staleness caught by the content-hash backstop, nothing-load-bearing + byte-stable regeneration, role-never-inferred (`phase 4`)
- [ ] **Phase E — orchestration scale-out**: deferred by the plan itself ("local pass first; Lambda fan-out per level only if measured wall-time demands it"). The family already reaches Lambda through the existing `mode="sweep"` worker invoke; per-level fan-out is unbuilt.
- [ ] **Phase F — seeded-reservoir overview fields (opt-in, espg-flagged)**: deferred. It gates on the option-B declaration grammar, which IS landed here (`output.pyramid.summarize` → pyramid block), but both B-generation and C-sampling act only on roster-kind ragged fields — and every ragged field shipped today is digest-kind (the ruling is explicitly forward-looking). The writer warn-skips declared summaries with a pointer to issue #265.

## How it was tested

- `tests/test_sweep_overview.py` — 63 tests: composability classes (shipped configs + synthetic metas), kernel laws (fill/NaN edges, int/float dtypes, two-hop composability, digest permutation stability), pyramid-block declaration + config grammar, and the writer end-to-end on real leaf zarrs (per declared order, windowed + all-time, coarser-than-shard accumulation, sibling contribution via the root MOC, debris invisibility, envelope inventory), plus the §8.3 obligations above.
- The issue #341 Bug A landmine: the fold opens leaf arrays **by name** — no member enumeration and no LIST anywhere on the overview path — so orphan array prefixes / foreign objects inside a leaf cannot crash it (tested with a junk array prefix + stray status-like object); a leaf missing a declared field contributes fill (schema evolution, tested); an unreadable or mixed-order leaf skips loudly (`failed` count), never fatally (tested). The no-LIST property also keeps the #327 `.zarr.status/` prefixes structurally out of reach.
- `tests/test_sweep.py` / `tests/test_hive.py` updated for the new default-family set and the manifest block.
- **`.github/scripts/bench_objects.py`** (the #240 object-count model, NOT workflow config — flagged here because §1 covers `.github/`): with `overview` in the default families, local runs now land overview zarrs in the store, which the model's hive walk pooled into `objects_other` and failed on. They now classify into their own `objects_overviews` bucket — the exact treatment the `*.rollup.json` bucket got in #300 (second-pass D9 caches, excluded from the audited write-path total; the #215 per-shard bypass guard is untouched, and a stray *id*-named zarr outside the dispatched leaf set still surfaces as a loud `other` finding). Classification unit test added.
- Full local suite: `uv run --extra test --extra catalog pytest` — 2900+ passed; the only failure is the known pre-existing `TestFunctionBuild::test_function_build_succeeds` (TestConsolidationGate did not reproduce locally).
- `ruff check` / `ruff format --check` clean on every touched file; the new code is mypy-clean (pre-existing findings in untouched files left alone, per §4).

## Questions for review

1. **RESOLVED (espg ruling, 2026-07-30): `overview` stays in `DEFAULT_FAMILIES`.** The condition was a config-level disable, which exists: `output.pyramid: false` in the yaml declares the overview family off per-store (the manifest pyramid block gets `orders: []` and the sweep no-ops, `declared: false`). Rather than switching the coded default, the fleet-scale operational configs opt out via that knob until Phase E sizing (b84f31b: the three `*_hive*` benchmark arms, `s2_neon_o9`, and the shipped `atl03_tdigest_strata_healpix`); local/small test configs keep the default.
2. **All-time fold defaults OFF** on windowed stores (`output.pyramid.all_time: true` opts in; a pre-existing `all.zarr` entry keeps being maintained either way). D13 recorded the all-time overview as "optional"; flag if it should default on. **This is now the only open question on the PR** — everything else below is resolved or informational.
3. **RESOLVED (spec-ratified): overview cell order = constant depth** (`cell_order − (shard_order − k)`): the arithmetic is now frozen in the PR #346 store spec §4.4 (implementation conforms to spec).
4. **Mixed-order source leaves** are skipped with a loud warning. The remaining gate is zagg-side and tracked in #347 (sweep fold semantics + the writer-side append guard) — the reader-side prerequisites are done (mortie#116 merged in 0.9.1; moczarr#8 closed via its PRs 22/25) and the skip's error text now points at #347 (553ca04, espg-confirmed). No writer emits heterogeneous cell orders yet; the overview writer itself is what makes the tree multi-order.
5. **D24 enforcement beyond this issue** is follow-up, not this PR: the mixed-order fold semantics + writer-side append guard are tracked in #347; recording the class into the semantic core rides with that work.
7. **RESOLVED (espg ruling, 2026-07-30): exact-fold NaN semantics** ([finding-3 thread](https://github.com/englacial/zagg/pull/344#discussion_r3680582363)): nan-skipping is the intended behavior — the `nan_policy: "skip"` declaration (pyramid block + overview attrs, `d211fff`) stands, plus a config-validation warning when a plain `min`/`max`/`sum` pairs a NaN fill (`818a788`; warning not error — the shipped atl06 config trips it by design and stays valid).
6. **Pre-existing local failures, not touched** (§4): ruff N818 on `src/zagg/registry.py` (`UnknownCapability`), codespell on `src/zagg/config.py:1095` ("unparseable"), and the known `TestFunctionBuild` failure.

Module sizes: the heavy lifting lives in the new `src/zagg/sweep_overview.py` (~830 lines); `src/zagg/sweep.py` grew ~18 lines to ~1034 (the family class + the `sweep_store` dispatch hook) — it was already at the ~1000 ceiling before this PR, and the split is issue #330's pending plan, deliberately not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HW3smGgEzF9LVWhXcbNv5s

