### PR TITLE
Bench fix pass: read-error exemplars, deploy-variant family + staleness guard, hive overwrite coherence (issue #341)

### DIFF
--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -136,6 +136,13 @@ RECORD_COLUMNS = [
     "streaming_mode",
     "tmp_mb",
     "ephemeral_cost_usd",
+    # Worker-build provenance (issues #341/#296): did the pre-dispatch guard
+    # actually verify that the resolved worker variant runs the same code as the
+    # freshly-deployed base function? "verified" | "skipped" (the probe
+    # degraded) | "base" (no ``worker:`` block, nothing to verify). Null on rows
+    # recorded before the guard existed -- which is exactly the window in which
+    # the issue #341 stale-variant numbers were measured.
+    "variant_guard",
 ]
 
 # summary["worker_phase_max"] key -> series column (issues #250/#256). A phase
@@ -293,6 +300,10 @@ def build_record(
     record["streaming_mode"] = context.get("streaming_mode")
     record["tmp_mb"] = context.get("tmp_mb")
     record["ephemeral_cost_usd"] = eph
+    # Worker-build provenance (issues #341/#296), threaded in by run_benchmark's
+    # pre-dispatch staleness guard; ``comment_markdown`` banners the "skipped"
+    # case so a degraded guard is visible in the artifact, not only in stderr.
+    record["variant_guard"] = context.get("variant_guard")
     return record
 
 
@@ -398,6 +409,18 @@ def comment_markdown(records: list[dict], worker_note: str = "") -> str:
     lines = [marker, f"### Lambda benchmark — `{_fmt(head.get('commit'))[:7]}`", ""]
     if worker_note:
         lines += [f"> ⚠️ {worker_note}", ""]
+    # Degraded staleness guard (issues #341/#296): a target whose variant probe
+    # failed was dispatched WITHOUT the CodeSha256 check, so its number may have
+    # been measured on a stale build. Name those targets above the table -- the
+    # stderr warning is invisible on an otherwise-green run.
+    unverified = sorted({r["target"] for r in records if r.get("variant_guard") == "skipped"})
+    if unverified:
+        lines += [
+            "> ⚠️ worker-build staleness guard SKIPPED (probe failed) for: "
+            f"`{'`, `'.join(unverified)}` — these numbers are not verified to have "
+            "run this commit's code (issue #341).",
+            "",
+        ]
     lines += _table_block(records)
     lines += [
         "",

--- a/.github/scripts/deploy_lambda.sh
+++ b/.github/scripts/deploy_lambda.sh
@@ -99,6 +99,8 @@ for SUFFIX in $VARIANTS; do
     echo "WARN: could not probe variant $VARIANT (skipping; it may now be STALE" \
       "relative to $FUNCTION): $PROBE_ERR" >&2
     echo "WARN: the deploy role likely needs lambda:GetFunctionConfiguration +" \
-      "Update* on the ${FUNCTION}-* family (see issue #341)" >&2
+      "Update* on this variant's exact ARN -- see the enumerated" \
+      "UpdateTestFunction/UpdateProdFunction Resource lists in" \
+      "deployment/aws/benchmark_cicd.yaml (issue #341; wildcards declined)" >&2
   fi
 done

--- a/.github/scripts/deploy_lambda.sh
+++ b/.github/scripts/deploy_lambda.sh
@@ -12,9 +12,17 @@
 # only the base left ${FN}-4096-disk on standup-time code, so every -disk arm
 # ran stale. The script now updates the WHOLE family from the same zip: each
 # default-matrix variant is probed (get-function-configuration) and updated if
-# it exists; a missing variant is skipped with a note (e.g. the test stack only
-# provisions the -disk trio). Pass --variants to override the suffix list
-# (--variants "" deploys the base only).
+# it exists; a missing variant is skipped with a note. Pass --variants to
+# override the suffix list (--variants "" deploys the base only) — the
+# test-deploy path DOES, because the test stack provisions only the -disk trio
+# and its role enumerates exactly those ARNs, so probing the prod default would
+# AccessDeny (not 404) and cry STALE on every green deploy.
+#
+# Probe-succeeds-then-update-fails (granted Get, denied Update) is NOT tolerated:
+# under `set -e` it aborts the loop, leaving the base plus some variants updated
+# and the rest stale, and the job goes red. That is deliberate — a red deploy is
+# recoverable, and the run_benchmark CodeSha256 guard refuses the benchmark that
+# would otherwise measure the half-updated family (issue #341).
 #
 # Shared by the release path (publish.yml -> production) and the benchmark
 # test-deploy path (lambda-benchmark.yml -> process-shard-test).

--- a/.github/scripts/deploy_lambda.sh
+++ b/.github/scripts/deploy_lambda.sh
@@ -5,17 +5,33 @@
 # is required so a deps/layer change is actually picked up, and the layer is read
 # from S3 because the zip can exceed Lambda's 50 MB direct-upload cap.
 #
+# The base function is only half the fleet (issue #341): template.yaml also
+# provisions pre-provisioned worker-size variants — ${FN}-<mem> and
+# ${FN}-<mem>-disk for each WorkerMemorySizes entry (default 2048,4096,8192) —
+# that run_benchmark resolves BY NAME from a target's `worker:` block. Updating
+# only the base left ${FN}-4096-disk on standup-time code, so every -disk arm
+# ran stale. The script now updates the WHOLE family from the same zip: each
+# default-matrix variant is probed (get-function-configuration) and updated if
+# it exists; a missing variant is skipped with a note (e.g. the test stack only
+# provisions the -disk trio). Pass --variants to override the suffix list
+# (--variants "" deploys the base only).
+#
 # Shared by the release path (publish.yml -> production) and the benchmark
 # test-deploy path (lambda-benchmark.yml -> process-shard-test).
 #
 # Usage:
 #   deploy_lambda.sh --function NAME --layer-bucket B --layer-key K \
-#       --function-zip PATH --region R
+#       --function-zip PATH --region R [--variants "-4096-disk -8192-disk"]
 #
 # Requires: aws CLI (creds in env). arm64 / python3.12 only (the deployed target).
 set -euo pipefail
 
+# Default variant family: the template.yaml WorkerMemorySizes matrix
+# ("2048,4096,8192"), plain + -disk. Keep in sync with the template.
+DEFAULT_VARIANTS="-2048 -4096 -8192 -2048-disk -4096-disk -8192-disk"
+
 FUNCTION="" LAYER_BUCKET="" LAYER_KEY="" FUNCTION_ZIP="" REGION=""
+VARIANTS="$DEFAULT_VARIANTS"
 while [ $# -gt 0 ]; do
   case "$1" in
     --function) FUNCTION="$2"; shift 2 ;;
@@ -23,6 +39,7 @@ while [ $# -gt 0 ]; do
     --layer-key) LAYER_KEY="$2"; shift 2 ;;
     --function-zip) FUNCTION_ZIP="$2"; shift 2 ;;
     --region) REGION="$2"; shift 2 ;;
+    --variants) VARIANTS="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -38,25 +55,50 @@ LAYER_ARN=$(aws lambda publish-layer-version \
   --region "$REGION" \
   --query LayerVersionArn --output text)
 
-# Config update (new layer) and code update can't overlap -- wait between them.
-aws lambda update-function-configuration \
-  --function-name "$FUNCTION" --layers "$LAYER_ARN" --region "$REGION"
-aws lambda wait function-updated --function-name "$FUNCTION" --region "$REGION"
-aws lambda update-function-code \
-  --function-name "$FUNCTION" --zip-file "fileb://${FUNCTION_ZIP}" --publish --region "$REGION"
+deploy_one() {
+  local FN="$1"
+  # Config update (new layer) and code update can't overlap -- wait between them.
+  aws lambda update-function-configuration \
+    --function-name "$FN" --layers "$LAYER_ARN" --region "$REGION"
+  aws lambda wait function-updated --function-name "$FN" --region "$REGION"
+  aws lambda update-function-code \
+    --function-name "$FN" --zip-file "fileb://${FUNCTION_ZIP}" --publish --region "$REGION"
 
-# Async-invoke hygiene (issue #151): the runner dispatches with
-# InvocationType=Event and polls for worker-written results; Lambda's async
-# defaults would re-run a timed-out/OOM'd shard twice with delays, so pin
-# retries to 0, and keep event age under the runner's 90 s poll margin so no
-# delivery starts after the runner stops listening (mirrors
-# ProcessFnAsyncConfig in deployment/aws/template.yaml -- keep in sync).
-# Warn-only: the deploy role may not yet carry
-# lambda:PutFunctionEventInvokeConfig, and the pipeline still works (just
-# noisier on worker crashes) without it.
-aws lambda put-function-event-invoke-config \
-  --function-name "$FUNCTION" --maximum-retry-attempts 0 \
-  --maximum-event-age-in-seconds 60 --region "$REGION" \
-  || echo "WARN: could not set event-invoke config on $FUNCTION (needs lambda:PutFunctionEventInvokeConfig); async service retries stay at the default" >&2
+  # Async-invoke hygiene (issue #151): the runner dispatches with
+  # InvocationType=Event and polls for worker-written results; Lambda's async
+  # defaults would re-run a timed-out/OOM'd shard twice with delays, so pin
+  # retries to 0, and keep event age under the runner's 90 s poll margin so no
+  # delivery starts after the runner stops listening (mirrors
+  # ProcessFnAsyncConfig in deployment/aws/template.yaml -- keep in sync).
+  # Warn-only: the deploy role may not yet carry
+  # lambda:PutFunctionEventInvokeConfig, and the pipeline still works (just
+  # noisier on worker crashes) without it.
+  aws lambda put-function-event-invoke-config \
+    --function-name "$FN" --maximum-retry-attempts 0 \
+    --maximum-event-age-in-seconds 60 --region "$REGION" \
+    || echo "WARN: could not set event-invoke config on $FN (needs lambda:PutFunctionEventInvokeConfig); async service retries stay at the default" >&2
 
-echo "deployed $FUNCTION (layer $LAYER_ARN)"
+  echo "deployed $FN (layer $LAYER_ARN)"
+}
+
+# Base function first (hard-required, unchanged failure semantics), then every
+# provisioned worker-size variant from the same layer version + zip (issue #341).
+deploy_one "$FUNCTION"
+
+for SUFFIX in $VARIANTS; do
+  VARIANT="${FUNCTION}${SUFFIX}"
+  if PROBE_ERR=$(aws lambda get-function-configuration \
+      --function-name "$VARIANT" --region "$REGION" 2>&1 >/dev/null); then
+    deploy_one "$VARIANT"
+  elif echo "$PROBE_ERR" | grep -q ResourceNotFoundException; then
+    echo "variant $VARIANT does not exist; skipping"
+  else
+    # Probe failed for a non-404 reason (most likely the deploy role's IAM is
+    # scoped to the base function name only): skip LOUDLY — a silently stale
+    # variant is exactly the issue #341 failure mode.
+    echo "WARN: could not probe variant $VARIANT (skipping; it may now be STALE" \
+      "relative to $FUNCTION): $PROBE_ERR" >&2
+    echo "WARN: the deploy role likely needs lambda:GetFunctionConfiguration +" \
+      "Update* on the ${FUNCTION}-* family (see issue #341)" >&2
+  fi
+done

--- a/.github/scripts/deploy_lambda.sh
+++ b/.github/scripts/deploy_lambda.sh
@@ -34,9 +34,18 @@
 # Requires: aws CLI (creds in env). arm64 / python3.12 only (the deployed target).
 set -euo pipefail
 
-# Default variant family: the template.yaml WorkerMemorySizes matrix
-# ("2048,4096,8192"), plain + -disk. Keep in sync with the template.
-DEFAULT_VARIANTS="-2048 -4096 -8192 -2048-disk -4096-disk -8192-disk"
+# Default update set: the template.yaml WorkerMemorySizes matrix
+# ("2048,4096,8192"), plain + -disk, PLUS the -extract twin. Keep in sync with
+# the template (tests/test_deploy_lambda.py guards the drift).
+#
+# -extract is not a worker-size variant — it is template.yaml's ExtractFn, a
+# separately-named function running the SAME code zip, layer, role and timeout
+# so full-archive extraction (issue #148) gets its own concurrency pool. It sat
+# on standup-time code permanently, which is issue #341's failure mode verbatim,
+# so it joins the loop: the probe-and-skip below covers the stacks that do not
+# provision it (the test stack has no -test-extract twin, and its deploy pins
+# --variants to the -disk trio, so it never probes this name).
+DEFAULT_VARIANTS="-2048 -4096 -8192 -2048-disk -4096-disk -8192-disk -extract"
 
 FUNCTION="" LAYER_BUCKET="" LAYER_KEY="" FUNCTION_ZIP="" REGION=""
 VARIANTS="$DEFAULT_VARIANTS"
@@ -90,7 +99,8 @@ deploy_one() {
 }
 
 # Base function first (hard-required, unchanged failure semantics), then every
-# provisioned worker-size variant from the same layer version + zip (issue #341).
+# provisioned sibling that runs the same zip — the worker-size variants and the
+# -extract twin — from the same layer version + zip (issue #341).
 deploy_one "$FUNCTION"
 
 for SUFFIX in $VARIANTS; do

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -146,6 +146,20 @@ def _resolve_target(manifest: dict, name: str) -> dict:
     raise KeyError(f"unknown target '{name}'; have {known}")
 
 
+def resolve_variant(function_name: str, worker: dict | None) -> str:
+    """The pre-provisioned worker variant a target's ``worker:`` block names.
+
+    ``-<memory>`` plus ``-disk`` when ``extra_disk``, appended to the base
+    function — the same rule as ``zagg.runner._resolve_function_name``. No
+    ``worker:`` block resolves the base function itself. Shared by
+    ``run_target`` and ``main``'s pre-dispatch staleness guard so the two
+    cannot drift.
+    """
+    if not worker:
+        return function_name
+    return function_name + f"-{worker['memory']}" + ("-disk" if worker.get("extra_disk") else "")
+
+
 def check_variant_current(client, function_name: str, resolved: str) -> None:
     """Refuse to dispatch onto a stale pre-provisioned worker variant (issue #341).
 
@@ -245,8 +259,7 @@ def run_target(
     resolved_function_name = function_name
     if worker:
         config.worker = dict(worker)
-        suffix = f"-{worker['memory']}" + ("-disk" if worker.get("extra_disk") else "")
-        resolved_function_name = function_name + suffix
+        resolved_function_name = resolve_variant(function_name, worker)
         tmp_mb = worker["memory"] + 2048 if worker.get("extra_disk") else 512
     # parent_order lives in the config grid for HEALPix; the kwarg is just a
     # legacy fallback. Rect grids ignore it. ``from_config`` gives us the grid
@@ -288,18 +301,9 @@ def run_target(
     else:
         from zagg.runner import agg
 
-        # Staleness guard (issue #341): a target whose ``worker:`` block resolved
-        # a pre-provisioned variant must run the same code as the base function
-        # the deploy path just updated — hard-fail before paying for a dispatch
-        # that benchmarks the wrong build.
-        if resolved_function_name != function_name:
-            import boto3
-
-            check_variant_current(
-                boto3.client("lambda", region_name=region),
-                function_name,
-                resolved_function_name,
-            )
+        # NOTE: the issue #341 CodeSha256 staleness guard runs in ``main``,
+        # BEFORE the dispatch pool spins up (fold review) — a stale variant
+        # must refuse without the sibling targets' dispatches being billed.
 
         # AOI-mask arm (issue #202): the committed map is the plain o9 map; build
         # the strict-AOI per-cell mask on the fly (mortie, no spherely) and
@@ -342,6 +346,33 @@ def run_target(
         zagg_version=zagg_version,
         objects=objects,
     )
+
+
+def check_requested_variants(manifest: dict, names: list[str], function_name: str, *, region: str):
+    """Probe every distinct worker variant the requested targets resolve (#341).
+
+    Called from ``main`` BEFORE the dispatch pool (fold review): running the
+    guard inside ``run_target`` meant a stale variant only raised after its
+    sibling targets had already been launched — the pool's ``shutdown(wait=True)``
+    then billed every one of them to completion (up to 900 s each) and the
+    exception escaped ``main`` before ``metrics.json`` was written, so the run
+    paid in full and recorded nothing. Up here the refusal costs two
+    ``GetFunctionConfiguration`` calls and zero dispatches.
+
+    Distinct variants are probed once, not once per target that shares them.
+    """
+    import boto3
+
+    client = None
+    seen: set[str] = set()
+    for name in names:
+        resolved = resolve_variant(function_name, _resolve_target(manifest, name).get("worker"))
+        if resolved == function_name or resolved in seen:
+            continue
+        seen.add(resolved)
+        if client is None:
+            client = boto3.client("lambda", region_name=region)
+        check_variant_current(client, function_name, resolved)
 
 
 def _utc_now_iso() -> str:
@@ -425,6 +456,13 @@ def main(argv: list[str] | None = None) -> int:
     for name in names:
         if name not in known:
             raise SystemExit(f"unknown target '{name}'; have {sorted(known)}")
+
+    # Worker-variant staleness guard (issue #341), in the same pre-dispatch slot
+    # as the name validation above: a target whose ``worker:`` block resolves a
+    # pre-provisioned variant must run the same code as the base function the
+    # deploy path just updated. Read-only probes, no dispatch, no auth yet.
+    if not args.dry_run:
+        check_requested_variants(manifest, names, args.function_name, region=args.region)
 
     # Authenticate once up front so the concurrent targets below don't race to
     # initialize earthaccess's process-global auth singleton (issue #137). Skipped

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -160,28 +160,58 @@ def resolve_variant(function_name: str, worker: dict | None) -> str:
     return function_name + f"-{worker['memory']}" + ("-disk" if worker.get("extra_disk") else "")
 
 
-def check_variant_current(client, function_name: str, resolved: str) -> None:
+def check_variant_current(client, function_name: str, resolved: str) -> str:
     """Refuse to dispatch onto a stale pre-provisioned worker variant (issue #341).
 
     The deploy path updates the base function and its worker-size variants from
     the same zip (deploy_lambda.sh); a variant whose ``CodeSha256`` differs from
     the base's is running different code than the run believes it is testing —
     the run 30503334617 failure mode, where ``-4096-disk`` served standup-time
-    code. Hard-fail on mismatch (the benchmark invoke role carries
-    ``lambda:GetFunctionConfiguration`` on both function families). A probe
-    that itself fails degrades to a warning so third-party stacks whose invoke
-    role lacks the permission still dispatch.
+    code.
+
+    The two probes are read separately and treated differently (fold review),
+    because ``except Exception`` around both swallowed the guard's own strongest
+    positive signal:
+
+    * **base probe fails** → degrade to a warning and return ``"skipped"``. This
+      is the genuine "this stack's invoke role carries no
+      ``lambda:GetFunctionConfiguration`` at all" case, and the only one where
+      continuing is defensible.
+    * **base probe succeeds, variant probe fails** → hard-fail. Under the issue
+      #341 enumeration ruling ``InvokeBenchmarkFunctions`` lists exact ARNs, so
+      an ``AccessDenied`` here means the variant is absent from the in-repo
+      enumeration — and a variant nobody enumerated for the invoke role is one
+      nobody enumerated for the deploy role either, i.e. one ``deploy_lambda.sh``
+      WARN-and-skipped, i.e. definitely stale. ``ResourceNotFound`` is harder
+      still: the dispatch would fail anyway, later and more opaquely.
+    * hashes differ → hard-fail.
+
+    Returns the guard's provenance status (``"verified"`` | ``"skipped"``), which
+    rides the benchmark record so a number measured on an unverified build is not
+    byte-indistinguishable from a verified one (issue #296).
     """
     try:
         base_sha = client.get_function_configuration(FunctionName=function_name)["CodeSha256"]
-        variant_sha = client.get_function_configuration(FunctionName=resolved)["CodeSha256"]
     except Exception as e:
         print(
-            f"WARN: could not compare CodeSha256 of {resolved} against {function_name} "
-            f"({e}); dispatching without the staleness guard",
+            f"WARN: could not probe base function {function_name} ({e}); dispatching "
+            f"{resolved} without the staleness guard — the run record is stamped "
+            f"variant_guard=skipped",
             file=sys.stderr,
         )
-        return
+        return "skipped"
+    try:
+        variant_sha = client.get_function_configuration(FunctionName=resolved)["CodeSha256"]
+    except Exception as e:
+        raise RuntimeError(
+            f"worker variant {resolved} is NOT REACHABLE ({e}) while base "
+            f"{function_name} probes fine, so this is specific to the variant: it is "
+            f"either not provisioned by template.yaml or absent from the enumerated "
+            f"InvokeBenchmarkFunctions ARNs in deployment/aws/benchmark_cicd.yaml. "
+            f"Either way deploy_lambda.sh cannot have updated it, so it would run "
+            f"code this benchmark is not testing (issue #341) — provision/enumerate "
+            f"the variant, or point the target's worker: block at one that exists."
+        ) from e
     if base_sha != variant_sha:
         raise RuntimeError(
             f"worker variant {resolved} is STALE: its CodeSha256 {variant_sha} does not "
@@ -190,6 +220,7 @@ def check_variant_current(client, function_name: str, resolved: str) -> None:
             f"(deploy_lambda.sh updates the base and every provisioned variant from "
             f"the same zip) and re-dispatch."
         )
+    return "verified"
 
 
 def run_target(
@@ -202,6 +233,7 @@ def run_target(
     function_name: str,
     context: dict,
     dry_run: bool = False,
+    variant_guard: str = "base",
 ) -> dict:
     """Dispatch one target's shard and return its benchmark record."""
     from zagg import __version__ as zagg_version
@@ -292,6 +324,12 @@ def run_target(
         # its /tmp size for the ephemeral cost. None on the default merge targets.
         streaming_mode=streaming_mode,
         tmp_mb=tmp_mb,
+        # Staleness-guard provenance (issues #341/#296): "verified" when the
+        # resolved variant's CodeSha256 was checked against the base, "skipped"
+        # when the probe degraded, "base" when no variant was resolved. Without
+        # it a number measured on an unverified build reads identically to one
+        # measured on a verified build.
+        variant_guard=variant_guard,
     )
 
     objects = None
@@ -348,7 +386,9 @@ def run_target(
     )
 
 
-def check_requested_variants(manifest: dict, names: list[str], function_name: str, *, region: str):
+def check_requested_variants(
+    manifest: dict, names: list[str], function_name: str, *, region: str
+) -> dict:
     """Probe every distinct worker variant the requested targets resolve (#341).
 
     Called from ``main`` BEFORE the dispatch pool (fold review): running the
@@ -360,19 +400,25 @@ def check_requested_variants(manifest: dict, names: list[str], function_name: st
     ``GetFunctionConfiguration`` calls and zero dispatches.
 
     Distinct variants are probed once, not once per target that shares them.
+    Returns ``{target_name: "verified" | "skipped" | "base"}`` — the per-record
+    provenance stamp (``"base"`` = no ``worker:`` block, nothing to verify).
     """
     import boto3
 
     client = None
-    seen: set[str] = set()
+    by_variant: dict[str, str] = {}
+    status: dict[str, str] = {}
     for name in names:
         resolved = resolve_variant(function_name, _resolve_target(manifest, name).get("worker"))
-        if resolved == function_name or resolved in seen:
+        if resolved == function_name:
+            status[name] = "base"
             continue
-        seen.add(resolved)
-        if client is None:
-            client = boto3.client("lambda", region_name=region)
-        check_variant_current(client, function_name, resolved)
+        if resolved not in by_variant:
+            if client is None:
+                client = boto3.client("lambda", region_name=region)
+            by_variant[resolved] = check_variant_current(client, function_name, resolved)
+        status[name] = by_variant[resolved]
+    return status
 
 
 def _utc_now_iso() -> str:
@@ -461,8 +507,11 @@ def main(argv: list[str] | None = None) -> int:
     # as the name validation above: a target whose ``worker:`` block resolves a
     # pre-provisioned variant must run the same code as the base function the
     # deploy path just updated. Read-only probes, no dispatch, no auth yet.
+    guard_status = dict.fromkeys(names, "base")
     if not args.dry_run:
-        check_requested_variants(manifest, names, args.function_name, region=args.region)
+        guard_status = check_requested_variants(
+            manifest, names, args.function_name, region=args.region
+        )
 
     # Authenticate once up front so the concurrent targets below don't race to
     # initialize earthaccess's process-global auth singleton (issue #137). Skipped
@@ -486,6 +535,7 @@ def main(argv: list[str] | None = None) -> int:
             function_name=args.function_name,
             context=context,
             dry_run=args.dry_run,
+            variant_guard=guard_status.get(name, "base"),
         )
 
     # Launch all targets concurrently (issue #137). Each is an independent

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -146,6 +146,38 @@ def _resolve_target(manifest: dict, name: str) -> dict:
     raise KeyError(f"unknown target '{name}'; have {known}")
 
 
+def check_variant_current(client, function_name: str, resolved: str) -> None:
+    """Refuse to dispatch onto a stale pre-provisioned worker variant (issue #341).
+
+    The deploy path updates the base function and its worker-size variants from
+    the same zip (deploy_lambda.sh); a variant whose ``CodeSha256`` differs from
+    the base's is running different code than the run believes it is testing —
+    the run 30503334617 failure mode, where ``-4096-disk`` served standup-time
+    code. Hard-fail on mismatch (the benchmark invoke role carries
+    ``lambda:GetFunctionConfiguration`` on both function families). A probe
+    that itself fails degrades to a warning so third-party stacks whose invoke
+    role lacks the permission still dispatch.
+    """
+    try:
+        base_sha = client.get_function_configuration(FunctionName=function_name)["CodeSha256"]
+        variant_sha = client.get_function_configuration(FunctionName=resolved)["CodeSha256"]
+    except Exception as e:
+        print(
+            f"WARN: could not compare CodeSha256 of {resolved} against {function_name} "
+            f"({e}); dispatching without the staleness guard",
+            file=sys.stderr,
+        )
+        return
+    if base_sha != variant_sha:
+        raise RuntimeError(
+            f"worker variant {resolved} is STALE: its CodeSha256 {variant_sha} does not "
+            f"match base {function_name}'s {base_sha}. The variant would run code this "
+            f"benchmark is not testing (issue #341) — redeploy the variant family "
+            f"(deploy_lambda.sh updates the base and every provisioned variant from "
+            f"the same zip) and re-dispatch."
+        )
+
+
 def run_target(
     name: str,
     manifest: dict,
@@ -255,6 +287,19 @@ def run_target(
         summary: dict = {}
     else:
         from zagg.runner import agg
+
+        # Staleness guard (issue #341): a target whose ``worker:`` block resolved
+        # a pre-provisioned variant must run the same code as the base function
+        # the deploy path just updated — hard-fail before paying for a dispatch
+        # that benchmarks the wrong build.
+        if resolved_function_name != function_name:
+            import boto3
+
+            check_variant_current(
+                boto3.client("lambda", region_name=region),
+                function_name,
+                resolved_function_name,
+            )
 
         # AOI-mask arm (issue #202): the committed map is the plain o9 map; build
         # the strict-AOI per-cell mask on the fly (mortie, no spherely) and

--- a/.github/workflows/lambda-benchmark.yml
+++ b/.github/workflows/lambda-benchmark.yml
@@ -143,12 +143,21 @@ jobs:
           set -euo pipefail
           KEY="lambda-test/${SHA}/lambda_layer_arm64.zip"
           aws s3 cp deployment/layers/lambda_layer_arm64.zip "s3://${STAGE_BUCKET}/${KEY}" --region "$REGION"
+          # --variants is pinned to the TEST-stack shape (issue #341): template.yaml
+          # provisions only ${FunctionName}-test-<size>-disk (WorkerTestDiskVariants
+          # — there is no test analogue of WorkerSizeVariants), and the deploy role
+          # enumerates exactly those ARNs. Without this, the script's prod default
+          # would probe the plain-memory trio, get AccessDenied (not 404) from the
+          # enumerated role, and print three "it may now be STALE" warnings on every
+          # green deploy — naming functions that will never exist. Kept in sync with
+          # the template by tests/test_deploy_lambda.py.
           .github/scripts/deploy_lambda.sh \
             --function "$FUNCTION_NAME" \
             --layer-bucket "$STAGE_BUCKET" \
             --layer-key "$KEY" \
             --function-zip "$(ls deployment/builds/lambda_function_arm64_*.zip)" \
-            --region "$REGION"
+            --region "$REGION" \
+            --variants "-2048-disk -4096-disk -8192-disk"
 
   merge-publish:
     needs: [detect, deploy-test]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,6 +182,9 @@ jobs:
   # update-function-configuration handles a deps change that the function-code
   # update alone would miss. Needs `distribute` so the layer is staged in S3 for
   # publish-layer-version (the layer zip can exceed the 50 MB direct-upload cap).
+  # deploy_lambda.sh updates the WHOLE worker-size variant family (base +
+  # ${FN}-<mem>[-disk], issue #341) from the same zip, so the pre-provisioned
+  # variants (e.g. process-shard-4096-disk) no longer stay on standup-time code.
   deploy-prod:
     name: Deploy production Lambda
     needs: [github-release, distribute]

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -265,8 +265,14 @@ Resources:
               # wildcard was proposed and declined -- enumeration keeps least
               # privilege. Base function plus the full prod worker-size family
               # (template.yaml's WorkerSizeVariants + WorkerDiskVariants loops
-              # over WorkerMemorySizes: plain + -disk). Drift against that
-              # matrix is guarded by tests/test_deploy_lambda.py.
+              # over WorkerMemorySizes: plain + -disk), plus the -extract twin
+              # (template.yaml's ExtractFn -- same code zip, so the release must
+              # redeploy it or it stays on standup-time code, issue #341's
+              # failure mode; it is dispatched by explicit name for full-archive
+              # extraction, issue #148, and never by suffix resolution, so the
+              # INVOKE role deliberately does not enumerate it -- the benchmark
+              # harness never touches it). Drift against that matrix is guarded
+              # by tests/test_deploy_lambda.py.
               - Sid: UpdateProdFunction
                 Effect: Allow
                 Action:
@@ -284,6 +290,7 @@ Resources:
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-2048-disk"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-4096-disk"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-8192-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-extract"
               - Sid: PublishProdLayer
                 Effect: Allow
                 # GetLayerVersion: update-function-configuration --layers validates

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -133,6 +133,14 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
+              # Enumerated exact ARNs (issue #341): the former
+              # ${...FunctionName}* wildcards were declined -- enumeration
+              # keeps least privilege. Each family lists its base function
+              # plus the variants template.yaml provisions for it (prod:
+              # WorkerSizeVariants + WorkerDiskVariants, plain + -disk; test:
+              # WorkerTestDiskVariants, -disk only). All invokes/probes are
+              # unqualified ($LATEST), so no :qualifier ARN forms are needed.
+              # Drift vs the matrix is guarded by tests/test_deploy_lambda.py.
               - Sid: InvokeBenchmarkFunctions
                 Effect: Allow
                 Action:
@@ -140,8 +148,17 @@ Resources:
                   - lambda:GetFunctionConfiguration
                   - lambda:GetFunctionConcurrency
                 Resource:
-                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}*"
-                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}*"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-2048"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-4096"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-8192"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-2048-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-4096-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-8192-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}-2048-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}-4096-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}-8192-disk"
               # Pre-flight worker-sizing probe (issue #28/#63 via concurrency.py);
               # these degrade gracefully but are needed for the guard to work.
               # Neither action supports resource-level scoping -> "*".

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -189,6 +189,12 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
+              # Enumerated exact ARNs (issue #341): a ${TestFunctionName}*
+              # wildcard was proposed and declined -- enumeration keeps least
+              # privilege. Base function plus exactly the variants the test
+              # stack provisions (template.yaml's WorkerTestDiskVariants loop
+              # over WorkerMemorySizes: the -disk trio only). Drift against
+              # that matrix is guarded by tests/test_deploy_lambda.py.
               - Sid: UpdateTestFunction
                 Effect: Allow
                 Action:
@@ -198,7 +204,11 @@ Resources:
                   - lambda:PutFunctionEventInvokeConfig
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
-                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}"
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}-2048-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}-4096-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestFunctionName}-8192-disk"
               - Sid: PublishTestLayer
                 Effect: Allow
                 # GetLayerVersion: update-function-configuration --layers validates
@@ -234,6 +244,12 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
+              # Enumerated exact ARNs (issue #341): a ${BenchmarkFunctionName}*
+              # wildcard was proposed and declined -- enumeration keeps least
+              # privilege. Base function plus the full prod worker-size family
+              # (template.yaml's WorkerSizeVariants + WorkerDiskVariants loops
+              # over WorkerMemorySizes: plain + -disk). Drift against that
+              # matrix is guarded by tests/test_deploy_lambda.py.
               - Sid: UpdateProdFunction
                 Effect: Allow
                 Action:
@@ -243,7 +259,14 @@ Resources:
                   - lambda:PutFunctionEventInvokeConfig
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
-                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}"
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-2048"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-4096"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-8192"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-2048-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-4096-disk"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${BenchmarkFunctionName}-8192-disk"
               - Sid: PublishProdLayer
                 Effect: Allow
                 # GetLayerVersion: update-function-configuration --layers validates

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -495,11 +495,27 @@ class HealpixGrid:
         template write alone only rewrites members the NEW schema declares —
         a schema-narrowed rerun would leave the retired members' objects
         behind (e.g. the post-#337 ``cell_ids`` chunk orphans), masquerading
-        as data and breaking store walks. Clearing up front also means
-        pydantic-zarr's overwrite walk (``GroupSpec.like`` →
-        ``Group.members()``) never has to parse a broken/orphan member dir —
-        an unknown array dir can die with "No array found in store" instead
-        of templating.
+        as data.
+
+        Scope of the justification (fold review — the evidence, not more): the
+        observed ``No array found in store … at path 19/cell_ids`` signature is
+        attributed by the issue's own diagnosis to the STALE DEPLOY, on FRESH
+        stores (the stale worker still expected the ``cell_ids`` member that
+        post-#337 configs no longer declare) — no orphan objects required. On the
+        pinned zarr 3.2.1 an orphan member dir does NOT kill the enumeration
+        either: ``members()`` emits ``Object at cell_ids is not recognized as a
+        component of a Zarr hierarchy`` and skips it. So this clear is not the fix
+        for the observed crash; it makes D4's "wholesale" literal and removes the
+        retired-member class, which is worth its cost (one LIST + N DELETE per
+        leaf write) on its own terms.
+
+        The issue also asked for a second layer — make the store WALKER
+        skip/inventory unknown array dirs rather than dying. Not landed, and
+        deliberately: zagg owns no walk that enumerates leaf members (nothing in
+        the tree calls ``members()``), and the one enumeration in play is
+        zarr's/pydantic-zarr's, which already warn-skips on the pinned version.
+        The residual is a leaf this run does not rewrite in a schema-narrowed
+        store, which ``validate_manifest`` now warns about by name.
 
         Scoping: the store is rooted AT the leaf, so ``delete_dir("")`` can only
         reach the leaf prefix — sibling prefixes (e.g. the run's

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -499,9 +499,17 @@ class HealpixGrid:
         pydantic-zarr's overwrite walk (``GroupSpec.like`` →
         ``Group.members()``) never has to parse a broken/orphan member dir —
         an unknown array dir can die with "No array found in store" instead
-        of templating. The store is rooted at the leaf, so the delete is
-        scoped to the leaf prefix; sibling prefixes (e.g. the run's
-        ``.zarr.status/`` objects) live outside it and are never touched.
+        of templating.
+
+        Scoping: the store is rooted AT the leaf, so ``delete_dir("")`` can only
+        reach the leaf prefix — sibling prefixes (e.g. the run's
+        ``<root>.zarr.status/`` objects, which live beside the store root) are
+        outside it. On the fleet backend that is not quite "by construction":
+        zarr's ``ObjectStore.delete_dir`` leaves the empty prefix un-slashed, so
+        the delimiter is re-added by obstore's prefix store. It does re-add it
+        (verified, and pinned by ``test_overwrite_clear_is_scoped_on_an_obstore_
+        prefix_store``), which is what makes a name-prefix twin like
+        ``<leaf>.status`` safe rather than merely unlikely.
         """
         spec = GroupSpec(members={self.group_path: self.shard_spec()}, attributes={})
         # Ragged vlen-array creation warns about the dtype NAME only

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -489,11 +489,28 @@ class HealpixGrid:
         object spanning the whole leaf, written at leaf block 0 — the
         ShardingCodec is vanilla zarr v3, so the leaf stays self-describing
         (D3), same as the ragged field's sharded vlen array (issue #209).
+
+        ``overwrite=True`` clears the leaf prefix FIRST (issue #341, Bug A):
+        D4 says a retried/overwritten leaf is replaced WHOLESALE, but the
+        template write alone only rewrites members the NEW schema declares —
+        a schema-narrowed rerun would leave the retired members' objects
+        behind (e.g. the post-#337 ``cell_ids`` chunk orphans), masquerading
+        as data and breaking store walks. Clearing up front also means
+        pydantic-zarr's overwrite walk (``GroupSpec.like`` →
+        ``Group.members()``) never has to parse a broken/orphan member dir —
+        an unknown array dir can die with "No array found in store" instead
+        of templating. The store is rooted at the leaf, so the delete is
+        scoped to the leaf prefix; sibling prefixes (e.g. the run's
+        ``.zarr.status/`` objects) live outside it and are never touched.
         """
         spec = GroupSpec(members={self.group_path: self.shard_spec()}, attributes={})
         # Ragged vlen-array creation warns about the dtype NAME only
         # (zarr-python#3517); message-scoped suppression, see grids.base.
         with zarr_config.set({"async.concurrency": 128}), vlen_dtype_warning_suppressed():
+            if overwrite:
+                from zarr.core.sync import sync
+
+                sync(store.delete_dir(""))
             spec.to_zarr(store, "", overwrite=overwrite)
         return store
 

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -1190,6 +1190,25 @@ def process_and_write_hive(
             # new template lands, and no enumeration ever walks stale/orphan
             # member dirs (the pre-#341 walk warned on the sidecar and could
             # die on an orphan array dir).
+            #
+            # This DOES widen the redundant-duplicate-writer window (fold
+            # review), and the change is deliberate. ``dispatch._LAMBDA_RETRYABLE``
+            # classifies off the exception string of the ``Invoke`` call itself,
+            # and for ``InvocationType=Event`` a request Lambda accepted whose
+            # HTTP response timed out is indistinguishable from one it never
+            # got — so a retry can produce a second live worker for one shard.
+            # Before: A wrote + stamped, B templated over the top, and if B died
+            # the leaf still held A's objects under A's stamp (stale-but-complete,
+            # certified). After: B's clear removes A's committed leaf first, so a
+            # B that dies mid-write leaves the leaf EMPTY and unstamped. Nothing
+            # is silently corrupt — the stamp is written last, so the leaf reads
+            # as debris and is re-dispatchable (test_leaf_clear_under_a_live_
+            # writer_leaves_debris_not_corruption) — but a redundant retry can now
+            # destroy a leaf that had already succeeded, which write-over could
+            # not. Refusing the clear on a valid stamp is the lever if that
+            # trade stops being acceptable; it is not taken here because D4 makes
+            # "replaced wholesale" the contract and a stamp must never block a
+            # retry.
             grid.emit_shard_template(store, overwrite=True)
             box["store"] = store
         return box["store"]

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -52,7 +52,6 @@ import json
 import logging
 import re
 import time
-import warnings
 from datetime import datetime, timezone
 
 import numpy as np
@@ -389,6 +388,9 @@ def validate_manifest(
         # already written under the OLD configuration. Their leaves are
         # stamped and walker-discoverable, so replacing just the manifest
         # would leave them masquerading as legal mixed-order data (D2).
+        # ``semantic_hash`` is a frozen key (D19), so overwrite does NOT
+        # bypass the semantic-hash refusal when both manifests carry one —
+        # a changed aggregation block over existing data refuses right here.
         listing = obstore.list_with_delimiter(store)
         children = [p.rstrip("/").split("/")[-1] for p in listing["common_prefixes"]]
         if any(_is_base_component(c) for c in children):
@@ -397,6 +399,32 @@ def validate_manifest(
                 f"different orders/identity: the digit tree already has shard "
                 f"data (e.g. {children[0]!r}/), and overwrite replaces the "
                 f"manifest only — clear the store root first"
+            )
+    if (
+        overwrite
+        and existing is not None
+        and frozen_matches
+        and existing.get("semantic_hash") is None
+        and manifest.get("semantic_hash") is not None
+    ):
+        # Hash-guard coherence (issue #341): ``_frozen_matches`` EXEMPTS
+        # ``semantic_hash`` when the existing manifest predates #299 (no hash
+        # to compare — the exemption keeps old stores resumable), so this
+        # overwrite proceeds even though the existing data's semantics cannot
+        # be verified. The store it leaves IS coherent going forward — the
+        # manifest rewrite stamps the run's hash, and every re-dispatched
+        # leaf is re-templated wholesale (``emit_shard_template`` clears the
+        # leaf prefix first) — but leaves this run does not rewrite may carry
+        # the old schema, so say so when shard data already exists.
+        listing = obstore.list_with_delimiter(store)
+        children = [p.rstrip("/").split("/")[-1] for p in listing["common_prefixes"]]
+        if any(_is_base_component(c) for c in children):
+            logger.warning(
+                f"overwriting {MANIFEST_NAME} at {store_root}: the existing manifest "
+                f"predates semantic hashing (issue #299), so semantic compatibility "
+                f"of the existing shard data cannot be verified; re-dispatched leaves "
+                f"are re-templated wholesale, but leaves this run does not rewrite "
+                f"may carry the old schema"
             )
     return existing
 
@@ -1138,14 +1166,14 @@ def process_and_write_hive(
             store = open_store(leaf_path, **store_kwargs)
             # overwrite=True: any existing prefix here is either debris from a
             # torn run (D4) or a prior committed write being redone — both are
-            # replaced wholesale; per-leaf state never blocks a retry. The
-            # overwrite enumeration warns about the prior attempt's coverage
-            # sidecar — the ONE foreign key we put there ourselves — so that
-            # specific warning is expected and suppressed; anything else in
-            # the prefix stays loud (review finding, PR #208 round 2).
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", message=f"Object at {COVERAGE_SIDECAR}")
-                grid.emit_shard_template(store, overwrite=True)
+            # replaced wholesale; per-leaf state never blocks a retry. Since
+            # issue #341 the template DELETES the leaf prefix up front, so the
+            # wholesale claim is literal: retired members of a narrowed schema
+            # (and the prior attempt's coverage sidecar) are gone before the
+            # new template lands, and no enumeration ever walks stale/orphan
+            # member dirs (the pre-#341 walk warned on the sidecar and could
+            # die on an orphan array dir).
+            grid.emit_shard_template(store, overwrite=True)
             box["store"] = store
         return box["store"]
 

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -400,32 +400,49 @@ def validate_manifest(
                 f"data (e.g. {children[0]!r}/), and overwrite replaces the "
                 f"manifest only — clear the store root first"
             )
-    if (
-        overwrite
-        and existing is not None
-        and frozen_matches
-        and existing.get("semantic_hash") is None
-        and manifest.get("semantic_hash") is not None
-    ):
-        # Hash-guard coherence (issue #341): ``_frozen_matches`` EXEMPTS
-        # ``semantic_hash`` when the existing manifest predates #299 (no hash
-        # to compare — the exemption keeps old stores resumable), so this
-        # overwrite proceeds even though the existing data's semantics cannot
-        # be verified. The store it leaves IS coherent going forward — the
-        # manifest rewrite stamps the run's hash, and every re-dispatched
-        # leaf is re-templated wholesale (``emit_shard_template`` clears the
-        # leaf prefix first) — but leaves this run does not rewrite may carry
-        # the old schema, so say so when shard data already exists.
+    # Hash-guard coherence (issue #341): ``_frozen_matches`` EXEMPTS
+    # ``semantic_hash`` when EITHER side lacks it (no hash to compare — the
+    # exemption keeps pre-#299 stores resumable), so an overwrite proceeds past
+    # a comparison that never happened. Warn on BOTH directions of that
+    # exemption (fold review: the guard was asymmetric where the exemption is
+    # symmetric), because they fail differently:
+    #
+    # * existing has no hash, this run does  -> the existing DATA's semantics are
+    #   unverifiable. The store is coherent going forward (the rewrite stamps
+    #   this run's hash, and every re-dispatched leaf is re-templated wholesale
+    #   — ``emit_shard_template`` clears the leaf prefix first) but leaves this
+    #   run does not rewrite may carry the old schema.
+    # * existing HAS a hash, this run does not -> the overwrite strips the
+    #   recorded hash from a hashed store, un-provenancing a #299 store rather
+    #   than merely failing to verify one. Strictly the worse direction, and the
+    #   one no warning covered.
+    #
+    # ``build_manifest`` always stamps a hash, so the second direction is not
+    # reachable from a zagg-built manifest today — it is the "older zagg (or a
+    # hand-assembled manifest) writes into a newer store" shape, one refactor of
+    # ``build_manifest`` away from being live.
+    hash_exempted = existing is not None and (existing.get("semantic_hash") is None) != (
+        manifest.get("semantic_hash") is None
+    )
+    if overwrite and frozen_matches and hash_exempted:
         listing = obstore.list_with_delimiter(store)
         children = [p.rstrip("/").split("/")[-1] for p in listing["common_prefixes"]]
         if any(_is_base_component(c) for c in children):
-            logger.warning(
-                f"overwriting {MANIFEST_NAME} at {store_root}: the existing manifest "
-                f"predates semantic hashing (issue #299), so semantic compatibility "
-                f"of the existing shard data cannot be verified; re-dispatched leaves "
-                f"are re-templated wholesale, but leaves this run does not rewrite "
-                f"may carry the old schema"
-            )
+            if existing.get("semantic_hash") is None:
+                detail = (
+                    "the existing manifest predates semantic hashing (issue #299), so "
+                    "semantic compatibility of the existing shard data cannot be "
+                    "verified; re-dispatched leaves are re-templated wholesale, but "
+                    "leaves this run does not rewrite may carry the old schema"
+                )
+            else:
+                detail = (
+                    "this run's manifest carries NO semantic hash while the existing "
+                    "one does (issue #299), so the overwrite DROPS the recorded hash "
+                    "from a hashed store — the existing shard data becomes "
+                    "un-provenanced, not merely unverified"
+                )
+            logger.warning(f"overwriting {MANIFEST_NAME} at {store_root}: {detail}")
     return existing
 
 

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -16,6 +16,7 @@ the same call-time way, so patching that symbol still intercepts reads.
 """
 
 import logging
+import threading
 import time
 import warnings
 from collections import deque
@@ -48,6 +49,12 @@ from zagg.processing.write import _build_output
 from zagg.schema import ProcessingMetadata
 
 logger = logging.getLogger(__name__)
+
+#: Read-error exemplars carried in the result payload (issue #341): the first
+#: N DISTINCT exception messages, each truncated — bounded by construction so
+#: the wire payload stays small; full tracebacks go to the worker log only.
+_EXEMPLAR_LIMIT = 3
+_EXEMPLAR_CHARS = 300
 
 
 def _granule_workers(data_source: dict) -> int:
@@ -306,6 +313,32 @@ def process_shard(
     files_processed = 0
     read_errors = 0
 
+    # Read-error exemplars (issue #341): the counter alone made the 121-failure
+    # strata run a blind "No data after filtering (N group reads raised)" —
+    # nothing in the log or the result carried even one message. Record the
+    # first _EXEMPLAR_LIMIT distinct messages for the result payload, and log
+    # the FULL traceback (WARNING) once per distinct message — repeats keep
+    # the existing one-line warning, so the issue #175 WorkerErrorCount metric
+    # filter (which matches "Traceback") fires at most _EXEMPLAR_LIMIT times
+    # per shard instead of once per failed group read. Lock-guarded: group
+    # errors are raised inside granule-pool threads (issue #180).
+    _exemplar_lock = threading.Lock()
+    read_error_exemplars: list = []
+
+    def _record_read_error(group: str, exc: Exception) -> None:
+        msg = f"{type(exc).__name__}: {exc}"[:_EXEMPLAR_CHARS]
+        with _exemplar_lock:
+            fresh = msg not in read_error_exemplars and len(read_error_exemplars) < _EXEMPLAR_LIMIT
+            if fresh:
+                read_error_exemplars.append(msg)
+        # A raised read error is always a real failure: a legitimately-empty
+        # group returns ``None`` (no exception), so WARNING does not get noisy
+        # on shards where many granules contribute 0 photons (issue #116).
+        # Logging at DEBUG hid the dem_h broadcast failure behind the
+        # misleading "No data after filtering"; swallowing the traceback hid
+        # the strata AttributeError entirely (issue #341).
+        logger.warning(f"  Error reading track {group}: {exc}", exc_info=fresh)
+
     # Streaming buffered aggregation (issue #148 phase 4): when
     # ``aggregation.streaming`` is set, reads accumulate for ``buffer_granules``
     # granules and are flushed instead of pooling the whole shard. ``mode:
@@ -378,14 +411,10 @@ def process_shard(
                     if chunk is not None:
                         reads.append(chunk)
                 except Exception as e:
-                    # A raised read error is always a real failure: a
-                    # legitimately-empty group returns ``None`` (no exception),
-                    # so promoting this to WARNING does not get noisy on shards
-                    # where many granules simply contribute 0 photons (issue
-                    # #116). Logging it at DEBUG hid the dem_h broadcast failure
-                    # behind the misleading "No data after filtering" below.
+                    # Warn + collect an exemplar (see _record_read_error): the
+                    # error is folded into ``read_errors`` by the main thread.
                     group_errors += 1
-                    logger.warning(f"  Error reading track {g}: {e}")
+                    _record_read_error(g, e)
                     continue
 
             # Per-granule backend hook (issue #160): side effects only (e.g.
@@ -490,6 +519,10 @@ def process_shard(
     metadata["files_processed"] = files_processed
     if read_errors:
         metadata["read_errors"] = read_errors
+        # Bounded diagnosis payload (issue #341): messages only, no tracebacks
+        # on the wire — full tracebacks were logged above. Success-path
+        # payloads (read_errors == 0) are unchanged.
+        metadata["read_error_exemplars"] = list(read_error_exemplars)
 
     if buffered is not None:
         # Drain the tail buffer (< buffer_granules granules) BEFORE the read
@@ -511,7 +544,13 @@ def process_shard(
                 f"  No data after filtering for shard {label} and "
                 f"{read_errors} group read(s) raised - skipping"
             )
-            metadata["error"] = f"No data after filtering ({read_errors} group reads raised)"
+            # Carry the exemplars in the error text too (issue #341): this
+            # string is what surfaces in the status object / run summary, so
+            # it must be a one-glance diagnosis, not just a count.
+            metadata["error"] = (
+                f"No data after filtering ({read_errors} group reads raised; "
+                f"e.g. {' | '.join(read_error_exemplars)})"
+            )
         else:
             logger.info(f"  No data after filtering for shard {label} - skipping")
             metadata["error"] = "No data after filtering"

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -312,6 +312,16 @@ def process_shard(
     all_reads = []
     files_processed = 0
     read_errors = 0
+    # Granule-scope failures (fold review, issue #341): a fault that kills the
+    # WHOLE granule rather than one group -- an H5Coro construction failure, a
+    # bad/expired credential, a URL-rewriter fault, a streaming flush blowing up
+    # -- is warn-and-continue by design (issue #116 semantics), but it used to
+    # leave NO trace in the result: not counted, not exemplared, so a shard whose
+    # every granule failed at granule scope returned the blind "No data after
+    # filtering". Counted separately from ``read_errors`` because the scope
+    # matters to the diagnosis (all groups vs one), and it is arguably the more
+    # likely fleet shape: credentials and endpoints kill granules, not groups.
+    granule_errors = 0
 
     # Read-error exemplars (issue #341): the counter alone made the 121-failure
     # strata run a blind "No data after filtering (N group reads raised)" —
@@ -325,7 +335,9 @@ def process_shard(
     _exemplar_lock = threading.Lock()
     read_error_exemplars: list = []
 
-    def _record_read_error(group: str, exc: Exception) -> None:
+    def _record_read_error(what: str, exc: Exception) -> None:
+        """Warn + exemplar one read failure. ``what`` is the log phrase (and so
+        the scope): ``reading track <group>`` or ``processing file <url>``."""
         msg = f"{type(exc).__name__}: {exc}"[:_EXEMPLAR_CHARS]
         with _exemplar_lock:
             fresh = msg not in read_error_exemplars and len(read_error_exemplars) < _EXEMPLAR_LIMIT
@@ -337,7 +349,7 @@ def process_shard(
         # Logging at DEBUG hid the dem_h broadcast failure behind the
         # misleading "No data after filtering"; swallowing the traceback hid
         # the strata AttributeError entirely (issue #341).
-        logger.warning(f"  Error reading track {group}: {exc}", exc_info=fresh)
+        logger.warning(f"  Error {what}: {exc}", exc_info=fresh)
 
     # Streaming buffered aggregation (issue #148 phase 4): when
     # ``aggregation.streaming`` is set, reads accumulate for ``buffer_granules``
@@ -414,7 +426,7 @@ def process_shard(
                     # Warn + collect an exemplar (see _record_read_error): the
                     # error is folded into ``read_errors`` by the main thread.
                     group_errors += 1
-                    _record_read_error(g, e)
+                    _record_read_error(f"reading track {g}", e)
                     continue
 
             # Per-granule backend hook (issue #160): side effects only (e.g.
@@ -455,15 +467,17 @@ def process_shard(
         future, so an out-of-order completion parks in its future until its
         turn — parked results are bounded by the pool width, and the fold
         (hence the aggregation output) is byte-identical to serial. A granule
-        whose read raised is warned and skipped here, same as the serial
-        except-continue.
+        whose read raised is warned, counted (``granule_errors``) and skipped
+        here, same as the serial except-continue.
         """
+        nonlocal granule_errors
         if granule_workers == 1:
             for s3_url in granule_urls:
                 try:
                     yield s3_url, *_read_granule(s3_url)
                 except Exception as e:
-                    logger.warning(f"  Error processing file {s3_url}: {e}")
+                    granule_errors += 1
+                    _record_read_error(f"processing file {s3_url}", e)
         else:
             with ThreadPoolExecutor(
                 max_workers=granule_workers, thread_name_prefix="zagg-granule"
@@ -477,7 +491,8 @@ def process_shard(
                     try:
                         reads, group_errors = future.result()
                     except Exception as e:
-                        logger.warning(f"  Error processing file {s3_url}: {e}")
+                        granule_errors += 1
+                        _record_read_error(f"processing file {s3_url}", e)
                         reads = None
                     # Top up BEFORE yielding (review): the head is done either
                     # way, so submitting its replacement here keeps the full
@@ -511,17 +526,24 @@ def process_shard(
             raise
         except Exception as e:
             # Fold-side failure (e.g. a streaming flush): same tolerated
-            # warn-and-continue the serial loop's outer ``except`` applied.
-            logger.warning(f"  Error processing file {s3_url}: {e}")
+            # warn-and-continue the serial loop's outer ``except`` applied —
+            # counted and exemplared like the read-side granule failures, since
+            # a shard that folds nothing looks identical to one that read
+            # nothing (fold review, issue #341).
+            granule_errors += 1
+            _record_read_error(f"processing file {s3_url}", e)
             continue
 
     logger.info(f"  Processed {files_processed}/{len(granule_urls)} files")
     metadata["files_processed"] = files_processed
     if read_errors:
         metadata["read_errors"] = read_errors
+    if granule_errors:
+        metadata["granule_errors"] = granule_errors
+    if read_errors or granule_errors:
         # Bounded diagnosis payload (issue #341): messages only, no tracebacks
         # on the wire — full tracebacks were logged above. Success-path
-        # payloads (read_errors == 0) are unchanged.
+        # payloads (no failures at either scope) are unchanged.
         metadata["read_error_exemplars"] = list(read_error_exemplars)
 
     if buffered is not None:
@@ -539,17 +561,21 @@ def process_shard(
         # so report it as such instead of the misleading text. Some groups may
         # have returned ``None`` (legitimately empty) rather than raised, so the
         # message is "no data AND N raised", not "all groups raised".
-        if read_errors:
-            logger.warning(
-                f"  No data after filtering for shard {label} and "
-                f"{read_errors} group read(s) raised - skipping"
+        if read_errors or granule_errors:
+            # Name the SCOPE of the failures, not just a count (fold review):
+            # "3 granule reads raised" and "3 group reads raised" point at very
+            # different causes (credentials/endpoint vs schema/variable).
+            raised = ", ".join(
+                f"{n} {scope} reads raised"
+                for n, scope in ((read_errors, "group"), (granule_errors, "granule"))
+                if n
             )
+            logger.warning(f"  No data after filtering for shard {label} and {raised} - skipping")
             # Carry the exemplars in the error text too (issue #341): this
             # string is what surfaces in the status object / run summary, so
             # it must be a one-glance diagnosis, not just a count.
             metadata["error"] = (
-                f"No data after filtering ({read_errors} group reads raised; "
-                f"e.g. {' | '.join(read_error_exemplars)})"
+                f"No data after filtering ({raised}; e.g. {' | '.join(read_error_exemplars)})"
             )
         else:
             logger.info(f"  No data after filtering for shard {label} - skipping")

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -56,6 +56,14 @@ logger = logging.getLogger(__name__)
 _EXEMPLAR_LIMIT = 3
 _EXEMPLAR_CHARS = 300
 
+#: Distinct messages whose FIRST occurrence logs a full traceback. Deliberately
+#: larger than :data:`_EXEMPLAR_LIMIT` (fold review): coupling the two meant the
+#: 4th distinct failure got neither an exemplar nor a traceback, so on a shard
+#: where three flavors of transient S3 error precede the real cause, the real
+#: cause was invisible. The bound still caps the issue #175 WorkerErrorCount
+#: metric filter (which matches "Traceback") at N per shard.
+_TRACEBACK_LIMIT = 5
+
 
 def _granule_workers(data_source: dict) -> int:
     """Granules in flight per shard (issue #180).
@@ -327,29 +335,34 @@ def process_shard(
     # strata run a blind "No data after filtering (N group reads raised)" —
     # nothing in the log or the result carried even one message. Record the
     # first _EXEMPLAR_LIMIT distinct messages for the result payload, and log
-    # the FULL traceback (WARNING) once per distinct message — repeats keep
-    # the existing one-line warning, so the issue #175 WorkerErrorCount metric
-    # filter (which matches "Traceback") fires at most _EXEMPLAR_LIMIT times
-    # per shard instead of once per failed group read. Lock-guarded: group
-    # errors are raised inside granule-pool threads (issue #180).
+    # the FULL traceback (WARNING) on the first occurrence of each of the first
+    # _TRACEBACK_LIMIT distinct messages — repeats keep the existing one-line
+    # warning. The two budgets are SEPARATE (fold review): the payload stays
+    # small on the wire while a distinct message beyond the payload cap still
+    # gets its traceback in the log, so a real cause behind three flavors of
+    # transient noise is not silently dropped. Lock-guarded: group errors are
+    # raised inside granule-pool threads (issue #180).
     _exemplar_lock = threading.Lock()
     read_error_exemplars: list = []
+    traced_messages: set = set()
 
     def _record_read_error(what: str, exc: Exception) -> None:
         """Warn + exemplar one read failure. ``what`` is the log phrase (and so
         the scope): ``reading track <group>`` or ``processing file <url>``."""
         msg = f"{type(exc).__name__}: {exc}"[:_EXEMPLAR_CHARS]
         with _exemplar_lock:
-            fresh = msg not in read_error_exemplars and len(read_error_exemplars) < _EXEMPLAR_LIMIT
-            if fresh:
+            if msg not in read_error_exemplars and len(read_error_exemplars) < _EXEMPLAR_LIMIT:
                 read_error_exemplars.append(msg)
+            trace = msg not in traced_messages and len(traced_messages) < _TRACEBACK_LIMIT
+            if trace:
+                traced_messages.add(msg)
         # A raised read error is always a real failure: a legitimately-empty
         # group returns ``None`` (no exception), so WARNING does not get noisy
         # on shards where many granules contribute 0 photons (issue #116).
         # Logging at DEBUG hid the dem_h broadcast failure behind the
         # misleading "No data after filtering"; swallowing the traceback hid
         # the strata AttributeError entirely (issue #341).
-        logger.warning(f"  Error {what}: {exc}", exc_info=fresh)
+        logger.warning(f"  Error {what}: {exc}", exc_info=trace)
 
     # Streaming buffered aggregation (issue #148 phase 4): when
     # ``aggregation.streaming`` is set, reads accumulate for ``buffer_granules``

--- a/src/zagg/schema.py
+++ b/src/zagg/schema.py
@@ -35,9 +35,14 @@ class ProcessingMetadata(TypedDict):
     # read is always a real error, so this surfaces a shard whose "no data"
     # result is actually a read failure rather than a legitimately-empty read.
     read_errors: NotRequired[int]
-    # First N distinct group-read exception messages, truncated (issue #341):
-    # the bounded diagnosis payload for ``read_errors`` — present exactly when
-    # ``read_errors`` is. Messages only; tracebacks stay in the worker log.
+    # Count of GRANULE-scope read failures (issue #341): the granule itself
+    # failed (H5Coro open, credentials, URL rewrite) or its fold did, so no
+    # group of it was read. Warn-and-continue like ``read_errors``, but a
+    # different diagnosis, hence a separate counter. Present only when non-zero.
+    granule_errors: NotRequired[int]
+    # First N distinct read exception messages, truncated (issue #341): the
+    # bounded diagnosis payload for ``read_errors``/``granule_errors`` — present
+    # exactly when either is. Messages only; tracebacks stay in the worker log.
     read_error_exemplars: NotRequired[list[str]]
     # Container telemetry (issue #171), stamped by the Lambda handler's
     # dispatcher into every per-unit envelope (all status branches) so the

--- a/src/zagg/schema.py
+++ b/src/zagg/schema.py
@@ -35,6 +35,10 @@ class ProcessingMetadata(TypedDict):
     # read is always a real error, so this surfaces a shard whose "no data"
     # result is actually a read failure rather than a legitimately-empty read.
     read_errors: NotRequired[int]
+    # First N distinct group-read exception messages, truncated (issue #341):
+    # the bounded diagnosis payload for ``read_errors`` — present exactly when
+    # ``read_errors`` is. Messages only; tracebacks stay in the worker log.
+    read_error_exemplars: NotRequired[list[str]]
     # Container telemetry (issue #171), stamped by the Lambda handler's
     # dispatcher into every per-unit envelope (all status branches) so the
     # runner can surface the warm-container RSS ratchet (#169). Absent on the

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -180,9 +180,10 @@ def test_codec_column_is_last_and_threaded(monkeypatch):
     cols = bench_metrics.RECORD_COLUMNS
     assert cols.index("codec") < cols.index("read") < cols.index("total_wall_s")
     # The wall breakdown (#180), read backend (#193), object counts (#240),
-    # store layout (#240 phase 4), worker phase split (#250/#256) and the
-    # streaming-mode/ephemeral axis (#272) appended in that order.
-    assert cols[-15:] == [
+    # store layout (#240 phase 4), worker phase split (#250/#256), the
+    # streaming-mode/ephemeral axis (#272) and the worker-build provenance stamp
+    # (#341/#296) appended in that order.
+    assert cols[-16:] == [
         "total_wall_s",
         "setup_s",
         "fanout_s",
@@ -198,6 +199,7 @@ def test_codec_column_is_last_and_threaded(monkeypatch):
         "streaming_mode",
         "tmp_mb",
         "ephemeral_cost_usd",
+        "variant_guard",
     ]
     g = HealpixGrid(parent_order=11, child_order=19)
     rec = bench_metrics.build_record(_summary(), grid=g, context={"codec": "sharded"})
@@ -436,7 +438,8 @@ def test_resolve_variant_matches_the_runner_rule():
 
 def test_variant_guard_passes_on_matching_sha():
     client = _StubLambdaClient({"process-shard": "abc", "process-shard-4096-disk": "abc"})
-    run_benchmark.check_variant_current(client, "process-shard", "process-shard-4096-disk")
+    status = run_benchmark.check_variant_current(client, "process-shard", "process-shard-4096-disk")
+    assert status == "verified"
 
 
 def test_variant_guard_hard_fails_on_stale_variant():
@@ -452,14 +455,40 @@ def test_variant_guard_hard_fails_on_stale_variant():
     assert "redeploy the variant family" in msg
 
 
-def test_variant_guard_degrades_on_probe_failure(capsys):
-    # A failed probe (e.g. an invoke role without lambda:GetFunctionConfiguration
-    # on the family) warns and continues — third-party stacks still dispatch.
+def test_variant_guard_degrades_only_when_the_BASE_probe_fails(capsys):  # noqa: N802
+    # A role with no lambda:GetFunctionConfiguration at all (the third-party
+    # stack case) fails the BASE probe -> warn and continue, stamped "skipped".
     client = _StubLambdaClient({}, raises=PermissionError("AccessDenied"))
-    run_benchmark.check_variant_current(client, "process-shard", "process-shard-4096-disk")
+    status = run_benchmark.check_variant_current(client, "process-shard", "process-shard-4096-disk")
+    assert status == "skipped"
     err = capsys.readouterr().err
-    assert "WARN: could not compare CodeSha256" in err
-    assert "without the staleness guard" in err
+    assert "could not probe base function process-shard" in err
+    assert "variant_guard=skipped" in err
+
+
+def test_variant_guard_hard_fails_when_only_the_variant_probe_fails():
+    # Fold review: base OK + variant denied/absent is the STALENESS signal, not
+    # a reason to degrade. Under the issue #341 enumeration ruling, a variant
+    # missing from InvokeBenchmarkFunctions is one deploy_lambda.sh
+    # WARN-and-skipped, so it cannot be current. Must name the two places to fix.
+    class _BaseOnly:
+        def __init__(self):
+            self.probed = []
+
+        def get_function_configuration(self, FunctionName):  # noqa: N803 (boto3 API)
+            self.probed.append(FunctionName)
+            if FunctionName == "process-shard-test":
+                return {"CodeSha256": "abc"}
+            raise PermissionError("AccessDeniedException")
+
+    client = _BaseOnly()
+    with pytest.raises(RuntimeError) as exc:
+        run_benchmark.check_variant_current(client, "process-shard-test", "process-shard-test-4096")
+    msg = str(exc.value)
+    assert "process-shard-test-4096" in msg and "NOT REACHABLE" in msg
+    assert "template.yaml" in msg and "benchmark_cicd.yaml" in msg
+    # The base probe ran first, so the diagnosis is genuinely variant-specific.
+    assert client.probed == ["process-shard-test", "process-shard-test-4096"]
 
 
 def _stub_boto3(monkeypatch, client):
@@ -536,6 +565,91 @@ def test_variant_guard_probes_each_distinct_variant_once(tmp_path, monkeypatch):
     )
     assert rc == 0
     assert client.probed == ["process-shard", "process-shard-4096-disk"]
+
+
+def _guard_stamping_run_target(name, manifest, base, **kwargs):
+    """run_target stand-in that echoes back the guard status main() handed it."""
+    rec = _fake_record(name, total_obs=1, max_memory_mb=1)
+    rec["variant_guard"] = kwargs["variant_guard"]
+    return rec
+
+
+def test_variant_guard_status_rides_the_record(tmp_path, monkeypatch):
+    # Provenance (issues #341/#296): the record carries whether the guard
+    # actually verified the build. A degraded probe must be legible in
+    # metrics.json and banner-ed in the PR comment, not only on stderr.
+    _stub_boto3(monkeypatch, _StubLambdaClient({}, raises=PermissionError("AccessDenied")))
+    monkeypatch.setattr(run_benchmark, "run_target", _guard_stamping_run_target)
+    out = tmp_path / "metrics.json"
+    comment = tmp_path / "comment.md"
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o9_hive",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(out),
+            "--out-comment",
+            str(comment),
+            "--no-fail-on-empty",
+            "--no-fail-on-object-mismatch",
+        ]
+    )
+    assert rc == 0
+    (rec,) = json.loads(out.read_text())
+    assert rec["variant_guard"] == "skipped"
+    body = comment.read_text()
+    assert "staleness guard SKIPPED" in body
+    assert "tdigest_healpix_o9_hive" in body
+
+
+def test_variant_guard_status_verified_and_base(tmp_path, monkeypatch):
+    # A clean probe stamps "verified"; a target with no ``worker:`` block has no
+    # variant to verify and stamps "base" (never null, so a missing stamp on a
+    # future row is unambiguously a pre-guard row).
+    _stub_boto3(
+        monkeypatch,
+        _StubLambdaClient({"process-shard": "same", "process-shard-4096-disk": "same"}),
+    )
+    monkeypatch.setattr(run_benchmark, "run_target", _guard_stamping_run_target)
+    out = tmp_path / "metrics.json"
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o9_hive",
+            "--target",
+            "tdigest_healpix_o10_inline",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(out),
+            "--no-fail-on-empty",
+            "--no-fail-on-object-mismatch",
+        ]
+    )
+    assert rc == 0
+    by_target = {r["target"]: r["variant_guard"] for r in json.loads(out.read_text())}
+    assert by_target == {
+        "tdigest_healpix_o9_hive": "verified",
+        "tdigest_healpix_o10_inline": "base",
+    }
+
+
+def test_variant_guard_column_is_in_the_series_schema():
+    # Appended to the stable RECORD_COLUMNS schema so update_series's reindex
+    # retains it (legacy rows read back null).
+    assert bench_metrics.RECORD_COLUMNS[-1] == "variant_guard"
+    rec = bench_metrics.build_record(
+        _summary(), grid=HealpixGrid(11, 19), context={"target": "t", "variant_guard": "verified"}
+    )
+    assert rec["variant_guard"] == "verified"
+    # No banner when nothing degraded.
+    assert "staleness guard SKIPPED" not in bench_metrics.comment_markdown([rec])
 
 
 def test_variant_guard_skipped_under_dry_run(tmp_path, monkeypatch):
@@ -1991,7 +2105,7 @@ def test_objects_columns_are_last_and_threaded():
     # appended after the object counts in phase 4; the #250/#256 phase split
     # then the #272 streaming-mode/ephemeral axis appended after those).
     cols = bench_metrics.RECORD_COLUMNS
-    assert cols[-10:-7] == ["objects_total", "objects_expected", "store_layout"]
+    assert cols[-11:-8] == ["objects_total", "objects_expected", "store_layout"]
     g = HealpixGrid(parent_order=11, child_order=19)
     rec = bench_metrics.build_record(_summary(), grid=g, context={}, objects=_objects_payload())
     assert rec["objects_total"] == 10

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -499,6 +499,14 @@ def _stub_boto3(monkeypatch, client):
     return client
 
 
+def _no_login(monkeypatch):
+    """Stub the multi-target auth warm-up (issue #137) -- it would otherwise
+    prompt for Earthdata credentials on a runner with no netrc."""
+    import zagg.auth as zauth
+
+    monkeypatch.setattr(zauth, "ensure_logged_in", lambda: None)
+
+
 def test_variant_guard_refuses_before_any_dispatch(tmp_path, monkeypatch):
     # Fold review: the guard used to live inside run_target, so a stale variant
     # only raised after the pool had launched every sibling — shutdown(wait=True)
@@ -516,6 +524,16 @@ def test_variant_guard_refuses_before_any_dispatch(tmp_path, monkeypatch):
         return _fake_record(name, total_obs=1, max_memory_mb=1)
 
     monkeypatch.setattr(run_benchmark, "run_target", _record)
+    # The guard must also precede the multi-target auth warm-up (issue #137), so
+    # a refusal costs no Earthdata login either -- assert it by making a login
+    # attempt fail the test rather than by stubbing it out.
+    import zagg.auth as zauth
+
+    monkeypatch.setattr(
+        zauth,
+        "ensure_logged_in",
+        lambda: pytest.fail("guard must refuse before ensure_logged_in()"),
+    )
     out = tmp_path / "metrics.json"
     with pytest.raises(RuntimeError, match="STALE"):
         run_benchmark.main(
@@ -543,6 +561,7 @@ def test_variant_guard_probes_each_distinct_variant_once(tmp_path, monkeypatch):
         monkeypatch,
         _StubLambdaClient({"process-shard": "same", "process-shard-4096-disk": "same"}),
     )
+    _no_login(monkeypatch)
     monkeypatch.setattr(
         run_benchmark,
         "run_target",
@@ -614,6 +633,7 @@ def test_variant_guard_status_verified_and_base(tmp_path, monkeypatch):
         monkeypatch,
         _StubLambdaClient({"process-shard": "same", "process-shard-4096-disk": "same"}),
     )
+    _no_login(monkeypatch)
     monkeypatch.setattr(run_benchmark, "run_target", _guard_stamping_run_target)
     out = tmp_path / "metrics.json"
     rc = run_benchmark.main(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -403,6 +403,50 @@ def test_run_target_dry_run():
     assert rec["total_obs"] is None  # no dispatch in dry-run
 
 
+# --- variant staleness guard (issue #341) ----------------------------------
+
+
+class _StubLambdaClient:
+    """get_function_configuration stub: CodeSha256 keyed by function name."""
+
+    def __init__(self, shas, raises=None):
+        self._shas = shas
+        self._raises = raises
+
+    def get_function_configuration(self, FunctionName):  # noqa: N803 (boto3 API)
+        if self._raises is not None:
+            raise self._raises
+        return {"CodeSha256": self._shas[FunctionName]}
+
+
+def test_variant_guard_passes_on_matching_sha():
+    client = _StubLambdaClient({"process-shard": "abc", "process-shard-4096-disk": "abc"})
+    run_benchmark.check_variant_current(client, "process-shard", "process-shard-4096-disk")
+
+
+def test_variant_guard_hard_fails_on_stale_variant():
+    # The run 30503334617 failure mode: the -disk variant serves standup-time
+    # code while the base was just deployed. Must name both hashes and the
+    # remediation (redeploy the family).
+    client = _StubLambdaClient({"process-shard": "newsha", "process-shard-4096-disk": "oldsha"})
+    with pytest.raises(RuntimeError) as exc:
+        run_benchmark.check_variant_current(client, "process-shard", "process-shard-4096-disk")
+    msg = str(exc.value)
+    assert "process-shard-4096-disk" in msg and "STALE" in msg
+    assert "newsha" in msg and "oldsha" in msg
+    assert "redeploy the variant family" in msg
+
+
+def test_variant_guard_degrades_on_probe_failure(capsys):
+    # A failed probe (e.g. an invoke role without lambda:GetFunctionConfiguration
+    # on the family) warns and continues — third-party stacks still dispatch.
+    client = _StubLambdaClient({}, raises=PermissionError("AccessDenied"))
+    run_benchmark.check_variant_current(client, "process-shard", "process-shard-4096-disk")
+    err = capsys.readouterr().err
+    assert "WARN: could not compare CodeSha256" in err
+    assert "without the staleness guard" in err
+
+
 def _fake_record(target, *, total_obs, max_memory_mb):
     # Minimal record with the fields main()'s per-target print + the empty-metrics
     # guard read (issue #145). Enough to drive main() without a real dispatch.

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -412,11 +412,26 @@ class _StubLambdaClient:
     def __init__(self, shas, raises=None):
         self._shas = shas
         self._raises = raises
+        self.probed: list = []
 
     def get_function_configuration(self, FunctionName):  # noqa: N803 (boto3 API)
+        self.probed.append(FunctionName)
         if self._raises is not None:
             raise self._raises
         return {"CodeSha256": self._shas[FunctionName]}
+
+
+def test_resolve_variant_matches_the_runner_rule():
+    # One suffix rule, shared by run_target and the pre-dispatch guard (so the
+    # name probed is always the name dispatched). Mirrors
+    # zagg.runner._resolve_function_name.
+    assert run_benchmark.resolve_variant("process-shard", None) == "process-shard"
+    assert run_benchmark.resolve_variant("process-shard", {}) == "process-shard"
+    assert run_benchmark.resolve_variant("process-shard", {"memory": 4096}) == "process-shard-4096"
+    assert (
+        run_benchmark.resolve_variant("process-shard", {"memory": 4096, "extra_disk": True})
+        == "process-shard-4096-disk"
+    )
 
 
 def test_variant_guard_passes_on_matching_sha():
@@ -445,6 +460,102 @@ def test_variant_guard_degrades_on_probe_failure(capsys):
     err = capsys.readouterr().err
     assert "WARN: could not compare CodeSha256" in err
     assert "without the staleness guard" in err
+
+
+def _stub_boto3(monkeypatch, client):
+    """Make ``boto3.client("lambda", ...)`` inside run_benchmark return ``client``."""
+    import boto3
+
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: client)
+    return client
+
+
+def test_variant_guard_refuses_before_any_dispatch(tmp_path, monkeypatch):
+    # Fold review: the guard used to live inside run_target, so a stale variant
+    # only raised after the pool had launched every sibling — shutdown(wait=True)
+    # then billed them all and the exception escaped main() before metrics.json
+    # was written. It now runs pre-pool: ZERO dispatches, and the two hive
+    # targets share one variant so it probes once, not twice.
+    client = _stub_boto3(
+        monkeypatch,
+        _StubLambdaClient({"process-shard": "newsha", "process-shard-4096-disk": "oldsha"}),
+    )
+    dispatched: list = []
+
+    def _record(name, *a, **k):
+        dispatched.append(name)
+        return _fake_record(name, total_obs=1, max_memory_mb=1)
+
+    monkeypatch.setattr(run_benchmark, "run_target", _record)
+    out = tmp_path / "metrics.json"
+    with pytest.raises(RuntimeError, match="STALE"):
+        run_benchmark.main(
+            [
+                "--targets",
+                str(BENCH / "targets.json"),
+                "--target",
+                "tdigest_healpix_o9_hive",
+                "--target",
+                "tdigest_healpix_o9_hive_sidecar",
+                "--commit",
+                "cafe123",
+                "--out-json",
+                str(out),
+            ]
+        )
+    assert dispatched == []  # nothing billed
+    assert client.probed == ["process-shard", "process-shard-4096-disk"]  # one probe pair
+
+
+def test_variant_guard_probes_each_distinct_variant_once(tmp_path, monkeypatch):
+    # Two targets, one shared variant -> one probe pair total (not one per
+    # target), and the run proceeds to dispatch normally.
+    client = _stub_boto3(
+        monkeypatch,
+        _StubLambdaClient({"process-shard": "same", "process-shard-4096-disk": "same"}),
+    )
+    monkeypatch.setattr(
+        run_benchmark,
+        "run_target",
+        lambda name, *a, **k: _fake_record(name, total_obs=1, max_memory_mb=1),
+    )
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o9_hive",
+            "--target",
+            "tdigest_healpix_o9_hive_sidecar",
+            "--commit",
+            "cafe123",
+            "--out-json",
+            str(tmp_path / "metrics.json"),
+            "--no-fail-on-object-mismatch",
+        ]
+    )
+    assert rc == 0
+    assert client.probed == ["process-shard", "process-shard-4096-disk"]
+
+
+def test_variant_guard_skipped_under_dry_run(tmp_path, monkeypatch):
+    # --dry-run does no dispatch, so it must not need (or make) AWS calls.
+    client = _stub_boto3(monkeypatch, _StubLambdaClient({}, raises=AssertionError("no AWS")))
+    rc = run_benchmark.main(
+        [
+            "--targets",
+            str(BENCH / "targets.json"),
+            "--target",
+            "tdigest_healpix_o9_hive",
+            "--commit",
+            "cafe123",
+            "--dry-run",
+            "--out-json",
+            str(tmp_path / "metrics.json"),
+        ]
+    )
+    assert rc == 0
+    assert client.probed == []
 
 
 def _fake_record(target, *, total_obs, max_memory_mb):

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -24,6 +24,11 @@ SCRIPT = REPO / ".github" / "scripts" / "deploy_lambda.sh"
 #: The template.yaml WorkerMemorySizes matrix the script defaults to (issue #341).
 FAMILY = ["-2048", "-4096", "-8192", "-2048-disk", "-4096-disk", "-8192-disk"]
 
+#: The subset the TEST stack provisions (template.yaml's WorkerTestDiskVariants
+#: loop, -disk only), which lambda-benchmark.yml pins via --variants so the
+#: enumerated deploy role never AccessDenies a probe (fold review, issue #341).
+TEST_STACK_VARIANTS = ["-2048-disk", "-4096-disk", "-8192-disk"]
+
 # Stub `aws`: log the full arg line; emit a LayerVersionArn on stdout for the
 # publish-layer-version call (the script captures it). get-function-configuration
 # probes succeed only for functions listed in $AWS_EXISTING (space-separated;
@@ -176,9 +181,9 @@ def _deployed(log):
 
 
 def test_variant_family_deployed_when_present(tmp_path):
-    # Issue #341: the whole worker-size family updates from the same zip. The
-    # test stack shape: only the -disk trio exists (template.yaml's
-    # WorkerTestDiskVariants loop); the plain-memory trio 404s and is skipped.
+    # Issue #341: the whole worker-size family updates from the same zip. On a
+    # stack that provisions a subset of the DEFAULT_VARIANTS list, the absent
+    # ones 404 and are skipped quietly.
     existing = [f"process-shard-test{s}" for s in ("-2048-disk", "-4096-disk", "-8192-disk")]
     result, log = _run_deploy(tmp_path, existing=existing)
     assert result.returncode == 0
@@ -191,6 +196,57 @@ def test_variant_family_deployed_when_present(tmp_path):
     assert len(probed) == len(FAMILY)
     for missing in ("-2048", "-4096", "-8192"):
         assert f"variant process-shard-test{missing} does not exist; skipping" in result.stdout
+
+
+def test_test_deploy_variant_set_probes_nothing_absent(tmp_path):
+    # Fold review: the workflow now pins --variants to the test-stack shape, so
+    # the plain-memory trio is never probed. Before, the enumerated deploy role
+    # AccessDenied those three probes (not 404), landing on the WARN branch and
+    # printing "it may now be STALE" on EVERY green deploy for functions that
+    # will never exist -- the one channel whose job is to make real staleness
+    # visible, crying wolf 3x per deploy.
+    existing = [f"process-shard-test{s}" for s in TEST_STACK_VARIANTS]
+    stub = STUB_AWS.replace(
+        'echo "An error occurred (ResourceNotFoundException) when calling the '
+        'GetFunctionConfiguration operation: Function not found: $4" >&2; exit 254',
+        'echo "An error occurred (AccessDeniedException) ..." >&2; exit 254',
+    )
+    result, log = _run_deploy(
+        tmp_path,
+        stub=stub,
+        existing=existing,
+        extra_args=["--variants", " ".join(TEST_STACK_VARIANTS)],
+    )
+    assert result.returncode == 0
+    assert _deployed(log) == ["process-shard-test", *existing]
+    assert len([line for line in log if "get-function-configuration" in line]) == len(
+        TEST_STACK_VARIANTS
+    )
+    assert "STALE" not in result.stderr
+    assert "does not exist; skipping" not in result.stdout
+
+
+def test_denied_update_aborts_the_family_loop(tmp_path):
+    # The granted-Get/denied-Update shape: the probe succeeds, the update does
+    # not. `set -e` aborts mid-family (base plus some variants updated, the rest
+    # stale) and the job goes red -- deliberate, and documented in the script:
+    # a red deploy is recoverable and the CodeSha256 guard refuses to benchmark
+    # the half-updated family.
+    stub = STUB_AWS.replace(
+        "exit 0\n",
+        'if [ "$2" = "update-function-code" ] && [ "$4" = "process-shard-test-4096-disk" ]; then\n'
+        '  echo "An error occurred (AccessDeniedException) ..." >&2; exit 254\nfi\nexit 0\n',
+        1,
+    )
+    result, log = _run_deploy(
+        tmp_path,
+        stub=stub,
+        existing=None,
+        extra_args=["--variants", " ".join(TEST_STACK_VARIANTS)],
+    )
+    assert result.returncode != 0
+    # The loop stopped at the denied variant: -8192-disk was never attempted.
+    assert "process-shard-test-8192-disk" not in "\n".join(log)
 
 
 def test_variant_probe_failure_warns_and_skips(tmp_path):
@@ -229,6 +285,7 @@ def test_variants_override(tmp_path):
 
 TEMPLATE = REPO / "deployment" / "aws" / "template.yaml"
 CICD = REPO / "deployment" / "aws" / "benchmark_cicd.yaml"
+BENCH_WORKFLOW = REPO / ".github" / "workflows" / "lambda-benchmark.yml"
 
 
 def _load_cfn(path):
@@ -290,6 +347,37 @@ def _script_default_variants():
     match = re.search(r'^DEFAULT_VARIANTS="([^"]*)"', SCRIPT.read_text(), re.MULTILINE)
     assert match, f"DEFAULT_VARIANTS not found in {SCRIPT}"
     return set(match.group(1).split())
+
+
+def _workflow_variants():
+    """The ``--variants`` suffix set lambda-benchmark.yml's deploy step pins."""
+    match = re.search(r'--variants "([^"]*)"', BENCH_WORKFLOW.read_text())
+    assert match, f"deploy step in {BENCH_WORKFLOW} passes no --variants"
+    return set(match.group(1).split())
+
+
+def test_test_deploy_workflow_pins_the_test_stack_variant_set():
+    # Fold review: the per-merge deploy must probe EXACTLY what the test stack
+    # provisions. Probing the prod default meant three AccessDenied probes (the
+    # deploy role enumerates only the -disk trio) landing on the loud
+    # "may now be STALE" branch on every green deploy, for functions that will
+    # never exist -- the same "nobody reads the warning" failure as issue #341.
+    test_suffixes, _ = _template_variant_suffixes()
+    assert _workflow_variants() == test_suffixes, (
+        f"the --variants list in {BENCH_WORKFLOW}'s deploy step and the "
+        f"WorkerTestDiskVariants loop in {TEMPLATE} disagree -- update whichever "
+        f"is stale, or the deploy either skips a provisioned variant (leaving it "
+        f"STALE, issue #341) or warns about one that does not exist"
+    )
+    # ...and every pinned suffix is enumerated on the deploy role, so no probe
+    # in the pinned set can AccessDeny.
+    arns = _statement_arns("DeployRole", "UpdateTestFunction")
+    for suffix in sorted(_workflow_variants()):
+        want = "function:${TestFunctionName}" + suffix
+        assert any(a.endswith(want) for a in arns), (
+            f"{BENCH_WORKFLOW} deploys test variant '{suffix}' but "
+            f"DeployRole.UpdateTestFunction in {CICD} has no ARN ending '{want}'"
+        )
 
 
 def test_deploy_role_enumerates_test_stack_variants():

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -276,7 +276,7 @@ def _template_variant_suffixes():
     return test, prod
 
 
-def _update_statement_arns(role, sid):
+def _statement_arns(role, sid):
     """The !Sub ARN strings of the role's Sid=<sid> policy statement."""
     tpl = _load_cfn(CICD)
     statements = tpl["Resources"][role]["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
@@ -295,7 +295,7 @@ def _script_default_variants():
 def test_deploy_role_enumerates_test_stack_variants():
     # Test-stack shape: base + every WorkerTestDiskVariants function.
     test_suffixes, _ = _template_variant_suffixes()
-    arns = _update_statement_arns("DeployRole", "UpdateTestFunction")
+    arns = _statement_arns("DeployRole", "UpdateTestFunction")
     assert any(a.endswith("function:${TestFunctionName}") for a in arns), (
         f"DeployRole.UpdateTestFunction in {CICD} must keep the base "
         "function:${TestFunctionName} ARN"
@@ -312,7 +312,7 @@ def test_deploy_role_enumerates_test_stack_variants():
 def test_release_role_enumerates_prod_variant_family():
     # Prod family: base + plain and -disk variants for every memory size.
     _, prod_suffixes = _template_variant_suffixes()
-    arns = _update_statement_arns("ReleaseRole", "UpdateProdFunction")
+    arns = _statement_arns("ReleaseRole", "UpdateProdFunction")
     assert any(a.endswith("function:${BenchmarkFunctionName}") for a in arns), (
         f"ReleaseRole.UpdateProdFunction in {CICD} must keep the base "
         "function:${BenchmarkFunctionName} ARN"
@@ -336,11 +336,37 @@ def test_script_default_family_matches_template_matrix():
     )
 
 
-def test_update_statements_enumerate_exact_arns():
-    # The issue #341 ruling: enumerated exact ARNs, no wildcard, in both
-    # Update statements (the invoke role's wildcard is a separate question).
-    for role, sid in (("DeployRole", "UpdateTestFunction"), ("ReleaseRole", "UpdateProdFunction")):
-        for arn in _update_statement_arns(role, sid):
+def test_invoke_role_enumerates_both_families():
+    # The invoke role dispatches (and CodeSha256-probes, issue #341) whatever
+    # variant a target's ``worker:`` block resolves, against either the prod or
+    # the test base function -- so it must enumerate both full families.
+    test_suffixes, prod_suffixes = _template_variant_suffixes()
+    arns = _statement_arns("BenchmarkInvokeRole", "InvokeBenchmarkFunctions")
+    families = [
+        ("${BenchmarkFunctionName}", sorted(prod_suffixes | _script_default_variants())),
+        ("${TestFunctionName}", sorted(test_suffixes)),
+    ]
+    for base, suffixes in families:
+        for suffix in ["", *suffixes]:
+            want = f"function:{base}{suffix}"
+            assert any(a.endswith(want) for a in arns), (
+                f"the benchmark harness can invoke/probe '{base}{suffix}' but "
+                f"BenchmarkInvokeRole.InvokeBenchmarkFunctions in {CICD} has no ARN "
+                f"ending '{want}' -- add the enumerated ARN (wildcards declined, issue #341)"
+            )
+
+
+def test_role_statements_enumerate_exact_arns():
+    # The issue #341 ruling: enumerated exact ARNs, no wildcard, in all three
+    # function-scoped statements (ConcurrencyProbe's "*" stays -- its actions
+    # take no resource-level scoping).
+    statements = (
+        ("DeployRole", "UpdateTestFunction"),
+        ("ReleaseRole", "UpdateProdFunction"),
+        ("BenchmarkInvokeRole", "InvokeBenchmarkFunctions"),
+    )
+    for role, sid in statements:
+        for arn in _statement_arns(role, sid):
             assert "*" not in arn, (
                 f"{role}.{sid} in {CICD} must enumerate exact ARNs, found wildcard: {arn}"
             )

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -11,6 +11,7 @@ skipped with a note, probe failures (IAM) warn loudly and skip.
 """
 
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -217,3 +218,129 @@ def test_variants_override(tmp_path):
     result2, log2 = _run_deploy(tmp_path / "sub2", extra_args=["--variants", ""])
     assert result2.returncode == 0
     assert _deployed(log2) == ["process-shard-test"]
+
+
+# --- IAM drift guard (issue #341) -------------------------------------------
+# The CI/CD roles' Update statements enumerate exact function ARNs (a
+# ${...FunctionName}* wildcard was proposed and declined), so every variant
+# suffix the deploy_lambda.sh family loop can target must have a matching
+# enumerated ARN in deployment/aws/benchmark_cicd.yaml or the deploy
+# WARN-and-skips it as stale.
+
+TEMPLATE = REPO / "deployment" / "aws" / "template.yaml"
+CICD = REPO / "deployment" / "aws" / "benchmark_cicd.yaml"
+
+
+def _load_cfn(path):
+    """Parse a CFN template, mapping short-form intrinsics (!Sub, !Ref, ...)
+    to {TagSuffix: value} dicts (same pattern as tests/test_lambda_build.py)."""
+    import yaml
+
+    class _CfnLoader(yaml.SafeLoader):
+        pass
+
+    def _cfn_multi(loader, tag_suffix, node):
+        if isinstance(node, yaml.ScalarNode):
+            return {tag_suffix: loader.construct_scalar(node)}
+        if isinstance(node, yaml.SequenceNode):
+            return {tag_suffix: loader.construct_sequence(node)}
+        return {tag_suffix: loader.construct_mapping(node)}
+
+    _CfnLoader.add_multi_constructor("!", _cfn_multi)
+    return yaml.load(path.read_text(), Loader=_CfnLoader)
+
+
+def _template_variant_suffixes():
+    """(test_suffixes, prod_suffixes) stamped by template.yaml's Fn::ForEach
+    loops over the WorkerMemorySizes matrix; test suffixes are relative to
+    TestFunctionName (= ``${FunctionName}-test``, the deploy target)."""
+    tpl = _load_cfn(TEMPLATE)
+    sizes = tpl["Parameters"]["WorkerMemorySizes"]["Default"].split(",")
+    test, prod = set(), set()
+    for key, val in tpl["Resources"].items():
+        if not key.startswith("Fn::ForEach::"):
+            continue
+        for resource in val[2].values():
+            fn = resource.get("Properties", {}).get("FunctionName")
+            pattern = fn.get("Sub", "") if isinstance(fn, dict) else ""
+            if "${WorkerMemory}" not in pattern:
+                continue
+            suffix = pattern.removeprefix("${FunctionName}")
+            for size in sizes:
+                stamped = suffix.replace("${WorkerMemory}", size)
+                if stamped.startswith("-test"):
+                    test.add(stamped.removeprefix("-test"))
+                else:
+                    prod.add(stamped)
+    assert test and prod, f"no Fn::ForEach variant loops found in {TEMPLATE}"
+    return test, prod
+
+
+def _update_statement_arns(role, sid):
+    """The !Sub ARN strings of the role's Sid=<sid> policy statement."""
+    tpl = _load_cfn(CICD)
+    statements = tpl["Resources"][role]["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
+    stmt = next(s for s in statements if s.get("Sid") == sid)
+    resource = stmt["Resource"]
+    items = resource if isinstance(resource, list) else [resource]
+    return [item["Sub"] if isinstance(item, dict) else item for item in items]
+
+
+def _script_default_variants():
+    match = re.search(r'^DEFAULT_VARIANTS="([^"]*)"', SCRIPT.read_text(), re.MULTILINE)
+    assert match, f"DEFAULT_VARIANTS not found in {SCRIPT}"
+    return set(match.group(1).split())
+
+
+def test_deploy_role_enumerates_test_stack_variants():
+    # Test-stack shape: base + every WorkerTestDiskVariants function.
+    test_suffixes, _ = _template_variant_suffixes()
+    arns = _update_statement_arns("DeployRole", "UpdateTestFunction")
+    assert any(a.endswith("function:${TestFunctionName}") for a in arns), (
+        f"DeployRole.UpdateTestFunction in {CICD} must keep the base "
+        "function:${TestFunctionName} ARN"
+    )
+    for suffix in sorted(test_suffixes):
+        want = "function:${TestFunctionName}" + suffix
+        assert any(a.endswith(want) for a in arns), (
+            f"deploy_lambda.sh targets test variant '{suffix}' but "
+            f"DeployRole.UpdateTestFunction in {CICD} has no ARN ending "
+            f"'{want}' -- add the enumerated ARN (wildcards declined, issue #341)"
+        )
+
+
+def test_release_role_enumerates_prod_variant_family():
+    # Prod family: base + plain and -disk variants for every memory size.
+    _, prod_suffixes = _template_variant_suffixes()
+    arns = _update_statement_arns("ReleaseRole", "UpdateProdFunction")
+    assert any(a.endswith("function:${BenchmarkFunctionName}") for a in arns), (
+        f"ReleaseRole.UpdateProdFunction in {CICD} must keep the base "
+        "function:${BenchmarkFunctionName} ARN"
+    )
+    for suffix in sorted(prod_suffixes | _script_default_variants()):
+        want = "function:${BenchmarkFunctionName}" + suffix
+        assert any(a.endswith(want) for a in arns), (
+            f"deploy_lambda.sh targets prod variant '{suffix}' but "
+            f"ReleaseRole.UpdateProdFunction in {CICD} has no ARN ending "
+            f"'{want}' -- add the enumerated ARN (wildcards declined, issue #341)"
+        )
+
+
+def test_script_default_family_matches_template_matrix():
+    # The script's DEFAULT_VARIANTS and template.yaml's prod variant loops are
+    # two copies of the same matrix; a size added to one must land in both.
+    _, prod_suffixes = _template_variant_suffixes()
+    assert _script_default_variants() == prod_suffixes, (
+        f"DEFAULT_VARIANTS in {SCRIPT} and the WorkerMemorySizes variant loops "
+        f"in {TEMPLATE} disagree -- update whichever is stale (issue #341)"
+    )
+
+
+def test_update_statements_enumerate_exact_arns():
+    # The issue #341 ruling: enumerated exact ARNs, no wildcard, in both
+    # Update statements (the invoke role's wildcard is a separate question).
+    for role, sid in (("DeployRole", "UpdateTestFunction"), ("ReleaseRole", "UpdateProdFunction")):
+        for arn in _update_statement_arns(role, sid):
+            assert "*" not in arn, (
+                f"{role}.{sid} in {CICD} must enumerate exact ARNs, found wildcard: {arn}"
+            )

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -540,6 +540,51 @@ def test_invoke_role_enumerates_both_families():
             )
 
 
+def test_benchmark_targets_resolve_only_provisioned_test_variants():
+    # Fold review: enumeration opened a reachable seam. ``_validate_worker``
+    # accepts ``{"memory": 4096}`` with NO ``extra_disk``, which resolves
+    # ``${TestFunctionName}-4096`` -- a name the test stack does not provision and
+    # the invoke role does not enumerate, so the sequence was probe ->
+    # AccessDenied -> warn-and-continue -> invoke -> AccessDenied again, as an
+    # opaque dispatch failure. The runtime half is now a loud pre-dispatch refusal
+    # (check_variant_current hard-fails when the base probes but the variant does
+    # not); this is the static half, so the "one targets.json edit away" case goes
+    # red in CI instead of costing an invoke to diagnose.
+    import json
+    import sys
+
+    sys.path.insert(0, str(REPO / ".github" / "scripts"))
+    import run_benchmark
+
+    manifest = json.loads((REPO / "tests" / "data" / "benchmark" / "targets.json").read_text())
+    test_suffixes, _ = _template_variant_suffixes()
+    arns = _statement_arns("BenchmarkInvokeRole", "InvokeBenchmarkFunctions")
+    checked = 0
+    for section in ("targets", "provisional_targets"):
+        for name, target in manifest.get(section, {}).items():
+            worker = target.get("worker") if isinstance(target, dict) else None
+            if not worker:
+                continue
+            checked += 1
+            # Resolve off an EMPTY base so the result is the bare suffix, using
+            # the harness's own rule rather than a copy of it.
+            suffix = run_benchmark.resolve_variant("", worker)
+            assert suffix in test_suffixes, (
+                f"benchmark target '{name}' has worker {worker!r}, which resolves "
+                f"'${{TestFunctionName}}{suffix}' -- a variant template.yaml does not "
+                f"provision for the test stack (it stamps {sorted(test_suffixes)}). The "
+                f"per-merge run would refuse at the pre-dispatch guard (issue #341); "
+                f"either set extra_disk, or provision + enumerate the variant."
+            )
+            want = "function:${TestFunctionName}" + suffix
+            assert any(a.endswith(want) for a in arns), (
+                f"benchmark target '{name}' resolves '{want}' but "
+                f"BenchmarkInvokeRole.InvokeBenchmarkFunctions in {CICD} does not "
+                f"enumerate it -- the probe and the invoke would both AccessDeny"
+            )
+    assert checked, "no benchmark target declares a worker: block -- guard is vacuous"
+
+
 def test_role_statements_enumerate_exact_arns():
     # The issue #341 ruling: enumerated exact ARNs, no wildcard, in all three
     # function-scoped statements (ConcurrencyProbe's "*" stays -- its actions

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -4,7 +4,10 @@ Runs the real script with a stub ``aws`` (no AWS) and asserts it issues the four
 calls in the required order with the right function/layer wiring: publish a layer
 version, point the function at it, wait, then update the code. The ordering (wait
 between the config + code updates) and the layer-from-S3 wiring are the parts that
-matter for a correct in-place deploy.
+matter for a correct in-place deploy. Since issue #341 the script also updates
+the worker-size variant family (``${FN}-<mem>[-disk]``) from the same layer/zip:
+each variant is probed with get-function-configuration; missing variants are
+skipped with a note, probe failures (IAM) warn loudly and skip.
 """
 
 import os
@@ -17,12 +20,23 @@ import pytest
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / ".github" / "scripts" / "deploy_lambda.sh"
 
+#: The template.yaml WorkerMemorySizes matrix the script defaults to (issue #341).
+FAMILY = ["-2048", "-4096", "-8192", "-2048-disk", "-4096-disk", "-8192-disk"]
+
 # Stub `aws`: log the full arg line; emit a LayerVersionArn on stdout for the
-# publish-layer-version call (the script captures it).
+# publish-layer-version call (the script captures it). get-function-configuration
+# probes succeed only for functions listed in $AWS_EXISTING (space-separated;
+# unset/empty means every probe succeeds); others 404 like the real CLI.
 STUB_AWS = """#!/bin/bash
 echo "$*" >> "$AWS_LOG"
 if [ "$2" = "publish-layer-version" ]; then
   echo "arn:aws:lambda:us-west-2:1:layer:demo-deps:7"
+fi
+if [ "$2" = "get-function-configuration" ] && [ -n "${AWS_EXISTING+x}" ]; then
+  case " $AWS_EXISTING " in
+    *" $4 "*) exit 0 ;;
+    *) echo "An error occurred (ResourceNotFoundException) when calling the GetFunctionConfiguration operation: Function not found: $4" >&2; exit 254 ;;
+  esac
 fi
 exit 0
 """
@@ -120,3 +134,86 @@ def test_missing_required_arg_errors(tmp_path):
         text=True,
     )
     assert result.returncode != 0
+
+
+def _run_deploy(tmp_path, stub=STUB_AWS, extra_args=(), existing=None):
+    """Run the script with the stub aws; return (result, aws log lines)."""
+    if shutil.which("bash") is None:
+        pytest.skip("bash unavailable")
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents=True)
+    (bindir / "aws").write_text(stub)
+    (bindir / "aws").chmod(0o755)
+    fn_zip = tmp_path / "fn.zip"
+    fn_zip.write_bytes(b"zip")
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "AWS_LOG": str(tmp_path / "aws.log"),
+    }
+    if existing is not None:
+        env["AWS_EXISTING"] = " ".join(existing)
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--function", "process-shard-test", "--layer-bucket", "b"]
+        + ["--layer-key", "k", "--function-zip", str(fn_zip), "--region", "us-west-2"]
+        + list(extra_args),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    log = (tmp_path / "aws.log").read_text().splitlines() if (tmp_path / "aws.log").exists() else []
+    return result, log
+
+
+def _deployed(log):
+    """Function names whose code was updated, in call order."""
+    return [
+        line.split("--function-name ")[1].split()[0]
+        for line in log
+        if "update-function-code" in line
+    ]
+
+
+def test_variant_family_deployed_when_present(tmp_path):
+    # Issue #341: the whole worker-size family updates from the same zip. The
+    # test stack shape: only the -disk trio exists (template.yaml's
+    # WorkerTestDiskVariants loop); the plain-memory trio 404s and is skipped.
+    existing = [f"process-shard-test{s}" for s in ("-2048-disk", "-4096-disk", "-8192-disk")]
+    result, log = _run_deploy(tmp_path, existing=existing)
+    assert result.returncode == 0
+    # ONE layer publish, shared by the whole family.
+    assert len([line for line in log if "publish-layer-version" in line]) == 1
+    # Base first, then each existing variant; missing variants skipped.
+    assert _deployed(log) == ["process-shard-test", *existing]
+    # Every default-family variant was probed.
+    probed = [line for line in log if "get-function-configuration" in line]
+    assert len(probed) == len(FAMILY)
+    for missing in ("-2048", "-4096", "-8192"):
+        assert f"variant process-shard-test{missing} does not exist; skipping" in result.stdout
+
+
+def test_variant_probe_failure_warns_and_skips(tmp_path):
+    # A non-404 probe failure (e.g. the deploy role's IAM scoped to the base
+    # name only) must warn loudly and continue — never fail the base deploy,
+    # never silently skip (issue #341).
+    stub = STUB_AWS.replace(
+        'echo "An error occurred (ResourceNotFoundException) when calling the '
+        'GetFunctionConfiguration operation: Function not found: $4" >&2; exit 254',
+        'echo "An error occurred (AccessDeniedException) ..." >&2; exit 254',
+    )
+    result, log = _run_deploy(tmp_path, stub=stub, existing=[])
+    assert result.returncode == 0
+    assert _deployed(log) == ["process-shard-test"]  # base still deployed
+    assert "WARN: could not probe variant" in result.stderr
+    assert "lambda:GetFunctionConfiguration" in result.stderr
+
+
+def test_variants_override(tmp_path):
+    # --variants replaces the default family; empty string deploys base only.
+    result, log = _run_deploy(tmp_path, extra_args=["--variants", "-4096-disk"], existing=None)
+    assert result.returncode == 0
+    assert _deployed(log) == ["process-shard-test", "process-shard-test-4096-disk"]
+
+    result2, log2 = _run_deploy(tmp_path / "sub2", extra_args=["--variants", ""])
+    assert result2.returncode == 0
+    assert _deployed(log2) == ["process-shard-test"]

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -318,12 +318,42 @@ def _load_cfn(path):
     return yaml.load(path.read_text(), Loader=_CfnLoader)
 
 
+def _effective_worker_memory_sizes():
+    """The memory sizes the DEPLOYED stacks actually provision.
+
+    ``WorkerMemorySizes`` is a ``CommaDelimitedList`` *parameter*, so reading its
+    ``Default`` is only the effective matrix while nothing overrides it. It is
+    determinable here rather than assumed: ``stand_up.sh`` is the one in-repo
+    standup path and its ``--parameter-overrides`` list does not name the
+    parameter, which
+    :func:`test_standup_does_not_override_the_worker_memory_matrix` pins. A stack
+    stood up BY HAND with a different list is the stated residual — it would
+    provision variants nothing here probes or enumerates (the template's own
+    comment makes it a non-free-form knob: each size needs a matching
+    ``WorkerDiskTmp`` entry and memory+2048 <= 10240).
+    """
+    tpl = _load_cfn(TEMPLATE)
+    return [s.strip() for s in tpl["Parameters"]["WorkerMemorySizes"]["Default"].split(",")]
+
+
+def test_standup_does_not_override_the_worker_memory_matrix():
+    # Fold review: the drift guard compares against the parameter DEFAULT. That
+    # is the effective deployed matrix only while no standup path overrides it --
+    # assert that, so the boundary is guarded instead of assumed.
+    standup = (REPO / "deployment" / "aws" / "stand_up.sh").read_text()
+    assert "WorkerMemorySizes" not in standup, (
+        "stand_up.sh now sets WorkerMemorySizes, so the deployed variant matrix "
+        "no longer equals template.yaml's parameter Default -- point "
+        "_effective_worker_memory_sizes() at the override (issue #341)"
+    )
+
+
 def _template_variant_suffixes():
     """(test_suffixes, prod_suffixes) stamped by template.yaml's Fn::ForEach
     loops over the WorkerMemorySizes matrix; test suffixes are relative to
     TestFunctionName (= ``${FunctionName}-test``, the deploy target)."""
     tpl = _load_cfn(TEMPLATE)
-    sizes = tpl["Parameters"]["WorkerMemorySizes"]["Default"].split(",")
+    sizes = _effective_worker_memory_sizes()
     test, prod = set(), set()
     for key, val in tpl["Resources"].items():
         if not key.startswith("Fn::ForEach::"):

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -21,8 +21,9 @@ import pytest
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / ".github" / "scripts" / "deploy_lambda.sh"
 
-#: The template.yaml WorkerMemorySizes matrix the script defaults to (issue #341).
-FAMILY = ["-2048", "-4096", "-8192", "-2048-disk", "-4096-disk", "-8192-disk"]
+#: The script's default update set (issue #341): the template.yaml
+#: WorkerMemorySizes matrix plus the same-zip ``-extract`` twin (ExtractFn).
+FAMILY = ["-2048", "-4096", "-8192", "-2048-disk", "-4096-disk", "-8192-disk", "-extract"]
 
 #: The subset the TEST stack provisions (template.yaml's WorkerTestDiskVariants
 #: loop, -disk only), which lambda-benchmark.yml pins via --variants so the
@@ -194,8 +195,18 @@ def test_variant_family_deployed_when_present(tmp_path):
     # Every default-family variant was probed.
     probed = [line for line in log if "get-function-configuration" in line]
     assert len(probed) == len(FAMILY)
-    for missing in ("-2048", "-4096", "-8192"):
+    for missing in ("-2048", "-4096", "-8192", "-extract"):
         assert f"variant process-shard-test{missing} does not exist; skipping" in result.stdout
+
+
+def test_extract_twin_deployed_when_present(tmp_path):
+    # The prod shape: the -extract twin exists and gets the same layer + zip as
+    # the base. Before this it was updated only at standup (issue #341).
+    existing = ["process-shard-test", "process-shard-test-extract"]
+    result, log = _run_deploy(tmp_path, existing=existing)
+    assert result.returncode == 0
+    assert "process-shard-test-extract" in _deployed(log)
+    assert "STALE" not in result.stderr
 
 
 def test_test_deploy_variant_set_probes_nothing_absent(tmp_path):
@@ -333,6 +344,25 @@ def _template_variant_suffixes():
     return test, prod
 
 
+def _template_named_twins():
+    """Suffixes of the separately-NAMED functions template.yaml stamps off the
+    same code zip (not worker-size variants): today just ``-extract``
+    (``ExtractFn``, issue #148). These run the deployed zip, so #341's rule
+    ("deploy every function that runs the code zip") covers them."""
+    tpl = _load_cfn(TEMPLATE)
+    twins = set()
+    for key, val in tpl["Resources"].items():
+        if key.startswith("Fn::ForEach::") or val.get("Type") != "AWS::Lambda::Function":
+            continue
+        fn = val.get("Properties", {}).get("FunctionName")
+        pattern = fn.get("Sub", "") if isinstance(fn, dict) else ""
+        if not pattern.startswith("${FunctionName}-") or "${WorkerMemory}" in pattern:
+            continue
+        twins.add(pattern.removeprefix("${FunctionName}"))
+    assert twins, f"no same-zip named twins found in {TEMPLATE}"
+    return twins
+
+
 def _statement_arns(role, sid):
     """The !Sub ARN strings of the role's Sid=<sid> policy statement."""
     tpl = _load_cfn(CICD)
@@ -415,13 +445,45 @@ def test_release_role_enumerates_prod_variant_family():
 
 
 def test_script_default_family_matches_template_matrix():
-    # The script's DEFAULT_VARIANTS and template.yaml's prod variant loops are
-    # two copies of the same matrix; a size added to one must land in both.
+    # The script's DEFAULT_VARIANTS and template.yaml's same-zip functions are
+    # two copies of one list: the prod worker-size loops PLUS the separately
+    # named twins (-extract). A size or a twin added to one must land in both.
     _, prod_suffixes = _template_variant_suffixes()
-    assert _script_default_variants() == prod_suffixes, (
-        f"DEFAULT_VARIANTS in {SCRIPT} and the WorkerMemorySizes variant loops "
-        f"in {TEMPLATE} disagree -- update whichever is stale (issue #341)"
+    assert _script_default_variants() == prod_suffixes | _template_named_twins(), (
+        f"DEFAULT_VARIANTS in {SCRIPT} and the same-zip functions in {TEMPLATE} "
+        f"(WorkerMemorySizes variant loops + named twins like ExtractFn) disagree "
+        f"-- update whichever is stale (issue #341)"
     )
+
+
+def test_extract_twin_is_deployed_and_enumerated():
+    # espg ruling on the fold review: the -extract twin runs the same code zip
+    # and was never redeployed, so `${FunctionName}-extract` sat on standup-time
+    # code permanently -- issue #341's failure mode verbatim, on the live
+    # full-archive extraction pool (issue #148). It is now in the deploy set and
+    # enumerated on the release role. The INVOKE role deliberately is NOT
+    # extended: the twin is reached by explicit function_name=, never by the
+    # benchmark harness's suffix resolution.
+    assert "-extract" in _template_named_twins()
+    assert "-extract" in _script_default_variants(), (
+        f"template.yaml stamps a -extract twin off the same code zip but {SCRIPT} "
+        f"does not deploy it -- it would stay on standup-time code (issue #341)"
+    )
+    prod = _statement_arns("ReleaseRole", "UpdateProdFunction")
+    want = "function:${BenchmarkFunctionName}-extract"
+    assert any(a.endswith(want) for a in prod), (
+        f"ReleaseRole.UpdateProdFunction in {CICD} has no ARN ending '{want}' -- "
+        f"the release deploy would WARN-and-skip the twin as STALE (issue #341)"
+    )
+    invoke = _statement_arns("BenchmarkInvokeRole", "InvokeBenchmarkFunctions")
+    assert not [a for a in invoke if a.endswith("-extract")], (
+        "the benchmark harness never invokes the -extract twin; keep it out of "
+        "InvokeBenchmarkFunctions (least privilege, issue #341)"
+    )
+    # The test stack has no -test-extract twin, so the pinned test-deploy set
+    # must not probe one (it would AccessDeny and cry STALE -- see the
+    # test-deploy variant-set guard above).
+    assert "-extract" not in _workflow_variants()
 
 
 def test_invoke_role_enumerates_both_families():
@@ -430,8 +492,12 @@ def test_invoke_role_enumerates_both_families():
     # the test base function -- so it must enumerate both full families.
     test_suffixes, prod_suffixes = _template_variant_suffixes()
     arns = _statement_arns("BenchmarkInvokeRole", "InvokeBenchmarkFunctions")
+    # The named twins in DEFAULT_VARIANTS (-extract) are DEPLOY targets, not
+    # harness-resolvable variants -- no ``worker:`` block can name one, so the
+    # invoke role must NOT enumerate them (least privilege, issue #341).
+    resolvable = _script_default_variants() - _template_named_twins()
     families = [
-        ("${BenchmarkFunctionName}", sorted(prod_suffixes | _script_default_variants())),
+        ("${BenchmarkFunctionName}", sorted(prod_suffixes | resolvable)),
         ("${TestFunctionName}", sorted(test_suffixes)),
     ]
     for base, suffixes in families:

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -371,6 +371,38 @@ class TestSemanticManifest:
         assert "predates semantic hashing" in caplog.text
         assert hive.read_manifest(str(root))["semantic_hash"] == fresh["semantic_hash"]
 
+    def test_overwrite_dropping_a_hash_from_a_hashed_store_warns(self, cfg, tmp_path, caplog):
+        # Fold review: the exemption in ``_frozen_matches`` is symmetric (either
+        # side missing the hash drops it from the comparison), so the guard must
+        # be too. This is the REVERSE direction — the existing store carries a
+        # hash and this run's manifest does not — which un-provenances a #299
+        # store rather than merely failing to verify one. Latent today
+        # (build_manifest always stamps) but the strictly worse direction.
+        root = tmp_path / "store"
+        grid = self._grid(cfg)
+        hive.ensure_manifest(str(root), hive.build_manifest(grid))
+        (root / "-5" / "1").mkdir(parents=True)
+        (root / "-5" / "1" / "obj").write_text("x")
+        unhashed = hive.build_manifest(grid)
+        del unhashed["semantic_hash"]
+        with caplog.at_level("WARNING"):
+            hive.ensure_manifest(str(root), unhashed, overwrite=True)
+        assert "DROPS the recorded hash" in caplog.text
+        assert "un-provenanced" in caplog.text
+
+    def test_overwrite_both_hashes_present_is_silent(self, cfg, tmp_path, caplog):
+        # Both sides hashed and equal -> the comparison actually happened, so
+        # neither exemption warning fires (the normal resume/redo path).
+        root = tmp_path / "store"
+        grid = self._grid(cfg)
+        hive.ensure_manifest(str(root), hive.build_manifest(grid))
+        (root / "-5" / "1").mkdir(parents=True)
+        (root / "-5" / "1" / "obj").write_text("x")
+        with caplog.at_level("WARNING"):
+            hive.ensure_manifest(str(root), hive.build_manifest(grid), overwrite=True)
+        assert "semantic hash" not in caplog.text
+        assert "predates semantic hashing" not in caplog.text
+
     def test_overwrite_pre_hash_store_empty_tree_is_silent(self, cfg, tmp_path, caplog):
         # No shard data -> nothing whose compatibility could be in question;
         # the manifest is simply replaced (hash stamped), no warning.

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -730,6 +730,38 @@ class TestLeafTemplateAndStamp:
         # Walker termination: no leaf at all is the same answer as debris.
         assert hive.read_commit(MemoryStore()) is None
 
+    def test_leaf_clear_under_a_live_writer_leaves_debris_not_corruption(self, cfg):
+        # Fold review on the clear-first template: the redundant-duplicate-writer
+        # window WIDENED, and this pins what it widened to.
+        #
+        # Two live workers on one shard is reachable — dispatch classifies
+        # retryability off the Invoke call's exception string, and an Event invoke
+        # Lambda accepted whose HTTP response timed out is indistinguishable from
+        # one it never got. Writer A commits and stamps; writer B (the redundant
+        # retry) re-templates and dies mid-write.
+        #
+        # Pre-#341 the leaf would still hold A's objects under A's stamp
+        # (stale-but-complete). Now B's clear removes them first, so the leaf is
+        # EMPTY and UNSTAMPED. That is a real loss of an already-successful leaf —
+        # but not silent corruption: the stamp is written last, so read_commit
+        # reports debris and the shard stays re-dispatchable, which is the property
+        # the walker and the retry model actually depend on.
+        store = MemoryStore()
+        g = self._grid(cfg)
+
+        # Writer A: template, write, stamp -> complete.
+        g.emit_shard_template(store, overwrite=True)
+        self._put(store, f"{g.group_path}/h_max/c/0")
+        hive.stamp_commit(store, cells_with_data=5, granule_count=2)
+        assert hive.read_commit(store)["complete"] is True
+
+        # Writer B: re-templates the same leaf (the clear fires) and then dies
+        # before writing anything or stamping.
+        g.emit_shard_template(store, overwrite=True)
+
+        assert not self._exists(store, f"{g.group_path}/h_max/c/0")  # A's data is gone
+        assert hive.read_commit(store) is None  # ...and it reads as debris, not complete
+
 
 # ── local write path (runner) ────────────────────────────────────────────────
 

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -335,6 +335,56 @@ class TestSemanticManifest:
         with pytest.raises(ValueError, match="does not match this run"):
             hive.validate_manifest(root, other)
 
+    def test_overwrite_semantic_mismatch_refuses_over_existing_shards(self, cfg, tmp_path):
+        # Issue #341 hash-guard ruling: overwrite does NOT bypass the
+        # semantic-hash refusal — the hash is a frozen key, so a changed
+        # aggregation block over a data-carrying store refuses even with
+        # overwrite=True (same posture as an orders change).
+        import copy
+
+        root = tmp_path / "store"
+        hive.ensure_manifest(str(root), hive.build_manifest(self._grid(cfg)))
+        (root / "-5" / "1").mkdir(parents=True)
+        (root / "-5" / "1" / "obj").write_text("x")
+        other_cfg = copy.deepcopy(cfg)
+        other_cfg.aggregation["variables"]["count"]["dtype"] = "int64"
+        other = hive.build_manifest(self._grid(other_cfg))
+        with pytest.raises(ValueError, match="clear the store root first"):
+            hive.ensure_manifest(str(root), other, overwrite=True)
+
+    def test_overwrite_pre_hash_store_with_data_warns_and_stamps_hash(self, cfg, tmp_path, caplog):
+        # Issue #341: a pre-#299 manifest carries no hash, so the frozen
+        # comparison EXEMPTS it and overwrite proceeds — the one legitimate
+        # bypass. It must be loud (semantic compatibility of the existing data
+        # is unverifiable) and must leave a coherent manifest: the rewrite
+        # stamps the run's hash.
+        root = tmp_path / "store"
+        grid = self._grid(cfg)
+        old = hive.build_manifest(grid)
+        del old["semantic_hash"]
+        hive.ensure_manifest(str(root), old)
+        (root / "-5" / "1").mkdir(parents=True)
+        (root / "-5" / "1" / "obj").write_text("x")
+        fresh = hive.build_manifest(grid)
+        with caplog.at_level("WARNING"):
+            hive.ensure_manifest(str(root), fresh, overwrite=True)
+        assert "predates semantic hashing" in caplog.text
+        assert hive.read_manifest(str(root))["semantic_hash"] == fresh["semantic_hash"]
+
+    def test_overwrite_pre_hash_store_empty_tree_is_silent(self, cfg, tmp_path, caplog):
+        # No shard data -> nothing whose compatibility could be in question;
+        # the manifest is simply replaced (hash stamped), no warning.
+        root = str(tmp_path / "store")
+        grid = self._grid(cfg)
+        old = hive.build_manifest(grid)
+        del old["semantic_hash"]
+        hive.ensure_manifest(root, old)
+        fresh = hive.build_manifest(grid)
+        with caplog.at_level("WARNING"):
+            hive.ensure_manifest(root, fresh, overwrite=True)
+        assert "predates semantic hashing" not in caplog.text
+        assert hive.read_manifest(root)["semantic_hash"] == fresh["semantic_hash"]
+
     def test_grouping_mismatch_refuses(self, cfg, tmp_path):
         # path_grouping IS frozen (path shape): an explicit different value
         # refuses; only ABSENT normalizes to 1.
@@ -486,6 +536,87 @@ class TestLeafTemplateAndStamp:
         g = self._grid(cfg)
         g.emit_shard_template(store, overwrite=True)
         g.emit_shard_template(store, overwrite=True)  # retry over debris
+
+    @staticmethod
+    def _put(store, key, payload=b"\x00" * 16):
+        from zarr.core.buffer import default_buffer_prototype
+        from zarr.core.sync import sync
+
+        sync(store.set(key, default_buffer_prototype().buffer.from_bytes(payload)))
+
+    @staticmethod
+    def _exists(store, key):
+        from zarr.core.sync import sync
+
+        return sync(store.exists(key))
+
+    def test_overwrite_survives_orphan_member_dir(self, cfg):
+        # Issue #341 (Bug A regression): a member dir holding chunk objects but
+        # no zarr.json — the shape the post-#337 ``cell_ids`` orphan left, which
+        # the store walk died on ("No array found in store ... at path
+        # 19/cell_ids") — must never kill the re-template. The leaf prefix is
+        # cleared wholesale up front, so the walk never parses the orphan.
+        store = MemoryStore()
+        g = self._grid(cfg)
+        g.emit_shard_template(store, overwrite=True)
+        self._put(store, f"{g.group_path}/cell_ids/c/0")  # orphan: chunks, no zarr.json
+        g.emit_shard_template(store, overwrite=True)  # must not raise
+        assert not self._exists(store, f"{g.group_path}/cell_ids/c/0")  # and it is gone
+
+    def test_overwrite_clears_retired_members(self, cfg):
+        # Issue #341 (Bug A): schema narrowing over an existing leaf round-trips
+        # clean — the retired member's metadata AND chunk objects are deleted,
+        # not left masquerading as data.
+        import copy
+
+        store = MemoryStore()
+        g = self._grid(cfg)
+        g.emit_shard_template(store, overwrite=True)
+        self._put(store, f"{g.group_path}/h_max/c/0")  # data in the member being dropped
+
+        cfg2 = copy.deepcopy(cfg)
+        del cfg2.aggregation["variables"]["h_max"]
+        g2 = HealpixGrid(parent_order=6, child_order=8, layout="fullsphere", config=cfg2)
+        g2.emit_shard_template(store, overwrite=True)
+
+        assert not self._exists(store, f"{g.group_path}/h_max/zarr.json")
+        assert not self._exists(store, f"{g.group_path}/h_max/c/0")
+        grp = zarr.open_group(store, path=g2.group_path, mode="r", zarr_format=3)
+        members = dict(grp.members())
+        assert "h_max" not in members
+        for name in ("morton", *get_data_vars(cfg2)):
+            assert grp[name].shape == (g2.cells_per_shard,)
+
+    def test_overwrite_clears_coverage_sidecar_without_warning(self, cfg):
+        # The pre-#341 overwrite walked the existing prefix and warned on the
+        # coverage sidecar (suppressed at the call site); the clear-first
+        # template deletes it silently — no enumeration warning at all.
+        import warnings as _warnings
+
+        store = MemoryStore()
+        g = self._grid(cfg)
+        g.emit_shard_template(store, overwrite=True)
+        self._put(store, hive.COVERAGE_SIDECAR)
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            g.emit_shard_template(store, overwrite=True)
+        assert not self._exists(store, hive.COVERAGE_SIDECAR)
+        assert not [w for w in caught if hive.COVERAGE_SIDECAR in str(w.message)]
+
+    def test_overwrite_clear_is_scoped_to_the_leaf(self, cfg, tmp_path):
+        # The store handed to emit_shard_template is rooted AT the leaf, so the
+        # up-front clear can only touch the leaf prefix — sibling objects (the
+        # run's ``.zarr.status/`` results live outside the leaf) survive.
+        from zagg.store import open_store
+
+        leaf = tmp_path / "leaf.zarr"
+        status = tmp_path / "leaf.zarr.status"
+        status.mkdir()
+        (status / "r.json").write_text("{}")
+        g = self._grid(cfg)
+        g.emit_shard_template(open_store(str(leaf)), overwrite=True)
+        g.emit_shard_template(open_store(str(leaf)), overwrite=True)
+        assert (status / "r.json").read_text() == "{}"
 
     def test_sharded_leaf_template_shards_whole_leaf(self, cfg):
         # issue #236: a sharded grid's leaf template wraps every dense array in

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -639,6 +639,13 @@ class TestLeafTemplateAndStamp:
         # The store handed to emit_shard_template is rooted AT the leaf, so the
         # up-front clear can only touch the leaf prefix — sibling objects (the
         # run's ``.zarr.status/`` results live outside the leaf) survive.
+        #
+        # NOTE (fold review): ``open_store`` on a non-s3 path returns a zarr
+        # ``LocalStore``, whose ``delete_dir("")`` is ``shutil.rmtree(root)`` —
+        # so on THIS backend the sibling is safe by filesystem semantics and this
+        # assertion cannot fail whatever the code does. It pins the local/debug
+        # path only; the prefix-string hazard lives on the fleet's obstore-backed
+        # store and is pinned by the test below.
         from zagg.store import open_store
 
         leaf = tmp_path / "leaf.zarr"
@@ -649,6 +656,49 @@ class TestLeafTemplateAndStamp:
         g.emit_shard_template(open_store(str(leaf)), overwrite=True)
         g.emit_shard_template(open_store(str(leaf)), overwrite=True)
         assert (status / "r.json").read_text() == "{}"
+
+    def test_overwrite_clear_is_scoped_on_an_obstore_prefix_store(self, cfg, tmp_path):
+        # Fold review: the real hazard is STRING-prefix, and it only exists on the
+        # fleet backend — ``open_store("s3://…")`` builds
+        # ``zarr.storage.ObjectStore(store=S3Store(bucket, prefix=…))``, and
+        # zarr's ``ObjectStore.delete_dir`` deliberately leaves the EMPTY prefix
+        # un-slashed, so scoping rests entirely on obstore's prefix store
+        # re-adding the delimiter. It does (obstore's ``PrefixStore`` resolves
+        # ``list(None)`` to the store's own prefix path and object_store's
+        # ``format_prefix`` appends DELIMITER), but that is a property of two
+        # third-party layers and no test here could regress it: every other
+        # delete_dir test uses MemoryStore or zarr LocalStore, neither of which
+        # can. This pins it against an obstore/zarr bump, using obstore's own
+        # LocalStore in prefix mode — the same ``ObjectStore`` + prefix-store
+        # composition the S3 path uses.
+        import obstore
+        from zarr.storage import ObjectStore
+
+        root = tmp_path / "root"
+        leaf = root / "12" / "34.zarr"
+        leaf.mkdir(parents=True)
+        # (a) a name-prefix sibling of the leaf: the adversarial shape a missing
+        # delimiter would sweep up.
+        twin = root / "12" / "34.zarr.status"
+        twin.mkdir()
+        (twin / "r.json").write_text("{}")
+        # (b) the REAL geometry: status objects live beside the store ROOT,
+        # several digit-tree levels above any leaf.
+        real_status = tmp_path / "root.zarr.status" / "run-1"
+        real_status.mkdir(parents=True)
+        (real_status / "34.json").write_text("{}")
+
+        store = ObjectStore(store=obstore.store.LocalStore(prefix=str(leaf)))
+        g = self._grid(cfg)
+        g.emit_shard_template(store, overwrite=True)
+        self._put(store, f"{g.group_path}/h_max/c/0")  # in-leaf debris
+        g.emit_shard_template(store, overwrite=True)
+
+        # The clear really ran (otherwise the survival assertions are vacuous)...
+        assert not self._exists(store, f"{g.group_path}/h_max/c/0")
+        # ...and touched nothing outside the leaf prefix.
+        assert (twin / "r.json").read_text() == "{}"
+        assert (real_status / "34.json").read_text() == "{}"
 
     def test_sharded_leaf_template_shards_whole_leaf(self, cfg):
         # issue #236: a sharded grid's leaf template wraps every dense array in

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -584,10 +584,16 @@ class TestLeafTemplateAndStamp:
 
     def test_overwrite_survives_orphan_member_dir(self, cfg):
         # Issue #341 (Bug A regression): a member dir holding chunk objects but
-        # no zarr.json — the shape the post-#337 ``cell_ids`` orphan left, which
-        # the store walk died on ("No array found in store ... at path
-        # 19/cell_ids") — must never kill the re-template. The leaf prefix is
-        # cleared wholesale up front, so the walk never parses the orphan.
+        # no zarr.json — the shape a retired post-#337 ``cell_ids`` member leaves.
+        # The leaf prefix is cleared wholesale up front, so the re-template never
+        # parses the orphan and the objects do not survive as pseudo-data.
+        #
+        # NOTE (fold review): on the pinned zarr 3.2.1 the enumeration would
+        # warn-skip this orphan rather than raise, so this pins the WHOLESALE
+        # replacement (the orphan's chunks are gone), not a crash fix — the
+        # observed "No array found in store ... at path 19/cell_ids" came from the
+        # stale deploy on fresh stores, not from orphans. See
+        # HealpixGrid.emit_shard_template's docstring.
         store = MemoryStore()
         g = self._grid(cfg)
         g.emit_shard_template(store, overwrite=True)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -6049,7 +6049,91 @@ class TestReadErrorExemplars:
         )
         assert meta["error"] is None
         assert "read_errors" not in meta
+        assert "granule_errors" not in meta
         assert "read_error_exemplars" not in meta
+
+
+class TestGranuleScopeReadErrors:
+    """Fold review on issue #341: a fault that kills the WHOLE granule (H5Coro
+    open, credentials, URL rewrite, or the fold side) is warn-and-continue by
+    design, but it used to leave no trace at all in the result — no counter, no
+    exemplar, no traceback — so a shard whose every granule failed at granule
+    scope returned the blind ``"No data after filtering"``. It now counts into
+    ``granule_errors`` and feeds the same exemplar budget."""
+
+    def _patch_h5(self, monkeypatch, factory):
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", factory)
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+
+    def test_serial_granule_failure_is_counted_and_exemplared(self, monkeypatch):
+        # The credential/endpoint shape: H5Coro construction raises for every
+        # granule. Previously: read_errors absent, error == "No data after
+        # filtering". Now: counted, exemplared, and the scope is named.
+        def factory(*a, **k):
+            raise RuntimeError("h5coro open failed: expired token")
+
+        self._patch_h5(monkeypatch, factory)
+        _df, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=_release_cfg()
+        )
+        assert meta["granule_errors"] == 2
+        assert "read_errors" not in meta  # no GROUP read ever ran
+        assert meta["read_error_exemplars"] == ["RuntimeError: h5coro open failed: expired token"]
+        assert meta["error"] == (
+            "No data after filtering (2 granule reads raised; "
+            "e.g. RuntimeError: h5coro open failed: expired token)"
+        )
+
+    def test_pool_granule_failure_is_counted_and_exemplared(self, monkeypatch):
+        # Same, through the issue #180 granule pool (the failure surfaces from
+        # future.result() in the main thread rather than from the serial yield).
+        def factory(*a, **k):
+            raise RuntimeError("h5coro open failed under pool")
+
+        self._patch_h5(monkeypatch, factory)
+        cfg = _release_cfg()
+        cfg.data_source["granule_workers"] = 2
+        _df, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=cfg
+        )
+        assert meta["granule_errors"] == 2
+        assert meta["read_error_exemplars"] == ["RuntimeError: h5coro open failed under pool"]
+
+    def test_first_distinct_granule_failure_logs_traceback(self, monkeypatch, caplog):
+        # The traceback was swallowed entirely at this scope; it now behaves like
+        # the group-scope handler (first distinct message carries exc_info).
+        import logging as _logging
+
+        def factory(*a, **k):
+            raise RuntimeError("boom open")
+
+        self._patch_h5(monkeypatch, factory)
+        with caplog.at_level(_logging.WARNING, logger="zagg.processing.worker"):
+            process_shard(
+                _ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=_release_cfg()
+            )
+        hits = [r for r in caplog.records if "Error processing file" in r.getMessage()]
+        assert len(hits) == 2
+        assert hits[0].exc_info  # first distinct: full traceback
+        assert not hits[1].exc_info  # repeat: one-liner
+
+    def test_both_scopes_are_reported_separately(self, monkeypatch):
+        # A shard failing at BOTH scopes names both counts, because the causes
+        # differ (schema/variable vs credentials/endpoint).
+        calls = {"n": 0}
+
+        def factory(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _PerGroupRaisingH5()
+            raise RuntimeError("open failed")
+
+        self._patch_h5(monkeypatch, factory)
+        _df, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=_release_cfg()
+        )
+        assert meta["read_errors"] == 1 and meta["granule_errors"] == 1
+        assert "1 group reads raised, 1 granule reads raised" in meta["error"]
 
 
 class TestGranuleReadPool:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5935,9 +5935,121 @@ class TestProcessShardCacheRelease:
         assert len(closes) == 1
         # A raised read is a real error, NOT a legitimately-empty read (issue
         # #116): the shard reports the read-error path and counts the failure,
-        # rather than the misleading "No data after filtering".
-        assert meta["error"] == "No data after filtering (1 group reads raised)"
+        # rather than the misleading "No data after filtering". The error text
+        # carries the first distinct exception message (issue #341).
+        assert meta["error"] == (
+            "No data after filtering (1 group reads raised; "
+            "e.g. RuntimeError: byte-range read failed)"
+        )
         assert meta["read_errors"] == 1
+        assert meta["read_error_exemplars"] == ["RuntimeError: byte-range read failed"]
+
+
+class _PerGroupRaisingH5:
+    """Stub whose every group read raises, message keyed on the group name."""
+
+    def readDatasets(self, datasets):  # noqa: N802 (mirror real h5coro API)
+        d = datasets[0]
+        path = d["dataset"] if isinstance(d, dict) else d
+        raise RuntimeError(f"boom {path.split('/')[1]}")
+
+    def close(self):
+        pass
+
+
+class TestReadErrorExemplars:
+    """Issue #341: the first N distinct group-read exception messages ride the
+    result payload (``read_error_exemplars``) and the no-data error text, and
+    the FIRST occurrence of each distinct message logs its full traceback at
+    WARNING (repeats keep the one-line warning). Bounded: N=3 distinct, ~300
+    chars each, no tracebacks on the wire."""
+
+    def _patch_h5(self, monkeypatch, factory):
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", factory)
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+
+    @staticmethod
+    def _multi_group_cfg(groups):
+        from zagg.config import PipelineConfig
+
+        return PipelineConfig(
+            data_source={
+                "groups": list(groups),
+                "coordinates": {"latitude": "/{group}/lat", "longitude": "/{group}/lon"},
+                "variables": {"h_li": "/{group}/h_li"},
+            },
+            aggregation={
+                "variables": {"count": {"function": "len", "dtype": "int32", "fill_value": 0}}
+            },
+        )
+
+    def test_exemplars_capped_distinct_and_in_error_text(self, monkeypatch):
+        # 5 groups -> 5 distinct failures; the payload carries the FIRST 3
+        # (group order — the serial loop is deterministic), the counter all 5.
+        self._patch_h5(monkeypatch, lambda *a, **k: _PerGroupRaisingH5())
+        cfg = self._multi_group_cfg(["gt1l", "gt1r", "gt2l", "gt2r", "gt3l"])
+        _df, meta = process_shard(_ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=cfg)
+        assert meta["read_errors"] == 5
+        assert meta["read_error_exemplars"] == [
+            "RuntimeError: boom gt1l",
+            "RuntimeError: boom gt1r",
+            "RuntimeError: boom gt2l",
+        ]
+        assert meta["error"] == (
+            "No data after filtering (5 group reads raised; "
+            "e.g. RuntimeError: boom gt1l | RuntimeError: boom gt1r | RuntimeError: boom gt2l)"
+        )
+
+    def test_exemplars_dedupe_by_message(self, monkeypatch):
+        # Two granules failing the same group with the same message: counted
+        # twice, exemplared once (the strata run's 121-identical-failures shape).
+        self._patch_h5(monkeypatch, lambda *a, **k: _PerGroupRaisingH5())
+        cfg = self._multi_group_cfg(["gt1l"])
+        _df, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=cfg
+        )
+        assert meta["read_errors"] == 2
+        assert meta["read_error_exemplars"] == ["RuntimeError: boom gt1l"]
+
+    def test_exemplar_messages_truncated(self, monkeypatch):
+        class _LongRaisingH5:
+            def readDatasets(self, datasets):  # noqa: N802
+                raise RuntimeError("x" * 1000)
+
+            def close(self):
+                pass
+
+        self._patch_h5(monkeypatch, lambda *a, **k: _LongRaisingH5())
+        cfg = self._multi_group_cfg(["gt1l"])
+        _df, meta = process_shard(_ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=cfg)
+        (msg,) = meta["read_error_exemplars"]
+        assert len(msg) == 300
+        assert msg.startswith("RuntimeError: xxx")
+
+    def test_first_distinct_failure_logs_traceback(self, monkeypatch, caplog):
+        # The full traceback was previously swallowed entirely (issue #341):
+        # the first occurrence of each distinct message now logs exc_info at
+        # WARNING; repeats keep the one-line warning (so the issue #175 metric
+        # filter fires at most N times per shard).
+        import logging as _logging
+
+        self._patch_h5(monkeypatch, lambda *a, **k: _PerGroupRaisingH5())
+        cfg = self._multi_group_cfg(["gt1l"])
+        with caplog.at_level(_logging.WARNING, logger="zagg.processing.worker"):
+            process_shard(_ReleaseGrid(), 0, ["s3://a", "s3://b"], s3_credentials={}, config=cfg)
+        records = [r for r in caplog.records if "Error reading track" in r.getMessage()]
+        assert len(records) == 2
+        assert records[0].exc_info  # first distinct: full traceback
+        assert not records[1].exc_info  # repeat: one-liner, no traceback
+
+    def test_success_path_payload_unchanged(self, monkeypatch):
+        self._patch_h5(monkeypatch, lambda *a, **k: _CloseRecordingH5(_canned_arrays(), []))
+        _df, meta = process_shard(
+            _ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=_release_cfg()
+        )
+        assert meta["error"] is None
+        assert "read_errors" not in meta
+        assert "read_error_exemplars" not in meta
 
 
 class TestGranuleReadPool:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5958,11 +5958,12 @@ class _PerGroupRaisingH5:
 
 
 class TestReadErrorExemplars:
-    """Issue #341: the first N distinct group-read exception messages ride the
-    result payload (``read_error_exemplars``) and the no-data error text, and
-    the FIRST occurrence of each distinct message logs its full traceback at
-    WARNING (repeats keep the one-line warning). Bounded: N=3 distinct, ~300
-    chars each, no tracebacks on the wire."""
+    """Issue #341: the first ``_EXEMPLAR_LIMIT`` distinct group-read exception
+    messages ride the result payload (``read_error_exemplars``) and the no-data
+    error text (bounded: 3 distinct, ~300 chars each, no tracebacks on the wire).
+    The traceback budget is SEPARATE and larger (``_TRACEBACK_LIMIT``): the first
+    occurrence of each of the first 5 distinct messages logs its full traceback
+    at WARNING, repeats keep the one-line warning."""
 
     def _patch_h5(self, monkeypatch, factory):
         monkeypatch.setattr("zagg.processing.h5coro.H5Coro", factory)
@@ -6041,6 +6042,37 @@ class TestReadErrorExemplars:
         assert len(records) == 2
         assert records[0].exc_info  # first distinct: full traceback
         assert not records[1].exc_info  # repeat: one-liner, no traceback
+
+    def test_traceback_budget_is_decoupled_from_the_exemplar_budget(self, monkeypatch, caplog):
+        # Fold review: ``fresh`` gated BOTH the exemplar list and exc_info, so
+        # the 4th distinct message got neither a message nor a traceback. On a
+        # shard where the first three failures are transient noise and the fourth
+        # is the real cause, the real cause was invisible. The payload cap stays
+        # at 3; the traceback cap is _TRACEBACK_LIMIT (5).
+        import logging as _logging
+
+        from zagg.processing.worker import _EXEMPLAR_LIMIT, _TRACEBACK_LIMIT
+
+        assert _TRACEBACK_LIMIT > _EXEMPLAR_LIMIT
+        groups = ["gt1l", "gt1r", "gt2l", "gt2r", "gt3l", "gt3r"]  # 6 distinct messages
+        self._patch_h5(monkeypatch, lambda *a, **k: _PerGroupRaisingH5())
+        cfg = self._multi_group_cfg(groups)
+        with caplog.at_level(_logging.WARNING, logger="zagg.processing.worker"):
+            _df, meta = process_shard(_ReleaseGrid(), 0, ["s3://a"], s3_credentials={}, config=cfg)
+        # Payload still bounded at 3 distinct messages...
+        assert len(meta["read_error_exemplars"]) == _EXEMPLAR_LIMIT
+        # ...but 5 distinct messages carried a traceback, including the 4th and
+        # 5th, which under the coupled budget had none.
+        traced = [r.getMessage() for r in caplog.records if "Error reading track" in r.getMessage()]
+        with_tb = [
+            r.getMessage()
+            for r in caplog.records
+            if "Error reading track" in r.getMessage() and r.exc_info
+        ]
+        assert len(traced) == len(groups)
+        assert len(with_tb) == _TRACEBACK_LIMIT
+        assert any("gt2r" in m for m in with_tb)  # the 4th distinct message
+        assert not any("gt3r" in m for m in with_tb)  # the 6th is past the cap
 
     def test_success_path_payload_unchanged(self, monkeypatch):
         self._patch_h5(monkeypatch, lambda *a, **k: _CloseRecordingH5(_canned_arrays(), []))


### PR DESCRIPTION
Closes #341
Refs #148

Three-phase fix pass for the two defects surfaced by benchmark run 30503334617 and diagnosed on the issue thread: the root cause of Bug B was the **deploy-variant gap** (the `-4096-disk` worker ran standup-time code — see the [diagnosis comment](https://github.com/englacial/zagg/issues/341#issuecomment-5125324032); the read stack is exonerated), and Bug A is the orphan-tolerance / overwrite-coherence gap on hive leaves.

**Scope note (CLAUDE.md §1):** `.github/scripts/deploy_lambda.sh`, `.github/scripts/run_benchmark.py`, `.github/workflows/publish.yml` (and `lambda-benchmark.yml` if its plumbing needed it) were explicitly named in scope by espg (2026-07-30, on-session), satisfying §1's naming requirement for CI/deploy files. `deployment/aws/benchmark_cicd.yaml` was subsequently named in scope by espg (2026-07-29, in-session) for phase 4's IAM ruling (both the deploy/release-role gap and, in a follow-up ruling the same day, the invoke-role wildcards). `lambda-benchmark.yml` needed no change through phase 4; the **fold-review round** did change it — one added `--variants` argument on the existing deploy step (plus a comment), under espg's "if its plumbing needed it" clause. No trigger, job, or step logic changed. `publish.yml`'s diff is a comment on the existing `deploy-prod` step only (no trigger, job, or step logic changed); its fix first *exercises* on the next release tag.

## Phases

- [x] **Phase 1 — worker read-error exemplars** (`src/zagg/processing/worker.py`, `src/zagg/schema.py`). The per-group read-error counter now carries evidence: the first **3 distinct** exception messages (each truncated to 300 chars, deduped by message, thread-safe under the issue #180 granule pool) ride the result payload as `read_error_exemplars`, and the no-data error text becomes `"No data after filtering (N group reads raised; e.g. <msg> | <msg> | <msg>)"`. The first occurrence of each distinct message also logs its **full traceback at WARNING** (previously swallowed entirely); repeats keep the one-line warning, so the issue #175 `WorkerErrorCount` metric filter (which matches `Traceback`) fires a bounded number of times per shard instead of once per failed group read. (Fold review decoupled the two budgets: payload stays 3 distinct messages, tracebacks go to 5 — `_TRACEBACK_LIMIT`.) Success-path payloads are unchanged. This would have made the 121-failure strata run a one-glance `AttributeError: 'dict' object has no attribute 'format'` diagnosis.

- [x] **Phase 2 — deploy-variant gap + staleness guard** (`.github/scripts/deploy_lambda.sh`, `.github/scripts/run_benchmark.py`, `.github/workflows/publish.yml` comment).
  - `deploy_lambda.sh` now updates the **whole worker-size variant family** from the same layer version + zip: after the base function (unchanged hard-required semantics), it iterates the `template.yaml` `WorkerMemorySizes` matrix (`-2048 -4096 -8192`, plain + `-disk`), probing each `${FN}${suffix}` with `get-function-configuration`. Present → the same config/wait/code/event-invoke sequence; `ResourceNotFoundException` → skipped with a note (the test stack only provisions the `-disk` trio, per `template.yaml`'s `WorkerTestDiskVariants` loop — whose own CAVEAT comment predicted exactly this gap); any other probe failure (IAM) → **loud stderr WARN** naming the variant as potentially stale, never a silent skip. `--variants "SUF1 SUF2"` overrides the family (`--variants ""` = base only).
  - `run_benchmark.py` gains `check_variant_current`: when a target's `worker:` block resolves a variant (the resolution seam at the former L213-218), the dispatch first compares the variant's `CodeSha256` against the base function's and **hard-fails** on mismatch, naming both hashes and the remediation ("redeploy the variant family"). A probe that itself fails degrades to warn-and-continue (third-party stacks without the wildcard permission still dispatch).
  - **IAM check (read-only, per instruction):** the benchmark **invoke** role in `deployment/aws/benchmark_cicd.yaml` carries `lambda:GetFunctionConfiguration` on both function families — as of phase 4 via **enumerated exact ARNs** (the former wildcards are gone) that cover every provisioned variant, so the guard stays **hard-fail** in our stack; the third-party degrade-to-warn path is unchanged. The deploy/release-role gap originally flagged under "Questions for review" (1) is closed by phase 4.
  - This is what unblocks the per-merge leg: per the [second diagnosis comment](https://github.com/englacial/zagg/issues/341#issuecomment-5125373641), every per-merge run stays red until a merge redeploys the variants via CI — which this phase makes the deploy script do.

- [x] **Phase 3 — Bug A: orphan tolerance + overwrite-clears-retired** (`src/zagg/grids/healpix.py`, `src/zagg/hive.py`).
  - **Reproduced first** (synthetic leaf: member with chunk objects, no `zarr.json`): on current zarr 3.2.1 the enumeration warn-skips the orphan, but the walk behavior is zarr-version-dependent and the *retired-member survival* is real on the store shapes the incident left. The fix removes the whole class: `emit_shard_template(store, overwrite=True)` now **clears the leaf prefix first** (`store.delete_dir("")` — the store is rooted at the leaf, so the delete is scoped to the leaf; `.zarr.status/` is a sibling prefix outside it — fold review replaced "by construction" with what is actually relied on, and added a test on the **obstore prefix backend** where the string-prefix hazard can bite). This makes D4's "replaced wholesale" literal: retired members of a narrowed schema (the post-#337 `cell_ids` orphans) are deleted before the new template lands, and pydantic-zarr's overwrite walk (`GroupSpec.like` → `Group.members()`) never parses a broken/orphan member dir — the walk that could die with `No array found in store ... at path 19/cell_ids` no longer has anything to die on. The `_leaf()` coverage-sidecar warning suppression became dead code and was removed (a test pins that no enumeration warning fires).
  - **Hash-guard ruling:** `overwrite=True` does **not** bypass the semantic-hash refusal — `semantic_hash` is a frozen key, so a changed aggregation block over a data-carrying store still raises `clear the store root first` (test added pinning it). The one legitimate bypass is a **pre-#299 manifest** (no hash → exempted from the frozen comparison so old stores stay resumable): that overwrite now proceeds **loudly** — a WARNING when shard data already exists (semantic compatibility unverifiable) — and leaves a coherent store: the manifest rewrite stamps the run's hash, and every re-dispatched leaf is re-templated wholesale. The residual (named in the warning): leaves the run does *not* rewrite may carry the old schema.

- [x] **Phase 4 — CI/CD role IAM: enumerated variant ARNs + drift guard** (`deployment/aws/benchmark_cicd.yaml`, `tests/test_deploy_lambda.py`, WARN-hint reword in `.github/scripts/deploy_lambda.sh`; commits 2b3686a + bf6fee9). Per the ruling — see resolved item (1) below — the proposed `${...FunctionName}*` wildcards were **declined**; all three function-scoped statements now enumerate exact ARNs from `template.yaml`'s `WorkerMemorySizes` matrix: `DeployRole.UpdateTestFunction` = base + the test-stack `WorkerTestDiskVariants` trio (`-2048-disk -4096-disk -8192-disk`); `ReleaseRole.UpdateProdFunction` = base + the full prod family (`-2048 -4096 -8192`, plain + `-disk`); `BenchmarkInvokeRole.InvokeBenchmarkFunctions` = both families (prod base+6, test base+3, 11 ARNs). No `*` remains in any of them (`ConcurrencyProbe`'s `Resource: "*"` stays — its actions take no resource-level scoping). All harness invokes/probes are **unqualified** (`$LATEST`; no `Qualifier=` anywhere in `runner.py`/`run_benchmark.py`/`concurrency.py`), so plain exact ARNs match and no `:qualifier` forms are needed; the enumerated invoke list covers every variant the phase-2 `CodeSha256` guard probes (all committed targets resolve `-4096-disk`), so the guard stays hard-fail. Drift guard: 5 tests in `tests/test_deploy_lambda.py` parse the template's `Fn::ForEach` loops (CFN-tag-tolerant loader, same pattern as `tests/test_lambda_build.py`), the script's `DEFAULT_VARIANTS`, and the three statements — a variant missing its enumerated ARN fails with a message naming the variant and the file to fix. The script's IAM-hint WARN now points at the enumerated lists instead of a `${FUNCTION}-*` family grant. **Both residuals originally listed here are closed by the fold-review round:** (a) the test-path plain-trio probe noise — `lambda-benchmark.yml` now pins `--variants` to the test-stack shape (`58e0850`); (b) the dropped `-extract` coverage — the twin is now deployed and enumerated on the release role (`19eb519`).

## Fold review (adversarial self-review round)

13 inline findings; 12 folded, 1 left standing. One commit per finding, tests in the same commit.

- [x] `2577d01` — **probe variants before the dispatch pool.** The guard moved from `run_target` into `main`'s pre-pool validation slot, so a stale variant refuses before `ensure_logged_in()`, before the pool, and before any sibling dispatch is billed. Distinct variants probed once via a new shared `resolve_variant` seam.
- [x] `e8c9641` — **degrade only on a base-probe failure.** Base OK + variant probe failing is the staleness signal under the enumeration ruling, so it hard-fails (naming `template.yaml` and `benchmark_cicd.yaml`); warn-and-continue survives only for a failing base probe. Plus a provenance stamp: new `variant_guard` record column (`verified`/`skipped`/`base`) and a PR-comment banner when the guard degrades (issue #296 shape).
- [x] `58e0850` — **pin the test-deploy variant set.** `lambda-benchmark.yml` passes `--variants "-2048-disk -4096-disk -8192-disk"`, killing three false "may now be STALE" warnings on every green deploy; drift test ties that argument to the template's test set *and* to the deploy role's ARNs. Also documents + tests the granted-`Get`/denied-`Update` abort.
- [x] `34c8607` — **instrument granule-scope read failures.** The three sibling handlers (serial, pool, fold-side) now count into a new `granule_errors` and feed the exemplar/traceback machinery, so a credential/endpoint fault no longer returns the blind "No data after filtering". Error text names the scope.
- [x] `19eb519` — **deploy and enumerate the `-extract` twin** (espg ruling; `Refs #148`). In `DEFAULT_VARIANTS` + `ReleaseRole.UpdateProdFunction`; deliberately **not** on the invoke role or the test deploy set; drift guard discovers same-zip named twins from the template.
- [x] `c95cfa2` — **symmetric semantic-hash exemption warning.** The reverse direction (existing store hashed, this run not) un-provenances a #299 store and now warns with direction-appropriate text.
- [x] `dbd14e3` — **traceback budget decoupled from the exemplar budget** (`_TRACEBACK_LIMIT = 5` vs `_EXEMPLAR_LIMIT = 3`), so the 4th distinct failure no longer loses both its message and its traceback.
- [x] `37e8b61` — **leaf-clear scoping pinned on the obstore prefix backend**, where the string-prefix hazard actually lives; the `LocalStore` test's comment now says what it can and cannot fail on.
- [x] `d076814` — **deployed matrix, not just the parameter default**: `stand_up.sh` is asserted not to override `WorkerMemorySizes`, converting an invisible gap into a guarded boundary.
- [x] `d1db8ba` — **widened duplicate-writer window stated and pinned.** The clear-first template lets a redundant retry destroy an already-committed leaf; the comment records the mechanism and the lever not taken (D4), and a test pins "debris, re-dispatchable" rather than silent corruption.
- [x] `86b6f6f` — **leaf-clear rationale matched to the evidence.** The observed `19/cell_ids` signature was the stale deploy on fresh stores; on pinned zarr 3.2.1 an orphan member warn-skips rather than raising (verified). The issue's layer (1) — walker resilience — is recorded as dropped: zagg owns no `members()` walk to harden.
- [x] `12b7084` — **targets guarded against un-provisioned test variants**, closing the `worker: {memory: X}`-without-`extra_disk` seam statically (the runtime half is `e8c9641`).
- [ ] **Left standing for @espg:** hoisting the `CodeSha256` guard into `zagg.runner._resolve_function_name` so operator `agg()` runs are covered too. Genuine scope expansion (a new AWS call on the production dispatch path); the production `-4096-disk` variant is stale *now* and the no-hand-redeploy ruling keeps that window open until the next tag, so it is worth a follow-up call rather than a silent fold. Details on the [thread](https://github.com/englacial/zagg/pull/345#discussion_r3680575461).

Also left standing (raised by the reviewer as an option, declined as a design call not a fold): asserting that *every* `(memory, extra_disk)` combination `_validate_worker` accepts resolves to an enumerated **test** ARN. It fails today, and its two exits — provision the test plain trio, or narrow `WORKER_MEMORIES`/the validator for the test leg — are @espg's call.

Gates after the fold round: `ruff check src tests .github/scripts` and `ruff format --check` clean on every touched file; full suite `2622 passed, 35 skipped` (excluding `tests/test_processing.py`, run separately: `228 passed`). Two **pre-existing** failures unrelated to this PR and deliberately not touched (§4): `N818` in `src/zagg/registry.py`, and a `ruff format` complaint in `tests/data/benchmark/README.md`.

## How it was tested

- New tests: **6** phase 1 (`tests/test_processing.py::TestReadErrorExemplars` + the updated exact-text assertion in the issue #116 test), **4 + 3** phase 2 (`tests/test_deploy_lambda.py` via the repo's existing stub-`aws` subprocess pattern: family deploy, 404-skip, IAM-warn, `--variants` override; `tests/test_benchmark.py` guard unit tests with a stub Lambda client: match, stale hard-fail naming both hashes, probe-failure degradation), **5** phase 4 (`tests/test_deploy_lambda.py` IAM drift guards: deploy-role enumeration, release-role enumeration, invoke-role both-families enumeration, script<->template matrix parity, no-wildcard sweep over all three statements — failure messages name the missing variant and the file), **8** phase 3 (`tests/test_hive.py`: orphan-walk regression, schema-narrowing round-trip, sidecar-cleared-silently, leaf-scoped delete, overwrite hash refusal over data, pre-hash warn + hash stamped, empty-tree silent, plus the existing idempotent-overwrite test still green).
- Full targeted suites green locally (`pytest tests/test_processing.py tests/test_benchmark.py tests/test_benchmark_objects.py tests/test_benchmark_shardmap.py tests/test_hive.py tests/test_hive_windows.py tests/test_runner.py tests/test_deploy_lambda.py tests/test_grids.py tests/test_output.py tests/test_lambda_handler.py tests/test_coverage.py tests/test_coverage_root.py`). `ruff check` / `ruff format --check` clean on every touched file.
- Bug A was reproduced and re-verified with synthetic scripts (obstore-backed store, orphan chunk dir, schema narrowing): pre-fix the retry walk warned on the orphan leftovers; post-fix the orphan objects are deleted and the walk sees a clean prefix.
- The `deploy_lambda.sh` family loop is fully covered by the stub-`aws` subprocess tests; it has **not** been run against live AWS (CLAUDE.md §1). `publish.yml`'s coverage first exercises on the next release tag.

## Questions for review

1. **RESOLVED — role IAM enumerated (phase 4):** the `${...FunctionName}*` wildcard proposed here was **declined by espg** (2026-07-29, in-session) as a security hole; phase 4 lands explicit ARN enumeration instead, and a follow-up ruling the same day extended it to the invoke role — so **no wildcard function ARNs remain in `benchmark_cicd.yaml`**: `DeployRole.UpdateTestFunction` = base + the test-stack `-disk` trio; `ReleaseRole.UpdateProdFunction` = base + the full plain/`-disk` family; `BenchmarkInvokeRole.InvokeBenchmarkFunctions` = both families enumerated (`ConcurrencyProbe`'s `Resource: "*"` is untouched — no resource-level scoping exists for those actions). Drift-guard tests tie all three lists to `template.yaml`'s `WorkerMemorySizes` matrix. The change becomes effective once the updated `benchmark_cicd.yaml` stack is applied (operator action; never run from here per §1). See the phase-4 bullet for the two known residuals (plain-trio probe noise on the test deploy path; dropped incidental `-extract` coverage, verified unused).
2. **Metric-filter cadence** (phase 1): the first-per-distinct-message tracebacks at WARNING now trip the issue #175 `WorkerErrorCount` filter up to **5×/shard** (`_TRACEBACK_LIMIT`, raised from 3 by the fold review so a real cause behind three flavors of transient noise still gets a traceback) on read failures that previously logged traceback-free one-liners. This reads as correct (a raised group read IS a worker error) but changes the metric's sensitivity — flag if alarm thresholds assume the old behavior.
3. **Flat-path symmetry** (phase 3): `emit_template` (the flat store template) keeps the old overwrite behavior — its `zarr.group(path, overwrite=True)` already clears the group prefix, but the pydantic-zarr pre-walk still runs over existing members. Left untouched since the issue scopes Bug A to hive leaves and flat is deprecated for HEALPix (#251/#253); say the word for the same clear-first there.
4. **Pre-existing lint**: `ruff check src tests` fails on `N818` in `src/zagg/registry.py` (`UnknownCapability` naming) on origin/main — untouched here, flagged per §4 (the PR lint bot selects `E,F,W,I` only, so it will not trip CI).


