### PR TITLE
Sweep telemetry: per-family durations + store-root run record (issue #353)

### DIFF
--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -155,8 +155,13 @@ def expected_object_counts(
         # OPTIONAL aggregation.yaml semantic core (issue #299, D19 — a
         # fail-open derived convenience riding the manifest write), same
         # fail-open posture as the root MOC.
+        # ... plus the OPTIONAL sweep run record (issue #353): the end-of-run
+        # sweep PUTs one ``sweep_stats_{ts}.json`` at the root per pass. Same
+        # fail-open posture again (telemetry, D9 — one warning and None), and
+        # on the Lambda path the sweep is fire-and-forget, so it may legitimately
+        # be absent at measurement time. Ceiling only; the floor stays 1.
         metadata_min = 1
-        metadata_max = 1 + (1 if coverage_moc else 0) + 1 + 1
+        metadata_max = 1 + (1 if coverage_moc else 0) + 1 + 1 + 1
         # Leaf fixed objects: leaf root zarr.json + group zarr.json + one
         # zarr.json per array, plus the in-leaf coverage.moc sidecar (written
         # for any populated leaf when the leaf has depth, i.e. child_order >
@@ -191,6 +196,19 @@ def expected_object_counts(
 def _is_run_parquet(key: str) -> bool:
     """A store-root run-level stats parquet (issue #297): ``stats_*.parquet``."""
     return "/" not in key and key.startswith("stats_") and key.endswith(".parquet")
+
+
+def _is_sweep_record(key: str) -> bool:
+    """A store-root sweep run record (issue #353): ``sweep_stats_*.json``.
+
+    One per sweep pass, and the local dispatcher sweeps in-process at end of
+    run (``sweep_after_run``, default on for hive) — so a hive run lands
+    exactly one of these at the root alongside the run parquet. Deliberately
+    outside the :func:`_is_run_parquet` grammar (a sweep record must never read
+    as a shard run record); counted as metadata for the same reason the run
+    parquet is — fixed, shard-independent, one object per run.
+    """
+    return "/" not in key and key.startswith("sweep_stats_") and key.endswith(".json")
 
 
 def _is_status_object(key: str) -> bool:
@@ -300,11 +318,16 @@ def store_object_counts(
             prefix.rstrip("/").rsplit("/", 1)[0] + "/": label for prefix, label in leaf_of.items()
         }
         for key in keys:
-            if key in (
-                hive.MANIFEST_NAME,
-                hive.ROOT_COVERAGE_NAME,
-                hive.AGGREGATION_CORE_NAME,
-            ) or _is_run_parquet(key):
+            if (
+                key
+                in (
+                    hive.MANIFEST_NAME,
+                    hive.ROOT_COVERAGE_NAME,
+                    hive.AGGREGATION_CORE_NAME,
+                )
+                or _is_run_parquet(key)
+                or _is_sweep_record(key)
+            ):
                 metadata += 1
                 continue
             # Leaf-prefix membership FIRST (issue #300 review): an object that

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -1043,6 +1043,11 @@ def _handle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
                     "mode": "sweep",
                     "n_leaves": summary["n_leaves"],
                     "families": summary["families"],
+                    # issue #353: a synchronous benchmark invoke reads timings
+                    # straight off the response; the store-root record is the
+                    # durable copy (fail-open -> null).
+                    "duration_s": summary["duration_s"],
+                    "record": summary.get("record"),
                 }
             ),
         }

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -1025,14 +1025,25 @@ def _handle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
     logger.info(f"Sweep mode: folding rollups at {event.get('store_path')}")
     try:
         store_kwargs = _output_store_kwargs(event)
+        t0 = time.perf_counter()
         if event.get("leaves") is not None:
             leaves = [(int(key), window) for key, window in event["leaves"]]
         else:
             leaves = discover_leaves(event["store_path"], store_kwargs=store_kwargs)
         if not leaves:
+            # Same key set as the swept response: a benchmark driver reading
+            # body["duration_s"] must not KeyError on a no-work invoke (#353).
             return {
                 "statusCode": 200,
-                "body": json.dumps({"ok": True, "mode": "sweep", "n_leaves": 0}),
+                "body": json.dumps(
+                    {
+                        "ok": True,
+                        "mode": "sweep",
+                        "n_leaves": 0,
+                        "duration_s": time.perf_counter() - t0,
+                        "record": None,
+                    }
+                ),
             }
         summary = run_sweep(event["store_path"], leaves, store_kwargs=store_kwargs)
         return {

--- a/deployment/aws/lambda_handler.py
+++ b/deployment/aws/lambda_handler.py
@@ -1028,8 +1028,10 @@ def _handle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
         t0 = time.perf_counter()
         if event.get("leaves") is not None:
             leaves = [(int(key), window) for key, window in event["leaves"]]
+            discover_s = None  # the work set rode inline; nothing was derived
         else:
             leaves = discover_leaves(event["store_path"], store_kwargs=store_kwargs)
+            discover_s = time.perf_counter() - t0
         if not leaves:
             # Same key set as the swept response: a benchmark driver reading
             # body["duration_s"] must not KeyError on a no-work invoke (#353).
@@ -1041,6 +1043,7 @@ def _handle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
                         "mode": "sweep",
                         "n_leaves": 0,
                         "duration_s": time.perf_counter() - t0,
+                        "discover_s": discover_s,
                         "record": None,
                     }
                 ),
@@ -1056,8 +1059,13 @@ def _handle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
                     "families": summary["families"],
                     # issue #353: a synchronous benchmark invoke reads timings
                     # straight off the response; the store-root record is the
-                    # durable copy (fail-open -> null).
+                    # durable copy (fail-open -> null). ``duration_s`` is the
+                    # fold alone -- run_sweep's own span, which is exactly what
+                    # the store-root record carries -- and ``discover_s`` the
+                    # work-set derivation, null when the leaves rode inline.
+                    # Invoke wall-clock is their sum, not duration_s.
                     "duration_s": summary["duration_s"],
+                    "discover_s": discover_s,
                     "record": summary.get("record"),
                 }
             ),

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -32,6 +32,10 @@ chain (shard nodes re-read their leaf sidecars each pass; interior nodes fold
 the freshly computed child payloads, so the rewrite cascades up). A second
 sweep over an unchanged tree recomputes but PUTs nothing.
 
+Each pass also PUTs its own small run record at the store root
+(``sweep_stats_{ts}.json`` — per-family durations + counts, issue #353); like
+every other sweep artifact it is regenerable telemetry, never truth.
+
 Rollup objects are JSON sidecars at digit nodes, named ``{family}.rollup.json``
 — deliberately DISTINCT from the leaf sidecar names (``stats.json`` /
 ``coverage.moc``): under D24 mixed-order stores a node can be leaf and
@@ -529,7 +533,14 @@ def get_family(name: str) -> SweepFamily:
     return cls()
 
 
-def run_sweep(store_root: str, leaves, *, families=None, store_kwargs: dict | None = None) -> dict:
+def run_sweep(
+    store_root: str,
+    leaves,
+    *,
+    families=None,
+    store_kwargs: dict | None = None,
+    record: bool = True,
+) -> dict:
     """One sweep pass: fold leaf artifacts up-tree for each family (D22).
 
     ``leaves`` is the run-record-derived work set — an iterable of
@@ -545,11 +556,20 @@ def run_sweep(store_root: str, leaves, *, families=None, store_kwargs: dict | No
     payload compare is the same-second backstop the generation stamp cannot see
     (module docstring). Returns a summary with
     per-family ``written`` / ``current`` (skip-if-current) / ``empty`` (no
-    artifact found) / ``failed`` (unmergeable, logged) counts.
+    artifact found) / ``failed`` (unmergeable, logged) counts, each carrying
+    its wall-clock ``duration_s`` (issue #353) plus a pass total — the sweep's
+    analogue of the workers' ``phase_timings``, so benchmark runs are not
+    limited to billed-duration inference.
+
+    Unless ``record=False``, the summary is also PUT at the store root as the
+    sweep's own run record (:func:`_write_sweep_record`, fail-open).
     """
+    import time
+
     from zagg.hive import MANIFEST_NAME, read_manifest
     from zagg.store import open_object_store
 
+    t0 = time.perf_counter()
     store_kwargs = dict(store_kwargs or {})
     manifest = read_manifest(store_root, **store_kwargs)
     if manifest is None:
@@ -566,14 +586,46 @@ def run_sweep(store_root: str, leaves, *, families=None, store_kwargs: dict | No
         "families": {},
     }
     for fam in fams:
+        fam_t0 = time.perf_counter()
         runner = getattr(fam, "sweep_store", None)
         if runner is not None:
-            summary["families"][fam.name] = runner(store_root, manifest, by_shard, store_kwargs)
+            result = runner(store_root, manifest, by_shard, store_kwargs)
         else:
-            summary["families"][fam.name] = _sweep_family(
+            result = _sweep_family(
                 store_root, store, fam, by_shard, shard_order, manifest.get("spec"), store_kwargs
             )
+        result["duration_s"] = time.perf_counter() - fam_t0
+        summary["families"][fam.name] = result
+    summary["duration_s"] = time.perf_counter() - t0
+    if record:
+        summary["record"] = _write_sweep_record(store, summary)
     return summary
+
+
+def _write_sweep_record(store, summary: dict) -> str | None:
+    """PUT the sweep's run record at the store root; its key, or ``None`` (#353).
+
+    One small JSON object per sweep pass — ``sweep_stats_{ts}.json``,
+    timestamp-first like the run parquets (D20) so a lexicographic listing is
+    chronological, and deliberately OUTSIDE the ``stats_*.parquet`` glob the
+    sweep's own run-record discovery scans (a sweep record must never read as
+    a shard run record). A second pass within the same wall-clock second
+    overwrites the first — acceptable for telemetry, which this is: fail-open
+    (one warning, ``None``), never truth, exactly like every other sweep
+    artifact (D9).
+    """
+    from datetime import datetime, timezone
+
+    import obstore
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    key = f"sweep_stats_{ts}.json"
+    try:
+        obstore.put(store, key, json.dumps({"spec": SWEEP_SPEC, **summary}, indent=1).encode())
+    except Exception as e:
+        logger.warning(f"sweep: run record write failed (fail-open, D9 — telemetry): {e}")
+        return None
+    return key
 
 
 def _normalize_leaves(leaves, shard_order: int):

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -605,6 +605,14 @@ def run_sweep(
 def _write_sweep_record(store, summary: dict) -> str | None:
     """PUT the sweep's run record at the store root; its key, or ``None`` (#353).
 
+    The return is deliberately the bare store-root-relative key, NOT the joined
+    ``{store_root}/{key}`` that ``telemetry.write_run_parquet`` hands back: it
+    is the same currency as every other key this sweep writes (the rollups), so
+    it is what you hand straight back to ``obstore`` against this same store.
+    Joining would mean plumbing ``store_root`` in here, where only the store
+    handle is held. Callers holding the response body alone re-join it with the
+    ``store_path`` they invoked with.
+
     One small JSON object per sweep pass — ``sweep_stats_{ts}.json``,
     timestamp-first like the run parquets (D20) so a lexicographic listing is
     chronological, and deliberately OUTSIDE the ``stats_*.parquet`` glob the

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2340,10 +2340,10 @@ def test_hive_config_expected_counts_root_moc_optional():
     # The committed hive arm's model: per-shard DATA is exact (11 objects/leaf,
     # the sharded-write-bypass tripwire), but the store-root coverage.moc is a
     # fail-open, regenerable D9 cache (runner.write_root_coverage) that may be
-    # present OR absent -- so store-root metadata is a [1, 4] window (the
+    # present OR absent -- so store-root metadata is a [1, 5] window (the
     # morton_hive.json manifest always; +coverage.moc, the run stats parquet,
-    # and aggregation.yaml when they land) and the total is [12, 15]. A real
-    # bypass still fails on
+    # aggregation.yaml, and the sweep run record when they land) and the total
+    # is [12, 16]. A real bypass still fails on
     # the exact per-shard count.
     import bench_objects
 
@@ -2362,14 +2362,16 @@ def test_hive_config_expected_counts_root_moc_optional():
     # shardmap.json siblings (issues #297/#300) = 11.
     # Store root: morton_hive.json (always) + coverage.moc (optional) + the
     # run stats parquet (optional, issue #297) + aggregation.yaml (optional,
-    # issue #299) -> [1, 4].
+    # issue #299) + the sweep run record (optional, issue #353 — one per
+    # end-of-run sweep pass; fire-and-forget on the Lambda path, so it may not
+    # have landed by measurement time) -> [1, 5].
     assert exp == {
-        "metadata": 4,
+        "metadata": 5,
         "metadata_min": 1,
         "per_shard_min": 11,
         "per_shard_max": 11,
         "total_min": 12,
-        "total_max": 15,
+        "total_max": 16,
         "exact": True,
     }
 

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -306,8 +306,10 @@ def test_hive_store_matches_model(tmp_path, monkeypatch):
     # is exact here and the real store matches it object-for-object.
     assert expected["exact"] is True
     # Through the runner: manifest + aggregation.yaml (issue #299) + root
-    # MOC + the run stats parquet (#297).
-    assert measured["objects_metadata"] == expected["metadata"] == 4
+    # MOC + the run stats parquet (#297) + the sweep run record (#353 — the
+    # end-of-run sweep PUTs one per pass, root-level and shard-independent,
+    # so it is accounted exactly like the run parquet).
+    assert measured["objects_metadata"] == expected["metadata"] == 5
     assert measured["objects_other"] == 0
     assert list(measured["objects_per_shard"]) == [_KEY_A]
     # The end-of-run sweep lands its rollups (issue #300) and overview zarrs
@@ -664,12 +666,12 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     # Exact: per leaf = root+group zarr.json (2) + one zarr.json AND one data
     # object per array + the coverage sidecar + the stats.json sibling
     # (issue #297); store root = manifest + aggregation.yaml (issue #299)
-    # + MOC + the run stats parquet.
+    # + MOC + the run stats parquet + the sweep run record (issue #353).
     n_arrays = len(grid.shard_spec().members)
     assert expected["exact"] is True
     # ... + the stats.json AND shardmap.json siblings (issues #297/#300).
     assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 2
-    assert expected["metadata"] == 4
+    assert expected["metadata"] == 5
     # Sweep rollups (issue #300) and overview zarrs (issue #201) ride their
     # own buckets, outside the write-path total this model audits.
     write_path = (

--- a/tests/test_coverage_root.py
+++ b/tests/test_coverage_root.py
@@ -291,14 +291,19 @@ class TestLocalRootCoverage:
         root, _shard = self._agg(monkeypatch, tmp_path, coverage_moc=False)
         assert hive.read_root_coverage(root) is None
         # Root carries the manifest, the successful shard's node dir (its
-        # stats sidecar) and the run stats parquet (issue #297) — but no
-        # coverage.moc.
+        # stats sidecar), the run stats parquet (issue #297) and the sweep run
+        # record (issue #353) — but no coverage.moc.
         listing = sorted(os.listdir(root))
         assert hive.ROOT_COVERAGE_NAME not in listing
         assert hive.MANIFEST_NAME in listing
         assert any(n.startswith("stats_") and n.endswith(".parquet") for n in listing)
-        # node dir + manifest + aggregation.yaml (issue #299) + run parquet.
-        assert len(listing) == 4
+        # The end-of-run sweep runs in-process on the local dispatcher
+        # (sweep_after_run, default on for hive), so its record is part of the
+        # default-run contract — assert it IS there, not merely tolerated.
+        assert any(n.startswith("sweep_stats_") and n.endswith(".json") for n in listing)
+        # node dir + manifest + aggregation.yaml (issue #299) + run parquet
+        # + sweep record (issue #353).
+        assert len(listing) == 5
 
 
 class TestLambdaCoverageDispatch:

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -1588,17 +1588,23 @@ class TestRunnerWiring:
         # (issue #299, D19 — rides the manifest write), the root coverage.moc
         # (issue #200 phase 3, default-on for hive), plus the successful
         # shard's node dir carrying its stats sidecar (issue #297; the mocked
-        # worker wrote no leaf, so the node holds only stats.json).
+        # worker wrote no leaf, so the node holds only stats.json), plus the
+        # end-of-run sweep's own run record (issue #353 — the local dispatcher
+        # sweeps in-process, so one lands at the root on every default hive
+        # run; part of the contract, hence enumerated rather than filtered).
         listing = sorted(os.listdir(root))
         node = listing[0]
         parquets = [n for n in listing if n.startswith("stats_") and n.endswith(".parquet")]
         assert len(parquets) == 1  # run-level stats parquet (issue #297 phase 3)
+        records = [n for n in listing if n.startswith("sweep_stats_") and n.endswith(".json")]
+        assert len(records) == 1  # sweep run record (issue #353)
         assert listing == [
             node,
             hive.AGGREGATION_CORE_NAME,
             hive.ROOT_COVERAGE_NAME,
             hive.MANIFEST_NAME,
             parquets[0],
+            records[0],
         ]
         from zagg.telemetry import read_sidecar
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1073,3 +1073,32 @@ class TestInvokeLambdaSweep:
         event = json.loads(client.invoke.call_args.kwargs["Payload"])
         assert "leaves" not in event
         assert event["discover"] is True
+
+
+class TestHandlerSweepResponse:
+    """``mode="sweep"`` returns the pass timings + record key (issue #353)."""
+
+    def test_response_carries_durations_and_record(self, tmp_path):
+        import importlib.util
+        from pathlib import Path as _Path
+
+        handler_path = _Path(__file__).parent.parent / "deployment" / "aws" / "lambda_handler.py"
+        spec = importlib.util.spec_from_file_location("zagg_lambda_handler_sweep", handler_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        event = {
+            "mode": "sweep",
+            "store_path": str(tmp_path),
+            "leaves": [[morton_word("-311"), None]],
+        }
+        response = mod._handle_sweep(event)
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["ok"] is True and body["n_leaves"] == 1
+        assert body["duration_s"] >= 0.0
+        assert body["families"]["stats"]["duration_s"] >= 0.0
+        # The record key round-trips: the object the handler names exists.
+        assert (tmp_path / body["record"]).exists()

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -212,6 +212,69 @@ class TestNothingLoadBearing:
         assert _rollup(tmp_path, "-3")["payload"] == merge(list(recs.values()))
 
 
+class TestRecordAndTimings:
+    """The sweep's own telemetry (issue #353): durations + store-root record."""
+
+    def test_families_and_total_carry_durations(self, tmp_path):
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        summary = run_sweep(str(tmp_path), _leaf_refs("-311"))
+        for result in summary["families"].values():
+            assert result["duration_s"] >= 0.0
+        # The pass total spans every family (and the pre-walk setup).
+        assert summary["duration_s"] >= max(r["duration_s"] for r in summary["families"].values())
+
+    def test_record_written_at_root(self, tmp_path):
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        summary = run_sweep(str(tmp_path), _leaf_refs("-311"))
+        records = sorted(tmp_path.glob("sweep_stats_*.json"))
+        assert [r.name for r in records] == [summary["record"]]
+        payload = json.loads(records[0].read_text())
+        assert payload["spec"] == SWEEP_SPEC
+        assert payload["n_leaves"] == 1
+        assert set(payload["families"]) == set(summary["families"])
+        assert payload["duration_s"] >= 0.0
+        # The record is the summary itself; its own key is set only after the PUT.
+        assert "record" not in payload
+
+    def test_record_false_writes_nothing(self, tmp_path):
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        summary = run_sweep(str(tmp_path), _leaf_refs("-311"), record=False)
+        assert "record" not in summary
+        assert list(tmp_path.glob("sweep_stats_*.json")) == []
+
+    def test_record_write_failure_is_fail_open(self, tmp_path, monkeypatch, caplog):
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        real_put = obstore.put
+
+        def flaky_put(store, key, *args, **kwargs):
+            if str(key).startswith("sweep_stats_"):
+                raise RuntimeError("boom")
+            return real_put(store, key, *args, **kwargs)
+
+        monkeypatch.setattr(obstore, "put", flaky_put)
+        with caplog.at_level("WARNING"):
+            summary = run_sweep(str(tmp_path), _leaf_refs("-311"))
+        # The record is telemetry: its failure never touches the fold result.
+        assert summary["record"] is None
+        assert summary["families"]["stats"]["written"] > 0
+        assert any("run record write failed" in m for m in caplog.messages)
+
+    def test_record_name_is_outside_the_run_parquet_glob(self, tmp_path):
+        # discover_leaves scans ``stats_.+\.parquet``; the sweep's own record
+        # must never read as a shard run record.
+        import re
+
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        summary = run_sweep(str(tmp_path), _leaf_refs("-311"))
+        assert not re.fullmatch(r"stats_.+\.parquet", summary["record"])
+        assert re.fullmatch(r"sweep_stats_[0-9]{8}T[0-9]{6}Z\.json", summary["record"])
+
+
 class TestWorkSetEdges:
     def test_missing_sidecar_leaf_is_skipped_not_fatal(self, tmp_path):
         _write_manifest(tmp_path)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1106,6 +1106,23 @@ class TestHandlerSweepResponse:
         assert body["families"]["stats"]["duration_s"] >= 0.0
         # The record key round-trips: the object the handler names exists.
         assert (tmp_path / body["record"]).exists()
+        # The leaves rode inline: no work set was derived to charge for.
+        assert body["discover_s"] is None
+
+    def test_discovery_path_reports_its_own_span(self, tmp_path):
+        # discover_leaves is a LIST + a parquet read per run record; it is not
+        # inside run_sweep's span, so it gets its own field rather than being
+        # folded into (or dropped from) duration_s.
+        mod = _handler_module()
+
+        _write_manifest(tmp_path)
+        _put_leaf(tmp_path, "-311")
+        _run_record(tmp_path, [_row("-311")])
+        response = mod._handle_sweep({"mode": "sweep", "store_path": str(tmp_path)})
+        body = json.loads(response["body"])
+        assert body["n_leaves"] == 1
+        assert body["discover_s"] >= 0.0
+        assert body["duration_s"] >= 0.0
 
     def test_no_work_response_carries_the_same_keys(self, tmp_path):
         # A no-work invoke (nothing swept, or discovery over a store with no
@@ -1113,9 +1130,9 @@ class TestHandlerSweepResponse:
         mod = _handler_module()
 
         _write_manifest(tmp_path)
-        for event in (
-            {"mode": "sweep", "store_path": str(tmp_path), "leaves": []},
-            {"mode": "sweep", "store_path": str(tmp_path), "discover": True},
+        for event, derived in (
+            ({"mode": "sweep", "store_path": str(tmp_path), "leaves": []}, False),
+            ({"mode": "sweep", "store_path": str(tmp_path), "discover": True}, True),
         ):
             response = mod._handle_sweep(event)
             assert response["statusCode"] == 200
@@ -1123,3 +1140,4 @@ class TestHandlerSweepResponse:
             assert body["ok"] is True and body["n_leaves"] == 0
             assert body["duration_s"] >= 0.0
             assert body["record"] is None
+            assert (body["discover_s"] >= 0.0) if derived else (body["discover_s"] is None)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -265,13 +265,19 @@ class TestRecordAndTimings:
 
     def test_record_name_is_outside_the_run_parquet_glob(self, tmp_path):
         # discover_leaves scans ``stats_.+\.parquet``; the sweep's own record
-        # must never read as a shard run record.
+        # must never read as a shard run record. The CLI makes this a live
+        # sequence -- main() discovers first and sweeps second, so every pass
+        # discovers over the previous pass's record.
         import re
+
+        from zagg.sweep import discover_leaves
 
         _write_manifest(tmp_path)
         _put_leaf(tmp_path, "-311")
+        _run_record(tmp_path, [_row("-311")])
         summary = run_sweep(str(tmp_path), _leaf_refs("-311"))
-        assert not re.fullmatch(r"stats_.+\.parquet", summary["record"])
+        # The record now sits at the root the NEXT pass discovers from.
+        assert discover_leaves(str(tmp_path)) == [(morton_word("-311"), None)]
         assert re.fullmatch(r"sweep_stats_[0-9]{8}T[0-9]{6}Z\.json", summary["record"])
 
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1075,17 +1075,21 @@ class TestInvokeLambdaSweep:
         assert event["discover"] is True
 
 
+def _handler_module():
+    import importlib.util
+
+    handler_path = Path(__file__).parent.parent / "deployment" / "aws" / "lambda_handler.py"
+    spec = importlib.util.spec_from_file_location("zagg_lambda_handler_sweep", handler_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 class TestHandlerSweepResponse:
     """``mode="sweep"`` returns the pass timings + record key (issue #353)."""
 
     def test_response_carries_durations_and_record(self, tmp_path):
-        import importlib.util
-        from pathlib import Path as _Path
-
-        handler_path = _Path(__file__).parent.parent / "deployment" / "aws" / "lambda_handler.py"
-        spec = importlib.util.spec_from_file_location("zagg_lambda_handler_sweep", handler_path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+        mod = _handler_module()
 
         _write_manifest(tmp_path)
         _put_leaf(tmp_path, "-311")
@@ -1102,3 +1106,20 @@ class TestHandlerSweepResponse:
         assert body["families"]["stats"]["duration_s"] >= 0.0
         # The record key round-trips: the object the handler names exists.
         assert (tmp_path / body["record"]).exists()
+
+    def test_no_work_response_carries_the_same_keys(self, tmp_path):
+        # A no-work invoke (nothing swept, or discovery over a store with no
+        # run records) must not change the response shape a driver reads.
+        mod = _handler_module()
+
+        _write_manifest(tmp_path)
+        for event in (
+            {"mode": "sweep", "store_path": str(tmp_path), "leaves": []},
+            {"mode": "sweep", "store_path": str(tmp_path), "discover": True},
+        ):
+            response = mod._handle_sweep(event)
+            assert response["statusCode"] == 200
+            body = json.loads(response["body"])
+            assert body["ok"] is True and body["n_leaves"] == 0
+            assert body["duration_s"] >= 0.0
+            assert body["record"] is None


### PR DESCRIPTION
Closes #353.

## What

Gives the rollup sweep the same telemetry posture the shard workers already have (`phase_timings` → run parquet), so the pyramid-sweep benchmark runs (PR #344 Phase E measurement, issue #347) are not limited to CloudWatch billed-duration inference:

1. **Per-family + total durations** — `run_sweep` times each family fold (`families.<name>.duration_s`) and the whole pass (`duration_s`), additive keys on the existing summary shape.
2. **A store-root run record** — each pass PUTs `sweep_stats_{ts}.json` (the summary itself, `spec: zagg-sweep/1`), timestamp-first like the run parquets (D20) so listing is chronological, and deliberately **outside** the `stats_*.parquet` glob `discover_leaves` scans, so a sweep record can never read as a shard run record. Fail-open (one warning, `record: null`) — telemetry, never truth (D9). `record=False` opts out.
3. **`mode="sweep"` handler response** — passes the pass total and the record key through, so a synchronous (RequestResponse) benchmark invoke captures timings directly. (`deployment/aws/lambda_handler.py` is named by issue #353.)

## Phases

- [x] Phase 1 — `run_sweep` durations + store-root record + tests (`phase 1`)
- [ ] Phase 2 — `mode="sweep"` handler response passthrough (`phase 2`)

## How it was tested

`tests/test_sweep.py::TestRecordAndTimings`: durations present per family and total (total ≥ every family), record written at root and equal to the summary (minus its own key), `record=False` writes nothing, record-write failure is fail-open (fold results untouched, one warning), and the record name is provably outside the `stats_.+\.parquet` discovery glob. Full `test_sweep.py` + `test_sweep_overview.py` + `test_telemetry.py` green locally; `ruff check` / `ruff format --check` clean.

## Questions for review

- **JSON vs parquet for the record**: the issue says "lands where the cost rollups already read." The run records are parquet; this PR writes JSON to keep the sweep record out of the `stats_*.parquet` discovery glob (and duckdb reads JSON fine). If the #296 cost rollups want a parquet row instead, that's a follow-up — flagging rather than deciding silently.
- **Overview fold bytes**: issue #353 said "where already cheap to know" — it is not (the fold would need byte accounting plumbed through `sweep_overview`'s leaf reads), so this PR records durations only. Left out deliberately.
- Same-second double-sweep overwrites the prior record (`timespec` seconds, like the D20 grammar) — accepted for telemetry; say the word if you want a nonce suffix.
