### PR TITLE
small fixes 2026-08-03: explicit-window point entries

### DIFF
--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -182,7 +182,11 @@ Validation: `output.windowing` requires the hive layout on a healpix grid;
 filter what it reads); explicit windows must be well-formed (frozen label
 grammar, `start < end`, unique labels, disjoint ranges — point entries are
 desugared first, so a point landing inside another window's range is a genuine
-overlap and is rejected). On the raster path
+overlap and is rejected). Because boundaries render at whole-second
+granularity, a range narrower than the second containing it (say
+`12:00:01.0Z` → `12:00:01.4Z`) would dispatch as an empty window; it is
+refused rather than widened — the point form is the spelling for one-second
+intent. On the raster path
 ([issue #247](https://github.com/englacial/zagg/issues/247)) membership is
 the acquisition's STAC `datetime`: `time_field` is optional (fixed to
 `datetime`) and the `epoch`/`scale`/`units` conversion knobs are rejected.

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -112,6 +112,7 @@ output:
     windows:                        # explicit schedule only:
       - {label: melt-2019, start: "2019-06-01", end: "2019-09-01"}
       - {label: melt-2020, start: "2020-06-01", end: "2020-09-01"}
+      - {label: scene-a, timestamp: "2021-03-14T12:00:00Z"}  # point form
 ```
 
 - **Leaf naming is frozen**: `{full_id}_{window}.zarr`, underscore separator,
@@ -120,6 +121,19 @@ output:
   chronological order; explicit labels are opaque (`[0-9A-Za-z-]{1,32}`) and
   decode only through the declared list. `quarterly` is grammar-reserved but
   not implemented (validation rejects it).
+- **An explicit entry may be a point** ([issue #355](https://github.com/englacial/zagg/issues/355)):
+  `{label, timestamp}` is sugar for the second-wide half-open `[t, t + 1s)`,
+  for time axes that are effectively discrete (single acquisitions, scene
+  timestamps, isolated campaign instants). Each entry declares *exactly one* of
+  `timestamp` or `start`+`end` — mixing them in one entry is rejected. The
+  desugaring happens in `zagg.config.get_windowing`, so the manifest and every
+  downstream consumer only ever see an ordinary `{label, start, end}` window.
+  One second is the grammar's own resolution (boundaries are whole seconds
+  throughout), which also keeps membership off float equality on observation
+  timestamps. *Consequence*: two acquisitions within the same wall-clock second
+  share a window, and two point entries inside one second are rejected as
+  overlapping — if that ever bites, the fix is an explicit `width` key on the
+  point form, not a guessed default.
 - **Boundaries are UTC calendar terms, half-open `[start, end)`.** Window
   bounds are converted to dataset units once at dispatch, using the declared
   `epoch`/`scale`/`units` and a fixed scale offset (`GPS−UTC = 18 s`,
@@ -149,7 +163,9 @@ output:
 Validation: `output.windowing` requires the hive layout on a healpix grid;
 `time_field` must be a declared `data_source` column (the worker can only
 filter what it reads); explicit windows must be well-formed (frozen label
-grammar, `start < end`, unique labels, disjoint ranges). On the raster path
+grammar, `start < end`, unique labels, disjoint ranges — point entries are
+desugared first, so a point landing inside another window's range is a genuine
+overlap and is rejected). On the raster path
 ([issue #247](https://github.com/englacial/zagg/issues/247)) membership is
 the acquisition's STAC `datetime`: `time_field` is optional (fixed to
 `datetime`) and the `epoch`/`scale`/`units` conversion knobs are rejected.

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -130,10 +130,13 @@ output:
   downstream consumer only ever see an ordinary `{label, start, end}` window.
   One second is the grammar's own resolution (boundaries are whole seconds
   throughout), which also keeps membership off float equality on observation
-  timestamps. *Consequence*: two acquisitions within the same wall-clock second
-  share a window, and two point entries inside one second are rejected as
-  overlapping — if that ever bites, the fix is an explicit `width` key on the
-  point form, not a guessed default.
+  timestamps (a sub-second `timestamp` normalizes to the whole second
+  containing it). *Consequence*: two acquisitions within the same wall-clock
+  second share a window, and two point entries inside one second are rejected
+  as overlapping — as is a point that lands inside an already-declared range
+  window, which is an ordinary overlap (see the validation paragraph below).
+  If that ever bites, the fix is an explicit `width` key on the point form, not
+  a guessed default.
 - **Boundaries are UTC calendar terms, half-open `[start, end)`.** Window
   bounds are converted to dataset units once at dispatch, using the declared
   `epoch`/`scale`/`units` and a fixed scale offset (`GPS−UTC = 18 s`,

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -138,8 +138,9 @@ output:
   as overlapping — as is a point that lands inside an already-declared range
   window, which is an ordinary overlap (see the validation paragraph below).
   If that ever bites, the fix is an explicit `width` key on the point form, not
-  a guessed default; until it exists, any key on a point entry other than
-  `label`/`timestamp` (`width` included) is rejected rather than ignored.
+  a guessed default; until it exists, any key on an entry beyond its own form's
+  (`label`/`timestamp` or `label`/`start`/`end`; `width` included) is rejected
+  rather than ignored.
 - **A point window that matches nothing fails SILENTLY** — it covers only the
   whole second containing `t`, so the declared `timestamp` must be the
   acquisition's own instant, copied from the item, not a rounded-off

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -112,7 +112,9 @@ output:
     windows:                        # explicit schedule only:
       - {label: melt-2019, start: "2019-06-01", end: "2019-09-01"}
       - {label: melt-2020, start: "2020-06-01", end: "2020-09-01"}
-      - {label: scene-a, timestamp: "2021-03-14T12:00:00Z"}  # point form
+      - {label: scene-a, timestamp: "2021-03-14T12:00:31.024Z"}  # point form:
+                                    #   the acquisition's OWN instant, copied
+                                    #   from the item — not a rounded-off one
 ```
 
 - **Leaf naming is frozen**: `{full_id}_{window}.zarr`, underscore separator,
@@ -136,7 +138,18 @@ output:
   as overlapping — as is a point that lands inside an already-declared range
   window, which is an ordinary overlap (see the validation paragraph below).
   If that ever bites, the fix is an explicit `width` key on the point form, not
-  a guessed default.
+  a guessed default; until it exists, any key on a point entry other than
+  `label`/`timestamp` (`width` included) is rejected rather than ignored.
+- **A point window that matches nothing fails SILENTLY** — it covers only the
+  whole second containing `t`, so the declared `timestamp` must be the
+  acquisition's own instant, copied from the item, not a rounded-off
+  approximation of it. STAC datetimes are rarely round seconds, so this is the
+  likely first-contact mistake: `timestamp: "2021-03-14T12:00:00Z"` matches
+  nothing for a scene whose `datetime` is `2021-03-14T12:00:31.024Z`. On the
+  point pipeline the window still dispatches and the worker's `ge`/`lt` filter
+  matches nothing, leaving an empty leaf; on raster the group is dropped at
+  dispatch (`runner._raster_windowed_units`) and no work unit, leaf, or warning
+  is produced at all. Neither path errors.
 - **Boundaries are UTC calendar terms, half-open `[start, end)`.** Window
   bounds are converted to dataset units once at dispatch, using the declared
   `epoch`/`scale`/`units` and a fixed scale offset (`GPS−UTC = 18 s`,

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -182,11 +182,18 @@ Validation: `output.windowing` requires the hive layout on a healpix grid;
 filter what it reads); explicit windows must be well-formed (frozen label
 grammar, `start < end`, unique labels, disjoint ranges — point entries are
 desugared first, so a point landing inside another window's range is a genuine
-overlap and is rejected). Because boundaries render at whole-second
-granularity, a range narrower than the second containing it (say
-`12:00:01.0Z` → `12:00:01.4Z`) would dispatch as an empty window; it is
-refused rather than widened — the point form is the spelling for one-second
-intent. On the raster path
+overlap and is rejected). Range bounds render at whole-second granularity
+exactly as a point `timestamp` does — **each bound truncates to the second
+containing it** — so a fractional bound silently retimes that edge of the
+window: `[12:00:00.0Z, 12:00:01.5Z)` dispatches as
+`[12:00:00, 12:00:01)`, dropping the declared half second of coverage at the
+tail. A range is never widened to recover the truncated fraction. The one
+case refused outright is total collapse: when *both* bounds render to the
+same second (say `12:00:01.0Z` → `12:00:01.4Z`) the window dispatches as an
+empty `ge x`/`lt x` pair, so it is rejected — the point form is the spelling
+for one-second intent. A sub-second range that *straddles* a second boundary
+(`12:00:01.9Z` → `12:00:02.1Z`) is still valid; it renders to the one-second
+window its truncated bounds describe. On the raster path
 ([issue #247](https://github.com/englacial/zagg/issues/247)) membership is
 the acquisition's STAC `datetime`: `time_field` is optional (fixed to
 `datetime`) and the `epoch`/`scale`/`units` conversion knobs are rejected.

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1091,6 +1091,16 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
                 f"entry declares exactly one of {{timestamp}} or {{start, end}} "
                 f"(got {entry!r})"
             )
+        extra = sorted(set(entry) - {"label", "timestamp"})
+        if extra:
+            # `width` is named as the escape hatch for the same-second edge but
+            # does not exist yet — accepting it silently would hand back a
+            # one-second window and a clean validate_config (review finding).
+            raise ValueError(
+                f"explicit point window entry carries unsupported key(s) "
+                f"{', '.join(extra)}; the point form is {{label, timestamp}} "
+                f"(got {entry!r})"
+            )
         point = _windows.parse_utc(entry["timestamp"])
         return point, point + _POINT_WINDOW_WIDTH
     return _windows.parse_utc(entry["start"]), _windows.parse_utc(entry["end"])

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1091,21 +1091,26 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
         # `width` is documented as the future escape hatch but does not exist
         # yet: accepting it silently would hand back a 1 s window and a clean
         # validate_config.
-        extra = sorted(set(entry) - {"label", "timestamp"})
+        extra = sorted(set(entry) - {"label", "timestamp"}, key=repr)
         if extra:
             raise ValueError(
                 f"explicit point window entry carries unsupported key(s) "
-                f"{', '.join(extra)}; the point form is {{label, timestamp}} "
-                f"(got {entry!r})"
+                f"{', '.join(map(repr, extra))}; the point form is "
+                f"{{label, timestamp}} (got {entry!r})"
             )
         point = _windows.parse_utc(entry["timestamp"])
         return point, point + _POINT_WINDOW_WIDTH
-    extra = sorted(set(entry) - {"label", "start", "end"})
+    # repr, not str: YAML 1.1 resolves bare `on`/`no`/numerals to bool/int
+    # keys, which are neither sortable against strings nor joinable — the
+    # TypeError would escape _validate_windowing_windows' ValueError wrapper
+    # and lose the `output.windowing.windows:` prefix. repr also shows the
+    # reader that the key came back coerced.
+    extra = sorted(set(entry) - {"label", "start", "end"}, key=repr)
     if extra:
         raise ValueError(
             f"explicit range window entry carries unsupported key(s) "
-            f"{', '.join(extra)}; the range form is {{label, start, end}} "
-            f"(got {entry!r})"
+            f"{', '.join(map(repr, extra))}; the range form is "
+            f"{{label, start, end}} (got {entry!r})"
         )
     start = _windows.parse_utc(entry["start"])
     end = _windows.parse_utc(entry["end"])

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1087,7 +1087,7 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
     if "timestamp" in entry:
         if ranged:
             raise ValueError(
-                f"explicit window entry carries both timestamp and {ranged[0]}; each "
+                f"explicit window entry carries both timestamp and {', '.join(ranged)}; each "
                 f"entry declares exactly one of {{timestamp}} or {{start, end}} "
                 f"(got {entry!r})"
             )

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1073,6 +1073,13 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
     range. Two acquisitions inside the same wall-clock second therefore share a
     window; if that ever bites, the fix is an explicit ``width`` key on the
     point form, not a guessed default.
+
+    Bounds are returned at the precision declared, but :func:`get_windowing`
+    renders them through ``windows.iso_utc`` (``timespec="seconds"``), so a
+    SUB-SECOND ``timestamp`` normalizes to the whole second CONTAINING it —
+    both ends truncate by the same fraction, so ``t`` still falls inside its
+    own window, and disjointness is preserved (validated-disjoint points are
+    >= 1 s apart, hence so are their truncated bounds).
     """
     from zagg import windows as _windows
 

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1070,10 +1070,13 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
     renders them through ``windows.iso_utc`` (``timespec="seconds"``), so a
     sub-second ``timestamp`` normalizes to the whole second containing it —
     truncation is monotone, so it can neither move ``t`` out of its own window
-    nor manufacture an overlap. A *range* whose bounds collapse to the same
-    rendered second would dispatch as an empty window, so it is refused here,
-    on the rendered values. See ``docs/hive_layout.md`` for the same-second
-    collision and the silent-miss edge.
+    nor manufacture an overlap. *Range* bounds truncate identically, each to
+    the second containing it, so a fractional ``start``/``end`` silently
+    retimes that edge of the window; a range is never widened to recover the
+    truncated fraction. The one refusal is total collapse — bounds that render
+    to the same second would dispatch as an empty window, so it is rejected
+    here, on the rendered values. See ``docs/hive_layout.md`` for the
+    bound-truncation edge, the same-second collision and the silent-miss edge.
     """
     from zagg import windows as _windows
 
@@ -1107,10 +1110,13 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
     start = _windows.parse_utc(entry["start"])
     end = _windows.parse_utc(entry["end"])
     if start < end and start.replace(microsecond=0) == end.replace(microsecond=0):
-        # Bounds render at whole-second granularity (windows.iso_utc,
-        # timespec="seconds"), so a sub-second range collapses to a `ge x` /
-        # `lt x` pair that silently matches nothing. Refuse rather than widen
-        # — the point form is the spelling for one-second intent.
+        # Each bound truncates to the second containing it (windows.iso_utc,
+        # timespec="seconds"), so a range with both bounds inside one second
+        # renders to a `ge x` / `lt x` pair that silently matches nothing.
+        # Refuse rather than widen — the point form is the spelling for
+        # one-second intent. Only this total collapse is refused: a fractional
+        # bound in a *different* second merely retimes that edge (documented in
+        # docs/hive_layout.md).
         raise ValueError(
             f"explicit window range is empty after truncation to whole-second "
             f"granularity: start {entry['start']!r} and end {entry['end']!r} "

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -6,6 +6,7 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta
 from importlib import resources
 from typing import Any, NotRequired, TypedDict
 
@@ -1052,13 +1053,53 @@ def _validate_windowing(config: PipelineConfig) -> None:
     _validate_windowing_windows(block, schedule)
 
 
+#: A ``{label, timestamp}`` point entry desugars to a window this wide (issue
+#: #355). One second is the window grammar's native resolution — boundaries
+#: are whole seconds throughout (``iso_utc`` renders ``timespec="seconds"``)
+#: — so a second-wide half-open window *is* the point window at grammar
+#: resolution, without introducing float equality on observation timestamps.
+_POINT_WINDOW_WIDTH = timedelta(seconds=1)
+
+
+def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
+    """The half-open UTC ``[start, end)`` of one explicit ``windows`` entry.
+
+    Two forms, discriminated on keys and never mixed (issue #355): the range
+    form ``{label, start, end}``, and the point sugar ``{label, timestamp}``
+    which desugars to ``[t, t + 1s)`` (:data:`_POINT_WINDOW_WIDTH`). Desugaring
+    happens here, at the config layer, so everything downstream —
+    ``windows_intersecting``, the catalog time filters, ``windowed_cell_config``,
+    leaf naming, the sweep, the pyramid — only ever sees an ordinary explicit
+    range. Two acquisitions inside the same wall-clock second therefore share a
+    window; if that ever bites, the fix is an explicit ``width`` key on the
+    point form, not a guessed default.
+    """
+    from zagg import windows as _windows
+
+    ranged = sorted({"start", "end"} & set(entry))
+    if "timestamp" in entry:
+        if ranged:
+            raise ValueError(
+                f"explicit window entry carries both timestamp and {ranged[0]}; each "
+                f"entry declares exactly one of {{timestamp}} or {{start, end}} "
+                f"(got {entry!r})"
+            )
+        point = _windows.parse_utc(entry["timestamp"])
+        return point, point + _POINT_WINDOW_WIDTH
+    return _windows.parse_utc(entry["start"]), _windows.parse_utc(entry["end"])
+
+
 def _validate_windowing_windows(block: dict, schedule: str) -> None:
     """Validate the ``windows`` list half of ``output.windowing`` (issue #246).
 
     Shared by the point-pipeline and raster branches of
     :func:`_validate_windowing`: frozen label grammar, half-open
     ``start < end``, unique labels, non-overlapping ranges — required for
-    ``schedule: explicit``, rejected otherwise.
+    ``schedule: explicit``, rejected otherwise. Point entries
+    (``{label, timestamp}``, issue #355) are desugared by
+    :func:`_explicit_window_bounds` before these checks, so they compose
+    unchanged: a point landing inside another window's range is a genuine
+    overlap and rejects.
     """
     from zagg import windows as _windows
 
@@ -1073,17 +1114,20 @@ def _validate_windowing_windows(block: dict, schedule: str) -> None:
     if not isinstance(declared_windows, list) or not declared_windows:
         raise ValueError(
             "output.windowing.windows is required for schedule: explicit — a "
-            "non-empty list of {label, start, end} entries"
+            "non-empty list of {label, start, end} (or {label, timestamp}) entries"
         )
     seen: dict = {}
     for entry in declared_windows:
-        if not isinstance(entry, dict) or not {"label", "start", "end"} <= set(entry):
+        if not isinstance(entry, dict) or not (
+            "label" in entry and ({"start", "end"} <= set(entry) or "timestamp" in entry)
+        ):
             raise ValueError(
-                f"each explicit window must be a {{label, start, end}} mapping (got {entry!r})"
+                f"each explicit window must be a {{label, start, end}} or "
+                f"{{label, timestamp}} mapping (got {entry!r})"
             )
         try:
             label = _windows.validate_label(entry["label"], "explicit")
-            start, end = _windows.parse_utc(entry["start"]), _windows.parse_utc(entry["end"])
+            start, end = _explicit_window_bounds(entry)
         except ValueError as e:
             raise ValueError(f"output.windowing.windows: {e}") from e
         if label == _windows.SCHEDULE_NONE_TOKEN:
@@ -1098,6 +1142,7 @@ def _validate_windowing_windows(block: dict, schedule: str) -> None:
                 f"declare a different explicit label"
             )
         if not start < end:
+            # Range form only — a desugared point is half-open by construction.
             raise ValueError(
                 f"explicit window {label!r} is not half-open: start "
                 f"{entry['start']!r} must precede end {entry['end']!r}"
@@ -2500,7 +2545,10 @@ def get_windowing(config: PipelineConfig) -> dict | None:
         {"schedule", "time_field", "epoch", "scale", "units", "windows"}
 
     ``epoch`` and explicit-window boundaries are canonicalized to ISO-8601
-    UTC strings; ``windows`` is ``None`` except for ``schedule: explicit``.
+    UTC strings; ``windows`` is ``None`` except for ``schedule: explicit``,
+    where a ``{label, timestamp}`` point entry is desugared to its second-wide
+    range (issue #355) so the normalized list is uniformly ``{label, start,
+    end}``.
     On the raster branch (``reader: raster``) ``time_field`` is the fixed STAC
     ``datetime`` and ``epoch``/``scale``/``units`` are hardcoded to the
     Unix-epoch UTC-seconds encoding any ISO instant normalizes to, rather than
@@ -2516,14 +2564,19 @@ def get_windowing(config: PipelineConfig) -> dict | None:
         return None
     declared = None
     if block["schedule"] == "explicit":
-        declared = [
-            {
-                "label": w["label"],
-                "start": _windows.iso_utc(_windows.parse_utc(w["start"])),
-                "end": _windows.iso_utc(_windows.parse_utc(w["end"])),
-            }
-            for w in block["windows"]
-        ]
+        # Point entries desugar HERE (issue #355): the normalized list is
+        # always the {label, start, end} range form, so no consumer — manifest
+        # temporal block included — ever sees a ``timestamp`` key.
+        declared = []
+        for w in block["windows"]:
+            start, end = _explicit_window_bounds(w)
+            declared.append(
+                {
+                    "label": w["label"],
+                    "start": _windows.iso_utc(start),
+                    "end": _windows.iso_utc(end),
+                }
+            )
     if (config.data_source or {}).get("reader") == "raster":
         # Raster membership is the acquisition's STAC ``datetime`` (issue
         # #247, ratified): the manifest records the resolved field plus the

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1070,7 +1070,9 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
     renders them through ``windows.iso_utc`` (``timespec="seconds"``), so a
     sub-second ``timestamp`` normalizes to the whole second containing it —
     truncation is monotone, so it can neither move ``t`` out of its own window
-    nor manufacture an overlap. See ``docs/hive_layout.md`` for the same-second
+    nor manufacture an overlap. A *range* whose bounds collapse to the same
+    rendered second would dispatch as an empty window, so it is refused here,
+    on the rendered values. See ``docs/hive_layout.md`` for the same-second
     collision and the silent-miss edge.
     """
     from zagg import windows as _windows
@@ -1102,7 +1104,20 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
             f"{', '.join(extra)}; the range form is {{label, start, end}} "
             f"(got {entry!r})"
         )
-    return _windows.parse_utc(entry["start"]), _windows.parse_utc(entry["end"])
+    start = _windows.parse_utc(entry["start"])
+    end = _windows.parse_utc(entry["end"])
+    if start < end and start.replace(microsecond=0) == end.replace(microsecond=0):
+        # Bounds render at whole-second granularity (windows.iso_utc,
+        # timespec="seconds"), so a sub-second range collapses to a `ge x` /
+        # `lt x` pair that silently matches nothing. Refuse rather than widen
+        # — the point form is the spelling for one-second intent.
+        raise ValueError(
+            f"explicit window range is empty after truncation to whole-second "
+            f"granularity: start {entry['start']!r} and end {entry['end']!r} "
+            f"both render as {_windows.iso_utc(start)!r}; use the point form "
+            f"{{label, timestamp}} for a one-second window"
+        )
+    return start, end
 
 
 def _validate_windowing_windows(block: dict, schedule: str) -> None:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1053,11 +1053,9 @@ def _validate_windowing(config: PipelineConfig) -> None:
     _validate_windowing_windows(block, schedule)
 
 
-#: A ``{label, timestamp}`` point entry desugars to a window this wide (issue
-#: #355). One second is the window grammar's native resolution — boundaries
-#: are whole seconds throughout (``iso_utc`` renders ``timespec="seconds"``)
-#: — so a second-wide half-open window *is* the point window at grammar
-#: resolution, without introducing float equality on observation timestamps.
+#: Width of the window a ``{label, timestamp}`` point entry desugars to (#355).
+#: One second is the grammar's native resolution — boundaries render at
+#: ``timespec="seconds"`` throughout — and keeps membership off float equality.
 _POINT_WINDOW_WIDTH = timedelta(seconds=1)
 
 
@@ -1065,21 +1063,13 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
     """The half-open UTC ``[start, end)`` of one explicit ``windows`` entry.
 
     Two forms, discriminated on keys and never mixed (issue #355): the range
-    form ``{label, start, end}``, and the point sugar ``{label, timestamp}``
-    which desugars to ``[t, t + 1s)`` (:data:`_POINT_WINDOW_WIDTH`). Desugaring
-    happens here, at the config layer, so everything downstream —
-    ``windows_intersecting``, the catalog time filters, ``windowed_cell_config``,
-    leaf naming, the sweep, the pyramid — only ever sees an ordinary explicit
-    range. Two acquisitions inside the same wall-clock second therefore share a
-    window; if that ever bites, the fix is an explicit ``width`` key on the
-    point form, not a guessed default.
-
-    Bounds are returned at the precision declared, but :func:`get_windowing`
+    ``{label, start, end}``, and the point sugar ``{label, timestamp}`` ->
+    ``[t, t + 1s)``. Bounds come back at declared precision; :func:`get_windowing`
     renders them through ``windows.iso_utc`` (``timespec="seconds"``), so a
-    SUB-SECOND ``timestamp`` normalizes to the whole second CONTAINING it —
-    both ends truncate by the same fraction, so ``t`` still falls inside its
-    own window, and disjointness is preserved (validated-disjoint points are
-    >= 1 s apart, hence so are their truncated bounds).
+    sub-second ``timestamp`` normalizes to the whole second containing it —
+    truncation is monotone, so it can neither move ``t`` out of its own window
+    nor manufacture an overlap. See ``docs/hive_layout.md`` for the same-second
+    collision and the silent-miss edge.
     """
     from zagg import windows as _windows
 
@@ -1091,11 +1081,11 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
                 f"entry declares exactly one of {{timestamp}} or {{start, end}} "
                 f"(got {entry!r})"
             )
+        # `width` is documented as the future escape hatch but does not exist
+        # yet: accepting it silently would hand back a 1 s window and a clean
+        # validate_config.
         extra = sorted(set(entry) - {"label", "timestamp"})
         if extra:
-            # `width` is named as the escape hatch for the same-second edge but
-            # does not exist yet — accepting it silently would hand back a
-            # one-second window and a clean validate_config (review finding).
             raise ValueError(
                 f"explicit point window entry carries unsupported key(s) "
                 f"{', '.join(extra)}; the point form is {{label, timestamp}} "
@@ -1114,9 +1104,8 @@ def _validate_windowing_windows(block: dict, schedule: str) -> None:
     ``start < end``, unique labels, non-overlapping ranges — required for
     ``schedule: explicit``, rejected otherwise. Point entries
     (``{label, timestamp}``, issue #355) are desugared by
-    :func:`_explicit_window_bounds` before these checks, so they compose
-    unchanged: a point landing inside another window's range is a genuine
-    overlap and rejects.
+    :func:`_explicit_window_bounds` first, so every check below runs on ordinary
+    bounds and composes unchanged.
     """
     from zagg import windows as _windows
 
@@ -2581,9 +2570,6 @@ def get_windowing(config: PipelineConfig) -> dict | None:
         return None
     declared = None
     if block["schedule"] == "explicit":
-        # Point entries desugar HERE (issue #355): the normalized list is
-        # always the {label, start, end} range form, so no consumer — manifest
-        # temporal block included — ever sees a ``timestamp`` key.
         declared = []
         for w in block["windows"]:
             start, end = _explicit_window_bounds(w)

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1064,7 +1064,9 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
 
     Two forms, discriminated on keys and never mixed (issue #355): the range
     ``{label, start, end}``, and the point sugar ``{label, timestamp}`` ->
-    ``[t, t + 1s)``. Bounds come back at declared precision; :func:`get_windowing`
+    ``[t, t + 1s)``. Either form refuses keys beyond its own — a dead or
+    typo'd key has no semantic effect, so it fails loud rather than riding
+    along. Bounds come back at declared precision; :func:`get_windowing`
     renders them through ``windows.iso_utc`` (``timespec="seconds"``), so a
     sub-second ``timestamp`` normalizes to the whole second containing it —
     truncation is monotone, so it can neither move ``t`` out of its own window
@@ -1093,6 +1095,13 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
             )
         point = _windows.parse_utc(entry["timestamp"])
         return point, point + _POINT_WINDOW_WIDTH
+    extra = sorted(set(entry) - {"label", "start", "end"})
+    if extra:
+        raise ValueError(
+            f"explicit range window entry carries unsupported key(s) "
+            f"{', '.join(extra)}; the range form is {{label, start, end}} "
+            f"(got {entry!r})"
+        )
     return _windows.parse_utc(entry["start"]), _windows.parse_utc(entry["end"])
 
 

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1109,10 +1109,12 @@ def _explicit_window_bounds(entry: dict) -> tuple[datetime, datetime]:
         )
     start = _windows.parse_utc(entry["start"])
     end = _windows.parse_utc(entry["end"])
-    if start < end and start.replace(microsecond=0) == end.replace(microsecond=0):
+    if start < end and _windows.iso_utc(start) == _windows.iso_utc(end):
         # Each bound truncates to the second containing it (windows.iso_utc,
         # timespec="seconds"), so a range with both bounds inside one second
-        # renders to a `ge x` / `lt x` pair that silently matches nothing.
+        # renders to a `ge x` / `lt x` pair that silently matches nothing. The
+        # predicate above calls the renderer rather than repeating its
+        # truncation, so the two cannot drift.
         # Refuse rather than widen — the point form is the spelling for
         # one-second intent. Only this total collapse is refused: a fractional
         # bound in a *different* second merely retimes that edge (documented in

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -453,8 +453,13 @@ class TestWindowingConfig:
             validate_config(cfg)
 
     def test_explicit_subsecond_range_spanning_a_second_boundary_allowed(self, cfg):
-        # A sub-second-wide range that straddles a second boundary renders to
-        # a real one-second window and stays valid.
+        # A sub-second-wide range that straddles a second boundary does NOT
+        # collapse — but it is RETIMED, not preserved: each bound truncates to
+        # the second containing it, so the declared [12:00:01.9, 12:00:02.1)
+        # renders as [12:00:01, 12:00:02) — 0.9 s earlier at the head, 0.1 s
+        # short at the tail. That truncation is the documented behavior for
+        # range bounds (docs/hive_layout.md); ranges are never widened, and
+        # only the total collapse to one second is refused.
         _windowed(
             cfg,
             schedule="explicit",

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -364,28 +364,37 @@ class TestWindowingConfig:
             }
         ]
 
-    def test_explicit_entry_mixing_both_forms_rejected(self, cfg):
-        # Exactly one of {timestamp} or {start, end} per entry.
-        for over in (
+    @pytest.mark.parametrize(
+        "entry",
+        [
             {"label": "w", "timestamp": "2019-06-01T12:00:00Z", "start": "2019-06-01"},
+            {"label": "w", "timestamp": "2019-06-01T12:00:00Z", "end": "2019-09-01"},
             {
                 "label": "w",
                 "timestamp": "2019-06-01T12:00:00Z",
                 "start": "2019-06-01",
                 "end": "2019-09-01",
             },
-        ):
-            _windowed(cfg, schedule="explicit", windows=[over])
-            with pytest.raises(ValueError, match="exactly one of"):
-                validate_config(cfg)
+        ],
+    )
+    def test_explicit_entry_mixing_both_forms_rejected(self, cfg, entry):
+        # Exactly one of {timestamp} or {start, end} per entry.
+        _windowed(cfg, schedule="explicit", windows=[entry])
+        with pytest.raises(ValueError, match="exactly one of"):
+            validate_config(cfg)
 
-    def test_explicit_entry_without_bounds_rejected(self, cfg):
-        # A label alone declares no range in either form; the half-range
-        # {label, start} is equally incomplete.
-        for over in ({"label": "w"}, {"label": "w", "start": "2019-06-01"}):
-            _windowed(cfg, schedule="explicit", windows=[over])
-            with pytest.raises(ValueError, match=r"\{label, timestamp\} mapping"):
-                validate_config(cfg)
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            {"label": "w"},  # a label alone declares no range in either form
+            {"label": "w", "start": "2019-06-01"},  # half a range is still no range
+            {"label": "w", "end": "2019-09-01"},
+        ],
+    )
+    def test_explicit_entry_without_bounds_rejected(self, cfg, entry):
+        _windowed(cfg, schedule="explicit", windows=[entry])
+        with pytest.raises(ValueError, match=r"\{label, timestamp\} mapping"):
+            validate_config(cfg)
 
     def test_explicit_point_bad_timestamp_rejected(self, cfg):
         _windowed(cfg, schedule="explicit", windows=[{"label": "w", "timestamp": "not-a-time"}])

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -442,6 +442,8 @@ class TestWindowingConfig:
         # start < end at declared precision, but both bounds render to the
         # same whole second (iso_utc, timespec="seconds") — the dispatched
         # ge/lt pair would silently match nothing. Refused, never widened.
+        # The message quotes the rendered second the predicate compared, so
+        # the refusal is tied to what get_windowing would actually emit.
         _windowed(
             cfg,
             schedule="explicit",
@@ -449,7 +451,11 @@ class TestWindowingConfig:
                 {"label": "w", "start": "2019-06-01T12:00:01.0Z", "end": "2019-06-01T12:00:01.4Z"}
             ],
         )
-        with pytest.raises(ValueError, match="empty after truncation to whole-second"):
+        with pytest.raises(
+            ValueError,
+            match=r"empty after truncation to whole-second .*"
+            r"both render as '2019-06-01T12:00:01\+00:00'",
+        ):
             validate_config(cfg)
 
     def test_explicit_subsecond_range_spanning_a_second_boundary_allowed(self, cfg):

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -345,6 +345,25 @@ class TestWindowingConfig:
             },
         ]
 
+    def test_explicit_point_subsecond_normalizes_to_its_whole_second(self, cfg):
+        # The grammar renders boundaries at whole-second precision (iso_utc,
+        # timespec="seconds"), so a sub-second timestamp normalizes to the
+        # second CONTAINING it — both ends truncate together, and the declared
+        # instant still falls inside its own window.
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[{"label": "scene-a", "timestamp": "2019-06-01T12:00:00.75Z"}],
+        )
+        validate_config(cfg)
+        assert get_windowing(cfg)["windows"] == [
+            {
+                "label": "scene-a",
+                "start": "2019-06-01T12:00:00+00:00",
+                "end": "2019-06-01T12:00:01+00:00",
+            }
+        ]
+
     def test_explicit_entry_mixing_both_forms_rejected(self, cfg):
         # Exactly one of {timestamp} or {start, end} per entry.
         for over in (

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -438,6 +438,39 @@ class TestWindowingConfig:
         ):
             validate_config(cfg)
 
+    def test_explicit_subsecond_range_collapses_and_is_rejected(self, cfg):
+        # start < end at declared precision, but both bounds render to the
+        # same whole second (iso_utc, timespec="seconds") — the dispatched
+        # ge/lt pair would silently match nothing. Refused, never widened.
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "w", "start": "2019-06-01T12:00:01.0Z", "end": "2019-06-01T12:00:01.4Z"}
+            ],
+        )
+        with pytest.raises(ValueError, match="empty after truncation to whole-second"):
+            validate_config(cfg)
+
+    def test_explicit_subsecond_range_spanning_a_second_boundary_allowed(self, cfg):
+        # A sub-second-wide range that straddles a second boundary renders to
+        # a real one-second window and stays valid.
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "w", "start": "2019-06-01T12:00:01.9Z", "end": "2019-06-01T12:00:02.1Z"}
+            ],
+        )
+        validate_config(cfg)
+        assert get_windowing(cfg)["windows"] == [
+            {
+                "label": "w",
+                "start": "2019-06-01T12:00:01+00:00",
+                "end": "2019-06-01T12:00:02+00:00",
+            }
+        ]
+
     def test_explicit_point_bad_timestamp_rejected(self, cfg):
         _windowed(cfg, schedule="explicit", windows=[{"label": "w", "timestamp": "not-a-time"}])
         with pytest.raises(ValueError, match="ISO-8601"):

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -365,22 +365,26 @@ class TestWindowingConfig:
         ]
 
     @pytest.mark.parametrize(
-        "entry",
+        "entry,named",
         [
-            {"label": "w", "timestamp": "2019-06-01T12:00:00Z", "start": "2019-06-01"},
-            {"label": "w", "timestamp": "2019-06-01T12:00:00Z", "end": "2019-09-01"},
-            {
-                "label": "w",
-                "timestamp": "2019-06-01T12:00:00Z",
-                "start": "2019-06-01",
-                "end": "2019-09-01",
-            },
+            ({"label": "w", "timestamp": "2019-06-01T12:00:00Z", "start": "2019-06-01"}, "start"),
+            ({"label": "w", "timestamp": "2019-06-01T12:00:00Z", "end": "2019-09-01"}, "end"),
+            (
+                {
+                    "label": "w",
+                    "timestamp": "2019-06-01T12:00:00Z",
+                    "start": "2019-06-01",
+                    "end": "2019-09-01",
+                },
+                # Both offending keys are named, so one edit fixes the entry.
+                "end, start",
+            ),
         ],
     )
-    def test_explicit_entry_mixing_both_forms_rejected(self, cfg, entry):
+    def test_explicit_entry_mixing_both_forms_rejected(self, cfg, entry, named):
         # Exactly one of {timestamp} or {start, end} per entry.
         _windowed(cfg, schedule="explicit", windows=[entry])
-        with pytest.raises(ValueError, match="exactly one of"):
+        with pytest.raises(ValueError, match=f"both timestamp and {named}; .*exactly one of"):
             validate_config(cfg)
 
     @pytest.mark.parametrize(

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -396,6 +396,20 @@ class TestWindowingConfig:
         with pytest.raises(ValueError, match=r"\{label, timestamp\} mapping"):
             validate_config(cfg)
 
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            # `width` is the documented future escape hatch and does not exist
+            # yet: it must fail loud, not silently yield a one-second window.
+            {"label": "w", "timestamp": "2019-06-01T12:00:00Z", "width": 3600},
+            {"label": "w", "timestamp": "2019-06-01T12:00:00Z", "duration": "1h"},
+        ],
+    )
+    def test_explicit_point_unsupported_key_rejected(self, cfg, entry):
+        _windowed(cfg, schedule="explicit", windows=[entry])
+        with pytest.raises(ValueError, match="unsupported key"):
+            validate_config(cfg)
+
     def test_explicit_point_bad_timestamp_rejected(self, cfg):
         _windowed(cfg, schedule="explicit", windows=[{"label": "w", "timestamp": "not-a-time"}])
         with pytest.raises(ValueError, match="ISO-8601"):

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -414,17 +414,48 @@ class TestWindowingConfig:
         with pytest.raises(ValueError, match="unsupported key"):
             validate_config(cfg)
 
+    def test_explicit_point_non_string_key_named(self, cfg):
+        # YAML 1.1 resolves bare `on:`/`no:`/numerals to bool/int keys, which
+        # cannot be sorted against strings or str-joined: the offenders must
+        # still be named as a ValueError (a TypeError would escape the
+        # output.windowing.windows: wrapper entirely) — PR #367.
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[{"label": "w", "timestamp": "2019-06-01T12:00:00Z", True: 1, 3: "x"}],
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"output\.windowing\.windows: .*unsupported key\(s\) 3, True; the point form",
+        ):
+            validate_config(cfg)
+
     @pytest.mark.parametrize(
         "entry,named",
         [
             (
                 {"label": "w", "start": "2019-06-01", "end": "2019-09-01", "width": 3600},
-                "width",
+                "'width'",
             ),
             (
                 # Every offending key is named, so one edit fixes the entry.
                 {"label": "w", "start": "2019-06-01", "end": "2019-09-01", "note": "x", "stop": 1},
-                "note, stop",
+                "'note', 'stop'",
+            ),
+            (
+                # YAML 1.1 hands back bool/int keys for bare `on:`/numerals;
+                # mixing them with a string key must still name the offenders
+                # rather than raising TypeError out of sorted()/join()
+                # (PR #367).
+                {
+                    "label": "w",
+                    "start": "2019-06-01",
+                    "end": "2019-09-01",
+                    "note": "x",
+                    True: 1,
+                    3: "y",
+                },
+                "'note', 3, True",
             ),
         ],
     )

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -414,6 +414,30 @@ class TestWindowingConfig:
         with pytest.raises(ValueError, match="unsupported key"):
             validate_config(cfg)
 
+    @pytest.mark.parametrize(
+        "entry,named",
+        [
+            (
+                {"label": "w", "start": "2019-06-01", "end": "2019-09-01", "width": 3600},
+                "width",
+            ),
+            (
+                # Every offending key is named, so one edit fixes the entry.
+                {"label": "w", "start": "2019-06-01", "end": "2019-09-01", "note": "x", "stop": 1},
+                "note, stop",
+            ),
+        ],
+    )
+    def test_explicit_range_unsupported_key_rejected(self, cfg, entry, named):
+        # The range form refuses unknown keys exactly like the point form: a
+        # dead or typo'd key has no semantic effect, so it fails loud rather
+        # than riding along (PR #367).
+        _windowed(cfg, schedule="explicit", windows=[entry])
+        with pytest.raises(
+            ValueError, match=rf"unsupported key\(s\) {named}; the range form is \{{label, start"
+        ):
+            validate_config(cfg)
+
     def test_explicit_point_bad_timestamp_rejected(self, cfg):
         _windowed(cfg, schedule="explicit", windows=[{"label": "w", "timestamp": "not-a-time"}])
         with pytest.raises(ValueError, match="ISO-8601"):

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -1100,7 +1100,9 @@ def _timed_rec(n, start, end):
 
 class TestWindowedUnits:
     """``runner._windowed_units``: one work unit per (shard, window), granules
-    subset by their shardmap time spans, bounds in dataset units."""
+    subset by their shardmap time spans, bounds in dataset units — plus its
+    raster analog ``_raster_windowed_units``, which decides membership at
+    dispatch instead."""
 
     def _windowing(self, cfg, **over):
         from zagg.config import get_windowing
@@ -1195,6 +1197,43 @@ class TestWindowedUnits:
         ge, lt = unit_cfg.data_source["filters"][-2:]
         assert (ge["op"], lt["op"]) == ("ge", "lt")
         assert lt["value"] - ge["value"] == 1.0
+
+    def test_raster_point_window_membership_is_half_open(self, cfg):
+        # Issue #355 on the RASTER path (``_raster_windowed_units``): membership
+        # is decided at dispatch from the group's earliest STAC datetime, with
+        # no worker-side filter — and groups outside every declared window are
+        # DROPPED, so a missed point window is a silent empty run rather than
+        # an error. Both halves are pinned here.
+        from zagg.runner import _raster_windowed_units
+
+        w = self._windowing(
+            cfg,
+            schedule="explicit",
+            windows=[{"label": "scene-a", "timestamp": "2021-03-14T12:00:00Z"}],
+        )
+
+        def _scene(gid, dt):
+            return {"id": gid, "assets": {"red": "r.tif"}, "datetime": dt, "time_key": gid}
+
+        units = _raster_windowed_units(
+            [
+                (
+                    11,
+                    [
+                        _scene("at-t", "2021-03-14T12:00:00Z"),
+                        _scene("sub-second", "2021-03-14T12:00:00.9Z"),
+                    ],
+                )
+            ],
+            w,
+        )
+        assert [(k, w_["label"], sorted(r["id"] for r in recs)) for k, recs, w_ in units] == [
+            (11, "scene-a", ["at-t", "sub-second"])
+        ]
+        # Exactly t + 1s is OUTSIDE the half-open window, and so is a realistic
+        # non-round scene datetime — both dispatch nothing at all.
+        assert _raster_windowed_units([(11, [_scene("at-end", "2021-03-14T12:00:01Z")])], w) == []
+        assert _raster_windowed_units([(11, [_scene("s2", "2021-03-14T12:00:31.024Z")])], w) == []
 
     def test_shard_with_no_matching_granules_dispatches_nothing(self, cfg):
         from zagg.runner import _windowed_units

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -318,6 +318,117 @@ class TestWindowingConfig:
         )
         validate_config(cfg)
 
+    def test_explicit_point_entry_desugars_to_a_second(self, cfg):
+        # Issue #355: {label, timestamp} is sugar for the second-wide half-open
+        # [t, t+1s). It desugars at the config layer, so the normalized list is
+        # uniformly {label, start, end} — no downstream consumer sees a
+        # ``timestamp`` key — and both forms may sit in one list.
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "scene-a", "timestamp": "2019-06-01T12:00:00Z"},
+                {"label": "melt-2020", "start": "2020-06-01", "end": "2020-09-01"},
+            ],
+        )
+        validate_config(cfg)
+        assert get_windowing(cfg)["windows"] == [
+            {
+                "label": "scene-a",
+                "start": "2019-06-01T12:00:00+00:00",
+                "end": "2019-06-01T12:00:01+00:00",
+            },
+            {
+                "label": "melt-2020",
+                "start": "2020-06-01T00:00:00+00:00",
+                "end": "2020-09-01T00:00:00+00:00",
+            },
+        ]
+
+    def test_explicit_entry_mixing_both_forms_rejected(self, cfg):
+        # Exactly one of {timestamp} or {start, end} per entry.
+        for over in (
+            {"label": "w", "timestamp": "2019-06-01T12:00:00Z", "start": "2019-06-01"},
+            {
+                "label": "w",
+                "timestamp": "2019-06-01T12:00:00Z",
+                "start": "2019-06-01",
+                "end": "2019-09-01",
+            },
+        ):
+            _windowed(cfg, schedule="explicit", windows=[over])
+            with pytest.raises(ValueError, match="exactly one of"):
+                validate_config(cfg)
+
+    def test_explicit_entry_without_bounds_rejected(self, cfg):
+        # A label alone declares no range in either form; the half-range
+        # {label, start} is equally incomplete.
+        for over in ({"label": "w"}, {"label": "w", "start": "2019-06-01"}):
+            _windowed(cfg, schedule="explicit", windows=[over])
+            with pytest.raises(ValueError, match=r"\{label, timestamp\} mapping"):
+                validate_config(cfg)
+
+    def test_explicit_point_bad_timestamp_rejected(self, cfg):
+        _windowed(cfg, schedule="explicit", windows=[{"label": "w", "timestamp": "not-a-time"}])
+        with pytest.raises(ValueError, match="ISO-8601"):
+            validate_config(cfg)
+
+    def test_explicit_point_reserved_all_label(self, cfg):
+        # The reserved-token check composes with the point form unchanged.
+        _windowed(cfg, schedule="explicit", windows=[{"label": "all", "timestamp": "2019-06-01"}])
+        with pytest.raises(ValueError, match="reserved schedule:none token"):
+            validate_config(cfg)
+
+    def test_explicit_point_inside_a_range_overlaps(self, cfg):
+        # A desugared point sitting inside another window's range is a genuine
+        # overlap — disjointness composes over both forms.
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "melt-2019", "start": "2019-06-01", "end": "2019-09-01"},
+                {"label": "scene-a", "timestamp": "2019-07-01T00:00:00Z"},
+            ],
+        )
+        with pytest.raises(ValueError, match="overlap"):
+            validate_config(cfg)
+
+    def test_explicit_points_in_the_same_second_overlap(self, cfg):
+        # The documented edge (issue #355): the point form's resolution is one
+        # second, so two labels inside the same wall-clock second collide and
+        # are rejected as overlapping. One second apart they merely touch.
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "scene-a", "timestamp": "2019-06-01T12:00:00Z"},
+                {"label": "scene-b", "timestamp": "2019-06-01T12:00:00.5Z"},
+            ],
+        )
+        with pytest.raises(ValueError, match="overlap"):
+            validate_config(cfg)
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "scene-a", "timestamp": "2019-06-01T12:00:00Z"},
+                {"label": "scene-b", "timestamp": "2019-06-01T12:00:01Z"},
+            ],
+        )
+        validate_config(cfg)
+
+    def test_explicit_point_duplicate_label(self, cfg):
+        _windowed(
+            cfg,
+            schedule="explicit",
+            windows=[
+                {"label": "scene", "timestamp": "2019-06-01T12:00:00Z"},
+                {"label": "scene", "timestamp": "2020-06-01T12:00:00Z"},
+            ],
+        )
+        with pytest.raises(ValueError, match="twice"):
+            validate_config(cfg)
+
     def test_raster_windowing_validates_on_hive(self):
         # Issue #247: raster + hive + windowing is legal; membership is the
         # acquisition's STAC datetime, so no time_field is required. The full
@@ -1031,6 +1142,31 @@ class TestWindowedUnits:
         assert [(w_["label"], [r["id"] for r in recs]) for _k, recs, w_ in units] == [
             ("melt-2019", ["g1"])
         ]
+
+    def test_point_window_dispatches_and_filters_one_second(self, cfg):
+        # Issue #355 round trip: a desugared point window rides the ordinary
+        # explicit path — granule subsetting, dataset-unit bounds, and the
+        # observation-level ge/lt filter pair are all one second wide.
+        from zagg.config import windowed_cell_config
+        from zagg.runner import _windowed_units
+
+        w = self._windowing(
+            cfg,
+            schedule="explicit",
+            windows=[{"label": "scene-a", "timestamp": "2019-06-01T12:00:00Z"}],
+        )
+        hit = _timed_rec(1, "2019-06-01T11:59:00Z", "2019-06-01T12:01:00Z")
+        miss = _timed_rec(2, "2019-06-02T00:00:00Z", "2019-06-02T00:05:00Z")
+        units = _windowed_units([(11, [hit, miss])], w, None)
+        assert [(w_["label"], [r["id"] for r in recs]) for _k, recs, w_ in units] == [
+            ("scene-a", ["g1"])
+        ]
+        window = units[0][2]
+        assert window["end"] - window["start"] == 1.0
+        unit_cfg, _windowing_out = windowed_cell_config(cfg, window)
+        ge, lt = unit_cfg.data_source["filters"][-2:]
+        assert (ge["op"], lt["op"]) == ("ge", "lt")
+        assert lt["value"] - ge["value"] == 1.0
 
     def test_shard_with_no_matching_granules_dispatches_nothing(self, cfg):
         from zagg.runner import _windowed_units


### PR DESCRIPTION
Bundled `small-fix` PR for 2026-08-03. Only one open `small-fix` issue exists today, so the bundle carries a single entry; the shape leaves room to append another.

## Bundle

- [x] Closes #355 — explicit windows accept `{label, timestamp}` point entries (desugar to a second-wide half-open range)
- [x] Range form rejects unknown keys (was "Questions for review" (5); fixed at espg's direction, 2026-08-05 — **behavior change**, described below)
- [x] Degenerate sub-second range entries refuse loudly (was "Questions for review" (6); fixed at espg's direction, 2026-08-05)

## What this changes (#355)

`schedule: explicit` windows previously had to be `{label, start, end}`; a 2-member `{label, timestamp}` entry failed with `each explicit window must be a {label, start, end} mapping`. This adds the point form as **sugar desugared at the config layer**:

- Each entry declares exactly one of `timestamp` **or** `start`+`end`, discriminated on keys; mixing the two in one entry raises, and the error names *every* offending range key so one edit fixes the entry.
- `timestamp: t` becomes the half-open `[t, t + 1s)`. One second is the window grammar's native resolution (boundaries render at `timespec="seconds"` throughout, and `windows.py` explicitly scopes second-scale exactness out), so a second-wide half-open window *is* the point window at grammar resolution — and it avoids float equality on observation timestamps.
- Any key on a point entry other than `label`/`timestamp` is **rejected**, so the documented-but-unimplemented `width` knob fails loud instead of being silently ignored.

Approach: one shared helper, `config._explicit_window_bounds(entry) -> (start, end)`, used by **both** `_validate_windowing_windows` and `get_windowing`, so validation and normalization can never disagree about what an entry means:

```python
    ranged = sorted({"start", "end"} & set(entry))
    if "timestamp" in entry:
        if ranged:
            raise ValueError(...)          # mixing the two forms
        extra = sorted(set(entry) - {"label", "timestamp"})
        if extra:
            raise ValueError(...)          # e.g. the not-yet-real `width`
        point = _windows.parse_utc(entry["timestamp"])
        return point, point + _POINT_WINDOW_WIDTH
    return _windows.parse_utc(entry["start"]), _windows.parse_utc(entry["end"])
```

`get_windowing`'s normalized `windows` list stays uniformly `{label, start, end}` — the desugar happens before it is built — so **everything downstream is untouched**: `windows_intersecting`, `window_time_filters`, `windowed_cell_config`, leaf naming, the sweep, and the pyramid all see an ordinary explicit window, and `hive.build_manifest`'s `temporal.windows` block (`src/zagg/hive.py`, which copies `windowing["windows"]` verbatim) never sees a `timestamp` key. No wire format, attrs grammar, or `spec` marker changes, so `docs/specification.md` and the conformance fixtures need no update.

Existing validation composes unchanged because it runs on the desugared bounds: frozen label grammar, the reserved `all` token, `start < end`, unique labels, and pairwise disjointness — a point that lands inside another window's range is a genuine overlap and is rejected.

**Documented edges (not solved, per the issue):**

- *Collision.* Two acquisitions within the same wall-clock second share a window. The stated fix if it ever bites is an explicit `width` key on the point form, not a guessed default now — and until that key exists it is rejected rather than ignored.
- *Miss, and it is silent.* A point window covers only the whole second containing `t`, so the declared `timestamp` must be the acquisition's own instant copied from the item, not a rounded-off approximation. STAC datetimes are rarely round seconds, so this is the likely first-contact mistake. On the point pipeline the window dispatches and the worker's `ge`/`lt` filter matches nothing (empty leaf); on raster, `runner._raster_windowed_units` drops the group at dispatch and no unit, leaf, or warning is produced at all. Neither path errors. Documented in `docs/hive_layout.md` and pinned by a raster test.

**Sub-second timestamps**, for the record: bounds are validated at declared precision but rendered through `windows.iso_utc` (`timespec="seconds"`), so `timestamp: "…T12:00:00.75Z"` normalizes to the whole second containing it, `[12:00:00, 12:00:01)`. Truncation is monotone, so it can neither move `t` out of its own window nor manufacture an overlap. Documented in the helper's docstring and pinned by a test.

## Review follow-ups fixed at espg's direction (2026-08-05)

Both were originally flagged-not-fixed under "Questions for review" ((5) and (6) below); espg ruled they be fixed inside this PR rather than filed as new issues.

**Range form rejects unknown keys** (`0de3d0a`). The `{label, start, end}` form now refuses unsupported keys exactly like the point form — same error style, naming every offending key and the allowed set (`explicit range window entry carries unsupported key(s) …; the range form is {label, start, end}`).

- **This is a deliberate behavior change**: a range entry carrying extra keys (say a typo'd `stop`, or a stale `width`) previously validated clean with the extras silently ignored; it now fails `validate_config`. Unknown keys have no semantic effect today, so the only configs broken are ones carrying latent typos or dead keys — which is the point of the change.

**Degenerate sub-second ranges refuse loudly** (`2e54462`). `{start: "…T12:00:01.0Z", end: "…T12:00:01.4Z"}` previously passed validation (`start < end` holds on the untruncated values) but both bounds render through `iso_utc` (`timespec="seconds"`) to the same instant, dispatching a `ge x` / `lt x` pair that silently matches nothing. `_explicit_window_bounds` now validates the *rendered* bounds: when the declared bounds satisfy `start < end` but truncate to the same whole second, it refuses with `explicit window range is empty after truncation to whole-second granularity: … both render as …; use the point form {label, timestamp} for a one-second window`. The range is never widened to rescue it — silent widening is worse than refusal, and the point form is the spelling for exactly-one-second intent. A sub-second-wide range that straddles a second boundary (e.g. `12:00:01.9Z → 12:00:02.1Z`) still renders to a real one-second window and remains valid; the point form is untouched.

## Phases

- [x] Phase 1 (`0401b25`) — `_explicit_window_bounds` desugar helper + `_validate_windowing_windows` / `get_windowing` wiring (`src/zagg/config.py`)
- [x] Phase 2 (`d0c8406`) — tests (`tests/test_hive_windows.py`)
- [x] Phase 3 (`7bd922f`) — docs (windowing section of `docs/hive_layout.md`)
- [x] In-context self-review + fold (`1f2542b`, `5b36af3`, `c11daaa`)
- [x] Fresh-context adversarial review + fold, five findings, one commit each: raster-path membership test (`fb3fd9d`), reject unsupported keys on a point entry (`614c7bd`), document the silent-miss edge (`f8db8a0`), name every offending range key in the mixed-form error (`1653707`), cut the duplicated prose (`6cd5bdc`)
- [x] Review follow-ups per espg direction, 2026-08-05: range-form unknown-key rejection (`0de3d0a`), degenerate sub-second range refusal (`2e54462`) — code, tests, and `docs/hive_layout.md` in each commit
- [x] Fresh-context adversarial review of the two follow-up commits + fold, three findings, one commit each: document range-bound truncation and name the retiming (`3d0576a`), compare rendered bounds through `iso_utc` (`f06a1e7`), name non-string extra keys instead of raising `TypeError` (`a34b7cf`)

## How it was tested

New coverage in `tests/test_hive_windows.py` (`TestWindowingConfig` + `TestWindowedUnits`), alongside the existing explicit-window tests:

- both forms in one `windows` list normalize to `{label, start, end}`, the point one second wide;
- a sub-second timestamp normalizes to its containing whole second;
- mixing `timestamp` with `start`/`end` in one entry is rejected (parametrized over all three shapes, each pinning the keys the message names);
- an unsupported key on a point entry — `width` included — is rejected;
- an unsupported key on a **range** entry is rejected, the message naming every offender and the allowed set (parametrized: one extra key, and two so the multi-key naming is pinned);
- a sub-second range that collapses at whole-second rendering is refused, the message naming the truncation;
- a sub-second-wide range spanning a second boundary stays valid and normalizes to its real one-second window;
- an entry with neither form — or half a range — is rejected;
- an unparseable `timestamp` is rejected;
- the reserved `all` token and duplicate labels reject through the point form too;
- a point inside another window's range is rejected as an overlap;
- two points inside the same wall-clock second reject as overlapping, one second apart merely touch;
- round trip on the point pipeline: a point window dispatches through `runner._windowed_units` (subsetting granules by their shardmap spans), its dataset-unit bounds are 1.0 apart, and `windowed_cell_config` injects a `ge`/`lt` filter pair exactly 1.0 apart;
- round trip on the **raster** path: `runner._raster_windowed_units` places scenes at `t` and `t + 0.9s` in the window, and dispatches **nothing at all** for a scene at exactly `t + 1s` (the half-open boundary) or at a realistic `12:00:31.024Z` (the silent-miss edge).

Gates: `uv sync --extra test`; `uv run pytest -v` → full suite green (results for the follow-up commits in the PR thread); `uv run ruff check` and `uv run ruff format --check` clean on every file this PR touches, and clean across `src tests` apart from the two pre-existing failures noted below.

## Questions for review

1. **Tests landed in `tests/test_hive_windows.py`, not `tests/test_config.py`.** The issue named `tests/test_config.py`, but the whole `output.windowing` block is covered by `TestWindowingConfig` in `tests/test_hive_windows.py` (`test_explicit_normalized`, `test_explicit_overlap`, `test_explicit_touching_ranges_allowed`, …) and `tests/test_config.py` has no windowing coverage at all. Point tests went next to their siblings. Say the word if they should move.
2. **Two pre-existing local gate failures, untouched here** (both also fail on `main` at `083af16`, and neither is reachable from this diff):
   - `ruff check src tests` → `N818` on `src/zagg/registry.py:64` (`class UnknownCapability(KeyError)`). The PR lint bot runs `--select=E,F,W,I`, so it does not see `N`; `pyproject.toml` selects `N`, so the local gate does.
   - `ruff format --check src tests` → `tests/data/benchmark/README.md` would be reformatted (a python code block inside a fixture README).

   Flagged rather than fixed, per the "do not fix unrelated pre-existing failures" rule. Happy to take either as a follow-up `small-fix` if wanted.
3. **`_POINT_WINDOW_WIDTH` is a module constant** in `config.py` rather than living in `windows.py`. It is a config-layer sugar detail that never reaches the window primitives, so it stayed with the desugar — moving it to `windows.py` is a one-liner if the primitive module is the preferred home.
4. **`src/zagg/config.py` is 2841 lines**, well past CLAUDE.md §4's ~1,200 guidance. It was 2785 lines on `main` at `083af16`, so the overage is pre-existing and this diff adds ~56 lines to an existing function pair rather than a new module's worth. Splitting a 2.8k-line config module is not a `small-fix`; raising it so the decision is on the record. #349 already owns config splitting, so that looks like the right home for it — confirming rather than assuming.
5. ~~**Should the `{label, start, end}` range form reject unsupported keys too?**~~ **Resolved — fixed at espg's direction, 2026-08-05** (`0de3d0a`). See "Review follow-ups" above; the unknown-key behavior change is described there.
6. ~~**A pre-existing bug found while reviewing, deliberately not fixed here:** a sub-second *range* entry normalizes to a degenerate empty window.~~ **Resolved — fixed at espg's direction, 2026-08-05** (`2e54462`). Validation now runs on the rendered bounds and refuses the collapse by name; see "Review follow-ups" above.
