### PR TITLE
Writer-side O11 content hashes (issue #342)

### DIFF
--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -982,6 +982,19 @@ rollup leaves all leaf reads intact.
   ("only `h_li_tdigest` differs in this leaf"); and the detection
   mechanism for stamped-but-torn leaves under the §2 concurrency
   contract's out-of-contract case.
+  *Writer-side addendum (espg-ratified 2026-07-31,
+  [#342](https://github.com/englacial/zagg/issues/342) — the recipe itself
+  was frozen in spec §5, pinned to the moczarr reference):* (1) sweep-written
+  **overview leaves are in scope** — the overview writer records the same §5
+  `content_hashes` sidecar, computed from the folded arrays it already holds;
+  (2) the overview envelope's sweep-internal **skip digest stays separate**
+  (different jobs: cheap pre-write idempotence check vs. verification record;
+  convergence may be revisited as a simplification later); (3) O11 recording
+  is **hive-only** — `store_layout: flat` has no leaf D20 sidecar to record
+  into, so the writer no-ops there and flat stores stay verifiable by running
+  the recipe manually; (4) the hash source is the **staged arrays** (no
+  read-back GETs), guarded in CI by a write-read parity test (staged hashes
+  == hashes recomputed from a full store read-back).
 - **O12 — retention/expiration (proposal, espg-directed to record
   2026-07-20)**: **product-level** retention is a *prefix* lifecycle rule
   (one rule per `{name}/` — delete or transition a whole product); 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -737,6 +737,16 @@ and is not a legal zagg array name). A leaf with no recorded
 report "nothing recorded" as a distinct outcome from a mismatch (the
 conservative dedup posture — an unverifiable leaf is never a hit).
 
+**Contract.** A sweep-built **overview** (§4) records its hashes in a sidecar
+the same way, and that sidecar is named from the overview's own basename —
+the stem plus `.stats.json` (`all.zarr` → `all.stats.json`, `2019.zarr` →
+`2019.stats.json`), a sibling object at the ancestor node. Unlike a source
+leaf's sidecar name, which is keyed to the store's `spec` revision, the stem
+grammar applies to an overview sidecar **unconditionally, at every
+revision**: one ancestor node holds every window's overview (§4.2), so a
+revision-keyed bare name would resolve all of them to a single `stats.json`
+at that node.
+
 *(Informative.)* The O11 hash is the verification half of the D19 identity
 split — the `semantic_hash` says two leaves were *intended* identical; O11
 says they *are* byte-identical — and doubles as the mismatch localizer

--- a/src/zagg/content_hash.py
+++ b/src/zagg/content_hash.py
@@ -125,7 +125,8 @@ def hash_arrays(group: Any, *, staged: Mapping[str, np.ndarray] | None = None) -
     for key, node in group.members(max_depth=None):
         if not isinstance(node, zarr.Array):
             continue
-        hashes[key] = hash_array(staged[key] if key in staged else node[...])
+        values = staged[key] if key in staged else node[...]
+        hashes[key] = hash_array(np.asarray(values))
     unused = set(staged) - set(hashes)
     if unused:
         logger.warning(

--- a/src/zagg/content_hash.py
+++ b/src/zagg/content_hash.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import threading
 from typing import Any, Mapping
 
 import numpy as np
@@ -38,6 +39,16 @@ logger = logging.getLogger(__name__)
 
 #: Width of the §5.2 vlen recipe's per-cell length prefix (uint64, LE).
 VLEN_LENGTH_PREFIX = 8
+
+#: Byte budget for out-of-order rows ONE :class:`StreamingArrayHash` may hold
+#: (issue #342 phase 5). The raster sink receives timesteps in *completion*
+#: order (``asyncio.as_completed``), so a row arriving before its predecessors
+#: must be parked until its turn. The budget bounds that parking — at typical
+#: raster leaf geometry (tens of acquisitions x a shard's cells) the whole
+#: array is well under it, while a pathological leaf degrades to "no recorded
+#: hash" (§5.3 unverifiable, not tampered) instead of eating the streaming
+#: write path's memory bound (issues #231/#232).
+STREAM_PENDING_MAX_BYTES = 64 * 1024 * 1024
 
 
 def _element_bytes(element: object) -> bytes:
@@ -124,6 +135,130 @@ def hash_arrays(group: Any, *, staged: Mapping[str, np.ndarray] | None = None) -
             sorted(unused),
         )
     return hashes
+
+
+#: Sentinel for "the fill row has not been materialized yet".
+_UNSET = object()
+
+
+class StreamingArrayHash:
+    """§5.2 digest of an array assembled from leading-axis rows as they are written.
+
+    The incremental hash source for write paths that never hold the whole
+    array (issue #342 phase 5, the raster hive leaf): a ``(time, cells)``
+    band is written one timestep at a time, and the concatenation of those
+    rows' decoded C-order little-endian bytes IS the array's full decoded
+    byte sequence — so a live ``sha256`` fed row by row finalizes to exactly
+    the digest :func:`hash_array` would compute over the assembled array. No
+    read-back, no whole-array staging.
+
+    Two things the identity depends on, both ENFORCED here rather than
+    assumed — a digest that is silently wrong is worse than no digest:
+
+    - **Unwritten rows still count.** The recipe covers the array's full
+      logical contents, so a row that never gets a slab contributes its
+      **fill** bytes. Rows missing at :meth:`finalize` are filled from
+      ``fill_value``; an array with a gap and no reconstructable fill is
+      dropped instead of hashed.
+    - **Order.** Rows may arrive in any order (the raster sink runs on
+      ``asyncio.as_completed``), so out-of-order rows are parked until their
+      turn — bounded by :data:`STREAM_PENDING_MAX_BYTES`. A row written
+      twice, a row outside the declared extent, a shape/dtype mismatch, or a
+      parking overflow all **invalidate** the digest: :meth:`finalize`
+      returns ``None`` and :attr:`invalid_reason` says why.
+
+    Thread-safe: the raster sink hands slabs off to worker threads when
+    ``write_buffer > 1``.
+    """
+
+    def __init__(self, shape, dtype, fill_value=None):
+        self.shape = tuple(int(s) for s in shape)
+        self.dtype = np.dtype(dtype)
+        self.fill_value = fill_value
+        self.invalid_reason: str | None = None
+        self._row_shape = self.shape[1:]
+        self._n_rows = self.shape[0] if self.shape else 0
+        self._digest = hashlib.sha256()
+        self._next = 0
+        self._pending: dict[int, np.ndarray] = {}
+        self._pending_bytes = 0
+        self._fill_row: Any = _UNSET
+        self._lock = threading.Lock()
+
+    def _invalidate(self, reason: str) -> None:
+        if self.invalid_reason is None:
+            self.invalid_reason = reason
+        self._pending.clear()
+        self._pending_bytes = 0
+
+    def _row_bytes(self, values: np.ndarray) -> bytes:
+        values = np.ascontiguousarray(values)
+        if values.dtype.byteorder == ">":  # canonical form is little-endian
+            values = values.astype(values.dtype.newbyteorder("<"))
+        return values.tobytes()
+
+    def update(self, index: int, values) -> None:
+        """Record the row written at leading-axis ``index`` (any order)."""
+        with self._lock:
+            if self.invalid_reason is not None:
+                return
+            index = int(index)
+            values = np.asarray(values)
+            if values.shape != self._row_shape or values.dtype != self.dtype:
+                self._invalidate(
+                    f"row {index} is {values.shape}/{values.dtype}, expected "
+                    f"{self._row_shape}/{self.dtype}"
+                )
+                return
+            if not 0 <= index < self._n_rows:
+                self._invalidate(f"row {index} is outside the array's {self._n_rows} rows")
+                return
+            if index < self._next or index in self._pending:
+                self._invalidate(f"row {index} was written more than once")
+                return
+            if index > self._next:
+                self._pending[index] = values
+                self._pending_bytes += values.nbytes
+                if self._pending_bytes > STREAM_PENDING_MAX_BYTES:
+                    self._invalidate(
+                        f"out-of-order rows exceeded the {STREAM_PENDING_MAX_BYTES}-byte "
+                        f"parking budget"
+                    )
+                return
+            self._digest.update(self._row_bytes(values))
+            self._next += 1
+            while self._next in self._pending:  # drain rows this one unblocked
+                row = self._pending.pop(self._next)
+                self._pending_bytes -= row.nbytes
+                self._digest.update(self._row_bytes(row))
+                self._next += 1
+
+    def finalize(self) -> str | None:
+        """The array's §5.2 digest, or ``None`` when it cannot be stood behind."""
+        with self._lock:
+            if self.invalid_reason is not None:
+                return None
+            for index in range(self._next, self._n_rows):
+                row = self._pending.pop(index, None)
+                if row is not None:
+                    self._pending_bytes -= row.nbytes
+                    self._digest.update(self._row_bytes(row))
+                    continue
+                if self._fill_row is _UNSET:
+                    self._fill_row = (
+                        None
+                        if self.fill_value is None
+                        else np.full(self._row_shape, self.fill_value, dtype=self.dtype).tobytes()
+                    )
+                if self._fill_row is None:
+                    self._invalidate(
+                        f"row {index} was never written and the array declares no "
+                        f"fill_value to reconstruct it"
+                    )
+                    return None
+                self._digest.update(self._fill_row)
+            self._next = self._n_rows
+            return self._digest.hexdigest()
 
 
 def combined_hash(hashes: Mapping[str, str]) -> str:

--- a/src/zagg/content_hash.py
+++ b/src/zagg/content_hash.py
@@ -80,7 +80,7 @@ def hash_array(values: np.ndarray) -> str:
     return hashlib.sha256(values.tobytes()).hexdigest()
 
 
-def hash_arrays(group: Any) -> dict[str, str]:
+def hash_arrays(group: Any, *, staged: Mapping[str, np.ndarray] | None = None) -> dict[str, str]:
     """O11 per-array hashes of every named zarr array beneath ``group``.
 
     ``group`` is an open zarr v3 group at the leaf ROOT; the scope is
@@ -88,14 +88,25 @@ def hash_arrays(group: Any) -> dict[str, str]:
     whatever named arrays exist beneath the root — data fields, ragged vlen
     payloads and their locations siblings, ``morton``, every coordinate —
     keyed by the array's path relative to the leaf root (e.g. ``"8/morton"``).
+
+    ``staged`` maps array keys to the IN-MEMORY values the writer just wrote
+    (the ratified issue #342 hash source: the leaf write path already holds
+    each array's full slab, so hashing is a memory-bandwidth pass, no data
+    GETs). A staged value is hashed in place of a store read-back; enumerated
+    arrays with no staged value (e.g. ``resolution: chunk`` companions, which
+    are written per chunk-block rather than as one slab) fall back to reading
+    that array back. The two sources are pinned equal by the write-read
+    parity test in ``tests/test_content_hash.py`` — the CI guard for the
+    dtype-cast/fill drift class §5 exists to catch.
     """
     import zarr
 
+    staged = staged or {}
     hashes: dict[str, str] = {}
     for key, node in group.members(max_depth=None):
         if not isinstance(node, zarr.Array):
             continue
-        hashes[key] = hash_array(node[...])
+        hashes[key] = hash_array(staged[key] if key in staged else node[...])
     return hashes
 
 

--- a/src/zagg/content_hash.py
+++ b/src/zagg/content_hash.py
@@ -1,0 +1,119 @@
+"""O11 content hashes: the writer-side port of the spec §5 recipe (issue #342).
+
+The logical content hash of a hive leaf is **per-array sha256 over decoded
+values** — never stored object bytes, so codec/packaging changes are invisible
+by construction while any value change flips the hash (exact bytes, no float
+tolerance). The recipe is NOT this module's to adjust: the normative text is
+``docs/specification.md`` §5 and the reference implementation is
+``moczarr.stats.hash_arrays`` / ``combined_hash`` (espg/moczarr PR #23),
+adopted verbatim here and pinned byte-for-byte by the committed conformance
+fixtures (``tests/data/spec/*.expected.json``, spec §7).
+
+Recipe summary (§5.2/§5.3):
+
+- fixed-width arrays hash as their full decoded contents, raw C-order
+  **little-endian** bytes at the declared dtype;
+- vlen (object-dtype) arrays hash per cell in flat C order as
+  ``u64le(len(payload)) || payload`` — the length prefix makes the digest
+  injective and covers the cell grid, not just the payloads;
+- an element with no byte recipe RAISES (a silently wrong digest is worse
+  than none);
+- ``combined`` = sha256 over the SORTED per-array hex digests joined by
+  ``"\\n"``, hashed as ASCII (array names deliberately excluded).
+
+Hashes are recorded in the leaf's D20 stats sidecar under ``content_hashes``
+in the §5.3 structured shape (:func:`content_hashes_record`); absence reads
+as *unverifiable, not tampered*.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Mapping
+
+import numpy as np
+
+#: Width of the §5.2 vlen recipe's per-cell length prefix (uint64, LE).
+VLEN_LENGTH_PREFIX = 8
+
+
+def _element_bytes(element: object) -> bytes:
+    """One vlen cell's decoded payload as raw little-endian bytes (§5.2).
+
+    ``variable_length_bytes`` cells decode to :class:`bytes` (zagg's ragged
+    payloads and their ``{field}_locations`` siblings). ``None`` — an
+    unwritten cell may decode as ``None``, not ``b""`` — is zero-length;
+    ``str`` covers a vlen-utf8 future; an ndarray (a typed ``zagg-ragged/2``
+    cell, spec §6) normalizes to C-contiguous little-endian bytes at its
+    element dtype. Anything else RAISES rather than hashing a ``repr`` — a
+    digest that is silently wrong is worse than no digest at all.
+    """
+    if element is None:
+        return b""
+    if isinstance(element, (bytes, bytearray, memoryview)):
+        return bytes(element)
+    if isinstance(element, str):
+        return element.encode()
+    if isinstance(element, np.ndarray):
+        values = np.ascontiguousarray(element)
+        if values.dtype.byteorder == ">":
+            values = values.astype(values.dtype.newbyteorder("<"))
+        return values.tobytes()
+    raise ValueError(
+        f"vlen element of type {type(element).__name__} has no O11 byte recipe "
+        f"(expected bytes, str, ndarray, or None)"
+    )
+
+
+def hash_array(values: np.ndarray) -> str:
+    """The §5.2 hash of ONE decoded array (fixed-width or vlen/object dtype)."""
+    values = np.ascontiguousarray(values)
+    if values.dtype.kind == "O":  # vlen: length-prefixed payloads, flat C order
+        digest = hashlib.sha256()
+        for element in values.ravel(order="C"):
+            payload = _element_bytes(element)
+            digest.update(len(payload).to_bytes(VLEN_LENGTH_PREFIX, "little"))
+            digest.update(payload)
+        return digest.hexdigest()
+    if values.dtype.byteorder == ">":  # canonical form is little-endian
+        values = values.astype(values.dtype.newbyteorder("<"))
+    return hashlib.sha256(values.tobytes()).hexdigest()
+
+
+def hash_arrays(group: Any) -> dict[str, str]:
+    """O11 per-array hashes of every named zarr array beneath ``group``.
+
+    ``group`` is an open zarr v3 group at the leaf ROOT; the scope is
+    discovery-based (§5.1): ``members(max_depth=None)``, so the key set is
+    whatever named arrays exist beneath the root — data fields, ragged vlen
+    payloads and their locations siblings, ``morton``, every coordinate —
+    keyed by the array's path relative to the leaf root (e.g. ``"8/morton"``).
+    """
+    import zarr
+
+    hashes: dict[str, str] = {}
+    for key, node in group.members(max_depth=None):
+        if not isinstance(node, zarr.Array):
+            continue
+        hashes[key] = hash_array(node[...])
+    return hashes
+
+
+def combined_hash(hashes: Mapping[str, str]) -> str:
+    """The O11 combined hash: sha256 of the sorted per-array hex digests.
+
+    Serialization pinned by §5.3 (and the committed fixtures): the digests
+    sorted lexically and joined with ``"\\n"``, hashed as ASCII — array
+    *names* deliberately excluded ("hash of the sorted per-array hashes"),
+    so ``combined`` is immune to enumeration order.
+    """
+    return hashlib.sha256("\n".join(sorted(hashes.values())).encode()).hexdigest()
+
+
+def content_hashes_record(hashes: Mapping[str, str]) -> dict:
+    """The §5.3 structured ``content_hashes`` sidecar record.
+
+    The ``arrays`` map is key-sorted so a regenerated record diffs cleanly
+    (``combined`` is order-immune either way — it sorts the digests).
+    """
+    return {"arrays": dict(sorted(hashes.items())), "combined": combined_hash(hashes)}

--- a/src/zagg/content_hash.py
+++ b/src/zagg/content_hash.py
@@ -29,9 +29,12 @@ as *unverifiable, not tampered*.
 from __future__ import annotations
 
 import hashlib
+import logging
 from typing import Any, Mapping
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 #: Width of the §5.2 vlen recipe's per-cell length prefix (uint64, LE).
 VLEN_LENGTH_PREFIX = 8
@@ -98,6 +101,11 @@ def hash_arrays(group: Any, *, staged: Mapping[str, np.ndarray] | None = None) -
     that array back. The two sources are pinned equal by the write-read
     parity test in ``tests/test_content_hash.py`` — the CI guard for the
     dtype-cast/fill drift class §5 exists to catch.
+
+    A staged key matching NO enumerated array warns: the digests stay correct
+    (that array was read back) but the staged seam is broken — silent
+    key-composition drift between writer and enumeration would otherwise turn
+    every hash into a read-back with no observable symptom.
     """
     import zarr
 
@@ -107,6 +115,14 @@ def hash_arrays(group: Any, *, staged: Mapping[str, np.ndarray] | None = None) -
         if not isinstance(node, zarr.Array):
             continue
         hashes[key] = hash_array(staged[key] if key in staged else node[...])
+    unused = set(staged) - set(hashes)
+    if unused:
+        logger.warning(
+            "staged values for %s match no array beneath the leaf root; those arrays "
+            "were hashed from a store read-back instead (staged keys must be array "
+            "paths relative to the leaf root, e.g. '8/morton')",
+            sorted(unused),
+        )
     return hashes
 
 

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -1236,8 +1236,11 @@ def process_and_write_hive(
     chunk_results: list | None = [] if sharded else None
 
     # O11 staged-array sink (issue #342): the leaf writers record each
-    # assembled slab here (refs, no copies) so the content hashes below run
-    # over the exact in-memory values written — the ratified hash source.
+    # assembled slab here (refs on the sharded path; the streaming path fills
+    # a leaf-wide slab chunk by chunk) so the content hashes below run over
+    # the exact in-memory values written — the ratified hash source. On the
+    # streaming path this re-adds the same O(dense leaf) term the sharded
+    # path's slab pass already accepts above (~1.3 MB at production geometry).
     staged: dict = {}
 
     # Ragged fields accumulate across the streamed chunks (leaf-LOCAL blocks)
@@ -1263,7 +1266,7 @@ def process_and_write_hive(
         _t0 = time.time()
         store = _leaf()
         local = leaf_block_index(grid, block_index, shard_key)
-        write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=local)
+        write_dataframe_to_zarr(carrier, store, grid=grid, chunk_idx=local, staged_out=staged)
         if ragged:
             ragged_chunks.append((local, ragged))
         _write_elapsed += time.time() - _t0
@@ -1356,9 +1359,14 @@ def process_and_write_hive(
     if not metadata.get("error") and "store" in box:
         # O11 content hashes (issue #342, spec §5): computed in-worker at
         # write, from the STAGED arrays (the ratified source — the write path
-        # already holds every slab, so this is a memory-bandwidth pass; only
-        # per-chunk-block companions fall back to a read-back inside
-        # ``hash_arrays``). Recorded on ``metadata`` for the caller's D20
+        # already holds every slab, so this is a memory-bandwidth pass).
+        # Dense and ragged arrays are staged on BOTH leaf paths: the sharded
+        # one-object-per-array pass and the per-chunk streaming path
+        # (``sharded`` is forced off whenever a leaf holds one inner chunk —
+        # the ``chunk_inner``-unset default). ``resolution: chunk`` companions
+        # are the one read-back fallback inside ``hash_arrays``: they are
+        # written per chunk-block, never as a leaf slab.
+        # Recorded on ``metadata`` for the caller's D20
         # sidecar (``telemetry.build_record``). Hive-only by ratified decision
         # (3): flat layouts have no leaf sidecar to record into, and no flat
         # writer computes hashes — those stores stay verifiable by running

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -1149,7 +1149,10 @@ def process_and_write_hive(
     lazy leaf template emission counts as write: in hive the worker owns its
     leaf's template PUTs (there is no dispatcher-side template), so excluding
     them would hide real write-out cost. ``profile`` is retained and
-    forwarded (it still gates dispatcher-side rollup verbosity).
+    forwarded (it still gates dispatcher-side rollup verbosity). On success
+    the O11 content hashes (issue #342, spec §5) are computed from the staged
+    arrays, returned as ``metadata["content_hashes"]`` for the caller's D20
+    sidecar, and timed as the ``hash`` phase.
 
     ``window`` (issue #246, D13/D15) is one dispatch unit's time window:
     ``{"label", "start", "end"}``, bounds half-open in DATASET units
@@ -1232,6 +1235,11 @@ def process_and_write_hive(
     sharded = getattr(grid, "sharded", False)
     chunk_results: list | None = [] if sharded else None
 
+    # O11 staged-array sink (issue #342): the leaf writers record each
+    # assembled slab here (refs, no copies) so the content hashes below run
+    # over the exact in-memory values written — the ratified hash source.
+    staged: dict = {}
+
     # Ragged fields accumulate across the streamed chunks (leaf-LOCAL blocks)
     # and are written ONCE after the stream (issue #209): the leaf's ragged
     # vlen array is a single ShardingCodec object spanning the shard, so a
@@ -1294,7 +1302,9 @@ def process_and_write_hive(
     # ``_write_chunk``.
     if sharded and chunk_results and not metadata.get("error"):
         _t0 = time.time()
-        write_leaf_to_zarr(chunk_results, _leaf(), grid=grid, shard_key=int(shard_key))
+        write_leaf_to_zarr(
+            chunk_results, _leaf(), grid=grid, shard_key=int(shard_key), staged_out=staged
+        )
         _write_elapsed += time.time() - _t0
     # Stamp ONLY a fully-written leaf: an errored shard (or one that streamed
     # no chunks) stays unstamped — debris by definition (D4). The stamp is the
@@ -1307,7 +1317,7 @@ def process_and_write_hive(
     if "store" in box and not metadata.get("error"):
         _t0 = time.time()
         if not sharded:
-            write_ragged_leaf_to_zarr(ragged_chunks, box["store"], grid=grid)
+            write_ragged_leaf_to_zarr(ragged_chunks, box["store"], grid=grid, staged_out=staged)
         words = np.concatenate(occupied) if occupied else None
         if words is not None and words.size == 0:
             words = None
@@ -1343,6 +1353,41 @@ def process_and_write_hive(
     # and a no-data shard (no leaf) stays write-less.
     if not metadata.get("error") and "phase_timings" in metadata and "store" in box:
         metadata["phase_timings"]["write"] = _write_elapsed
+    if not metadata.get("error") and "store" in box:
+        # O11 content hashes (issue #342, spec §5): computed in-worker at
+        # write, from the STAGED arrays (the ratified source — the write path
+        # already holds every slab, so this is a memory-bandwidth pass; only
+        # per-chunk-block companions fall back to a read-back inside
+        # ``hash_arrays``). Recorded on ``metadata`` for the caller's D20
+        # sidecar (``telemetry.build_record``). Hive-only by ratified decision
+        # (3): flat layouts have no leaf sidecar to record into, and no flat
+        # writer computes hashes — those stores stay verifiable by running
+        # the §5 recipe manually. Fail-open: the record is telemetry-class
+        # (D9), and §5.3 reads absence as unverifiable, never tampered — a
+        # dropped record is strictly safer than a wrong one (the §5.2 raise
+        # gate lands here as a warning + no record).
+        _t0 = time.time()
+        try:
+            import warnings
+
+            from zagg.content_hash import content_hashes_record, hash_arrays
+
+            group = zarr.open_group(box["store"], path="", mode="r", zarr_format=3)
+            with warnings.catch_warnings():
+                # The leaf's own coverage sidecar is the one known non-zarr
+                # object under the prefix; ``members()`` warn-skips it (the
+                # ``process_and_write_raster_hive`` suppression precedent).
+                warnings.filterwarnings("ignore", message=f"Object at {COVERAGE_SIDECAR}")
+                metadata["content_hashes"] = content_hashes_record(
+                    hash_arrays(group, staged=staged)
+                )
+        except Exception as e:
+            logger.warning(f"O11 content hashing failed (fail-open, issue #342): {e}")
+        else:
+            # Same "populated phase_timings" gate as the write stamp above:
+            # the timing rides an existing dict, never seeds one.
+            if "phase_timings" in metadata:
+                metadata["phase_timings"]["hash"] = time.time() - _t0
     return metadata
 
 

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import logging
 import os
 import re
 import threading
@@ -29,6 +30,8 @@ import warnings
 from urllib.parse import urlparse
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # TIFF SampleFormat x BitsPerSample -> numpy dtype, for sizing the fill return
 # when a shard has no valid cells (no tile fetched, so no decoded buffer to
@@ -978,7 +981,14 @@ def raster_leaf_spec(grid, config, n_time: int):
 
 
 def emit_raster_leaf_template(
-    store, grid, config, shard_key: int, times_us: np.ndarray, *, overwrite: bool = False
+    store,
+    grid,
+    config,
+    shard_key: int,
+    times_us: np.ndarray,
+    *,
+    overwrite: bool = False,
+    staged_out: dict | None = None,
 ):
     """Write one leaf's template plus its ``time`` and ``morton`` coords.
 
@@ -990,6 +1000,11 @@ def emit_raster_leaf_template(
     first slab (mirroring ``process_and_write_hive``'s lazy ``_leaf``) with
     ``overwrite=True`` so a no-data shard never creates the ``.zarr/`` prefix
     and a retry replaces debris wholesale (D4).
+
+    ``staged_out`` (issue #342): when a dict is passed, the coordinate arrays
+    written here are recorded in it under their leaf-relative paths — the
+    O11 hash source for the arrays this function writes WHOLE (the band
+    arrays stream per timestep and hash incrementally instead).
     """
     from zarr import config as zarr_config
     from zarr import open_array
@@ -999,24 +1014,39 @@ def emit_raster_leaf_template(
     with zarr_config.set({"async.concurrency": 128}):
         spec.to_zarr(store, "", overwrite=overwrite)
         arr = open_array(store, path=f"{grid.group_path}/time", zarr_format=3, consolidated=False)
-        arr[:] = np.asarray(times_us, dtype=np.int64)
+        times = np.asarray(times_us, dtype=np.int64)
+        arr[:] = times
         arr = open_array(store, path=f"{grid.group_path}/morton", zarr_format=3, consolidated=False)
         arr[:] = children
+        cell_ids = None
         if grid.emit_cell_ids:
             arr = open_array(
                 store, path=f"{grid.group_path}/cell_ids", zarr_format=3, consolidated=False
             )
-            arr[:] = np.asarray(grid.encode_cell_ids(children), dtype=np.uint64)
+            cell_ids = np.asarray(grid.encode_cell_ids(children), dtype=np.uint64)
+            arr[:] = cell_ids
+    if staged_out is not None:
+        staged_out[f"{grid.group_path}/time"] = times
+        staged_out[f"{grid.group_path}/morton"] = children
+        if cell_ids is not None:
+            staged_out[f"{grid.group_path}/cell_ids"] = cell_ids
     return store
 
 
-def write_raster_leaf_slab(store, grid, t_idx: int, slab: dict):
+def write_raster_leaf_slab(store, grid, t_idx: int, slab: dict, *, streams: dict | None = None):
     """Write one timestep's slab at LEAF-LOCAL indices: ``array[t, :] = values``.
 
     The leaf's arrays span exactly one shard, so the cell axis needs no
     block offset (contrast :func:`write_raster_slab`); ``t_idx`` is the
     leaf-local timestep from the leaf's own time index. Chunk-aligned by
     construction (whole rows of ``(1, cells_per_chunk)`` chunks).
+
+    ``streams`` (issue #342) maps leaf-relative array paths to
+    :class:`~zagg.content_hash.StreamingArrayHash` accumulators: each row is
+    fed to its array's digest AS WRITTEN — after the dtype cast, so the
+    hashed bytes are exactly the stored ones. The accumulators are
+    thread-safe (this function runs on worker threads at ``write_buffer >
+    1``) and tolerate the sink's completion-order arrival.
     """
     from zarr import config as zarr_config
     from zarr import open_array
@@ -1026,7 +1056,12 @@ def write_raster_leaf_slab(store, grid, t_idx: int, slab: dict):
             arr = open_array(
                 store, path=f"{grid.group_path}/{name}", zarr_format=3, consolidated=False
             )
-            arr[int(t_idx), :] = np.asarray(values, dtype=arr.dtype)
+            cast = np.asarray(values, dtype=arr.dtype)
+            arr[int(t_idx), :] = cast
+            if streams is not None:
+                stream = streams.get(f"{grid.group_path}/{name}")
+                if stream is not None:
+                    stream.update(int(t_idx), cast)
     return store
 
 
@@ -1082,6 +1117,59 @@ def write_raster_coords(store, grid, shard_key: int):
     return store
 
 
+def _arm_leaf_hashes(store, staged: dict, streams: dict) -> None:
+    """Create one O11 accumulator per leaf array not written whole (issue #342).
+
+    Discovery-based like the §5.1 scope itself: every named array beneath the
+    freshly templated leaf root that ``staged`` does not already cover gets a
+    :class:`~zagg.content_hash.StreamingArrayHash` sized from the array's own
+    metadata — so a band that never receives a slab still finalizes (all
+    fill), and a member added to the template later is picked up without
+    touching this code. Fail-open: on any error the leaf simply records no
+    hashes (§5.3 unverifiable, not tampered).
+    """
+    try:
+        import zarr
+
+        from zagg.content_hash import StreamingArrayHash
+
+        group = zarr.open_group(store, path="", mode="r", zarr_format=3)
+        for key, node in group.members(max_depth=None):
+            if not isinstance(node, zarr.Array) or key in staged:
+                continue
+            streams[key] = StreamingArrayHash(node.shape, node.dtype, node.metadata.fill_value)
+    except Exception as e:
+        logger.warning(f"O11 hash accumulators unavailable for this leaf (fail-open): {e}")
+        streams.clear()
+        staged.clear()
+
+
+def _finalize_leaf_hashes(staged: dict, streams: dict) -> dict | None:
+    """The leaf's §5.3 ``content_hashes`` record, or ``None`` (issue #342).
+
+    All-or-nothing by design: a partial map would read as "array missing" to
+    a §5.1 verifier and its ``combined`` would be a digest of a subset, so an
+    array whose incremental digest cannot be stood behind (out-of-order
+    write, unwritten row with no fill, parking overflow) drops the WHOLE
+    record with one warning naming the array and the reason.
+    """
+    from zagg.content_hash import content_hashes_record, hash_array
+
+    if not staged and not streams:
+        return None
+    hashes = {key: hash_array(values) for key, values in staged.items()}
+    for key, stream in streams.items():
+        digest = stream.finalize()
+        if digest is None:
+            logger.warning(
+                f"O11: no content hashes recorded for this leaf — {key} could not be "
+                f"hashed incrementally ({stream.invalid_reason})"
+            )
+            return None
+        hashes[key] = digest
+    return content_hashes_record(hashes)
+
+
 def process_and_write_raster_hive(
     shard_key,
     granules,
@@ -1126,10 +1214,20 @@ def process_and_write_raster_hive(
     sidecar PUT) -> stamp. ``cells_with_data`` counts the occupied-cell
     union; ``granule_count`` the unit's acquisitions (asset-carrying
     entries). Phase timings are always collected (issue #297):
-    ``metadata["phase_timings"] = {"sample", "write"}`` with the leaf
+    ``metadata["phase_timings"] = {"sample", "write", "hash"}`` with the leaf
     write-out (template + slabs + sidecar + stamp) as ``write``; the
     per-stage ``stages`` block (issue #249) stays gated on ``profile`` /
     a passed ``stage_stats`` (the local dispatcher's debug-logging flavor).
+
+    O11 content hashes (issue #342 phase 5) are accumulated INCREMENTALLY:
+    this path never holds a whole band array (it streams one timestep at a
+    time, issues #231/#232), so each row is folded into a live per-array
+    ``sha256`` as it is written and finalized here into
+    ``metadata["content_hashes"]`` (§5.3), which the caller's
+    ``telemetry.build_record`` rides into the leaf's D20 sidecar. Equivalent
+    to hashing the assembled array by construction — pinned against
+    ``content_hash.hash_arrays`` over a store read-back in
+    ``tests/test_content_hash.py``.
     """
     from zagg.hive import (
         COVERAGE_SIDECAR,
@@ -1152,6 +1250,15 @@ def process_and_write_raster_hive(
     time_index, times_us = raster_time_index([granules])
     box: dict = {}
     write_s = 0.0
+    # O11 incremental hashing (issue #342 phase 5). The raster leaf never
+    # holds a whole band array — it streams one timestep at a time (issues
+    # #231/#232) — so the §5 digest is accumulated row by row as each slab is
+    # written, instead of staging the array (the spatial path's source) or
+    # reading it back. ``staged`` carries the coordinate arrays this path
+    # DOES write whole (template time); ``streams`` the per-band
+    # accumulators, keyed the same way.
+    staged: dict = {}
+    streams: dict = {}
 
     def _leaf():
         if "store" not in box:
@@ -1166,15 +1273,22 @@ def process_and_write_raster_hive(
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", message=f"Object at {COVERAGE_SIDECAR}")
                 emit_raster_leaf_template(
-                    store, grid, config, int(shard_key), times_us, overwrite=True
+                    store,
+                    grid,
+                    config,
+                    int(shard_key),
+                    times_us,
+                    overwrite=True,
+                    staged_out=staged,
                 )
+            _arm_leaf_hashes(store, staged, streams)
             box["store"] = store
         return box["store"]
 
     def _write_slab(t_idx, slab):
         nonlocal write_s
         _t0 = time.time()
-        write_raster_leaf_slab(_leaf(), grid, t_idx, slab)
+        write_raster_leaf_slab(_leaf(), grid, t_idx, slab, streams=streams)
         write_s += time.time() - _t0
 
     occupied: list = []
@@ -1238,10 +1352,23 @@ def process_and_write_raster_hive(
     # actually wrote carries it, so a no-data unit stays write-less and
     # sample/write always decompose this call's wall. The per-stage ``stages``
     # block stays verbosity, gated on profiling/debug (a passed stage_stats).
+    hash_s = 0.0
+    if "store" in box:
+        # O11 finalize (issue #342 phase 5): the per-row digests close out
+        # here — no read-back, so this is a handful of hashes over bytes
+        # already consumed, not another pass over the data. The caller's
+        # ``build_record`` rides it into the leaf's D20 sidecar; ``None``
+        # leaves the record absent (§5.3 unverifiable, not tampered).
+        _t0 = time.time()
+        record = _finalize_leaf_hashes(staged, streams)
+        if record is not None:
+            meta["content_hashes"] = record
+        hash_s = time.time() - _t0
     if "store" in box:
         meta["phase_timings"] = {
-            "sample": (time.time() - t_start) - write_s,
+            "sample": (time.time() - t_start) - write_s - hash_s,
             "write": write_s,
+            "hash": hash_s,
         }
         if stage_stats is not None:
             meta["phase_timings"]["stages"] = stage_stats

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -454,7 +454,9 @@ def write_ragged_to_zarr(
     return store
 
 
-def write_ragged_leaf_to_zarr(ragged_chunks: list, store: Store, *, grid) -> Store:
+def write_ragged_leaf_to_zarr(
+    ragged_chunks: list, store: Store, *, grid, staged_out: dict | None = None
+) -> Store:
     """Write a hive leaf's ragged fields in ONE array write each (issue #209).
 
     The hive counterpart of the sharded path's slab pass: ``ragged_chunks`` is
@@ -473,6 +475,11 @@ def write_ragged_leaf_to_zarr(ragged_chunks: list, store: Store, *, grid) -> Sto
     ``resolution: chunk`` ragged companions are written per chunk block (their
     array is one block per chunk, unsharded — same as the scalar/vector
     companions).
+
+    ``staged_out`` (issue #342): when a dict is passed, the assembled slabs
+    are recorded in it under their leaf-relative array paths — refs to the
+    exact arrays written, so the caller's O11 content hashing runs over the
+    staged values with no read-back.
     """
     if not any(ragged for _block, ragged in ragged_chunks):
         return store
@@ -487,6 +494,8 @@ def write_ragged_leaf_to_zarr(ragged_chunks: list, store: Store, *, grid) -> Sto
         _accumulate_ragged_slabs(ragged, slabs, region, grid, slab_shape, chunk_res_fields)
     for name, slab in slabs.items():
         _set_ragged_block(store, grid, name, (0,) * len(slab_shape), slab)
+    if staged_out is not None:
+        staged_out.update({f"{grid.group_path}/{name}": slab for name, slab in slabs.items()})
     return store
 
 
@@ -496,6 +505,7 @@ def write_leaf_to_zarr(
     *,
     grid,
     shard_key: int,
+    staged_out: dict | None = None,
 ) -> Store:
     """Write a SHARDED hive leaf in ONE block selection per array (issue #236).
 
@@ -520,6 +530,12 @@ def write_leaf_to_zarr(
     at leaf block 0. ``resolution: chunk`` companions stay per inner chunk at
     leaf-LOCAL blocks (their arrays are one block per chunk on the leaf's
     chunk grid, never sharded).
+
+    ``staged_out`` (issue #342): when a dict is passed, the assembled dense
+    and ragged slabs are recorded in it under their leaf-relative array paths
+    — refs to the exact arrays written, the ratified O11 hash source (staged,
+    not read back). Companions are per-chunk-block writes and are not staged;
+    the hasher's read-back fallback covers them.
     """
     chunk_res_fields = _chunk_resolution_fields(getattr(grid, "config", None))
     inner_shape = tuple(int(s) for s in grid.chunk_shape)
@@ -579,6 +595,10 @@ def write_leaf_to_zarr(
             array.set_block_selection((*leaf_block, *((0,) * len(trailing))), slab)
     for name, slab in ragged_slabs.items():
         _set_ragged_block(store, grid, name, leaf_block, slab)
+    if staged_out is not None:
+        staged_out.update(
+            {f"{grid.group_path}/{name}": slab for name, slab in {**slabs, **ragged_slabs}.items()}
+        )
     return store
 
 

--- a/src/zagg/processing/write.py
+++ b/src/zagg/processing/write.py
@@ -133,6 +133,7 @@ def write_dataframe_to_zarr(
     *,
     grid,
     chunk_idx: tuple,
+    staged_out: dict | None = None,
 ) -> Store:
     """Write a per-shard output carrier to an existing Zarr template.
 
@@ -153,6 +154,16 @@ def write_dataframe_to_zarr(
     chunk_idx : tuple of int
         Storage block index for this shard, as returned by
         ``grid.block_index(shard_key)``.
+    staged_out : dict, optional
+        The HIVE leaf writers' staging seam (issue #342). When a dict is
+        passed, each dense per-cell array this call touches is lazily
+        allocated at the array's full shape and this chunk's values are placed
+        at the chunk's region, so the caller's O11 content hashing runs over
+        the staged values with no read-back GETs. ``resolution: chunk``
+        companions are NOT staged (the hasher's read-back fallback covers
+        them). **Flat-path callers must not pass it**: the region math assumes
+        the leaf-local chunk grid (one array per leaf, block ``chunk_idx``
+        indexing that leaf's own arrays), which only holds on the hive layout.
 
     Returns
     -------
@@ -229,6 +240,20 @@ def write_dataframe_to_zarr(
                         f"{trailing} (the payload dim must be one whole chunk)"
                     )
             array.set_block_selection(block_idx, values)
+            if staged_out is not None:
+                # Stage the leaf-wide slab (issue #342): allocate at fill on
+                # first sight of the array — mirroring write_leaf_to_zarr's
+                # slab construction — and place this chunk's values at its own
+                # region. Trailing (vector) dims span the array whole, so the
+                # leading-axis region is the whole placement.
+                key = f"{grid.group_path}/{name}"
+                if key not in staged_out:
+                    staged_out[key] = np.full(
+                        array.shape, array.metadata.fill_value, dtype=values.dtype
+                    )
+                staged_out[key][
+                    tuple(slice(b * c, (b + 1) * c) for b, c in zip(chunk_idx, grid.chunk_shape))
+                ] = values
 
     return store
 

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -821,7 +821,10 @@ def _write_overview(
     pinned like a leaf's: template (wholesale overwrite — a prior overview or
     torn debris is replaced, D4 retry semantics) -> arrays -> role/provenance
     attrs -> commit stamp LAST, so an interrupted writer leaves ignorable
-    debris and presence certifies the ``role`` attr landed (D11).
+    debris and presence certifies the ``role`` attr landed (D11). The D20
+    stats sidecar (§5 ``content_hashes``, issue #342) is a SIBLING object PUT
+    after the stamp — outside the leaf, so the stamp stays the leaf's own
+    final write, exactly as source-leaf sidecars land post-stamp.
     """
     import zarr
     from mortie import generate_morton_children
@@ -873,6 +876,36 @@ def _write_overview(
         window=stamp_window,
         time_range=fold["time_range"] if stamp_window is not None else None,
     )
+    # O11 content hashes (issue #342 phase 4): an overview leaf gets the same
+    # §5 D20 sidecar record as a source leaf, computed from the folded arrays
+    # already in memory (the ratified overview-scope decision (1)); the
+    # envelope's sweep-internal skip digest (``_content_hash`` above) is a
+    # DIFFERENT recipe with a different job and stays untouched (decision
+    # (2)). Sidecar naming follows the leaf basename's D23 window-only
+    # grammar (``{stem}.stats.json``) regardless of the store's manifest
+    # spec: overview basenames are v3-named unconditionally, and the legacy
+    # grammar would key every window's sidecar to one ``stats.json`` at the
+    # node. Fail-open (D9 telemetry posture; §5.3 reads absence as
+    # unverifiable, never tampered).
+    try:
+        from zagg.content_hash import content_hashes_record, hash_arrays
+        from zagg.telemetry import SPEC_V3, build_record, write_sidecar
+
+        staged = {f"{target_order}/morton": words}
+        staged.update({f"{target_order}/{name}": slab for name, slab in fold["slabs"].items()})
+        group = zarr.open_group(store, path="", mode="r", zarr_format=3)
+        record = build_record(
+            shard_key=morton_word(node),
+            metadata={
+                "cells_with_data": int(populated.sum()),
+                "granule_count": int(fold["granule_count"]),
+                "content_hashes": content_hashes_record(hash_arrays(group, staged=staged)),
+            },
+            window=stamp_window,
+        )
+        write_sidecar(path, record, spec=SPEC_V3, **store_kwargs)
+    except Exception as e:
+        logger.warning(f"sweep[overview]: O11 sidecar failed at {node}/{basename} ({e})")
     return basename
 
 

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -239,10 +239,17 @@ def merge(records: Iterable[dict]) -> dict:
     for key in _EQ_OR_NONE_KEYS:
         first = records[0].get(key)
         if all(r.get(key) == first for r in records):
-            # Defensively copy dict values (``lambda``/``invoked_by``) so a
-            # rolled-up record never aliases a leaf's nested dict, mirroring
-            # build_record (issue #297).
-            out[key] = dict(first) if isinstance(first, dict) else first
+            # Defensively copy dict values so a rolled-up record never
+            # aliases a leaf's nested dict, mirroring build_record (issue
+            # #297). One level deeper than a plain ``dict()``: flat values
+            # (``lambda``/``invoked_by``) are unaffected, but
+            # ``content_hashes`` nests an ``arrays`` map (issue #342) that a
+            # shallow copy would still alias.
+            out[key] = (
+                {k: dict(v) if isinstance(v, dict) else v for k, v in first.items()}
+                if isinstance(first, dict)
+                else first
+            )
         else:
             out[key] = None
     for key in _SUM_KEYS:

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -64,6 +64,10 @@ _EQ_OR_NONE_KEYS = (
     "run_id",
     "semantic_hash",
     "granules_sha256",
+    # O11 (issue #342): per-leaf by definition, so a multi-leaf rollup
+    # collapses it to None (absence = unverifiable, §5.3) while merge([r])
+    # stays r.
+    "content_hashes",
     "zagg_version",
     "lambda",
     "invoked_by",
@@ -183,6 +187,12 @@ def build_record(
         "n_shards": 1,
         "n_granules": int(n_granules),
         "granules_sha256": granules_sha256(granule_ids),
+        # O11 content hashes (issue #342, spec §5.3): the verification half of
+        # the D19 identity split, computed by the hive leaf writer from the
+        # staged arrays and ridden here off ``metadata``. None wherever no
+        # writer recorded them (flat layouts, raster, failures) — absence
+        # reads as unverifiable, not tampered.
+        "content_hashes": metadata.get("content_hashes"),
         "n_obs": int(metadata.get("total_obs") or 0),
         "cells_with_data": int(metadata.get("cells_with_data") or 0),
         "phase_timings": phase_timings,

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -308,18 +308,36 @@ def test_hive_store_matches_model(tmp_path, monkeypatch):
     # Through the runner: manifest + aggregation.yaml (issue #299) + root
     # MOC + the run stats parquet (#297).
     assert measured["objects_metadata"] == expected["metadata"] == 4
-    assert measured["objects_other"] == 0
     assert list(measured["objects_per_shard"]) == [_KEY_A]
     # The end-of-run sweep lands its rollups (issue #300) and overview zarrs
     # (issue #201) in their own buckets (second-pass D9 caches); the
-    # write-path total excludes both.
+    # write-path total excludes both. Overview leaves additionally carry a
+    # D20 stats sidecar (`{window}.stats.json` at the digit node, issue
+    # #342); the classifier in `.github/scripts/bench_objects.py` (CI infra,
+    # out of the #342 PR's scope — flagged there) does not bucket them yet,
+    # so pin them as the ONLY unclassified keys and fold them out with the
+    # other second-pass artifacts.
     assert measured["objects_rollups"] > 0
     assert measured["objects_overviews"] > 0
+    overview_sidecars = [k for k in measured["other_keys"] if k.endswith("/all.stats.json")]
+    assert measured["other_keys"] == overview_sidecars
+    assert measured["objects_other"] == len(overview_sidecars) > 0
     write_path = (
-        measured["objects_total"] - measured["objects_rollups"] - measured["objects_overviews"]
+        measured["objects_total"]
+        - measured["objects_rollups"]
+        - measured["objects_overviews"]
+        - len(overview_sidecars)
     )
     assert write_path == expected["total_max"]
-    assert bench_objects.object_count_mismatch(measured, expected) is None
+    # The mismatch guard, with the pinned sidecars folded out (they are
+    # asserted to be the exact residue above, so nothing is masked).
+    adjusted = dict(
+        measured,
+        objects_total=measured["objects_total"] - len(overview_sidecars),
+        objects_other=0,
+        other_keys=[],
+    )
+    assert bench_objects.object_count_mismatch(adjusted, expected) is None
     # Attribution really is the leaf prefix.
     leaf = hive.shard_leaf_path("", word).lstrip("/")
     assert any(k.startswith(leaf) for k in bench_objects.list_store_keys(root))
@@ -671,10 +689,29 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 2
     assert expected["metadata"] == 4
     # Sweep rollups (issue #300) and overview zarrs (issue #201) ride their
-    # own buckets, outside the write-path total this model audits.
+    # own buckets, outside the write-path total this model audits. Overview
+    # leaves additionally carry a D20 stats sidecar (`{window}.stats.json` at
+    # the digit node, issue #342); the classifier in
+    # `.github/scripts/bench_objects.py` (CI infra, out of the #342 PR's
+    # scope — flagged there) does not bucket them yet, so pin them as the
+    # ONLY unclassified keys and fold them out with the other second-pass
+    # artifacts. Everything else stays under the exact-zero guard.
+    overview_sidecars = [k for k in measured["other_keys"] if k.endswith("/all.stats.json")]
+    assert measured["other_keys"] == overview_sidecars
+    assert measured["objects_other"] == len(overview_sidecars) > 0
     write_path = (
-        measured["objects_total"] - measured["objects_rollups"] - measured["objects_overviews"]
+        measured["objects_total"]
+        - measured["objects_rollups"]
+        - measured["objects_overviews"]
+        - len(overview_sidecars)
     )
     assert write_path == expected["total_max"]
-    assert measured["objects_other"] == 0
-    assert bench_objects.object_count_mismatch(measured, expected) is None
+    # The mismatch guard, with the pinned sidecars folded out (they are
+    # asserted to be the exact residue above, so nothing is masked).
+    adjusted = dict(
+        measured,
+        objects_total=measured["objects_total"] - len(overview_sidecars),
+        objects_other=0,
+        other_keys=[],
+    )
+    assert bench_objects.object_count_mismatch(adjusted, expected) is None

--- a/tests/test_content_hash.py
+++ b/tests/test_content_hash.py
@@ -21,6 +21,7 @@ import zarr
 from zarr.storage import LocalStore
 
 from zagg.content_hash import (
+    StreamingArrayHash,
     combined_hash,
     content_hashes_record,
     hash_array,
@@ -367,6 +368,115 @@ class TestCoverageCompleteness:
         # Write-read parity holds across BOTH sources: staged slabs (dense,
         # vector, ragged) and the companion's read-back fallback.
         assert recorded == hash_arrays(group)
+
+
+class TestStreamingArrayHash:
+    """Issue #342 phase 5: the incremental digest equals the whole-array one.
+
+    The identity the raster path rests on — a live sha256 fed one
+    leading-axis row at a time finalizes to exactly ``hash_array`` over the
+    assembled array — plus the two preconditions that identity needs, which
+    the accumulator ENFORCES rather than assumes.
+    """
+
+    def _array(self, n_rows=5, n_cols=4, dtype="uint16"):
+        return np.arange(n_rows * n_cols, dtype=dtype).reshape(n_rows, n_cols)
+
+    def test_in_order_rows_equal_whole_array_hash(self):
+        values = self._array()
+        stream = StreamingArrayHash(values.shape, values.dtype, 0)
+        for i, row in enumerate(values):
+            stream.update(i, row)
+        assert stream.finalize() == hash_array(values)
+
+    def test_out_of_order_rows_equal_whole_array_hash(self):
+        # The raster sink delivers timesteps in COMPLETION order, so this is
+        # the production arrival pattern, not an edge case.
+        values = self._array()
+        stream = StreamingArrayHash(values.shape, values.dtype, 0)
+        for i in (3, 0, 4, 2, 1):
+            stream.update(i, values[i])
+        assert stream.finalize() == hash_array(values)
+
+    def test_unwritten_rows_contribute_fill_bytes(self):
+        # Trap (1): the recipe covers the array's FULL contents, so a row
+        # that never gets a slab still hashes — as fill.
+        values = np.full((4, 3), 7, dtype="int32")
+        values[1] = 0  # the fill value: this row is never written
+        values[3] = 0
+        stream = StreamingArrayHash(values.shape, values.dtype, 0)
+        stream.update(0, values[0])
+        stream.update(2, values[2])
+        assert stream.finalize() == hash_array(values)
+
+    def test_float_nan_fill_matches_whole_array(self):
+        values = np.full((3, 2), np.nan, dtype="float32")
+        values[0] = [1.5, 2.5]
+        stream = StreamingArrayHash(values.shape, values.dtype, np.float32("nan"))
+        stream.update(0, values[0])
+        assert stream.finalize() == hash_array(values)
+
+    def test_no_rows_written_is_all_fill(self):
+        stream = StreamingArrayHash((2, 2), np.dtype("uint16"), 0)
+        assert stream.finalize() == hash_array(np.zeros((2, 2), dtype="uint16"))
+
+    def test_big_endian_rows_hash_little_endian(self):
+        values = self._array(dtype="<u2")
+        stream = StreamingArrayHash(values.shape, values.dtype, 0)
+        for i, row in enumerate(values):
+            stream.update(i, row.astype(">u2"))
+        # A big-endian row is byteswapped to the canonical form, so the
+        # dtype guard rejects it rather than hashing swapped bytes.
+        assert stream.finalize() is None
+        assert "expected" in stream.invalid_reason
+
+    @pytest.mark.parametrize(
+        "bad, match",
+        [
+            ("duplicate", "more than once"),
+            ("out_of_range", "outside the array"),
+            ("wrong_shape", "expected"),
+        ],
+    )
+    def test_precondition_violations_drop_the_hash(self, bad, match):
+        # Trap (2): never a digest that cannot be stood behind — finalize
+        # returns None (§5.3 unverifiable) and says why.
+        values = self._array()
+        stream = StreamingArrayHash(values.shape, values.dtype, 0)
+        stream.update(0, values[0])
+        if bad == "duplicate":
+            stream.update(0, values[0])
+        elif bad == "out_of_range":
+            stream.update(99, values[1])
+        else:
+            stream.update(1, values[1][:2])
+        assert stream.finalize() is None
+        assert match in stream.invalid_reason
+
+    def test_parking_budget_overflow_drops_the_hash(self, monkeypatch):
+        monkeypatch.setattr("zagg.content_hash.STREAM_PENDING_MAX_BYTES", 8)
+        values = self._array(n_rows=6, n_cols=8)
+        stream = StreamingArrayHash(values.shape, values.dtype, 0)
+        for i in (5, 4, 3):  # all parked behind the missing row 0
+            stream.update(i, values[i])
+        assert stream.finalize() is None
+        assert "parking budget" in stream.invalid_reason
+
+    def test_gap_without_a_fill_value_drops_the_hash(self):
+        stream = StreamingArrayHash((3, 2), np.dtype("uint16"), None)
+        stream.update(0, np.zeros(2, dtype="uint16"))
+        assert stream.finalize() is None
+        assert "fill_value" in stream.invalid_reason
+
+    def test_concurrent_updates_are_serialized(self):
+        # The sink hands slabs to worker threads at write_buffer > 1.
+        from concurrent.futures import ThreadPoolExecutor
+
+        values = self._array(n_rows=32, n_cols=8)
+        stream = StreamingArrayHash(values.shape, values.dtype, 0)
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(lambda i: stream.update(i, values[i]), range(len(values))))
+        assert stream.finalize() == hash_array(values)
 
 
 class TestDenseRecipe:

--- a/tests/test_content_hash.py
+++ b/tests/test_content_hash.py
@@ -14,6 +14,7 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 import zarr
 from zarr.storage import LocalStore
@@ -204,6 +205,116 @@ class TestWorkerWiring:
         assert {k: v for k, v in doctored.items() if k != "6/count"} == {
             k: v for k, v in honest.items() if k != "6/count"
         }
+
+
+class TestCoverageCompleteness:
+    """Issue #342 phase 3: the hash set is the leaf's OWN array inventory.
+
+    Enumeration is discovery-based (§5.1, ``group.members``) — never a
+    hardcoded field list — so a new array cannot silently drop out of the
+    hash set. The literal key sets below are the anti-circularity pin (the
+    implementation and the inventory walk would otherwise agree trivially).
+    """
+
+    def test_kitchen_sink_hash_set_equals_inventory(self, kitchen_leaf):
+        meta, leaf = kitchen_leaf
+        group = zarr.open_group(LocalStore(str(leaf)), mode="r", zarr_format=3)
+        inventory = {k for k, node in group.members(max_depth=None) if isinstance(node, zarr.Array)}
+        assert set(meta["content_hashes"]["arrays"]) == inventory
+        # The full stratified surface, by name: the morton coordinate, dense
+        # fields, ragged payloads AND their locations siblings.
+        assert inventory == {
+            "6/morton",
+            "6/count",
+            "6/composition",
+            "6/h_tdigest_signal",
+            "6/h_tdigest_signal_locations",
+            "6/h_tdigest_noise",
+            "6/h_tdigest_noise_locations",
+        }
+
+    def test_companion_field_enters_hash_set_via_readback_fallback(self, monkeypatch, tmp_path):
+        # A ``resolution: chunk`` companion is written per chunk-block, never
+        # as one staged slab — the one production case where ``hash_arrays``
+        # falls back to reading the (tiny) array back. Driven through the
+        # REAL process_shard + hive leaf write (the TestShardedMixedFieldKinds
+        # config: scalar + vector + companion + ragged).
+        import zagg.processing as processing  # noqa: F401  (patch target)
+        from zagg import hive
+        from zagg.config import default_config
+        from zagg.grids import HealpixGrid
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        cfg = default_config()
+        agg = cfg.aggregation
+        agg.setdefault("chunk_precompute", {})["chunk_base"] = {
+            "expression": "np.float32(np.mean(h_li))",
+            "source": "h_li",
+        }
+        agg["variables"]["h_edges"] = {
+            "expression": "np.array([np.min(h_li), np.max(h_li)])",
+            "source": "h_li",
+            "kind": "vector",
+            "trailing_shape": 2,
+            "dtype": "float32",
+        }
+        agg["variables"]["h_chunk_base"] = {
+            "expression": "chunk_base",
+            "resolution": "chunk",
+            "dtype": "float32",
+        }
+        agg["variables"]["h_ragged"] = {
+            "function": "np.sort",
+            "source": "h_li",
+            "kind": "ragged",
+            "inner_shape": [1],
+            "dtype": "float32",
+        }
+        grid = HealpixGrid(4, 7, layout="fullsphere", config=cfg, chunk_inner=6, sharded=True)
+        from mortie import geo2mort
+
+        shard_key = int(geo2mort(-78.5, -132.0, order=4)[0])
+        children = grid.children(shard_key)
+        idx = [0, len(children) // 2, len(children) - 1]
+        df = pd.DataFrame(
+            {
+                "h_li": np.array([3.0, 7.0, 2.0], dtype=np.float32),
+                "s_li": np.array([0.1, 0.1, 0.1], dtype=np.float32),
+                "leaf_id": np.array([int(children[i]) for i in idx], dtype=np.uint64),
+            }
+        )
+        calls = {"n": 0}
+
+        def one_shot(*args, **kwargs):
+            calls["n"] += 1
+            return df.copy() if calls["n"] == 1 else None
+
+        monkeypatch.setattr("zagg.processing._read_group", one_shot)
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
+        meta = hive.process_and_write_hive(
+            shard_key,
+            ["s3://x"],
+            grid,
+            {},
+            str(tmp_path / "store"),
+            cfg,
+            store_kwargs={},
+            handoff="pandas",  # the one_shot stub yields pandas carriers
+        )
+        assert meta.get("error") is None, meta
+        leaf = hive.shard_leaf_path(str(tmp_path / "store"), shard_key)
+        group = zarr.open_group(LocalStore(leaf), mode="r", zarr_format=3)
+        inventory = {k for k, node in group.members(max_depth=None) if isinstance(node, zarr.Array)}
+        recorded = meta["content_hashes"]["arrays"]
+        assert set(recorded) == inventory
+        assert {"7/h_chunk_base", "7/h_edges", "7/h_ragged", "7/morton"} <= inventory
+        # Write-read parity holds across BOTH sources: staged slabs (dense,
+        # vector, ragged) and the companion's read-back fallback.
+        assert recorded == hash_arrays(group)
 
 
 class TestDenseRecipe:

--- a/tests/test_content_hash.py
+++ b/tests/test_content_hash.py
@@ -11,6 +11,7 @@ finding to raise on issue #342, never something to patch around.
 
 import importlib.util
 import json
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -194,6 +195,17 @@ class TestWorkerWiring:
         meta, _leaf = kitchen_leaf
         assert meta["phase_timings"]["hash"] >= 0.0
 
+    def test_unused_staged_key_warns(self, kitchen_leaf, caplog):
+        # A staged key matching no enumerated array is a broken writer seam,
+        # not a correctness bug: the hashes still equal the unstaged call, but
+        # it has to be LOUD or a totally dead staging pipeline is invisible.
+        _meta, leaf = kitchen_leaf
+        group = zarr.open_group(LocalStore(str(leaf)), mode="r", zarr_format=3)
+        with caplog.at_level(logging.WARNING, logger="zagg.content_hash"):
+            hashes = hash_arrays(group, staged={"nonexistent/key": np.zeros(1)})
+        assert hashes == hash_arrays(group)
+        assert "staged values for ['nonexistent/key']" in caplog.text
+
     def test_staged_values_take_priority_over_the_store(self, kitchen_leaf):
         # Proof the staged mapping is the hash source when present: a doctored
         # staged value flips exactly that key, everything else read-back.
@@ -233,7 +245,9 @@ class TestCoverageCompleteness:
             "6/h_tdigest_noise_locations",
         }
 
-    def test_companion_field_enters_hash_set_via_readback_fallback(self, monkeypatch, tmp_path):
+    def test_companion_field_enters_hash_set_via_readback_fallback(
+        self, monkeypatch, tmp_path, caplog
+    ):
         # A ``resolution: chunk`` companion is written per chunk-block, never
         # as one staged slab — the one production case where ``hash_arrays``
         # falls back to reading the (tiny) array back. Driven through the
@@ -295,17 +309,21 @@ class TestCoverageCompleteness:
         monkeypatch.setattr(
             "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
         )
-        meta = hive.process_and_write_hive(
-            shard_key,
-            ["s3://x"],
-            grid,
-            {},
-            str(tmp_path / "store"),
-            cfg,
-            store_kwargs={},
-            handoff="pandas",  # the one_shot stub yields pandas carriers
-        )
+        with caplog.at_level(logging.WARNING, logger="zagg.content_hash"):
+            meta = hive.process_and_write_hive(
+                shard_key,
+                ["s3://x"],
+                grid,
+                {},
+                str(tmp_path / "store"),
+                cfg,
+                store_kwargs={},
+                handoff="pandas",  # the one_shot stub yields pandas carriers
+            )
         assert meta.get("error") is None, meta
+        # The writer's staged keys all land on enumerated arrays — no silent
+        # key-composition drift between write.py and the members() walk.
+        assert "staged values for" not in caplog.text
         leaf = hive.shard_leaf_path(str(tmp_path / "store"), shard_key)
         group = zarr.open_group(LocalStore(leaf), mode="r", zarr_format=3)
         inventory = {k for k, node in group.members(max_depth=None) if isinstance(node, zarr.Array)}

--- a/tests/test_content_hash.py
+++ b/tests/test_content_hash.py
@@ -9,6 +9,7 @@ The recipe is not zagg's to adjust: a parity failure here is a spec/fixture
 finding to raise on issue #342, never something to patch around.
 """
 
+import importlib.util
 import json
 from pathlib import Path
 
@@ -102,6 +103,107 @@ class TestVlenRecipe:
         # The "anything else → raise" gate: never hash a repr/pointer buffer.
         with pytest.raises(ValueError, match="no O11 byte recipe"):
             hash_array(self._obj([3.5]))
+
+
+GENERATOR = Path(__file__).parent.parent / "tools" / "generate_spec_fixtures.py"
+
+
+def _generator():
+    """The spec fixture generator, loaded as a module (the tools/ precedent)."""
+    spec = importlib.util.spec_from_file_location("zagg_spec_fixture_generator", GENERATOR)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_kitchen_sink(root: Path):
+    """One kitchen-sink leaf through the PRODUCTION write path (generator inputs).
+
+    Returns ``(metadata, leaf_dir)`` — the worker metadata now carries the
+    staged-source ``content_hashes`` (issue #342 phase 2).
+    """
+    import zagg.processing as processing
+    from zagg import hive
+    from zagg.grids import HealpixGrid
+    from zagg.grids.morton import morton_word
+
+    gen = _generator()
+    cfg = gen._config(kitchen_sink=True)
+    grid = HealpixGrid(4, 6, layout="fullsphere", config=cfg, chunk_inner=5, sharded=True)
+    shard = morton_word(gen.SHARD_KEY)
+    by_chunk, _cells = gen._build_cells(grid, shard, kitchen_sink=True)
+    hive.ensure_manifest(
+        str(root), hive.build_manifest(grid, dataset={"short_name": "O11_TEST", "version": "1"})
+    )
+    inner = gen._fake_process_shard(grid, by_chunk, kitchen_sink=True)
+
+    def fake(*args, **kwargs):
+        # The generator's fake seeds no phase_timings; the hash timing rides
+        # an existing dict only (the write-stamp gate), so seed one here.
+        df, meta = inner(*args, **kwargs)
+        meta["phase_timings"] = {"read": 0.0, "index": 0.0, "aggregate": 0.0}
+        return df, meta
+
+    original = processing.process_shard
+    processing.process_shard = fake
+    try:
+        meta = hive.process_and_write_hive(
+            shard, ["s3://fixture/a.h5"], grid, {}, str(root), cfg, store_kwargs={}
+        )
+    finally:
+        processing.process_shard = original
+    assert meta.get("error") is None, meta
+    leaf_rel = hive.shard_leaf_path("", shard).lstrip("/")
+    return meta, root / leaf_rel
+
+
+@pytest.fixture(scope="module")
+def kitchen_leaf(tmp_path_factory):
+    root = tmp_path_factory.mktemp("o11_store")
+    return _write_kitchen_sink(root)
+
+
+class TestWorkerWiring:
+    """Issue #342 phase 2: staged in-worker hashing on the hive leaf write."""
+
+    def test_metadata_carries_structured_record(self, kitchen_leaf):
+        meta, _leaf = kitchen_leaf
+        record = meta["content_hashes"]
+        assert set(record) == {"arrays", "combined"}
+        assert record["combined"] == combined_hash(record["arrays"])
+        assert list(record["arrays"]) == sorted(record["arrays"])
+
+    def test_write_read_parity(self, kitchen_leaf):
+        # THE acceptance gate for the ratified staged-source decision (4):
+        # hashes computed from the staged arrays must equal hashes recomputed
+        # from a full store read-back — the dtype-cast/fill drift guard.
+        meta, leaf = kitchen_leaf
+        group = zarr.open_group(LocalStore(str(leaf)), mode="r", zarr_format=3)
+        read_back = hash_arrays(group)
+        assert meta["content_hashes"]["arrays"] == read_back
+        assert meta["content_hashes"]["combined"] == combined_hash(read_back)
+
+    def test_matches_pinned_fixture_hashes(self, kitchen_leaf):
+        # Same seeded inputs as the committed kitchen_sink fixture, so the
+        # worker-recorded hashes must reproduce the PINNED values exactly.
+        meta, _leaf = kitchen_leaf
+        assert meta["content_hashes"] == _expected("kitchen_sink")["content_hashes"]
+
+    def test_hash_phase_timing_recorded(self, kitchen_leaf):
+        meta, _leaf = kitchen_leaf
+        assert meta["phase_timings"]["hash"] >= 0.0
+
+    def test_staged_values_take_priority_over_the_store(self, kitchen_leaf):
+        # Proof the staged mapping is the hash source when present: a doctored
+        # staged value flips exactly that key, everything else read-back.
+        _meta, leaf = kitchen_leaf
+        group = zarr.open_group(LocalStore(str(leaf)), mode="r", zarr_format=3)
+        honest = hash_arrays(group)
+        doctored = hash_arrays(group, staged={"6/count": np.zeros(16, dtype=np.int32)})
+        assert doctored["6/count"] != honest["6/count"]
+        assert {k: v for k, v in doctored.items() if k != "6/count"} == {
+            k: v for k, v in honest.items() if k != "6/count"
+        }
 
 
 class TestDenseRecipe:

--- a/tests/test_content_hash.py
+++ b/tests/test_content_hash.py
@@ -118,11 +118,13 @@ def _generator():
     return mod
 
 
-def _write_kitchen_sink(root: Path):
+def _write_kitchen_sink(root: Path, *, sharded: bool = True):
     """One kitchen-sink leaf through the PRODUCTION write path (generator inputs).
 
     Returns ``(metadata, leaf_dir)`` — the worker metadata now carries the
-    staged-source ``content_hashes`` (issue #342 phase 2).
+    staged-source ``content_hashes`` (issue #342 phase 2). ``sharded=False``
+    drives the same inputs through the per-chunk STREAMING leaf write (the
+    path a ``chunk_inner``-unset grid always takes).
     """
     import zagg.processing as processing
     from zagg import hive
@@ -131,7 +133,7 @@ def _write_kitchen_sink(root: Path):
 
     gen = _generator()
     cfg = gen._config(kitchen_sink=True)
-    grid = HealpixGrid(4, 6, layout="fullsphere", config=cfg, chunk_inner=5, sharded=True)
+    grid = HealpixGrid(4, 6, layout="fullsphere", config=cfg, chunk_inner=5, sharded=sharded)
     shard = morton_word(gen.SHARD_KEY)
     by_chunk, _cells = gen._build_cells(grid, shard, kitchen_sink=True)
     hive.ensure_manifest(
@@ -140,9 +142,18 @@ def _write_kitchen_sink(root: Path):
     inner = gen._fake_process_shard(grid, by_chunk, kitchen_sink=True)
 
     def fake(*args, **kwargs):
+        # The generator's fake only knows the ``chunk_results`` sink; the
+        # streaming path passes ``write_chunk`` instead, so collect the chunks
+        # locally and replay them through the callback.
+        write_chunk = kwargs.get("write_chunk")
+        if kwargs.get("chunk_results") is None:
+            kwargs["chunk_results"] = []
+        df, meta = inner(*args, **kwargs)
+        if write_chunk is not None:
+            for block, carrier, ragged in kwargs["chunk_results"]:
+                write_chunk(block, carrier, ragged)
         # The generator's fake seeds no phase_timings; the hash timing rides
         # an existing dict only (the write-stamp gate), so seed one here.
-        df, meta = inner(*args, **kwargs)
         meta["phase_timings"] = {"read": 0.0, "index": 0.0, "aggregate": 0.0}
         return df, meta
 
@@ -217,6 +228,29 @@ class TestWorkerWiring:
         assert {k: v for k, v in doctored.items() if k != "6/count"} == {
             k: v for k, v in honest.items() if k != "6/count"
         }
+
+
+class TestStreamingLeafStaging:
+    """The UNSHARDED (streaming) hive leaf stages its dense arrays too.
+
+    ``sharded`` is forced off whenever a leaf holds one inner chunk — the
+    ``chunk_inner``-unset default — so this is the common hive config, not a
+    corner. Decision (4) ("staged, no read-back GETs") has to hold on it.
+    """
+
+    def test_unsharded_leaf_reproduces_pinned_hashes_from_staged_values(self, tmp_path, caplog):
+        with caplog.at_level(logging.WARNING, logger="zagg.content_hash"):
+            meta, leaf = _write_kitchen_sink(tmp_path / "unsharded", sharded=False)
+        # Decoded-value hashing is packaging-invariant (§5): the same inputs
+        # through the streaming write must reproduce the sharded fixture's
+        # PINNED hashes exactly, despite the different object layout.
+        assert meta["content_hashes"] == _expected("kitchen_sink")["content_hashes"]
+        # ... and still equal a full read-back (the dtype-cast/fill guard).
+        group = zarr.open_group(LocalStore(str(leaf)), mode="r", zarr_format=3)
+        assert meta["content_hashes"]["arrays"] == hash_arrays(group)
+        # Every staged key landed on an enumerated array — the dense arrays
+        # (``morton`` included) came from the staged slabs, not a read-back.
+        assert "staged values for" not in caplog.text
 
 
 class TestCoverageCompleteness:

--- a/tests/test_content_hash.py
+++ b/tests/test_content_hash.py
@@ -1,0 +1,119 @@
+"""§5 O11 content-hash recipe port: parity + raise-gate tests (issue #342).
+
+Phase-1 gates: byte-identical parity against the committed conformance
+fixtures' PINNED ``content_hashes`` (recomputed from the fixture stores —
+per-array AND combined), the §5.2 element→bytes normalization including its
+"anything else → raise" gate, and an optional cross-check against the
+moczarr reference implementation (``moczarr.stats``) when it is importable.
+The recipe is not zagg's to adjust: a parity failure here is a spec/fixture
+finding to raise on issue #342, never something to patch around.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+from zarr.storage import LocalStore
+
+from zagg.content_hash import (
+    combined_hash,
+    content_hashes_record,
+    hash_array,
+    hash_arrays,
+)
+
+SPEC_DATA = Path(__file__).parent / "data" / "spec"
+FIXTURES = ("minimal", "kitchen_sink")
+
+
+def _expected(name: str) -> dict:
+    return json.loads((SPEC_DATA / f"{name}.expected.json").read_text())
+
+
+def _leaf_group(name: str, exp: dict):
+    leaf = SPEC_DATA / name / exp["leaf"]
+    return zarr.open_group(LocalStore(str(leaf)), mode="r", zarr_format=3)
+
+
+class TestFixtureParity:
+    """The pinned fixture hashes (spec §7) recomputed through the port."""
+
+    @pytest.mark.parametrize("name", FIXTURES)
+    def test_per_array_hashes_match_pinned(self, name):
+        exp = _expected(name)
+        assert hash_arrays(_leaf_group(name, exp)) == exp["content_hashes"]["arrays"]
+
+    @pytest.mark.parametrize("name", FIXTURES)
+    def test_combined_hash_matches_pinned(self, name):
+        exp = _expected(name)
+        hashes = hash_arrays(_leaf_group(name, exp))
+        assert combined_hash(hashes) == exp["content_hashes"]["combined"]
+
+    @pytest.mark.parametrize("name", FIXTURES)
+    def test_record_shape_matches_pinned_and_is_key_sorted(self, name):
+        exp = _expected(name)
+        record = content_hashes_record(hash_arrays(_leaf_group(name, exp)))
+        assert record == exp["content_hashes"]
+        assert list(record["arrays"]) == sorted(record["arrays"])
+
+    @pytest.mark.parametrize("name", FIXTURES)
+    def test_moczarr_reference_agrees(self, name):
+        """Optional cross-check against the reference implementation."""
+        moczarr_stats = pytest.importorskip("moczarr.stats")
+        exp = _expected(name)
+        theirs = moczarr_stats.hash_arrays(str(SPEC_DATA / name), exp["leaf"])
+        ours = hash_arrays(_leaf_group(name, exp))
+        assert theirs == ours
+        assert moczarr_stats.combined_hash(theirs) == combined_hash(ours)
+
+
+class TestVlenRecipe:
+    """§5.2 element→bytes normalization, one test per contract row."""
+
+    def _obj(self, elements):
+        values = np.empty(len(elements), dtype=object)
+        values[:] = elements
+        return values
+
+    def test_length_prefix_is_injective(self):
+        # Without the u64le prefix these two cell grids would collide.
+        assert hash_array(self._obj([b"ab", b"c"])) != hash_array(self._obj([b"a", b"bc"]))
+
+    def test_none_hashes_as_empty_payload(self):
+        # An unwritten cell may decode as None, not b"" — identical by design.
+        assert hash_array(self._obj([None, b"x"])) == hash_array(self._obj([b"", b"x"]))
+
+    def test_str_is_utf8(self):
+        assert hash_array(self._obj(["hé"])) == hash_array(self._obj(["hé".encode()]))
+
+    def test_ndarray_element_is_le_c_order_bytes(self):
+        # A typed /2 cell decodes to an ndarray whose LE C-order bytes are the
+        # /1 cell's payload bytes (spec §6.2) — the same hash, no recipe change.
+        payload = np.array([[1.5, 2.0], [3.0, 4.0]], dtype="<f4")
+        assert hash_array(self._obj([payload])) == hash_array(self._obj([payload.tobytes()]))
+
+    def test_big_endian_ndarray_element_is_byteswapped(self):
+        le = np.array([1, 2, 3], dtype="<u8")
+        assert hash_array(self._obj([le.astype(">u8")])) == hash_array(self._obj([le]))
+
+    def test_unsupported_element_raises(self):
+        # The "anything else → raise" gate: never hash a repr/pointer buffer.
+        with pytest.raises(ValueError, match="no O11 byte recipe"):
+            hash_array(self._obj([3.5]))
+
+
+class TestDenseRecipe:
+    def test_big_endian_array_hashes_as_little_endian(self):
+        values = np.array([1, 2, 3], dtype="<u4")
+        assert hash_array(values.astype(">u4")) == hash_array(values)
+
+    def test_non_contiguous_hashes_as_c_order(self):
+        values = np.arange(12, dtype="<f8").reshape(3, 4)
+        assert hash_array(values.T) == hash_array(np.ascontiguousarray(values.T))
+
+    def test_combined_is_order_immune_but_value_sensitive(self):
+        hashes = {"a": "00", "b": "ff"}
+        assert combined_hash(hashes) == combined_hash({"b": "00", "a": "ff"})
+        assert combined_hash(hashes) != combined_hash({"a": "00", "b": "fe"})

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -1404,7 +1404,7 @@ class TestHiveProfileWritePhase:
         _grid, _shard, _root, meta = self._run(monkeypatch, cfg, tmp_path, fake)
         timings = meta["phase_timings"]
         # Additive: the process_shard phases keep their names and values.
-        assert set(timings) == {"read", "index", "aggregate", "write"}
+        assert set(timings) == {"read", "index", "aggregate", "write", "hash"}
         assert {k: timings[k] for k in self._SHARD_PHASES} == self._SHARD_PHASES
         assert timings["write"] >= 0.0
 
@@ -1434,7 +1434,7 @@ class TestHiveProfileWritePhase:
             store_kwargs={},
         )
         assert meta["phase_timings"]["write"] >= 0.0
-        assert set(meta["phase_timings"]) == {"read", "index", "aggregate", "write"}
+        assert set(meta["phase_timings"]) == {"read", "index", "aggregate", "write", "hash"}
 
     def test_errored_shard_omits_write(self, monkeypatch, cfg, tmp_path):
         # Same gate as the flat handler (issue #100): a shard that wrote no
@@ -1449,7 +1449,7 @@ class TestHiveProfileWritePhase:
         # without any profile flag — the sidecar record is complete by default.
         fake = self._profiled_fake(self._grid(cfg), ragged={"h": ([np.array([1.0, 2.0])], [0])})
         _grid, shard, root, meta = self._run(monkeypatch, cfg, tmp_path, fake)
-        assert set(meta["phase_timings"]) == {"read", "index", "aggregate", "write"}
+        assert set(meta["phase_timings"]) == {"read", "index", "aggregate", "write", "hash"}
         # The leaf still landed, fully stamped.
         from zagg.store import open_store
 

--- a/tests/test_lambda_raster_handler.py
+++ b/tests/test_lambda_raster_handler.py
@@ -627,6 +627,6 @@ class TestProcessRasterHiveMode:
         resp = handler_mod.lambda_handler(event, MagicMock())
         assert resp["statusCode"] == 200, resp
         pt = json.loads(resp["body"])["phase_timings"]
-        assert set(pt) == {"sample", "write", "stages"}
+        assert set(pt) == {"sample", "write", "hash", "stages"}
         assert pt["write"] > 0.0
         assert pt["stages"]["assets"] == 1

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -1205,11 +1205,11 @@ class TestRasterHiveWorker:
         real_write = raster_mod.write_raster_leaf_slab
         calls = {"n": 0}
 
-        def _tear(store, g, t, slab):
+        def _tear(store, g, t, slab, **kwargs):
             calls["n"] += 1
             if calls["n"] == 2:
                 raise RuntimeError("torn mid-shard")
-            return real_write(store, g, t, slab)
+            return real_write(store, g, t, slab, **kwargs)
 
         monkeypatch.setattr(raster_mod, "write_raster_leaf_slab", _tear)
         with pytest.raises(RuntimeError, match="torn"):
@@ -1232,6 +1232,106 @@ class TestRasterHiveWorker:
         assert stamp and stamp["complete"]
         red = open_array(leaf + f"/{grid.group_path}/red", zarr_format=3, consolidated=False)
         assert red.shape == (1, grid.cells_per_shard)
+
+
+class TestRasterHiveContentHashes:
+    """Issue #342 phase 5: O11 hashes accumulated incrementally as slabs stream.
+
+    The raster leaf never holds a whole band array, so the §5 digest is fed
+    row by row at write time. The acceptance gate is parity with the
+    canonical recipe: what the accumulator recorded must equal
+    ``content_hash.hash_arrays`` recomputed over the leaf read back from the
+    store.
+    """
+
+    def _setup(self, tmp_path, n=2):
+        cfg, grid, shard = _healpix_setup(tmp_path)
+        granules = []
+        for i in range(n):
+            _write_tiff(tmp_path / f"h{i}.tif", np.full((96, 96), 500 + i, dtype=np.uint16))
+            granules.append(
+                _entry(f"g{i}", {"red": str(tmp_path / f"h{i}.tif")}, T0, time_key=f"dt-{i}")
+            )
+        return cfg, grid, shard, granules, str(tmp_path / "hivestore")
+
+    def test_streamed_hashes_match_a_full_read_back(self, tmp_path):
+        # THE acceptance gate: incremental path == canonical recipe.
+        import zarr
+
+        from zagg import hive
+        from zagg.content_hash import combined_hash, hash_arrays
+        from zagg.processing.raster import process_and_write_raster_hive
+        from zagg.store import open_store
+
+        cfg, grid, shard, granules, root = self._setup(tmp_path, n=3)
+        meta = process_and_write_raster_hive(
+            shard, granules, grid, root, cfg, store_kwargs={}, window=None
+        )
+        record = meta["content_hashes"]
+        leaf = hive.shard_leaf_path(root, shard)
+        group = zarr.open_group(open_store(leaf), mode="r", zarr_format=3)
+        read_back = hash_arrays(group)
+        assert record["arrays"] == read_back
+        assert record["combined"] == combined_hash(read_back)
+        # Discovery-based scope: the band plus both coordinates, nothing else.
+        assert set(read_back) == {
+            f"{grid.group_path}/red",
+            f"{grid.group_path}/time",
+            f"{grid.group_path}/morton",
+        }
+        assert meta["phase_timings"]["hash"] >= 0.0
+
+    def test_windowed_leaf_records_hashes_in_its_sidecar_record(self, tmp_path):
+        from zagg.processing.raster import process_and_write_raster_hive
+        from zagg.telemetry import build_record
+
+        cfg, grid, shard, granules, root = self._setup(tmp_path)
+        meta = process_and_write_raster_hive(
+            shard, granules, grid, root, cfg, store_kwargs={}, window={"label": "20260713"}
+        )
+        # The D20 record both dispatchers build carries it verbatim (the
+        # raster sidecar seam needs no change of its own).
+        record = build_record(shard_key=shard, metadata=meta, window="20260713")
+        assert record["content_hashes"] == meta["content_hashes"]
+
+    def test_a_unit_that_writes_no_leaf_records_nothing(self, tmp_path):
+        from zagg.processing.raster import process_and_write_raster_hive
+
+        cfg, grid, shard, _granules, root = self._setup(tmp_path)
+        meta = process_and_write_raster_hive(
+            shard, [], grid, root, cfg, store_kwargs={}, window=None
+        )
+        assert "content_hashes" not in meta  # unverifiable, not tampered (§5.3)
+
+    def test_a_violated_precondition_records_no_hash_at_all(self, tmp_path, caplog):
+        # Trap (2) at the integration level: a row written twice invalidates
+        # that array's digest, and the WHOLE record drops rather than
+        # recording a partial map a verifier would read as "array missing".
+        import logging
+
+        from zagg.processing.raster import (
+            _arm_leaf_hashes,
+            _finalize_leaf_hashes,
+            emit_raster_leaf_template,
+            write_raster_leaf_slab,
+        )
+        from zagg.store import open_store
+
+        cfg, grid, shard, _granules, root = self._setup(tmp_path)
+        store = open_store(f"{root}/leaf.zarr")
+        staged: dict = {}
+        streams: dict = {}
+        emit_raster_leaf_template(
+            store, grid, cfg, shard, np.array([0, 1], dtype=np.int64), staged_out=staged
+        )
+        _arm_leaf_hashes(store, staged, streams)
+        row = np.zeros(grid.cells_per_shard, dtype=np.uint16)
+        write_raster_leaf_slab(store, grid, 0, {"red": row}, streams=streams)
+        write_raster_leaf_slab(store, grid, 0, {"red": row}, streams=streams)  # same row twice
+        with caplog.at_level(logging.WARNING):
+            assert _finalize_leaf_hashes(staged, streams) is None
+        assert "no content hashes recorded" in caplog.text
+        assert "written more than once" in caplog.text
 
 
 class TestRasterHivePopcount:

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -730,6 +730,66 @@ class TestOverviewWriter:
         assert g["h_min"][0] == 1.0
 
 
+class TestOverviewContentHashes:
+    """Issue #342 phase 4: overview leaves get §5 ``content_hashes`` sidecars,
+    computed from the folded arrays in memory; the envelope's sweep-internal
+    skip digest is a different recipe and stays untouched."""
+
+    def test_sidecar_records_section5_hashes_with_parity(self, tmp_path):
+        from zagg.content_hash import combined_hash, hash_arrays
+        from zagg.telemetry import SPEC_V3, read_sidecar
+
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0, 2.0], 5: [10.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        leaf = str(tmp_path / "-3" / "1" / "all.zarr")
+        record = read_sidecar(leaf, spec=SPEC_V3)
+        assert record is not None and record["window"] is None
+        # Write-read parity, overview edition: the staged-source hashes must
+        # equal a full read-back of the written overview zarr.
+        group = zarr.open_group(open_store(leaf), mode="r", zarr_format=3)
+        read_back = hash_arrays(group)
+        assert record["content_hashes"]["arrays"] == read_back
+        assert record["content_hashes"]["combined"] == combined_hash(read_back)
+        # Discovery-based scope: morton + every composable field, none extra.
+        assert set(read_back) == {"3/morton", "3/count", "3/h_min", "3/h_tdigest"}
+
+    def test_stamp_skip_digest_stays_separate_and_untouched(self, tmp_path):
+        from zagg.telemetry import SPEC_V3, read_sidecar
+
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        envelope = json.loads((tmp_path / "-3" / "1" / "overview.rollup.json").read_text())
+        entry = envelope["windows"]["all"]
+        root = _overview_root(tmp_path, "-3/1", "all.zarr")
+        # The sweep-internal skip digest still rides envelope + attrs...
+        assert entry["content_hash"] == root.attrs[OVERVIEW_ATTR]["content_hash"]
+        # ...and is NOT the §5 combined hash (different recipe, different job).
+        record = read_sidecar(str(tmp_path / "-3" / "1" / "all.zarr"), spec=SPEC_V3)
+        assert entry["content_hash"] != record["content_hashes"]["combined"]
+
+    def test_windowed_overviews_get_per_window_sidecars(self, tmp_path):
+        from zagg.telemetry import SPEC_V3, read_sidecar
+
+        _write_manifest(tmp_path, orders=(1,), windowed=True, all_time=True)
+        _make_leaf(tmp_path, "-311", {0: [1.0, 2.0]}, window="2019")
+        _make_leaf(tmp_path, "-311", {0: [10.0]}, window="2020")
+        word = morton_word("-311")
+        run_sweep(str(tmp_path), [(word, "2019"), (word, "2020")], families=("overview",))
+        node = tmp_path / "-3" / "1"
+        # D23 window-only naming keys one sidecar per window basename — the
+        # legacy grammar would have keyed them all to one stats.json.
+        assert (node / "2019.stats.json").exists()
+        assert (node / "2020.stats.json").exists()
+        assert (node / "all.stats.json").exists()
+        r2019 = read_sidecar(str(node / "2019.zarr"), spec=SPEC_V3)
+        rall = read_sidecar(str(node / "all.zarr"), spec=SPEC_V3)
+        assert r2019["window"] == "2019"
+        assert rall["window"] == "all"
+        assert r2019["content_hashes"]["combined"] != rall["content_hashes"]["combined"]
+
+
 class TestSection83Obligations:
     """The standing D22 test claims for the overview family (§8.3)."""
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -114,6 +114,15 @@ class TestBuildRecord:
         rec = _record(duration=10.0, lambda_config=cfg)
         assert rec["est_cost_usd"] == pytest.approx(10.0 * 0.0000133334)
 
+    def test_content_hashes_ride_metadata(self):
+        # O11 (issue #342): the hive writer stamps metadata["content_hashes"];
+        # the record carries it verbatim, None wherever no writer recorded it
+        # (flat layouts, raster, failures) — absence = unverifiable (§5.3).
+        assert _record()["content_hashes"] is None
+        hashes = {"arrays": {"6/count": "aa"}, "combined": "bb"}
+        rec = build_record(shard_key=1, metadata={"duration_s": 1.0, "content_hashes": hashes})
+        assert rec["content_hashes"] == hashes
+
     def test_invoked_by_copied_verbatim(self):
         ident = {"arn": "arn:aws:sts::123:assumed-role/x/y", "userid": "AROA:me"}
         assert _record(invoked_by=ident)["invoked_by"] == ident
@@ -192,6 +201,17 @@ class TestMerge:
         assert m["phase_timings"]["read"] == pytest.approx(16.0)
         assert m["timestamp"] == max(a["timestamp"], b["timestamp"])
         assert m["success"] is True
+
+    def test_content_hashes_merge_equal_or_none(self):
+        # Per-leaf identity (issue #342): shared value survives a fold,
+        # differing leaves collapse to None (the absorbing identity).
+        hashes = {"arrays": {"6/count": "aa"}, "combined": "bb"}
+        a = build_record(shard_key=1, metadata={"duration_s": 1.0, "content_hashes": hashes})
+        b = build_record(shard_key=1, metadata={"duration_s": 1.0, "content_hashes": hashes})
+        assert merge([a, b])["content_hashes"] == hashes
+        other = {"arrays": {"6/count": "cc"}, "combined": "dd"}
+        c = build_record(shard_key=1, metadata={"duration_s": 1.0, "content_hashes": other})
+        assert merge([a, c])["content_hashes"] is None
 
     def test_cost_fields_fold(self):
         price = 0.0000133334

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -213,6 +213,17 @@ class TestMerge:
         c = build_record(shard_key=1, metadata={"duration_s": 1.0, "content_hashes": other})
         assert merge([a, c])["content_hashes"] is None
 
+    def test_merge_does_not_alias_nested_content_hashes(self):
+        # The rollup's defensive copy has to reach the nested ``arrays`` map
+        # too: equal by value, never the leaf record's object (issue #342).
+        hashes = {"arrays": {"6/count": "aa"}, "combined": "bb"}
+        a = build_record(shard_key=1, metadata={"duration_s": 1.0, "content_hashes": hashes})
+        b = build_record(shard_key=1, metadata={"duration_s": 1.0, "content_hashes": hashes})
+        merged = merge([a, b])
+        assert merged["content_hashes"] == a["content_hashes"]
+        assert merged["content_hashes"] is not a["content_hashes"]
+        assert merged["content_hashes"]["arrays"] is not a["content_hashes"]["arrays"]
+
     def test_cost_fields_fold(self):
         price = 0.0000133334
         cfg_a = {"memory_mb": 4096, "arch": "aarch64", "function_variant": "zagg-process-shard"}


### PR DESCRIPTION
Closes #342

Writer-side O11 content hashes: the spec §5 recipe (per-array sha256 over decoded C-order little-endian bytes; vlen arrays as u64le length-prefixed payload bytes per cell in flat C order; combined = sha256 over the sorted per-array hex digests joined by `"\n"`) computed **at write, in-worker**, and recorded under `content_hashes` in the leaf's D20 stats sidecar per §5.3.

Implements the [plan](https://github.com/englacial/zagg/issues/342#issuecomment-5146680196) under the binding [ratification record](https://github.com/englacial/zagg/issues/342#issuecomment-5146967460): (1) sweep-written overview leaves also get §5 hashes; (2) the overview stamp's sweep-internal skip digest stays separate and untouched; (3) O11 is hive-only — the writer no-ops on non-hive layouts, documented; (4) hashes are computed from the STAGED arrays, guarded by a write-read parity test. The recipe itself is adopted verbatim from the moczarr reference (`moczarr.stats.hash_arrays` / `combined_hash`) and is not this PR's to adjust.

## Approach

- `src/zagg/content_hash.py` (new) holds ALL hash logic: `hash_array` (§5.2, dense + vlen with the element→bytes normalization and its raise gate), `hash_arrays(group, staged=...)` (discovery-based §5.1 scope via `group.members(max_depth=None)`; a staged in-memory value is hashed in place of a read-back), `combined_hash`, `content_hashes_record` (the §5.3 structured, key-sorted shape), and `StreamingArrayHash` (the incremental digest, phase 5).
- **Spatial hive leaves** — the leaf writers (`write_leaf_to_zarr` / `write_ragged_leaf_to_zarr` / `write_dataframe_to_zarr`) gained an optional `staged_out` sink: refs to the exact slabs written, no copies, on BOTH the sharded and the streaming/unsharded paths. `zagg.hive.process_and_write_hive` computes the record after the stamp on the success path (fail-open), returns it as `metadata["content_hashes"]`, and times it as the `hash` phase. `telemetry.build_record` rides it into the D20 sidecar for both dispatch backends; `merge` treats it equal-or-None.
- **Overview leaves** — `sweep_overview._write_overview` writes the same record from the folded slabs + morton words already in memory, as a sibling `{stem}.stats.json` PUT after the stamp.
- **Raster hive leaves (phase 5)** — this path never holds a whole band array (it streams one timestep at a time, issues #231/#232), so neither staging nor read-back applies. Instead each array carries a live `sha256` fed **row by row as written**: the concatenation of the written rows' decoded C-order LE bytes IS the array's full decoded byte sequence, so the incremental digest finalizes to exactly what `hash_array` over the assembled array would produce. Coordinates (`time`/`morton`/`cell_ids`) are written whole at template time and hash from their staged values.

  Both correctness traps are **enforced, not assumed** — §5 covers an array's full contents, and a digest that is silently wrong is worse than none:
  - *unwritten rows still count*: rows missing at finalize contribute their **fill** bytes (an array with a gap and no reconstructable fill is dropped);
  - *order is a precondition*: the sink delivers timesteps in **completion** order (`asyncio.as_completed`, and on worker threads at `write_buffer > 1`), so out-of-order rows are parked until their turn under a byte budget (`STREAM_PENDING_MAX_BYTES`, 64 MiB); a row written twice, a row outside the extent, a shape/dtype mismatch, or a parking overflow **invalidates** the digest. An invalidated array drops the **whole** leaf record (a partial map would read as "array missing" to a §5.1 verifier and its `combined` would be a digest of a subset), with one warning naming the array and the reason.

## Phases

- [x] Phase 1 — recipe port (`1f72cab`)
- [x] Phase 2 — worker wiring, staged source (`c9aefd7`)
- [x] Phase 3 — coverage completeness (`2051ae7`)
- [x] Phase 4 — overview leaves + §8.2 O11 addendum (`954d9b4`, `cb43209`)
- [x] Phase 5 — raster hive leaves, incremental streaming hash (`144e831`)
- [x] Spec: the overview sidecar naming grammar pinned in §5.3 (`e178868`)

## Review round

Adversarial self-review posted 4 inline findings; 3 folded — `2dc7f85` (deep-copy nested `content_hashes` on merge), `d160d2c` (warn on staged keys matching no array), `1bf700e` (stage dense arrays on the streaming leaf path too, pinned by an unsharded kitchen-sink test reproducing the committed sharded fixture's hashes byte-for-byte). The [naming finding](https://github.com/englacial/zagg/pull/356#discussion_r3693345107) was escalated and is now resolved by the first ruling below.

## How it was tested

- `uv run pytest -q`: **3153 passed**, 37 skipped, 1 failed — `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`, environment-only (its `pip` resolves cp310 wheels in this sandbox), untouched by this PR.
- **The phase-5 acceptance gate**: a raster hive leaf written through the real streaming path, then re-hashed in the test with `content_hash.hash_arrays` over the leaf **read back from the store** — the streamed record equals the read-back per-array map and `combined` byte-for-byte (`TestRasterHiveContentHashes::test_streamed_hashes_match_a_full_read_back`). Plus 12 `StreamingArrayHash` unit tests: in-order == out-of-order == whole-array hash, unwritten rows == fill bytes, NaN fill, every precondition violation dropping the hash with its reason, the parking-budget overflow, and a threaded concurrent-update case.
- Spatial parity is pinned both ways: staged hashes == full read-back, and the worker-recorded record byte-matches the committed `kitchen_sink.expected.json` on **both** the sharded and unsharded paths.
- `ruff check` / `ruff format --check` clean on all touched files. One pre-existing repo-wide finding unrelated to this PR: `N818` on `src/zagg/registry.py::UnknownCapability` (CI's lint bot selects only `E,F,W,I`, so CI is unaffected).
- `origin/main` merged in (`f6d0178`) to clear a CONFLICTING state that was silently suppressing CI on this branch; the one conflict was `tests/test_benchmark_objects.py` (issue #353's metadata count vs this PR's overview-sidecar residue pin) and both assertions are kept.

## Module sizes

`hive.py` (1,446) and `sweep_overview.py` (934 here, crossing 1,200 once PR #360 lands) both exceed the old ceiling **by design**, per espg's standing ruling: no split in this PR. The mechanical splits attach to PR #349 (issue #330 PR-A), where the seam analysis is posted; `hive.py`'s split there is a known mechanical-move conflict to be resolved on that PR's rebase.

## Questions for review — resolved

- ~~Overview sidecar naming~~ — **ruled: keep the D23 grammar as shipped** (`{stem}.stats.json`), because per-window overview sidecars at one ancestor node would otherwise collide on a single `stats.json`. Now pinned in `docs/specification.md` §5.3 (`e178868`).
- ~~Module size~~ — **ruled: approved**, no split here (see above).
- ~~Overview sidecar record shape~~ — **ruled: keep `telemetry.build_record`.** The D20 schema is what the sweep's stats fold and the cost rollups already parse; a bespoke shape would need its own parser and would break `telemetry.merge`, and the null run-only fields are honest — the artifact had no run.
- ~~Raster hive leaves~~ — **ruled: wire them, no read-back** — landed as phase 5 above.

## Still standing

- The **write-seam deviation** stands as accepted: the plan named `processing/worker.py`, but the hive leaf write (and the only place the staged slabs exist) is `zagg.hive.process_and_write_hive`, shared by both dispatch backends — wiring there also keeps `deployment/aws/lambda_handler.py` untouched.
- The `.github/scripts/bench_objects.py` classifier does not yet bucket the new overview sidecars; `tests/test_benchmark_objects.py` pins them as the only unclassified residue and folds them out of the write-path total. That gap is being fixed separately under issue #362.
