### PR TITLE
Subtree span reads for the ragged vlen readers (issue #351)

### DIFF
--- a/docs/ragged_layout.md
+++ b/docs/ragged_layout.md
@@ -115,15 +115,19 @@ and hive-leaf writers are pinned to store byte-identical per-cell payloads
   out-of-range index raises `IndexError` naming the valid range (no negative-index
   wrap); an absent cell returns the zero-length `(0, *inner_shape)` array. Works
   on the `{field}_locations` sibling too.
-- **Sub-leaf subtree read** *(planned —
-  [issue #351](https://github.com/englacial/zagg/issues/351))* — the nested
+- **Sub-leaf subtree read** (`subtree=` on the sweep readers —
+  [issue #351](https://github.com/englacial/zagg/issues/351)) — the nested
   cells axis makes the subtree below any ancestor one **contiguous cell span**
-  (normative in the spec's §1.5 subtree-spans clause), so "everything below
-  this morton node" is a contiguous slice: the shard-index suffix plus only
+  (normative in the spec's §1.5 subtree-spans clause), so `read_tensors`,
+  `read_raw_values`, and `read_locations` take `subtree=` (a packed area word
+  or its decimal string) and slice only that span: the shard-index suffix plus
   the covering inner chunks — `read_cell`'s 2-GET pattern generalized to a
-  span, never the whole-array sweep. Until it lands, region granularity is the
-  hive leaf: coverage-MOC/AOI selection picks leaves (issue #200), each swept
-  whole.
+  span, never the whole-array sweep. The per-cell readers accept any order
+  down to a single cell; `read_tensors` emits whole read chunks only
+  (`subtree_order ≤ block_order ≤ chunk_order`) and refuses finer words,
+  pointing at the per-cell readers. A well-formed word disjoint from the axis
+  warns once and yields nothing — so an empty yield is ambiguous without the
+  warning — while malformed or too-deep words raise.
 
 ## Spatially faithful tensors (deinterleave, blocks, mask)
 

--- a/docs/ragged_layout.md
+++ b/docs/ragged_layout.md
@@ -124,8 +124,10 @@ and hive-leaf writers are pinned to store byte-identical per-cell payloads
   the covering inner chunks — `read_cell`'s 2-GET pattern generalized to a
   span, never the whole-array sweep. The per-cell readers accept any order
   down to a single cell; `read_tensors` emits whole read chunks only
-  (`subtree_order ≤ block_order ≤ chunk_order`) and refuses finer words,
-  pointing at the per-cell readers. A well-formed word disjoint from the axis
+  (`max(subtree_order, axis_root_order) ≤ block_order ≤ chunk_order` — the
+  floor is the order of the span actually *visited*, i.e. the subtree clipped
+  to the axis, so a word above the axis root takes the root's order) and
+  refuses finer words, pointing at the per-cell readers. A well-formed word disjoint from the axis
   warns once and yields nothing — so an empty yield is ambiguous without the
   warning — while malformed or too-deep words raise.
 

--- a/docs/ragged_layout.md
+++ b/docs/ragged_layout.md
@@ -127,9 +127,12 @@ and hive-leaf writers are pinned to store byte-identical per-cell payloads
   (`max(subtree_order, axis_root_order) ≤ block_order ≤ chunk_order` — the
   floor is the order of the span actually *visited*, i.e. the subtree clipped
   to the axis, so a word above the axis root takes the root's order) and
-  refuses finer words, pointing at the per-cell readers. A well-formed word disjoint from the axis
-  warns once and yields nothing — so an empty yield is ambiguous without the
-  warning — while malformed or too-deep words raise.
+  refuses finer words, pointing at the per-cell readers. A well-formed word
+  disjoint from the axis warns at most once per call and yields nothing — so an
+  empty yield is ambiguous without the warning, and whether the warning is
+  *delivered* is the caller's `warnings` filter's call (the default action
+  dedups a repeat of the same warning in one process) — while malformed or
+  too-deep words raise.
 
 ## Spatially faithful tensors (deinterleave, blocks, mask)
 

--- a/src/zagg/readers/_layout.py
+++ b/src/zagg/readers/_layout.py
@@ -78,7 +78,14 @@ def normalize_subtree(subtree) -> tuple[int, str, int]:
 
 
 def subtree_cell_span(
-    subtree, anchor: int, anchor_index: int, cell_order: int, n_cells: int, field: str
+    subtree,
+    anchor: int,
+    anchor_index: int,
+    cell_order: int,
+    n_cells: int,
+    field: str,
+    *,
+    stacklevel: int = 2,
 ) -> tuple[int, int]:
     """Cell-index span ``[start, stop)`` of ``subtree`` on a nested cells axis.
 
@@ -102,11 +109,17 @@ def subtree_cell_span(
 
     The span is returned intersected with the axis: a word at or above the
     axis root clips to the whole axis (every stored cell is its
-    descendant), and a well-formed word DISJOINT from the axis warns once —
-    naming the word and the axis root — and returns the empty span
-    ``(0, 0)``. Out-of-domain is a data answer (the ratified issue #351
-    fork (3)), so an empty read is ambiguous between "in-domain, nothing
-    stored" and "outside the domain" unless the warning is observed.
+    descendant), and a well-formed word DISJOINT from the axis warns — naming
+    the word and the axis root — and returns the empty span ``(0, 0)``.
+    Out-of-domain is a data answer (the ratified issue #351 fork (3)), so an
+    empty read is ambiguous between "in-domain, nothing stored" and "outside
+    the domain" unless the warning is observed — and DELIVERY of that warning
+    is the caller's ``warnings`` filter's call: the default ``default`` action
+    dedups on (message, category, module, lineno), so a second call with the
+    same word is silent in the same process. The guarantee is "at most once
+    per call" (never per cell or per chunk). ``stacklevel`` is the caller's
+    depth from here — the readers pass the depth that attributes the warning
+    to THEIR caller rather than to zagg's own frames.
     Raises ``ValueError`` for a malformed word, or one deeper than the
     cells-axis order (grammatically impossible — nothing stored could be
     its descendant).
@@ -153,7 +166,7 @@ def subtree_cell_span(
         warnings.warn(
             f"subtree {decimal} is outside this axis' order-{root_order} root "
             f"{morton_decimal(root)} — yielding nothing",
-            stacklevel=2,
+            stacklevel=stacklevel,
         )
         return 0, 0
     return start, stop

--- a/src/zagg/readers/_layout.py
+++ b/src/zagg/readers/_layout.py
@@ -78,7 +78,7 @@ def normalize_subtree(subtree) -> tuple[int, str, int]:
 
 
 def subtree_cell_span(
-    subtree, anchor: int, cell_order: int, n_cells: int, field: str
+    subtree, anchor: int, anchor_index: int, cell_order: int, n_cells: int, field: str
 ) -> tuple[int, int]:
     """Cell-index span ``[start, stop)`` of ``subtree`` on a nested cells axis.
 
@@ -91,6 +91,14 @@ def subtree_cell_span(
     hive leaf's shard subtree) subtracts its root's own span start, with the
     root derived from ``anchor`` — any WRITTEN cell word (the morton anchor
     slice the caller already read); no store bytes are touched here.
+
+    That identity is CHECKED, not assumed: ``anchor`` sits at ``anchor_index``
+    on the axis, so ``nested(anchor) - root_start`` must equal ``anchor_index``
+    or the axis is not in canonical nested placement, and this arithmetic
+    would hand back plausible-but-wrong cells silently — the single-root
+    geometry is INFERRED from ``4**depth == n_cells`` alone, and this is the
+    first reader that derives absolute placement instead of searching for it
+    (review, PR #357). A mismatch raises ``ValueError``.
 
     The span is returned intersected with the axis: a word at or above the
     axis root clips to the whole axis (every stored cell is its
@@ -119,14 +127,27 @@ def subtree_cell_span(
     lo = int(h) * 4**d
     n = int(n_cells)
     depth = (n.bit_length() - 1) // 2
-    if 4**depth != n:
-        # A fullsphere axis (12·4^c cells): the nested id IS the axis
-        # position, and every well-formed word's span lies inside it.
+    # A fullsphere axis (12·4^c cells) starts at 0 — the nested id IS the axis
+    # position, and every well-formed word's span lies inside it. A single-root
+    # power-of-four axis starts at its root's own span start.
+    single_root = 4**depth == n
+    root_order, root, root_start = cell_order - depth, 0, 0
+    if single_root:
+        root = int(clip2order(root_order, np.asarray([anchor], dtype=np.uint64))[0])
+        (rh,), _ro = mort2healpix(np.asarray([root], dtype=np.uint64))
+        root_start = int(rh) * 4**depth
+    (ah,), _ao = mort2healpix(np.asarray([anchor], dtype=np.uint64))
+    if int(ah) - root_start != int(anchor_index):
+        raise ValueError(
+            f"{field!r}'s cells axis is not in canonical nested placement: cell "
+            f"{int(anchor_index)} carries morton {morton_decimal(int(anchor))}, whose "
+            f"nested id puts it at axis position {int(ah) - root_start}. A subtree "
+            f"span is derived arithmetically (cell position == nested id minus the "
+            f"axis root's start), so this axis would yield the wrong cells"
+        )
+    if not single_root:
         return lo, lo + 4**d
-    root_order = cell_order - depth
-    root = int(clip2order(root_order, np.asarray([anchor], dtype=np.uint64))[0])
-    (rh,), _ro = mort2healpix(np.asarray([root], dtype=np.uint64))
-    lo -= int(rh) * 4**depth
+    lo -= root_start
     start, stop = max(lo, 0), min(lo + 4**d, n)
     if start >= stop:
         warnings.warn(

--- a/src/zagg/readers/_layout.py
+++ b/src/zagg/readers/_layout.py
@@ -21,13 +21,23 @@ i.e. the texture's slow axis ``i`` feeds ``bit_combine``'s second (odd-bit,
 — so a zagg tensor uploads to a gridlook texture with no further shuffle.
 ``tensor[0, 0]`` is the subtree's south corner; rows advance toward the
 north-west edge, columns toward the north-east edge.
+
+Subtree spans (issue #351)
+--------------------------
+The same nested ordering makes "everything below one morton node" a
+contiguous cell-index span (normative: zagg ``docs/specification.md`` §1.5).
+:func:`normalize_subtree` and :func:`subtree_cell_span` are the pure
+arithmetic behind the readers' ``subtree=`` keyword — no store access.
 """
 
 from __future__ import annotations
 
+import warnings
+
+import numpy as np
 from mortie import rank_to_xy, xy_to_rank
 
-__all__ = ["rank_to_rowcol", "rowcol_to_rank"]
+__all__ = ["rank_to_rowcol", "rowcol_to_rank", "normalize_subtree", "subtree_cell_span"]
 
 
 def rank_to_rowcol(rank, depth: int):
@@ -49,3 +59,80 @@ def rowcol_to_rank(row, col, depth: int):
     (scalars or arrays; values must be ``< 2**depth``).
     """
     return xy_to_rank(col, row, depth)
+
+
+def normalize_subtree(subtree) -> tuple[int, str, int]:
+    """Normalize a ``subtree=`` argument to ``(word, decimal, order)``.
+
+    Both ratified currencies (issue #351): a packed morton AREA word
+    (``int``) or a decimal morton string (``str``). A parsed string always
+    yields the area word (mortie's spec §4 parse tie-break), so no kind
+    flag is needed. Raises ``ValueError`` on a malformed member of either
+    currency (an unparseable string, an invalid packed word).
+    """
+    from zagg.grids.morton import morton_decimal, morton_word
+
+    word = morton_word(subtree) if isinstance(subtree, str) else int(subtree)
+    decimal = morton_decimal(word)  # raises on an invalid/negative packed word
+    return word, decimal, len(decimal) - (2 if decimal.startswith("-") else 1)
+
+
+def subtree_cell_span(
+    subtree, anchor: int, cell_order: int, n_cells: int, field: str
+) -> tuple[int, int]:
+    """Cell-index span ``[start, stop)`` of ``subtree`` on a nested cells axis.
+
+    The spec §1.5 subtree-span identity, resolved by pure arithmetic: a
+    cell's axis position is its HEALPix NESTED id (chunks are keyed by the
+    parent's nested id — ``HealpixGrid.block_index`` — and the in-chunk
+    position is the nested rank), so the order-``k`` subtree below a word
+    with nested id ``h`` occupies ``[h·4^d, (h+1)·4^d)`` (``d = cell_order
+    - k``) in fullsphere coordinates. A single-root power-of-four axis (a
+    hive leaf's shard subtree) subtracts its root's own span start, with the
+    root derived from ``anchor`` — any WRITTEN cell word (the morton anchor
+    slice the caller already read); no store bytes are touched here.
+
+    The span is returned intersected with the axis: a word at or above the
+    axis root clips to the whole axis (every stored cell is its
+    descendant), and a well-formed word DISJOINT from the axis warns once —
+    naming the word and the axis root — and returns the empty span
+    ``(0, 0)``. Out-of-domain is a data answer (the ratified issue #351
+    fork (3)), so an empty read is ambiguous between "in-domain, nothing
+    stored" and "outside the domain" unless the warning is observed.
+    Raises ``ValueError`` for a malformed word, or one deeper than the
+    cells-axis order (grammatically impossible — nothing stored could be
+    its descendant).
+    """
+    from mortie import clip2order, mort2healpix
+
+    from zagg.grids.morton import morton_decimal
+
+    word, decimal, order = normalize_subtree(subtree)
+    if order > cell_order:
+        raise ValueError(
+            f"subtree {decimal} is order {order} — deeper than {field!r}'s "
+            f"order-{cell_order} cells axis, so nothing stored can be its descendant "
+            f"(a subtree names an ancestor, at any order up to the cell order)"
+        )
+    d = cell_order - order
+    (h,), _o = mort2healpix(np.asarray([word], dtype=np.uint64))
+    lo = int(h) * 4**d
+    n = int(n_cells)
+    depth = (n.bit_length() - 1) // 2
+    if 4**depth != n:
+        # A fullsphere axis (12·4^c cells): the nested id IS the axis
+        # position, and every well-formed word's span lies inside it.
+        return lo, lo + 4**d
+    root_order = cell_order - depth
+    root = int(clip2order(root_order, np.asarray([anchor], dtype=np.uint64))[0])
+    (rh,), _ro = mort2healpix(np.asarray([root], dtype=np.uint64))
+    lo -= int(rh) * 4**depth
+    start, stop = max(lo, 0), min(lo + 4**d, n)
+    if start >= stop:
+        warnings.warn(
+            f"subtree {decimal} is outside this axis' order-{root_order} root "
+            f"{morton_decimal(root)} — yielding nothing",
+            stacklevel=2,
+        )
+        return 0, 0
+    return start, stop

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -61,6 +61,12 @@ anchors a fixed ``n_bins * resolution`` window at the floor of that range
 counts via :func:`zagg.stats.tdigest.cdf_from_tdigest`, and decodes the hive
 leaf's ``coverage.moc`` occupancy sidecar (when present) into the uint8
 ``mask`` channel on the same deinterleaved layout.
+
+All three sweep readers accept ``subtree=`` (issue #351): the nested cells
+axis makes "everything below one morton ancestor" a contiguous cell span
+(spec §1.5 subtree spans), so a restricted read fetches only the stored
+objects the span covers — on a sharded store the index suffix plus the
+covering inner chunks, on the flat layout the covering chunk objects.
 """
 
 from __future__ import annotations
@@ -594,6 +600,7 @@ def read_tensors(
     fit: FitMode = "raise",
     dtype: TensorDtype = "uint32",
     block_order: int | None = None,
+    subtree: int | str | None = None,
     max_block_bytes: int = 2 * 1024**3,
     zarr_format: Literal[2, 3] = 3,
 ) -> Iterator[tuple[np.ndarray, np.ndarray, tuple[float, float], int]]:
@@ -660,7 +667,24 @@ def read_tensors(
     block_order : int, optional
         HEALPix order of the emitted blocks (default ``None`` — one block per
         read chunk). Must be at or coarser than the chunk order; a block is
-        assembled from whole read chunks with one shared z-window.
+        assembled from whole read chunks with one shared z-window. With a
+        ``subtree`` the composed bound is ``subtree_order <= block_order <=
+        chunk_order``, so blocks tile the subtree.
+    subtree : int or str, optional
+        Restrict the sweep to the read chunks below this morton ancestor —
+        packed area word or decimal string, as in :func:`read_raw_values`
+        (issue #351; spec §1.5): only stored objects overlapping the
+        subtree's cell span are fetched. The subtree must be at or coarser
+        than the READ-CHUNK order — a finer word raises, pointing at the
+        per-cell readers, because a sub-chunk block would re-derive its
+        z-window from fewer cells and stop being a slice of the chunk tensor
+        (the ratified v1 refusal; recover a sub-chunk region client-side as
+        a corner slice of the chunk tensor instead, keeping its shared
+        ``(offset, gain)``). A well-formed word disjoint from this axis
+        warns once per call (naming the word and the axis root) and yields
+        nothing — so an **empty yield is ambiguous** between "in-domain,
+        nothing stored" and "outside the domain"; the warning is the only
+        discriminator. Malformed / too-deep words raise ``ValueError``.
     max_block_bytes : int, optional
         Refuse a block whose emitted tensor would exceed this many bytes
         (default 2 GiB) — the guard on the ``block_order`` footgun. Raise it
@@ -701,7 +725,8 @@ def read_tensors(
         On an unknown ``dtype``/``fit``, a store missing the ragged element
         attrs or the ``morton`` sibling, an out-of-range ``block_order``, a
         block tensor over ``max_block_bytes``, a corrupt/misaligned occupancy
-        sidecar, or (with ``fit="raise"``) a block whose trimmed range
+        sidecar, a ``subtree`` finer than the read chunks (or malformed /
+        too-deep), or (with ``fit="raise"``) a block whose trimmed range
         overflows the fixed window.
     """
     if dtype not in _TENSOR_DTYPES:
@@ -714,7 +739,19 @@ def read_tensors(
     side, depth = _tensor_side(arr, field)
     cells_per_chunk = side * side
 
-    chunks = _iter_populated_chunks(arr)
+    span = _subtree_span(arr, morton, field, subtree)
+    if span is not None and span != (0, 0) and span[1] - span[0] < cells_per_chunk:
+        # The ratified issue #351 v1 refusal: the store's smallest fetch unit
+        # is the inner chunk (no I/O win), and a sub-chunk block would
+        # re-derive its z-window from fewer cells — NOT a slice of the chunk
+        # tensor, breaking the subtree ≡ filtered-sweep equality contract.
+        raise ValueError(
+            f"subtree {subtree!r} is finer than {field!r}'s read chunks "
+            f"({cells_per_chunk} cells): read_tensors emits whole-chunk blocks "
+            f"only; use read_raw_values / read_locations / read_cell, which "
+            f"accept any subtree order down to a single cell"
+        )
+    chunks = _iter_populated_chunks(arr, span)
     first = next(chunks, None)
     if first is None:
         return
@@ -727,11 +764,18 @@ def read_tensors(
         # the block subtree must be whole read chunks (coarser or equal).
         cell_order = _cells_order(first_words, field, first[0])
         chunk_order = cell_order - depth
-        if not 0 <= int(block_order) <= chunk_order:
+        min_order = 0
+        if span is not None:
+            # Blocks must tile INSIDE the subtree span (subtree_order ≤
+            # block_order — issue #351): a coarser block would reach past the
+            # span and label a partial assembly with the bigger block's word.
+            min_order = cell_order - ((span[1] - span[0]).bit_length() - 1) // 2
+        if not min_order <= int(block_order) <= chunk_order:
             raise ValueError(
                 f"block_order {block_order} is out of range: a block assembles whole "
-                f"read chunks, so it must be between 0 and the chunk order "
-                f"{chunk_order} (block_order=None reads per chunk)"
+                f"read chunks within the visited span, so it must be between "
+                f"{min_order} and the chunk order {chunk_order} "
+                f"(block_order=None reads per chunk)"
             )
         block_depth = cell_order - int(block_order)
         block_cells = 4**block_depth

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -330,7 +330,11 @@ def _stored_chunk_spans(arr) -> list[tuple[int, int]]:
     return [(o * span, min((o + 1) * span, int(arr.shape[0]))) for o in ordinals]
 
 
-def _iter_populated_chunks(arr, span: tuple[int, int] | None = None) -> Iterator[tuple[int, list]]:
+def _iter_populated_chunks(
+    arr,
+    span: tuple[int, int] | None = None,
+    spans: list[tuple[int, int]] | None = None,
+) -> Iterator[tuple[int, list]]:
     """Yield ``(chunk_start, [(cell_pos, raw_bytes), ...])`` per populated chunk.
 
     Restricted to the stored objects (:func:`_stored_chunk_spans`), each read
@@ -357,9 +361,16 @@ def _iter_populated_chunks(arr, span: tuple[int, int] | None = None) -> Iterator
     covering chunk objects), and non-overlapping stored objects are skipped
     without a fetch. A finer-than-chunk restriction is the caller's rank
     filter — this generator always yields whole read chunks.
+
+    ``spans`` passes in an ALREADY-LISTED :func:`_stored_chunk_spans` result,
+    so a ``subtree=`` read (whose span :func:`_subtree_span` resolved against
+    that same listing) LISTs the array's data keys once instead of twice — the
+    only whole-array-scale operation left on a read path framed as "never a
+    whole-array sweep", and a paginated LIST per ~1000 objects on the flat
+    fullsphere layout (review, PR #357). ``None`` lists here.
     """
     cells_per_chunk = int(arr.chunks[0])
-    for span_start, span_stop in _stored_chunk_spans(arr):
+    for span_start, span_stop in _stored_chunk_spans(arr) if spans is None else spans:
         if span is not None:
             span_start = max(span_start, span[0] - span[0] % cells_per_chunk)
             span_stop = min(span_stop, span[1] + -span[1] % cells_per_chunk)
@@ -373,27 +384,32 @@ def _iter_populated_chunks(arr, span: tuple[int, int] | None = None) -> Iterator
                 yield span_start + offset, populated
 
 
-def _subtree_span(arr, morton, field, subtree) -> tuple[int, int] | None:
-    """Resolve the readers' ``subtree=`` to its cell span on this axis.
+def _subtree_span(arr, morton, field, subtree) -> tuple[tuple[int, int] | None, list | None]:
+    """Resolve the readers' ``subtree=`` to ``(span, spans)`` on this axis.
 
-    ``None`` = no restriction (no ``subtree`` given); ``(0, 0)`` = visit
-    nothing (a disjoint word — :func:`~zagg.readers._layout.subtree_cell_span`
+    ``span`` is ``None`` = no restriction (no ``subtree`` given); ``(0, 0)`` =
+    visit nothing (a disjoint word — :func:`~zagg.readers._layout.subtree_cell_span`
     already warned — or an empty store, which has nothing below any word).
     The anchor is the first stored span's first read chunk of the ``morton``
     coordinate — one small slice, no payload bytes (the dense coordinate
     write covers every chunk of a stored span). A malformed ``subtree``
     raises even on an empty store.
+
+    ``spans`` is the :func:`_stored_chunk_spans` listing the span was resolved
+    against (``None`` when there was no ``subtree`` and nothing was listed):
+    the caller threads it straight into :func:`_iter_populated_chunks` so the
+    restricted read LISTs the array once, not twice.
     """
     if subtree is None:
-        return None
+        return None, None
     spans = _stored_chunk_spans(arr)
     if not spans:
         normalize_subtree(subtree)  # malformed still raises; nothing to visit
-        return 0, 0
+        return (0, 0), spans
     words = morton[spans[0][0] : spans[0][0] + int(arr.chunks[0])]
     cell_order = _cells_order(words, field, spans[0][0])
     anchor = int(words[words != 0][0])
-    return subtree_cell_span(subtree, anchor, cell_order, int(arr.shape[0]), field)
+    return subtree_cell_span(subtree, anchor, cell_order, int(arr.shape[0]), field), spans
 
 
 def _open_morton(store: Store, field: str, zarr_format):
@@ -739,7 +755,7 @@ def read_tensors(
     side, depth = _tensor_side(arr, field)
     cells_per_chunk = side * side
 
-    span = _subtree_span(arr, morton, field, subtree)
+    span, spans = _subtree_span(arr, morton, field, subtree)
     if span is not None and span != (0, 0) and span[1] - span[0] < cells_per_chunk:
         # The ratified issue #351 v1 refusal: the store's smallest fetch unit
         # is the inner chunk (no I/O win), and a sub-chunk block would
@@ -751,7 +767,7 @@ def read_tensors(
             f"only; use read_raw_values / read_locations / read_cell, which "
             f"accept any subtree order down to a single cell"
         )
-    chunks = _iter_populated_chunks(arr, span)
+    chunks = _iter_populated_chunks(arr, span, spans)
     first = next(chunks, None)
     if first is None:
         return
@@ -917,8 +933,8 @@ def read_raw_values(
     side, depth = _tensor_side(arr, field)
     cells_per_chunk = side * side
 
-    span = _subtree_span(arr, morton, field, subtree)
-    for start, populated in _iter_populated_chunks(arr, span):
+    span, spans = _subtree_span(arr, morton, field, subtree)
+    for start, populated in _iter_populated_chunks(arr, span, spans):
         word = _chunk_word(morton[start : start + cells_per_chunk], field, start)
         for rank, raw in populated:
             if span is not None and not span[0] <= start + rank < span[1]:
@@ -1003,8 +1019,8 @@ def read_locations(
     side, depth = _tensor_side(loc_arr, loc_field)
     cells_per_chunk = side * side
 
-    span = _subtree_span(loc_arr, morton, loc_field, subtree)
-    for start, populated in _iter_populated_chunks(loc_arr, span):
+    span, spans = _subtree_span(loc_arr, morton, loc_field, subtree)
+    for start, populated in _iter_populated_chunks(loc_arr, span, spans):
         word = _chunk_word(morton[start : start + cells_per_chunk], loc_field, start)
         for rank, raw in populated:
             if span is not None and not span[0] <= start + rank < span[1]:

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -418,6 +418,11 @@ def _subtree_span(arr, morton, field, subtree) -> tuple[tuple[int, int] | None, 
         cell_order,
         int(arr.shape[0]),
         field,
+        # The disjoint-word warning belongs to the READER's caller: from
+        # subtree_cell_span that is here (2), the reader's own frame (3) —
+        # a generator, so it runs on the consumer's first next() — and the
+        # consumer (4). Anything less points inside zagg.
+        stacklevel=4,
     )
     return span, spans
 
@@ -711,10 +716,13 @@ def read_tensors(
         (the ratified v1 refusal; recover a sub-chunk region client-side as
         a corner slice of the chunk tensor instead, keeping its shared
         ``(offset, gain)``). A well-formed word disjoint from this axis
-        warns once per call (naming the word and the axis root) and yields
-        nothing — so an **empty yield is ambiguous** between "in-domain,
-        nothing stored" and "outside the domain"; the warning is the only
-        discriminator. Malformed / too-deep words raise ``ValueError``.
+        warns at most once per call (naming the word and the axis root) and
+        yields nothing — so an **empty yield is ambiguous** between
+        "in-domain, nothing stored" and "outside the domain"; the warning is
+        the only discriminator, and whether it is DELIVERED is the caller's
+        ``warnings`` filter's call (the default action dedups a repeat of the
+        same warning in the same process). Malformed / too-deep words raise
+        ``ValueError``.
     max_block_bytes : int, optional
         Refuse a block whose emitted tensor would exceed this many bytes
         (default 2 GiB) — the guard on the ``block_order`` footgun. Raise it
@@ -915,10 +923,12 @@ def read_raw_values(
         identity). Only stored objects overlapping the subtree's contiguous
         cell span are fetched; a finer-than-chunk subtree filters ranks
         inside its one covering read chunk. A well-formed word disjoint
-        from this axis warns once per call (naming the word and the axis
-        root) and yields nothing — so an **empty yield is ambiguous**
+        from this axis warns at most once per call (naming the word and the
+        axis root) and yields nothing — so an **empty yield is ambiguous**
         between "in-domain, nothing stored" and "outside the domain"; the
-        warning is the only discriminator. A malformed word, or one deeper
+        warning is the only discriminator, and its DELIVERY is the caller's
+        ``warnings`` filter's call (the default action dedups a repeat of the
+        same warning in the same process). A malformed word, or one deeper
         than the cells-axis order, raises :class:`ValueError`.
     zarr_format : int, optional
         Zarr format version (default 3).
@@ -994,7 +1004,8 @@ def read_locations(
         Restrict the sweep to the cells below this morton ancestor, at any
         order down to a single cell — packed area word or decimal string,
         exactly as in :func:`read_raw_values` (issue #351). Same caveat: a
-        well-formed word disjoint from this axis warns once and yields
+        well-formed word disjoint from this axis warns at most once per call
+        (delivery subject to the caller's ``warnings`` filter) and yields
         nothing, so an **empty yield is ambiguous** between "in-domain,
         nothing stored" and "outside the domain" — the warning is the only
         discriminator; malformed / too-deep words raise :class:`ValueError`.

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -392,8 +392,10 @@ def _subtree_span(arr, morton, field, subtree) -> tuple[tuple[int, int] | None, 
     already warned — or an empty store, which has nothing below any word).
     The anchor is the first stored span's first read chunk of the ``morton``
     coordinate — one small slice, no payload bytes (the dense coordinate
-    write covers every chunk of a stored span). A malformed ``subtree``
-    raises even on an empty store.
+    write covers every chunk of a stored span); its own axis index is passed
+    alongside so :func:`~zagg.readers._layout.subtree_cell_span` can CHECK the
+    nested-placement identity it derives from. A malformed ``subtree`` raises
+    even on an empty store.
 
     ``spans`` is the :func:`_stored_chunk_spans` listing the span was resolved
     against (``None`` when there was no ``subtree`` and nothing was listed):
@@ -408,8 +410,16 @@ def _subtree_span(arr, morton, field, subtree) -> tuple[tuple[int, int] | None, 
         return (0, 0), spans
     words = morton[spans[0][0] : spans[0][0] + int(arr.chunks[0])]
     cell_order = _cells_order(words, field, spans[0][0])
-    anchor = int(words[words != 0][0])
-    return subtree_cell_span(subtree, anchor, cell_order, int(arr.shape[0]), field), spans
+    written = int(np.flatnonzero(words)[0])
+    span = subtree_cell_span(
+        subtree,
+        int(words[written]),
+        spans[0][0] + written,
+        cell_order,
+        int(arr.shape[0]),
+        field,
+    )
+    return span, spans
 
 
 def _open_morton(store: Store, field: str, zarr_format):

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -694,8 +694,12 @@ def read_tensors(
         HEALPix order of the emitted blocks (default ``None`` — one block per
         read chunk). Must be at or coarser than the chunk order; a block is
         assembled from whole read chunks with one shared z-window. With a
-        ``subtree`` the composed bound is ``subtree_order <= block_order <=
-        chunk_order``, so blocks tile the subtree.
+        ``subtree`` the floor is the order of the span actually VISITED — the
+        subtree CLIPPED to this axis — so the composed bound is
+        ``max(subtree_order, axis_root_order) <= block_order <= chunk_order``:
+        blocks tile the visited span, and a word above the axis root (which
+        clips to the whole axis) takes the ROOT's order as its floor, not its
+        own.
     subtree : int or str, optional
         Restrict the sweep to the read chunks below this morton ancestor —
         packed area word or decimal string, as in :func:`read_raw_values`

--- a/src/zagg/readers/tdigest_tensor.py
+++ b/src/zagg/readers/tdigest_tensor.py
@@ -75,7 +75,12 @@ import zarr
 from zarr.abc.store import Store
 
 from zagg.grids.base import RAGGED_ELEMENT_ATTR, RAGGED_SPEC
-from zagg.readers._layout import rank_to_rowcol, rowcol_to_rank
+from zagg.readers._layout import (
+    normalize_subtree,
+    rank_to_rowcol,
+    rowcol_to_rank,
+    subtree_cell_span,
+)
 from zagg.stats.tdigest import cdf_from_tdigest, quantile_from_tdigest
 
 __all__ = [
@@ -319,7 +324,7 @@ def _stored_chunk_spans(arr) -> list[tuple[int, int]]:
     return [(o * span, min((o + 1) * span, int(arr.shape[0]))) for o in ordinals]
 
 
-def _iter_populated_chunks(arr) -> Iterator[tuple[int, list]]:
+def _iter_populated_chunks(arr, span: tuple[int, int] | None = None) -> Iterator[tuple[int, list]]:
     """Yield ``(chunk_start, [(cell_pos, raw_bytes), ...])`` per populated chunk.
 
     Restricted to the stored objects (:func:`_stored_chunk_spans`), each read
@@ -337,15 +342,52 @@ def _iter_populated_chunks(arr) -> Iterator[tuple[int, list]]:
     the same index the writer placed it at, and the index the readers
     deinterleave to a tensor position (``rank_to_rowcol``, issue #336); it is
     never a row-major position (nested order is a Z-order curve).
+
+    ``span`` (issue #351) restricts the sweep to the stored objects
+    overlapping the ``[start, stop)`` cell span, clipped to whole read
+    chunks — the spec §1.5 contiguous-slice read plan: only the covering
+    portion of each overlapping object is sliced (on a sharded store the
+    index suffix plus the covering inner chunks; on the flat layout the
+    covering chunk objects), and non-overlapping stored objects are skipped
+    without a fetch. A finer-than-chunk restriction is the caller's rank
+    filter — this generator always yields whole read chunks.
     """
     cells_per_chunk = int(arr.chunks[0])
     for span_start, span_stop in _stored_chunk_spans(arr):
-        span = arr[span_start:span_stop]
+        if span is not None:
+            span_start = max(span_start, span[0] - span[0] % cells_per_chunk)
+            span_stop = min(span_stop, span[1] + -span[1] % cells_per_chunk)
+            if span_start >= span_stop:
+                continue
+        data = arr[span_start:span_stop]
         for offset in range(0, span_stop - span_start, cells_per_chunk):
-            block = span[offset : offset + cells_per_chunk]
+            block = data[offset : offset + cells_per_chunk]
             populated = [(pos, block[pos]) for pos in range(len(block)) if len(block[pos])]
             if populated:
                 yield span_start + offset, populated
+
+
+def _subtree_span(arr, morton, field, subtree) -> tuple[int, int] | None:
+    """Resolve the readers' ``subtree=`` to its cell span on this axis.
+
+    ``None`` = no restriction (no ``subtree`` given); ``(0, 0)`` = visit
+    nothing (a disjoint word — :func:`~zagg.readers._layout.subtree_cell_span`
+    already warned — or an empty store, which has nothing below any word).
+    The anchor is the first stored span's first read chunk of the ``morton``
+    coordinate — one small slice, no payload bytes (the dense coordinate
+    write covers every chunk of a stored span). A malformed ``subtree``
+    raises even on an empty store.
+    """
+    if subtree is None:
+        return None
+    spans = _stored_chunk_spans(arr)
+    if not spans:
+        normalize_subtree(subtree)  # malformed still raises; nothing to visit
+        return 0, 0
+    words = morton[spans[0][0] : spans[0][0] + int(arr.chunks[0])]
+    cell_order = _cells_order(words, field, spans[0][0])
+    anchor = int(words[words != 0][0])
+    return subtree_cell_span(subtree, anchor, cell_order, int(arr.shape[0]), field)
 
 
 def _open_morton(store: Store, field: str, zarr_format):
@@ -775,6 +817,7 @@ def read_raw_values(
     store: Store,
     field: str,
     *,
+    subtree: int | str | None = None,
     zarr_format: Literal[2, 3] = 3,
 ) -> Iterator[tuple[int, tuple[int, int], np.ndarray]]:
     """Yield ``(morton_index, (row, col), values)`` raw samples per populated cell.
@@ -791,6 +834,18 @@ def read_raw_values(
         Zarr store holding the ragged vlen array (issue #209 layout).
     field : str
         Array path.
+    subtree : int or str, optional
+        Restrict the sweep to the cells below this morton ancestor — a
+        packed area word (``int``) or its decimal string (``str``), at ANY
+        order down to a single cell (issue #351; the spec §1.5 subtree-span
+        identity). Only stored objects overlapping the subtree's contiguous
+        cell span are fetched; a finer-than-chunk subtree filters ranks
+        inside its one covering read chunk. A well-formed word disjoint
+        from this axis warns once per call (naming the word and the axis
+        root) and yields nothing — so an **empty yield is ambiguous**
+        between "in-domain, nothing stored" and "outside the domain"; the
+        warning is the only discriminator. A malformed word, or one deeper
+        than the cells-axis order, raises :class:`ValueError`.
     zarr_format : int, optional
         Zarr format version (default 3).
 
@@ -809,17 +864,21 @@ def read_raw_values(
     Raises
     ------
     ValueError
-        If any cell's digest carries a merged centroid (weight > 1), so the raw
-        values cannot be recovered without loss.
+        If any swept cell's digest carries a merged centroid (weight > 1), so
+        the raw values cannot be recovered without loss; or on a malformed /
+        too-deep ``subtree``.
     """
     arr, elem_dtype, elem_shape, _meta = _open_ragged(store, field, zarr_format)
     morton = _open_morton(store, field, zarr_format)
     side, depth = _tensor_side(arr, field)
     cells_per_chunk = side * side
 
-    for start, populated in _iter_populated_chunks(arr):
+    span = _subtree_span(arr, morton, field, subtree)
+    for start, populated in _iter_populated_chunks(arr, span):
         word = _chunk_word(morton[start : start + cells_per_chunk], field, start)
         for rank, raw in populated:
+            if span is not None and not span[0] <= start + rank < span[1]:
+                continue
             digest = _decode_cell(raw, elem_dtype, elem_shape)
             weights = np.asarray(digest[:, 1], dtype=np.float64)
             if np.any(weights > 1.0):
@@ -835,6 +894,7 @@ def read_locations(
     store: Store,
     field: str,
     *,
+    subtree: int | str | None = None,
     zarr_format: Literal[2, 3] = 3,
 ) -> Iterator[tuple[int, tuple[int, int], np.ndarray]]:
     """Yield ``(morton_index, (row, col), locations)`` per populated cell.
@@ -856,6 +916,14 @@ def read_locations(
         Zarr store holding the ragged vlen arrays (issue #209 layout).
     field : str
         The PAYLOAD array's path (not the sibling's).
+    subtree : int or str, optional
+        Restrict the sweep to the cells below this morton ancestor, at any
+        order down to a single cell — packed area word or decimal string,
+        exactly as in :func:`read_raw_values` (issue #351). Same caveat: a
+        well-formed word disjoint from this axis warns once and yields
+        nothing, so an **empty yield is ambiguous** between "in-domain,
+        nothing stored" and "outside the domain" — the warning is the only
+        discriminator; malformed / too-deep words raise :class:`ValueError`.
     zarr_format : int, optional
         Zarr format version (default 3).
 
@@ -872,7 +940,7 @@ def read_locations(
     ------
     ValueError
         If the field declares no locations channel (it was not written as a
-        located ragged field).
+        located ragged field), or on a malformed / too-deep ``subtree``.
     """
     _arr, _dt, _sh, meta = _open_ragged(store, field, zarr_format)
     sibling = meta.get("locations")
@@ -891,9 +959,12 @@ def read_locations(
     side, depth = _tensor_side(loc_arr, loc_field)
     cells_per_chunk = side * side
 
-    for start, populated in _iter_populated_chunks(loc_arr):
+    span = _subtree_span(loc_arr, morton, loc_field, subtree)
+    for start, populated in _iter_populated_chunks(loc_arr, span):
         word = _chunk_word(morton[start : start + cells_per_chunk], loc_field, start)
         for rank, raw in populated:
+            if span is not None and not span[0] <= start + rank < span[1]:
+                continue
             row, col = rank_to_rowcol(rank, depth)
             yield word, (int(row), int(col)), _decode_cell(raw, loc_dtype, loc_shape)
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -21,6 +21,7 @@ from zagg.grids import HealpixGrid
 from zagg.grids.morton import morton_word
 from zagg.processing import write_ragged_to_zarr, write_shard_to_zarr
 from zagg.readers.tdigest_tensor import (
+    cell_index,
     chunk_z_range,
     rasterize_cell,
     read_cell,
@@ -144,6 +145,33 @@ def _sharded_store(store, *, populate, values=None):
         targets[local] = base + 11
     write_shard_to_zarr(chunk_results, store, grid=grid, shard_key=shard6)
     return grid, shard6, targets
+
+
+def _leaf_store(digest_ranks, *, located=False, seed=35):
+    """A hive-leaf store (issue #199): the vlen layout scoped to ONE shard —
+    ``_KEY_A``'s 4096-cell single-root axis (order-6 shard, order-12 cells,
+    K==1). Returns ``(store, shard_word, {rank: values})``; 5 values per cell,
+    so digests stay unmerged (losslessly recoverable)."""
+    from zagg.processing import write_ragged_leaf_to_zarr
+
+    rng = np.random.default_rng(seed)
+    grid = HealpixGrid(6, 12, layout="fullsphere", config=_cfg(located), sharded=False)
+    word = morton_word(_KEY_A)
+    store = MemoryStore()
+    grid.emit_shard_template(store)
+    children = np.asarray(grid.children(word), dtype=np.uint64)
+    zarr.open_array(store, path="12/morton", mode="r+")[:] = children
+    ranks = sorted(digest_ranks)
+    vals = {r: rng.uniform(10.0, 30.0, 5) for r in ranks}
+    if located:
+        from conftest import point_words
+
+        pairs = [build_tdigest(vals[r], delta=512, locations=point_words(5, r + 1)) for r in ranks]
+        ragged = {"h_tdigest": ([p[0] for p in pairs], ranks, [p[1] for p in pairs])}
+    else:
+        ragged = {"h_tdigest": ([build_tdigest(vals[r], delta=512) for r in ranks], ranks)}
+    write_ragged_leaf_to_zarr([((0,), ragged)], store, grid=grid)
+    return store, word, vals
 
 
 class TestRasterizeCell:
@@ -559,6 +587,202 @@ class TestReadLocations:
         store, _g, _w = _build_store({_KEY_A: {0: np.array([1.0, 2.0])}})
         with pytest.raises(ValueError, match="declares no locations channel"):
             list(read_locations(store, "12/h_tdigest"))
+
+
+class TestSubtreePerCellReaders:
+    """Issue #351 phase 1: ``subtree=`` on the per-cell sweep readers.
+
+    Golden contract (the ratified acceptance criterion): ``reader(...,
+    subtree=w)`` equals the whole-store sweep filtered to the cells that are
+    descendants of ``w``. The filter here is INDEPENDENT of the reader's span
+    arithmetic — each yielded cell's word is resolved through ``cell_index``
+    plus the stored ``morton`` coordinate, then coarsened with
+    ``mortie.clip2order`` — so the two paths cannot share a bug.
+    """
+
+    @staticmethod
+    def _filtered(store, field, out, subtree_key):
+        """Whole-sweep entries whose CELL word descends from ``subtree_key``."""
+        from mortie import clip2order
+
+        from zagg.grids.morton import morton_decimal
+
+        word = morton_word(subtree_key) if isinstance(subtree_key, str) else int(subtree_key)
+        decimal = morton_decimal(word)
+        order = len(decimal) - (2 if decimal.startswith("-") else 1)
+        morton = zarr.open_array(store, path="12/morton", mode="r")
+        kept = []
+        for m, (row, col), payload in out:
+            cell = int(morton[cell_index(store, field, m, row, col)])
+            if int(clip2order(order, np.asarray([cell], dtype=np.uint64))[0]) == word:
+                kept.append((m, (row, col), payload))
+        return kept
+
+    @staticmethod
+    def _assert_same(got, expected):
+        assert [(m, rc) for m, rc, _v in got] == [(m, rc) for m, rc, _v in expected]
+        for (_m, _rc, g), (_m2, _rc2, e) in zip(got, expected):
+            np.testing.assert_array_equal(g, e)
+
+    @staticmethod
+    def _flat():
+        """Two populated shards on the flat fullsphere store; every digest
+        unmerged so ``read_raw_values`` is lossless."""
+        vals = {
+            _KEY_A: {0: [3.0, 1.0], 5: [2.0], 100: [7.0, 4.0], 4095: [9.0]},
+            _KEY_B: {7: [5.0, 6.0], 63: [8.0]},
+        }
+        store, _grid, words = _build_store(
+            {k: {c: np.asarray(v) for c, v in cells.items()} for k, cells in vals.items()}
+        )
+        return store, words
+
+    @pytest.mark.parametrize("key", [_KEY_A, _KEY_B])
+    def test_flat_store_equals_filtered_sweep_both_currencies(self, key):
+        store, words = self._flat()
+        sweep = list(read_raw_values(store, "12/h_tdigest"))
+        expected = self._filtered(store, "12/h_tdigest", sweep, key)
+        assert len(expected) > 0
+        # Ratified fork (1): packed area word (int) and decimal string (str)
+        # are the same currency — both normalize to the packed word.
+        self._assert_same(
+            list(read_raw_values(store, "12/h_tdigest", subtree=words[key])), expected
+        )
+        self._assert_same(list(read_raw_values(store, "12/h_tdigest", subtree=key)), expected)
+
+    def test_sub_chunk_subtree_filters_ranks_inside_the_covering_chunk(self):
+        from mortie import generate_morton_children
+
+        store, words = self._flat()
+        sweep = list(read_raw_values(store, "12/h_tdigest"))
+        # The order-9 first child of shard A covers chunk-local ranks [0, 64):
+        # fixture cells 0 and 5, but not 100 or 4095. Ranks 0 and 5
+        # deinterleave to (0, 0) and (0, 3) (issue #336).
+        sub = int(np.asarray(generate_morton_children(words[_KEY_A], 9))[0])
+        got = list(read_raw_values(store, "12/h_tdigest", subtree=sub))
+        self._assert_same(got, self._filtered(store, "12/h_tdigest", sweep, sub))
+        assert [rc for _m, rc, _v in got] == [(0, 0), (0, 3)]
+
+    def test_single_cell_subtree(self):
+        from mortie import generate_morton_children
+
+        store, words = self._flat()
+        sweep = list(read_raw_values(store, "12/h_tdigest"))
+        # An order-12 subtree IS one cell: rank 100 of shard A.
+        cell_word = int(np.asarray(generate_morton_children(words[_KEY_A], 12))[100])
+        got = list(read_raw_values(store, "12/h_tdigest", subtree=cell_word))
+        assert len(got) == 1
+        self._assert_same(got, self._filtered(store, "12/h_tdigest", sweep, cell_word))
+
+    def test_sharded_store_equals_filtered_sweep(self):
+        from mortie import generate_morton_children
+
+        store = MemoryStore()
+        _grid_, shard6, _targets = _sharded_store(store, populate={0, 3, 7, 12})
+        sweep = list(read_raw_values(store, "12/h_tdigest"))
+        # The order-7 first child of the shard covers inner chunks 0..3, of
+        # which locals 0 and 3 are populated.
+        sub = int(np.asarray(generate_morton_children(shard6, 7))[0])
+        got = list(read_raw_values(store, "12/h_tdigest", subtree=sub))
+        self._assert_same(got, self._filtered(store, "12/h_tdigest", sweep, sub))
+        assert len(got) == 2
+
+    def test_leaf_store_subtree_equals_filtered_sweep(self):
+        from mortie import generate_morton_children
+
+        store, word, _vals = _leaf_store([0, 5, 100, 4095])
+        sweep = list(read_raw_values(store, "12/h_tdigest"))
+        sub = int(np.asarray(generate_morton_children(word, 9))[0])
+        got = list(read_raw_values(store, "12/h_tdigest", subtree=sub))
+        self._assert_same(got, self._filtered(store, "12/h_tdigest", sweep, sub))
+        assert len(got) == 2
+
+    def test_out_of_domain_word_warns_once_then_yields_nothing(self):
+        import warnings
+
+        store, _word, _vals = _leaf_store([0, 5])
+        # Shard B is disjoint from this leaf's single-root axis: the ratified
+        # fork (3) — ONE warning per reader call naming the word and the axis
+        # root, then an empty yield. The warning is the only discriminator vs
+        # "in-domain, nothing stored" (the docstring ambiguity).
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            out = list(read_raw_values(store, "12/h_tdigest", subtree=morton_word(_KEY_B)))
+        assert out == []
+        msgs = [str(w.message) for w in rec if "outside this axis" in str(w.message)]
+        assert msgs == [
+            f"subtree {_KEY_B} is outside this axis' order-6 root {_KEY_A} — yielding nothing"
+        ]
+
+    def test_ancestor_of_the_axis_root_clips_to_the_whole_axis(self):
+        from mortie import clip2order
+
+        store, word, _vals = _leaf_store([0, 4095])
+        # A word ABOVE the leaf's root: every stored cell is its descendant,
+        # so the subtree read equals the unrestricted sweep (the golden filter
+        # keeps everything) — no warning, not an empty yield.
+        parent = int(clip2order(3, np.asarray([word], dtype=np.uint64))[0])
+        got = list(read_raw_values(store, "12/h_tdigest", subtree=parent))
+        self._assert_same(got, list(read_raw_values(store, "12/h_tdigest")))
+        assert len(got) == 2
+
+    def test_in_domain_empty_subtree_yields_nothing_silently(self):
+        import warnings
+
+        from mortie import generate_morton_children
+
+        store, words = self._flat()
+        # Both in-domain on the fullsphere axis, both empty: an unpopulated
+        # corner INSIDE stored shard A (ranks [128, 192)), and a whole shard
+        # with no stored object at all.
+        empty_sub = int(np.asarray(generate_morton_children(words[_KEY_A], 9))[2])
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            assert list(read_raw_values(store, "12/h_tdigest", subtree=empty_sub)) == []
+            assert list(read_raw_values(store, "12/h_tdigest", subtree="3333333")) == []
+        assert [w for w in rec if "outside this axis" in str(w.message)] == []
+
+    @pytest.mark.parametrize("bad", ["", "abc", "913", 3, -5])
+    def test_malformed_subtree_raises(self, bad):
+        store, _words = self._flat()
+        with pytest.raises(ValueError):
+            list(read_raw_values(store, "12/h_tdigest", subtree=bad))
+
+    def test_deeper_than_the_cells_axis_raises(self):
+        store, _words = self._flat()
+        with pytest.raises(ValueError, match="deeper than"):
+            list(read_raw_values(store, "12/h_tdigest", subtree=_KEY_A + "1111111"))
+
+    def test_empty_store_yields_nothing_but_malformed_still_raises(self):
+        store = MemoryStore()
+        _grid().emit_template(store)
+        assert list(read_raw_values(store, "12/h_tdigest", subtree=_KEY_A)) == []
+        with pytest.raises(ValueError):
+            list(read_raw_values(store, "12/h_tdigest", subtree="abc"))
+
+    def test_subtree_none_is_the_default_sweep(self):
+        store, _words = self._flat()
+        self._assert_same(
+            list(read_raw_values(store, "12/h_tdigest", subtree=None)),
+            list(read_raw_values(store, "12/h_tdigest")),
+        )
+
+    def test_read_locations_subtree_equals_filtered_sweep(self):
+        from mortie import generate_morton_children
+
+        store, word, _vals = _leaf_store([3, 9, 300], located=True)
+        sweep = list(read_locations(store, "12/h_tdigest"))
+        # Order-9 first child: ranks [0, 64) — cells 3 and 9, not 300.
+        sub = int(np.asarray(generate_morton_children(word, 9))[0])
+        got = list(read_locations(store, "12/h_tdigest", subtree=sub))
+        self._assert_same(got, self._filtered(store, "12/h_tdigest", sweep, sub))
+        assert len(got) == 2
+
+    def test_read_locations_out_of_domain_warns_and_is_empty(self):
+        store, _word, _vals = _leaf_store([0, 7], located=True)
+        with pytest.warns(UserWarning, match="outside this axis' order-6 root"):
+            out = list(read_locations(store, "12/h_tdigest", subtree=morton_word(_KEY_B)))
+        assert out == []
 
 
 class TestReadCell:

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -777,6 +777,20 @@ class TestSubtreePerCellReaders:
             f"subtree {_KEY_B} is outside this axis' order-6 root {_KEY_A} — yielding nothing"
         ]
 
+    @pytest.mark.parametrize("reader", [read_raw_values, read_locations, read_tensors])
+    def test_out_of_domain_warning_is_attributed_to_the_caller(self, reader):
+        import warnings
+
+        store, _word, _vals = _leaf_store([0, 5], located=True)
+        # The readers are generators, so the warning fires on the consumer's
+        # first next() — the stacklevel must reach THIS frame, not a zagg one
+        # (review, PR #357).
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            list(reader(store, "12/h_tdigest", subtree=morton_word(_KEY_B)))
+        (w,) = [r for r in rec if "outside this axis" in str(r.message)]
+        assert w.filename == __file__
+
     def test_ancestor_of_the_axis_root_clips_to_the_whole_axis(self):
         from mortie import clip2order
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -926,6 +926,44 @@ class TestSubtreeReadTensors:
         for sub in (words[_KEY_A], _KEY_A):
             self._assert_same(list(read_tensors(store, "12/h_tdigest", subtree=sub)), expected)
 
+    def test_span_covering_two_stored_objects(self):
+        """A span wider than ONE stored object (review, PR #357): the order-5
+        parent of two populated sibling order-6 shards. The clip loop skips a
+        disjoint object AND clips two covered ones in the same read, and
+        ``block_order=5`` assembles a single block ACROSS the two objects."""
+        sibling = "1121122"  # _KEY_A's order-6 sibling; parent "112112"
+        parent = "112112"
+        store, _grid_, words = _build_store(
+            {
+                _KEY_A: {0: np.asarray([3.0, 1.0]), 4095: np.asarray([9.0])},
+                sibling: {9: np.asarray([5.0, 6.0]), 200: np.asarray([7.0])},
+                _KEY_B: {7: np.asarray([8.0])},  # disjoint: never fetched
+            }
+        )
+        word = morton_word(parent)
+        # Per-cell: every cell of BOTH objects, none of shard B's.
+        sweep = list(read_raw_values(store, "12/h_tdigest"))
+        got_cells = list(read_raw_values(store, "12/h_tdigest", subtree=parent))
+        TestSubtreePerCellReaders._assert_same(
+            got_cells,
+            TestSubtreePerCellReaders._filtered(store, "12/h_tdigest", sweep, parent),
+        )
+        assert len(got_cells) == 4
+        # Per chunk: one block per stored object, both yielded.
+        per_chunk = list(read_tensors(store, "12/h_tdigest", subtree=parent))
+        assert [o[3] for o in per_chunk] == [words[_KEY_A], words[sibling]]
+        self._assert_same(
+            per_chunk, self._filtered(list(read_tensors(store, "12/h_tdigest")), word, 5)
+        )
+        # And ONE order-5 block assembled across the two stored objects, equal
+        # to the same block from the unrestricted block_order=5 sweep.
+        assembled = self._filtered(
+            list(read_tensors(store, "12/h_tdigest", block_order=5)), word, 5
+        )
+        got = list(read_tensors(store, "12/h_tdigest", subtree=parent, block_order=5))
+        assert len(got) == len(assembled) == 1 and got[0][0].shape == (128, 128, 128)
+        self._assert_same(got, assembled)
+
     def test_sharded_store_per_chunk_and_block_assembly(self):
         from mortie import generate_morton_children
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1012,6 +1012,19 @@ class TestSubtreeReadTensors:
         assert len(list(read_tensors(store, "12/h_tdigest", subtree=sub, block_order=8))) == 2
         assert len(list(read_tensors(store, "12/h_tdigest", subtree=sub, block_order=7))) == 1
 
+    def test_ancestor_word_block_order_floor_is_the_axis_root(self):
+        from mortie import clip2order
+
+        store, word = _sharded_leaf_store([11, 300])
+        # A word ABOVE the leaf's order-6 root clips to the whole axis, so the
+        # block_order floor is the ROOT's order — not the subtree's. That is
+        # the documented bound max(subtree_order, axis_root_order) ≤
+        # block_order ≤ chunk_order (review, PR #357).
+        above = int(clip2order(4, np.asarray([word], dtype=np.uint64))[0])
+        with pytest.raises(ValueError, match="must be between 6 and the chunk order 8"):
+            list(read_tensors(store, "12/h_tdigest", subtree=above, block_order=5))
+        assert len(list(read_tensors(store, "12/h_tdigest", subtree=above, block_order=6))) == 1
+
     def test_hive_leaf_subtree_keeps_the_occupancy_mask(self):
         from mortie import generate_morton_children
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -99,15 +99,19 @@ def _build_store(shards, *, delta=512, located_locs=None):
 
 
 class _CountingStore(MemoryStore):
-    """MemoryStore recording every satisfied GET as ``(key, byte_range, nbytes)``."""
+    """MemoryStore recording every satisfied GET as ``(key, byte_range, nbytes)``
+    and every LIST as its prefix (a LIST is not a GET, so the two accountings
+    are separate — review, PR #357)."""
 
     def __init__(self, *a, **k):
         super().__init__(*a, **k)
         self.gets: list = []
+        self.lists: list = []
 
     def with_read_only(self, read_only=True):
         s = _CountingStore(store_dict=self._store_dict, read_only=read_only)
         s.gets = self.gets
+        s.lists = self.lists
         return s
 
     async def get(self, key, prototype, byte_range=None):
@@ -115,6 +119,10 @@ class _CountingStore(MemoryStore):
         if r is not None:
             self.gets.append((key, byte_range, len(r)))
         return r
+
+    def list_prefix(self, prefix):
+        self.lists.append(prefix)
+        return super().list_prefix(prefix)
 
 
 def _sharded_store(store, *, populate, values=None):
@@ -943,6 +951,21 @@ class TestSubtreeReadTensors:
         b_block = grid.block_index(morton_word(_KEY_B))[0]
         assert len(data_gets) == 1
         assert not data_gets[0][0].endswith(f"c/{b_block}")
+
+    @pytest.mark.parametrize("reader", [read_tensors, read_raw_values])
+    def test_subtree_read_lists_the_data_keys_once(self, reader):
+        from mortie import generate_morton_children
+
+        store = _CountingStore()
+        _grid_, shard6, _t = _sharded_store(store, populate={0, 3, 7, 12})
+        sub = int(np.asarray(generate_morton_children(shard6, 7))[0])
+        store.lists.clear()
+        assert len(list(reader(store, "12/h_tdigest", subtree=sub))) >= 1
+        # The span resolution and the sweep share ONE listing: on the flat
+        # fullsphere layout this is a paginated LIST per ~1000 objects, so a
+        # second one would double the only whole-array-scale operation left on
+        # a read path framed as "never a whole-array sweep" (review, PR #357).
+        assert store.lists.count("12/h_tdigest/c/") == 1
 
     def test_sub_chunk_subtree_refused_pointing_at_per_cell_readers(self):
         from mortie import generate_morton_children

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -805,6 +805,27 @@ class TestSubtreePerCellReaders:
             assert list(read_raw_values(store, "12/h_tdigest", subtree="3333333")) == []
         assert [w for w in rec if "outside this axis" in str(w.message)] == []
 
+    @pytest.mark.parametrize("geometry", ["fullsphere", "leaf"])
+    def test_misplaced_morton_coordinate_raises(self, geometry):
+        """The identity the whole feature rests on — axis position == nested id
+        minus the axis root's start — is checked, not assumed (review, PR
+        #357). Rolling a stored span's morton coordinate by one cell breaks it
+        while leaving every other guard satisfied (the cells still share their
+        chunk ancestor), so without the check the span arithmetic would name
+        plausible-but-wrong cells silently."""
+        if geometry == "leaf":
+            store, sub, _vals = _leaf_store([0, 5])
+            blocks = [0]
+        else:
+            store, words = self._flat()
+            grid, sub = _grid(), words[_KEY_A]
+            blocks = [grid.block_index(w)[0] * grid.cells_per_chunk for w in words.values()]
+        arr = zarr.open_array(store, path="12/morton", mode="r+")
+        for base in blocks:
+            arr[base : base + 4096] = np.roll(arr[base : base + 4096], 1)
+        with pytest.raises(ValueError, match="not in canonical nested placement"):
+            list(read_raw_values(store, "12/h_tdigest", subtree=sub))
+
     @pytest.mark.parametrize("bad", ["", "abc", "913", 3, -5])
     def test_malformed_subtree_raises(self, bad):
         store, _words = self._flat()

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -174,6 +174,61 @@ def _leaf_store(digest_ranks, *, located=False, seed=35):
     return store, word, vals
 
 
+def _put_object(store, key, payload):
+    """PUT raw bytes into a zarr store (the MemoryStore sidecar write)."""
+    from zarr.core.buffer import default_buffer_prototype
+    from zarr.core.sync import sync
+
+    sync(store.set(key, default_buffer_prototype().buffer.from_bytes(payload)))
+
+
+def _sharded_leaf_store(digest_ranks, extra_occupied=(), *, stamp=True, seed=41):
+    """A committed 16-chunk hive leaf: ``_KEY_A``'s order-6 shard, order-12
+    cells, ``chunk_inner=8`` (256-cell read chunks) under one leaf-wide
+    ShardingCodec object — with an exact ``coverage.moc`` occupancy sidecar
+    when ``stamp``. Returns ``(store, shard_word)``."""
+    from zagg import hive
+    from zagg.processing import write_ragged_leaf_to_zarr
+
+    rng = np.random.default_rng(seed)
+    cfg = _cfg()
+    cfg.output["grid"]["chunk_inner"] = 8
+    cfg.output["grid"]["sharded"] = True
+    grid = HealpixGrid(6, 12, layout="fullsphere", config=cfg, chunk_inner=8, sharded=True)
+    word = morton_word(_KEY_A)
+    store = MemoryStore()
+    grid.emit_shard_template(store)
+    children = np.asarray(grid.children(word), dtype=np.uint64)
+    zarr.open_array(store, path="12/morton", mode="r+")[:] = children
+    per_chunk: dict[int, list[int]] = {}
+    for rank in sorted(digest_ranks):
+        per_chunk.setdefault(rank // grid.cells_per_chunk, []).append(rank % grid.cells_per_chunk)
+    entries = [
+        (
+            (block,),
+            {
+                "h_tdigest": (
+                    [build_tdigest(rng.uniform(10.0, 30.0, 60), delta=512) for _ in local],
+                    local,
+                )
+            },
+        )
+        for block, local in sorted(per_chunk.items())
+    ]
+    write_ragged_leaf_to_zarr(entries, store, grid=grid)
+    if stamp:
+        occupied = np.sort(children[sorted(set(digest_ranks) | set(extra_occupied))])
+        bitmap = hive.encode_coverage_bitmap(word, occupied, 12)
+        _put_object(store, hive.COVERAGE_SIDECAR, bitmap)
+        hive.stamp_commit(
+            store,
+            cells_with_data=len(digest_ranks),
+            granule_count=1,
+            coverage=hive.build_coverage(word, occupied, 12, bitmap=bitmap),
+        )
+    return store, word
+
+
 class TestRasterizeCell:
     def test_empty_digest_all_zero(self):
         out = rasterize_cell(np.empty((0, 2), dtype=np.float32), 0.0, 0.5, 16)
@@ -783,6 +838,184 @@ class TestSubtreePerCellReaders:
         with pytest.warns(UserWarning, match="outside this axis' order-6 root"):
             out = list(read_locations(store, "12/h_tdigest", subtree=morton_word(_KEY_B)))
         assert out == []
+
+
+class TestSubtreeReadTensors:
+    """Issue #351 phase 2: ``subtree=`` on :func:`read_tensors`.
+
+    Golden contract: the subtree read equals the whole-store sweep filtered
+    to the blocks below ``w`` — and the equality is BIT-WISE because blocks
+    are whole read chunks: each emitted block derives its z-window from the
+    same populated cell set in both reads (no cell outside the span ever
+    joins a block), so tensor, mask, ``(offset, gain)``, and morton id all
+    match exactly. Sub-chunk subtrees are refused in v1 (the z-window would
+    re-derive from fewer cells — no longer a slice of the chunk tensor).
+    """
+
+    @staticmethod
+    def _filtered(out, word, order):
+        """Whole-sweep blocks whose morton id descends from ``word``."""
+        from mortie import clip2order
+
+        return [
+            o for o in out if int(clip2order(order, np.asarray([o[3]], dtype=np.uint64))[0]) == word
+        ]
+
+    @staticmethod
+    def _assert_same(got, expected):
+        assert [o[3] for o in got] == [o[3] for o in expected]
+        for (t, m, s, _w), (te, me, se, _we) in zip(got, expected):
+            np.testing.assert_array_equal(t, te)
+            np.testing.assert_array_equal(m, me)
+            assert s == se
+
+    def test_flat_store_equals_filtered_sweep_both_currencies(self):
+        rng = np.random.default_rng(40)
+        store, _grid_, words = _build_store(
+            {
+                _KEY_A: {0: rng.uniform(10, 30, 500), 4095: rng.uniform(12, 28, 400)},
+                _KEY_B: {7: rng.uniform(40, 60, 300)},
+            }
+        )
+        sweep = list(read_tensors(store, "12/h_tdigest"))
+        expected = self._filtered(sweep, words[_KEY_A], 6)
+        assert len(expected) == 1
+        for sub in (words[_KEY_A], _KEY_A):
+            self._assert_same(list(read_tensors(store, "12/h_tdigest", subtree=sub)), expected)
+
+    def test_sharded_store_per_chunk_and_block_assembly(self):
+        from mortie import generate_morton_children
+
+        store = MemoryStore()
+        _grid_, shard6, _t = _sharded_store(store, populate={0, 3, 7, 12})
+        # Order-7 first child of the shard = inner chunks 0..3 (locals 0, 3
+        # populated). Per-chunk blocks AND one assembled order-7 block must
+        # both equal the filtered whole sweep at the same block_order.
+        sub = int(np.asarray(generate_morton_children(shard6, 7))[0])
+        per_chunk = self._filtered(list(read_tensors(store, "12/h_tdigest")), sub, 7)
+        assert len(per_chunk) == 2
+        self._assert_same(list(read_tensors(store, "12/h_tdigest", subtree=sub)), per_chunk)
+        assembled = self._filtered(list(read_tensors(store, "12/h_tdigest", block_order=7)), sub, 7)
+        got = list(read_tensors(store, "12/h_tdigest", subtree=sub, block_order=7))
+        assert len(got) == len(assembled) == 1 and got[0][0].shape == (32, 32, 128)
+        self._assert_same(got, assembled)
+
+    def test_sharded_get_accounting_fetches_only_the_covering_span(self):
+        from mortie import generate_morton_children
+
+        store = _CountingStore()
+        grid, shard6, _t = _sharded_store(store, populate={0, 3, 7, 12})
+        sub = int(np.asarray(generate_morton_children(shard6, 7))[0])
+        store.gets.clear()
+        out = list(read_tensors(store, "12/h_tdigest", subtree=sub))
+        assert len(out) == 2
+        data_gets = [g for g in store.gets if "/h_tdigest/c/" in g[0]]
+        # The §1.5 read plan on a sharded store: the shard-index suffix plus
+        # ONLY the covering inner chunks (populated locals 0 and 3 of the
+        # span's chunks 0..3; zarr may coalesce the adjacent ranges) — all
+        # ranged GETs, never the whole object.
+        assert all(rng_ is not None for _k, rng_, _n in data_gets)
+        (obj_key, _r0, n0), *chunk_gets = data_gets
+        assert n0 == 16 * grid.chunks_per_shard + 4  # the shard-index suffix
+        assert len(chunk_gets) >= 1
+        # Decode the shard index: local 7's payload starts right after locals
+        # 0 and 3, so every fetched chunk range must end BEFORE it — the
+        # out-of-span locals 7 and 12 are never touched.
+        obj = store._store_dict[obj_key].to_bytes()
+        idx = np.frombuffer(obj[-n0:-4], dtype="<u8").reshape(-1, 2)
+        chunk7_start = int(idx[7][0])
+        assert chunk7_start > 0
+        assert all(int(r.end) <= chunk7_start for _k, r, _n in chunk_gets)
+
+    def test_flat_get_accounting_skips_disjoint_objects(self):
+        rng = np.random.default_rng(42)
+        grid = _grid()
+        store = _CountingStore()
+        grid.emit_template(store)
+        for key in (_KEY_A, _KEY_B):
+            _write_shard(grid, store, key, {3: rng.uniform(10.0, 30.0, 200)})
+        store.gets.clear()
+        out = list(read_tensors(store, "12/h_tdigest", subtree=_KEY_A))
+        assert [o[3] for o in out] == [morton_word(_KEY_A)]
+        data_gets = [g for g in store.gets if "/h_tdigest/c/" in g[0]]
+        # Flat layout: one whole-object GET for the covering chunk; shard B's
+        # object is never touched.
+        b_block = grid.block_index(morton_word(_KEY_B))[0]
+        assert len(data_gets) == 1
+        assert not data_gets[0][0].endswith(f"c/{b_block}")
+
+    def test_sub_chunk_subtree_refused_pointing_at_per_cell_readers(self):
+        from mortie import generate_morton_children
+
+        store, words = TestSubtreePerCellReaders._flat()
+        sub = int(np.asarray(generate_morton_children(words[_KEY_A], 9))[0])
+        with pytest.raises(ValueError, match="read_raw_values") as excinfo:
+            list(read_tensors(store, "12/h_tdigest", subtree=sub))
+        assert "read_cell" in str(excinfo.value)
+
+    def test_block_order_coarser_than_the_subtree_raises(self):
+        from mortie import generate_morton_children
+
+        store = MemoryStore()
+        _grid_, shard6, _t = _sharded_store(store, populate={0, 3})
+        sub = int(np.asarray(generate_morton_children(shard6, 7))[0])
+        # The composed bound: subtree_order (7) ≤ block_order ≤ chunk_order (8).
+        with pytest.raises(ValueError, match="block_order .* out of range"):
+            list(read_tensors(store, "12/h_tdigest", subtree=sub, block_order=6))
+        # Both in-bound ends still read: block_order == chunk_order (8) gives
+        # per-chunk blocks (populated locals 0 and 3), block_order ==
+        # subtree_order (7) one assembled block.
+        assert len(list(read_tensors(store, "12/h_tdigest", subtree=sub, block_order=8))) == 2
+        assert len(list(read_tensors(store, "12/h_tdigest", subtree=sub, block_order=7))) == 1
+
+    def test_hive_leaf_subtree_keeps_the_occupancy_mask(self):
+        from mortie import generate_morton_children
+
+        store, word = _sharded_leaf_store([11, 300, 1000, 4000], extra_occupied=[12, 301, 2500])
+        sub = int(np.asarray(generate_morton_children(word, 7))[0])
+        # Child 0 covers leaf cells [0, 1024) = read chunks 0..3: digests
+        # 11/300/1000 (chunks 0, 1, 3) and occupancy-only cells 12/301 — but
+        # not 4000 (chunk 15) or 2500 (chunk 9, which has no digest at all).
+        per_chunk = self._filtered(list(read_tensors(store, "12/h_tdigest")), sub, 7)
+        got = list(read_tensors(store, "12/h_tdigest", subtree=sub))
+        assert len(got) == 3
+        self._assert_same(got, per_chunk)
+        # The 3-state mask machinery is untouched: the occupancy-only cells
+        # inside the span still read as state 1.
+        assert sum(int((m == 1).sum()) for _t, m, _s, _w in got) == 2
+        # And the assembled subtree block agrees with the filtered assembly.
+        assembled = self._filtered(list(read_tensors(store, "12/h_tdigest", block_order=7)), sub, 7)
+        self._assert_same(
+            list(read_tensors(store, "12/h_tdigest", subtree=sub, block_order=7)), assembled
+        )
+
+    def test_out_of_domain_warns_once_and_empty_in_domain_is_silent(self):
+        import warnings
+
+        from mortie import generate_morton_children
+
+        store, word = _sharded_leaf_store([11])
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            assert list(read_tensors(store, "12/h_tdigest", subtree=morton_word(_KEY_B))) == []
+        msgs = [str(w.message) for w in rec if "outside this axis" in str(w.message)]
+        assert msgs == [
+            f"subtree {_KEY_B} is outside this axis' order-6 root {_KEY_A} — yielding nothing"
+        ]
+        # In-domain child with nothing stored (chunks 12..15): silent empty —
+        # the docstring ambiguity; the absent warning is the in-domain signal.
+        empty_sub = int(np.asarray(generate_morton_children(word, 7))[3])
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            assert list(read_tensors(store, "12/h_tdigest", subtree=empty_sub)) == []
+        assert [w for w in rec if "outside this axis" in str(w.message)] == []
+
+    def test_malformed_and_too_deep_raise(self):
+        store, _words = TestSubtreePerCellReaders._flat()
+        with pytest.raises(ValueError):
+            list(read_tensors(store, "12/h_tdigest", subtree="abc"))
+        with pytest.raises(ValueError, match="deeper than"):
+            list(read_tensors(store, "12/h_tdigest", subtree=_KEY_A + "1111111"))
 
 
 class TestReadCell:


### PR DESCRIPTION
Closes #351

Span-restricted subtree reads for the ragged vlen readers: a `subtree=` keyword on the three sweep readers (`read_raw_values`, `read_locations`, `read_tensors`), implementing the normative spec §1.5 "Subtree spans" clause (`docs/specification.md`, landed on main in c0493ba). Binds to the [implementation plan](https://github.com/englacial/zagg/issues/351#issuecomment-5146756732), the [ratified decision record](https://github.com/englacial/zagg/issues/351#issuecomment-5146868655) (both currencies; sub-chunk refusal in `read_tensors` v1; warn+empty for well-formed out-of-domain words; `ValueError` for malformed/impossible words; docstrings state the empty-yield ambiguity), and the [§4 module-cap waiver](https://github.com/englacial/zagg/issues/351#issuecomment-5147013259) (option (1): `tdigest_tensor.py` may cross ~1000 lines for this feature; no pre-split).

## Approach

- **Span identity** (`readers/_layout.py`, pure arithmetic — no store access): a cell's axis position is its HEALPix NESTED id — chunks are keyed by the parent's nested id (`HealpixGrid.block_index` / `mort2healpix`) and the in-chunk position is the nested rank — so the order-`k` subtree below a word with nested id `h` occupies `[h·4^d, (h+1)·4^d)` (`d = c − k`) in fullsphere coordinates. A single-root power-of-four axis (a hive leaf) subtracts its root's span start, with the root derived from one written anchor word exactly as `_load_occupancy` derives the shard word. Verified numerically before writing: `generate_morton_children(w, k)` yields exactly the ascending nested-id range.
- **Currency normalization** (`normalize_subtree`): packed area word (int) or decimal string (str), both normalized at the top of the call; a parsed string always yields the area word (mortie spec §4 tie-break), per ratified fork (1).
- **Fetch restriction**: the span is intersected with `_stored_chunk_spans` before any payload read (`_iter_populated_chunks(arr, span)` clips each stored object's slice to the covering read chunks and skips non-overlapping objects without a fetch) — the §1.5 read plan: index suffix + covering inner chunks on sharded, covering chunk objects on flat. Sub-chunk restriction is a rank filter inside the one covering chunk (per-cell readers only, per ratified fork (2)).
- **Out-of-domain** (ratified fork (3)): a well-formed word disjoint from the axis warns once per reader call — `subtree {word} is outside this axis' order-{k} root {root} — yielding nothing` — then yields nothing; malformed words and words deeper than the cells-axis order raise `ValueError`. Reader docstrings state the empty-yield ambiguity explicitly; tests pin the exact warning text.

## Phases

- [x] Phase 1 — span arithmetic + currency normalization in `readers/_layout.py`; span∩stored-spans in `_iter_populated_chunks`; `subtree=` on `read_raw_values` / `read_locations` (any order down to a single cell); tests: golden equality vs independently-filtered whole sweep on flat, sharded, and hive-leaf stores, both currencies, warn+empty (exact text, once per call), malformed/too-deep raises, `subtree=None` regression.
- [x] Phase 2 — `subtree=` on `read_tensors`: span-restricted block assembly, `subtree_order ≤ block_order ≤ chunk_order`, sub-chunk refusal pointing at the per-cell readers, occupancy-mask blocks unchanged; GET accounting with a counting store; empty/out-of-domain edges; hive-leaf case.
- [x] Phase 3 — flip the `docs/ragged_layout.md` third-access-mode bullet from "(planned)" to the landed API (spec §1.5 untouched — already normative).

## How it was tested

`uv run ruff check` + `ruff format --check` on the touched files, and `uv run pytest tests/test_readers.py tests/test_reader_layout.py` (104 passed by phase 3 = 76 baseline + 28 new; 113 after the review-fold commits) per phase commit. Full suite before the final push: `uv run pytest -q` — **3090 passed, 35 skipped, 1 failed**; the one failure is `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`, the known environment-only failure (pip has no network in the sandbox) — pre-existing and unrelated to this change (the fold pass also observed an intermittent pre-existing timing race in `tests/test_client_transport.py::TestStatusPoller::test_invoke_fault_burns_an_attempt_and_retries`, present on the base commit too). The golden filter in the new tests is deliberately independent of the reader's span arithmetic: each yielded cell resolves through `cell_index` + the stored `morton` coordinate, then coarsens with `mortie.clip2order` — the two paths cannot share a bug.

Note: `ruff check src tests` on this branch reports one **pre-existing** `N818` (`src/zagg/registry.py:64`, `UnknownCapability`) under the locked ruff 0.16.1 — present on clean main (c0493ba), unrelated to this change, so it is flagged here rather than fixed (per repo conventions §4). The touched files are clean. Final `tdigest_tensor.py` size: **1,140 lines** after the review folds (the §4 waiver projected ~1,055–1,070; the overshoot is the decision-record-mandated docstring text plus the reviewer's nested-placement invariant check and single-LIST plumbing — flagging the delta for transparency).

## Questions for review

1. **Ancestor-of-the-root words clip to the whole axis rather than warn+empty.** The decision record's out-of-domain example is a *sibling* branch ("433… outside … root 431…" — disjoint, the moczarr no-coverage posture), and the acceptance criterion is `subtree read ≡ whole sweep filtered to descendants of w` — for a word *above* a leaf's root, every stored cell IS a descendant of `w`, so this implementation returns the span∩axis intersection (the whole leaf) and reserves warn+empty for genuinely disjoint words. This keeps the golden equality universal over well-formed words (pinned in `test_ancestor_of_the_axis_root_clips_to_the_whole_axis`). If the intent was instead "any word not at-or-below the root warns and yields nothing", say so and phase 2 will flip it (one clamp + one test).
2. **Empty store**: with no stored objects there is no anchor word, so neither the axis root nor the cells-axis order is derivable — a syntactically valid `subtree` yields nothing silently (no domain warning, no too-deep check), while malformed words still raise at parse time. Pinned in `test_empty_store_yields_nothing_but_malformed_still_raises`; flag if the too-deep check should instead consult some other order source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnmnBoL5eTCGPMEYUtHrRK
