### PR TITLE
Benchmark: record the measurement before asserting object counts

### DIFF
--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -279,11 +279,12 @@ def has_empty_metrics(record: dict) -> bool:
     is ``False``, so an unguarded predicate would retain that row as a real point.
 
     ONE definition, shared by ``run_benchmark``'s ``--fail-on-empty`` tripwire and
-    ``update_series``'s retention filter (issue #365). The two used to be the same
-    predicate by construction: an empty run aborted the job, so the append step
-    never ran. Now that the append runs regardless of the tripwire verdict, the
-    appender has to recognise exactly the junk row the tripwire names -- otherwise
-    record-before-assert would retain the obs=0 point it was meant to reject.
+    ``update_series``'s retention filter (issue #365). The two are still the same
+    predicate by construction today: an empty run aborts the job, so the append
+    step never runs. Once the append runs regardless of the tripwire verdict (the
+    workflow gate, a later phase), the appender has to recognise exactly the junk
+    row the tripwire names -- otherwise record-before-assert would retain the
+    obs=0 point it was meant to reject.
     """
     max_memory_mb = record.get("max_memory_mb")
     total_obs = record.get("total_obs")

--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -240,6 +240,16 @@ def _runtime_s(summary: dict) -> float | None:
     return None
 
 
+def _is_nan(value) -> bool:
+    """Is this the float NaN a missing number degrades to off parquet or JSON?
+
+    A legacy parquet row reads a missing number back as NaN rather than None
+    after the reindex, and ``json.dumps``/``json.loads`` round-trip the bare
+    ``NaN`` token, so a metrics JSON can carry one too.
+    """
+    return isinstance(value, float) and math.isnan(value)
+
+
 def memory_pct_of_cap(max_memory_mb, memory_gb) -> float | None:
     """Fraction of the Lambda memory cap a shard peaked at (issue #120).
 
@@ -251,8 +261,7 @@ def memory_pct_of_cap(max_memory_mb, memory_gb) -> float | None:
     """
     if max_memory_mb is None or memory_gb is None:
         return None
-    # A legacy parquet row reads back as NaN, not None, after the reindex.
-    if isinstance(max_memory_mb, float) and math.isnan(max_memory_mb):
+    if _is_nan(max_memory_mb):
         return None
     cap_mb = memory_gb * 1024.0
     if cap_mb <= 0:
@@ -265,6 +274,9 @@ def has_empty_metrics(record: dict) -> bool:
 
     ``total_obs`` 0/missing or a null ``max_memory_mb`` is the signature of a
     silent OOM -- there is no measurement in the row, only the shape of one.
+    NaN counts as missing on either field, same as in :func:`memory_pct_of_cap`:
+    a metrics JSON round-trips the bare ``NaN`` token, and ``not float("nan")``
+    is ``False``, so an unguarded predicate would retain that row as a real point.
 
     ONE definition, shared by ``run_benchmark``'s ``--fail-on-empty`` tripwire and
     ``update_series``'s retention filter (issue #365). The two used to be the same
@@ -273,7 +285,9 @@ def has_empty_metrics(record: dict) -> bool:
     appender has to recognise exactly the junk row the tripwire names -- otherwise
     record-before-assert would retain the obs=0 point it was meant to reject.
     """
-    return not record.get("total_obs") or record.get("max_memory_mb") is None
+    max_memory_mb = record.get("max_memory_mb")
+    total_obs = record.get("total_obs")
+    return not total_obs or _is_nan(total_obs) or max_memory_mb is None or _is_nan(max_memory_mb)
 
 
 def build_record(

--- a/.github/scripts/bench_metrics.py
+++ b/.github/scripts/bench_metrics.py
@@ -116,9 +116,8 @@ RECORD_COLUMNS = [
     # count is data-dependent, i.e. not exact) -- the sharded-write-bypass
     # tripwire (issue #215). Null on rows recorded before the metric existed.
     # The per-run record additionally carries the JSON-only
-    # ``objects_per_shard`` / ``objects_telemetry`` / ``objects_mismatch``
-    # keys, which the reindex to these columns deliberately drops from the
-    # parquet series.
+    # ``objects_per_shard`` / ``objects_telemetry`` keys, which the reindex to
+    # these columns deliberately drops from the parquet series.
     "objects_total",
     "objects_expected",
     # Store-layout axis (issue #240 phase 4): "flat" | "hive". Null on rows
@@ -161,6 +160,14 @@ RECORD_COLUMNS = [
     # earlier rows. Appended last per the stable-schema rule, so it sits away
     # from the objects columns it belongs with.
     "objects_write_path",
+    # The object-count tripwire's verdict (issue #365): the mismatch description
+    # when the audited count deviated from the expectation, null when it agreed.
+    # Retained rather than left JSON-only because the run that trips the tripwire
+    # is now RECORDED before the job goes red -- so the row has to say why it is
+    # anomalous, or a reader hits an unexplained step in the object counts with
+    # nothing in the series to attribute it to. Null on rows recorded before the
+    # column existed (and on every clean run since).
+    "objects_mismatch",
 ]
 
 # summary["worker_phase_max"] key -> series column (issues #250/#256). A phase
@@ -253,6 +260,22 @@ def memory_pct_of_cap(max_memory_mb, memory_gb) -> float | None:
     return max_memory_mb / cap_mb
 
 
+def has_empty_metrics(record: dict) -> bool:
+    """Did this target come back without a usable measurement (issue #145)?
+
+    ``total_obs`` 0/missing or a null ``max_memory_mb`` is the signature of a
+    silent OOM -- there is no measurement in the row, only the shape of one.
+
+    ONE definition, shared by ``run_benchmark``'s ``--fail-on-empty`` tripwire and
+    ``update_series``'s retention filter (issue #365). The two used to be the same
+    predicate by construction: an empty run aborted the job, so the append step
+    never ran. Now that the append runs regardless of the tripwire verdict, the
+    appender has to recognise exactly the junk row the tripwire names -- otherwise
+    record-before-assert would retain the obs=0 point it was meant to reject.
+    """
+    return not record.get("total_obs") or record.get("max_memory_mb") is None
+
+
 def build_record(
     summary: dict,
     *,
@@ -329,15 +352,15 @@ def build_record(
     wpm = summary.get("worker_phase_max") or {}
     for src, col in PHASE_MAP.items():
         record[col] = wpm.get(src)
-    # Store object counts (issue #240). The two scalar columns are retained in
-    # the parquet series; per_shard/mismatch ride the metrics.json record only
-    # (update_series's reindex drops them).
+    # Store object counts (issue #240). The scalar columns and the mismatch
+    # verdict (issue #365) are retained in the parquet series; per_shard rides
+    # the metrics.json record only (update_series's reindex drops it).
     o = objects or {}
     record["objects_total"] = o.get("objects_total")
     record["objects_write_path"] = o.get("objects_write_path")
     record["objects_expected"] = o.get("objects_expected")
     record["objects_per_shard"] = o.get("objects_per_shard")
-    # Per-run root telemetry (issue #362): JSON-only like per_shard/mismatch —
+    # Per-run root telemetry (issue #362): JSON-only like per_shard --
     # reported so an accumulating shared store is legible, never audited.
     record["objects_telemetry"] = o.get("objects_telemetry")
     record["objects_mismatch"] = o.get("objects_mismatch")

--- a/.github/scripts/full_aoi_series.py
+++ b/.github/scripts/full_aoi_series.py
@@ -80,7 +80,9 @@ FULL_AOI_COLUMNS = [
     # measured store object total and the config-derived expectation (null
     # when the layout's count is data-dependent). The run record's
     # ``objects_mismatch`` description stays JSON-only (dropped by the
-    # reindex), like the per-merge series.
+    # reindex) on this leg: the release harness never fails on a mismatch, so
+    # its point is retained either way -- unlike the per-merge series, where a
+    # mismatch turns the job red and the row has to carry the reason (#365).
     "objects_total",
     "objects_expected",
     # Store-layout axis + flat<->hive parity verdict (issue #240 phase 4).

--- a/.github/scripts/full_aoi_series.py
+++ b/.github/scripts/full_aoi_series.py
@@ -81,8 +81,10 @@ FULL_AOI_COLUMNS = [
     # when the layout's count is data-dependent). The run record's
     # ``objects_mismatch`` description stays JSON-only (dropped by the
     # reindex) on this leg: the release harness never fails on a mismatch, so
-    # its point is retained either way -- unlike the per-merge series, where a
-    # mismatch turns the job red and the row has to carry the reason (#365).
+    # its point is retained either way. The per-merge series takes the other
+    # route: a mismatch there turns the job red and today the row is discarded
+    # with it, and once the workflow gate of issue #365 lets that run reach the
+    # append, the row will carry the reason in its ``objects_mismatch`` column.
     "objects_total",
     "objects_expected",
     # Store-layout axis + flat<->hive parity verdict (issue #240 phase 4).

--- a/.github/scripts/run_benchmark.py
+++ b/.github/scripts/run_benchmark.py
@@ -575,9 +575,7 @@ def main(argv: list[str] | None = None) -> int:
     # series row) unnoticed (issue #145). Fail loudly on any real target that
     # came back empty; --dry-run emits empty metrics by design, so it's exempt.
     if args.fail_on_empty and not args.dry_run:
-        empty = [
-            r["target"] for r in records if not r.get("total_obs") or r.get("max_memory_mb") is None
-        ]
+        empty = [r["target"] for r in records if bench_metrics.has_empty_metrics(r)]
         if empty:
             print(
                 "benchmark target(s) returned empty metrics (obs=0 / "

--- a/.github/scripts/update_series.py
+++ b/.github/scripts/update_series.py
@@ -6,6 +6,10 @@ pre-merge PR runs are reported as an ephemeral comment and dropped (too noisy
 while chasing a regression). This module is the read/append/write core plus a
 thin CLI; ``plot_series.py`` renders the GitHub Pages charts from the same file.
 
+This is also where a run's records are judged RETAINABLE (issue #365): the merge
+job appends whatever the benchmark's tripwires concluded, so rejecting a junk
+measurement is this module's job, not the job ordering's.
+
 Re-running a merge (a re-dispatch of the same commit) replaces that commit's rows
 rather than double-counting, so the series stays one row per (commit, target).
 """
@@ -44,7 +48,16 @@ def append_records(existing: pd.DataFrame, records: list[dict]) -> pd.DataFrame:
 
     Keeping the last write makes a merge re-run idempotent instead of duplicating
     a point in the plotted history.
+
+    Appending NOTHING leaves the series byte-identical rather than rewriting it:
+    concat against an all-null frame widens every integer column to float (issue
+    #365). That path is no longer rare -- the retention filter in :func:`main`
+    drops an unusable run's records, so a silently OOM'd merge now arrives here
+    with an empty list, and a run that measured nothing must not be able to
+    change the dtypes of every point that came before it.
     """
+    if not records:
+        return existing.reset_index(drop=True)
     new = records_to_frame(records)
     # Avoid concat with an all-empty frame (pandas FutureWarning on dtype union).
     combined = new if existing.empty else pd.concat([existing, new], ignore_index=True)

--- a/.github/scripts/update_series.py
+++ b/.github/scripts/update_series.py
@@ -6,9 +6,12 @@ pre-merge PR runs are reported as an ephemeral comment and dropped (too noisy
 while chasing a regression). This module is the read/append/write core plus a
 thin CLI; ``plot_series.py`` renders the GitHub Pages charts from the same file.
 
-This is also where a run's records are judged RETAINABLE (issue #365): the merge
-job appends whatever the benchmark's tripwires concluded, so rejecting a junk
-measurement is this module's job, not the job ordering's.
+This is also where a run's records are judged RETAINABLE (issue #365): once the
+merge job appends whatever the benchmark's tripwires concluded, rejecting a junk
+measurement becomes this module's job rather than the job ordering's. That
+workflow gate is a later phase and is NOT on this branch -- today the append
+still only runs when the tripwires passed, so the filter in :func:`main` is the
+precondition for that change, inert until the gate lands.
 
 Re-running a merge (a re-dispatch of the same commit) replaces that commit's rows
 rather than double-counting, so the series stays one row per (commit, target).
@@ -49,12 +52,14 @@ def append_records(existing: pd.DataFrame, records: list[dict]) -> pd.DataFrame:
     Keeping the last write makes a merge re-run idempotent instead of duplicating
     a point in the plotted history.
 
-    Appending NOTHING leaves the series byte-identical rather than rewriting it:
-    concat against an all-null frame widens every integer column to float (issue
-    #365). That path is no longer rare -- the retention filter in :func:`main`
-    drops an unusable run's records, so a silently OOM'd merge now arrives here
-    with an empty list, and a run that measured nothing must not be able to
-    change the dtypes of every point that came before it.
+    Appending NOTHING returns the series unchanged, so the unconditional
+    :func:`save_series` that follows rewrites it byte-identically and the data
+    branch sees no commit: concat against an all-null frame would instead widen
+    every integer column to float (issue #365). That path stops being rare once
+    the workflow gate lands -- the retention filter in :func:`main` drops an
+    unusable run's records, so a silently OOM'd merge will arrive here with an
+    empty list, and a run that measured nothing must not be able to change the
+    dtypes of every point that came before it.
     """
     if not records:
         return existing.reset_index(drop=True)
@@ -84,9 +89,11 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("records JSON must be a list of record objects")
 
     # What may be retained is decided HERE, at the retention boundary, rather than
-    # by whether the benchmark job got this far (issue #365): the merge workflow now
-    # appends even when a tripwire fired, so a run whose metrics are junk must be
-    # rejected by this filter instead of by the job aborting before the append.
+    # by whether the benchmark job got this far (issue #365): once the merge workflow
+    # appends even when a tripwire fired, a run whose metrics are junk has to be
+    # rejected by this filter instead of by the job aborting before the append. The
+    # workflow gate is a later phase, so until it lands this filter only ever sees
+    # runs that already passed their tripwires.
     #   - non-merge (the locked design): a stray PR record must never evict a
     #     retained merge point via the (commit, target) dedup.
     #   - empty metrics (issue #145): obs=0 / null peak memory is a silent OOM, a

--- a/.github/scripts/update_series.py
+++ b/.github/scripts/update_series.py
@@ -70,13 +70,28 @@ def main(argv: list[str] | None = None) -> int:
     if not isinstance(records, list):
         raise SystemExit("records JSON must be a list of record objects")
 
-    # Only merge runs are retained (the locked design). Enforce it at the boundary
-    # so a stray non-merge record can never evict a retained merge point via the
-    # (commit, target) dedup. Report drops -- a silent skip would read as "stored".
-    retained = [r for r in records if r.get("event") == "merge"]
-    dropped = len(records) - len(retained)
-    if dropped:
-        print(f"skipping {dropped} non-merge record(s); only merge runs are retained")
+    # What may be retained is decided HERE, at the retention boundary, rather than
+    # by whether the benchmark job got this far (issue #365): the merge workflow now
+    # appends even when a tripwire fired, so a run whose metrics are junk must be
+    # rejected by this filter instead of by the job aborting before the append.
+    #   - non-merge (the locked design): a stray PR record must never evict a
+    #     retained merge point via the (commit, target) dedup.
+    #   - empty metrics (issue #145): obs=0 / null peak memory is a silent OOM, a
+    #     junk point that would plot as a real dip to zero.
+    # An object-count mismatch (issue #240) is NOT in this list -- that run measured
+    # fine and is exactly the point worth keeping; its verdict rides the row's
+    # ``objects_mismatch`` column. Every drop is reported: a silent skip reads as
+    # "stored".
+    retained, dropped = [], []
+    for r in records:
+        if r.get("event") != "merge":
+            dropped.append((r.get("target"), "non-merge run"))
+        elif bench_metrics.has_empty_metrics(r):
+            dropped.append((r.get("target"), "empty metrics (obs=0 / no peak memory)"))
+        else:
+            retained.append(r)
+    for target, why in dropped:
+        print(f"skipping record for '{target}': {why}")
 
     existing = load_series(args.series)
     updated = append_records(existing, retained)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -116,10 +116,11 @@ def test_build_record_cost_per_100km2():
     assert rec["max_memory_mb"] == 1963.0  # threaded from the summary (issue #120)
     # The record is the series schema plus the JSON-only object-count keys
     # (issues #240/#362) that update_series's reindex deliberately drops.
+    # ``objects_mismatch`` is no longer among them -- it became a retained column
+    # in issue #365, so a recorded anomaly is explicable from the series alone.
     assert set(rec) == set(bench_metrics.RECORD_COLUMNS) | {
         "objects_per_shard",
         "objects_telemetry",
-        "objects_mismatch",
     }
 
 
@@ -182,9 +183,10 @@ def test_codec_column_is_last_and_threaded(monkeypatch):
     assert cols.index("codec") < cols.index("read") < cols.index("total_wall_s")
     # The wall breakdown (#180), read backend (#193), object counts (#240),
     # store layout (#240 phase 4), worker phase split (#250/#256), the
-    # streaming-mode/ephemeral axis (#272) and the worker-build provenance stamp
-    # (#341/#296) appended in that order.
-    assert cols[-17:] == [
+    # streaming-mode/ephemeral axis (#272), the worker-build provenance stamp
+    # (#341/#296), the netted write-path count (#362) and the tripwire verdict
+    # (#365) appended in that order.
+    assert cols[-18:] == [
         "total_wall_s",
         "setup_s",
         "fanout_s",
@@ -202,6 +204,7 @@ def test_codec_column_is_last_and_threaded(monkeypatch):
         "ephemeral_cost_usd",
         "variant_guard",
         "objects_write_path",
+        "objects_mismatch",
     ]
     g = HealpixGrid(parent_order=11, child_order=19)
     rec = bench_metrics.build_record(_summary(), grid=g, context={"codec": "sharded"})
@@ -665,8 +668,9 @@ def test_variant_guard_status_verified_and_base(tmp_path, monkeypatch):
 def test_variant_guard_column_is_in_the_series_schema():
     # Appended to the stable RECORD_COLUMNS schema so update_series's reindex
     # retains it (legacy rows read back null). No longer LAST: the issue #362
-    # netted-count column appended after it, per the same rule.
-    assert bench_metrics.RECORD_COLUMNS[-2] == "variant_guard"
+    # netted-count column and the issue #365 tripwire verdict appended after it,
+    # per the same rule.
+    assert bench_metrics.RECORD_COLUMNS[-3] == "variant_guard"
     rec = bench_metrics.build_record(
         _summary(), grid=HealpixGrid(11, 19), context={"target": "t", "variant_guard": "verified"}
     )
@@ -2191,21 +2195,23 @@ def test_objects_columns_are_last_and_threaded():
     # appended after the object counts in phase 4; the #250/#256 phase split
     # then the #272 streaming-mode/ephemeral axis appended after those).
     cols = bench_metrics.RECORD_COLUMNS
-    assert cols[-12:-9] == ["objects_total", "objects_expected", "store_layout"]
-    # The netted audited count (issue #362) is a SEPARATE column, appended last
-    # rather than redefining ``objects_total`` -- so a row written before it
-    # cannot be misread as having been audited on the netted figure.
-    assert cols[-1] == "objects_write_path"
+    assert cols[-13:-10] == ["objects_total", "objects_expected", "store_layout"]
+    # The netted audited count (issue #362) is a SEPARATE column, appended after
+    # them rather than redefining ``objects_total`` -- so a row written before it
+    # cannot be misread as having been audited on the netted figure. The tripwire
+    # verdict (issue #365) appended after that.
+    assert cols[-2:] == ["objects_write_path", "objects_mismatch"]
     g = HealpixGrid(parent_order=11, child_order=19)
     rec = bench_metrics.build_record(_summary(), grid=g, context={}, objects=_objects_payload())
     assert rec["objects_total"] == 10
     assert rec["objects_expected"] == 10
     assert rec["objects_write_path"] == 10  # nothing to net out in this payload
-    # per_shard/mismatch ride the metrics.json record only -- deliberately NOT
-    # series columns (update_series's reindex drops them).
+    # per_shard rides the metrics.json record only -- deliberately NOT a series
+    # column (update_series's reindex drops it). The mismatch verdict IS retained
+    # (issue #365), null on this clean payload.
     assert rec["objects_per_shard"] == {"1121121": 4}
     assert rec["objects_mismatch"] is None
-    assert "objects_per_shard" not in cols and "objects_mismatch" not in cols
+    assert "objects_per_shard" not in cols
     # No measurement (dry-run / legacy) -> null columns, not a crash.
     bare = bench_metrics.build_record(_summary(), grid=g, context={})
     assert bare["objects_total"] is None and bare["objects_expected"] is None

--- a/tests/test_benchmark_recording.py
+++ b/tests/test_benchmark_recording.py
@@ -152,6 +152,48 @@ def test_an_all_dropped_batch_leaves_the_series_untouched(tmp_path):
     assert after.equals(before)
 
 
+def test_appending_to_a_series_that_predates_the_column(tmp_path):
+    # The riskiest property here: series.parquet is a long-lived file on the
+    # benchmarks data branch, written before ``objects_mismatch`` existed, and
+    # append_records never reindexes the COMBINED frame -- the column arrives
+    # purely via pd.concat's column union. Every other test builds its "existing"
+    # frame from records_to_frame, which already has the column, so this is the
+    # one path they don't cover.
+    series = tmp_path / "series.parquet"
+    legacy = update_series.records_to_frame([_rec(commit="c0")]).drop(columns=["objects_mismatch"])
+    update_series.save_series(legacy, series)
+    assert "objects_mismatch" not in update_series.load_series(series).columns
+
+    update_series.main(
+        [
+            "--series",
+            str(series),
+            "--records",
+            _write(tmp_path, [_rec(commit="c1", mismatch="expected 10, measured 12")]),
+        ]
+    )
+    out = update_series.load_series(series)
+    # The column is added, the pre-existing row reads as "no anomaly" rather than
+    # dropping out, and the history keeps its order and its integer dtypes.
+    assert list(out.columns) == list(bench_metrics.RECORD_COLUMNS)
+    assert out["commit"].tolist() == ["c0", "c1"]
+    assert out["objects_mismatch"].tolist() == [None, "expected 10, measured 12"]
+    assert out["total_obs"].dtype == legacy["total_obs"].dtype
+
+    # ...and a later batch onto that now-present column still lands as a string.
+    update_series.main(
+        [
+            "--series",
+            str(series),
+            "--records",
+            _write(tmp_path, [_rec(commit="c2", mismatch="expected 10, measured 11")]),
+        ]
+    )
+    out = update_series.load_series(series)
+    assert out["objects_mismatch"].tolist()[-1] == "expected 10, measured 11"
+    assert out["total_obs"].dtype == legacy["total_obs"].dtype
+
+
 def test_mixed_batch_keeps_the_good_records(tmp_path):
     series = tmp_path / "series.parquet"
     update_series.main(

--- a/tests/test_benchmark_recording.py
+++ b/tests/test_benchmark_recording.py
@@ -35,7 +35,7 @@ def _rec(commit="c1", target="t1", *, event="merge", obs=5_000_000, mem=1200.0, 
         "max_memory_mb": mem,
         "objects_total": 12,
         "objects_write_path": 12,
-        "objects_expected": 10,
+        "objects_expected": 12,
         "objects_mismatch": mismatch,
     }
 
@@ -195,7 +195,14 @@ def test_appending_to_a_series_that_predates_the_column(tmp_path):
 
 
 def test_mixed_batch_keeps_the_good_records(tmp_path):
+    # A PARTIALLY dropped batch takes the concat branch, not the ``not records``
+    # early return -- so the dtype guarantee pinned above for an all-dropped batch
+    # has to hold on this path too: the surviving records must not widen the
+    # retained history's integer columns to float.
     series = tmp_path / "series.parquet"
+    seed = update_series.records_to_frame([_rec(commit="c0", target="t0")])
+    update_series.save_series(seed, series)
+    before = update_series.load_series(series)
     update_series.main(
         [
             "--series",
@@ -212,4 +219,6 @@ def test_mixed_batch_keeps_the_good_records(tmp_path):
         ]
     )
     out = update_series.load_series(series)
-    assert sorted(out["target"]) == ["t1", "t3"]
+    assert sorted(out["target"]) == ["t0", "t1", "t3"]
+    assert out["total_obs"].dtype == before["total_obs"].dtype
+    assert out["objects_total"].dtype == before["objects_total"].dtype

--- a/tests/test_benchmark_recording.py
+++ b/tests/test_benchmark_recording.py
@@ -120,6 +120,22 @@ def test_a_dropped_record_cannot_evict_a_retained_one(tmp_path):
     assert out["total_obs"].tolist() == [5_000_000]
 
 
+def test_an_all_dropped_batch_leaves_the_series_untouched(tmp_path):
+    # ...and leaves it untouched *in dtype*, not just in values: appending an
+    # all-null frame widens every integer column to float, so an OOM'd run --
+    # which now reaches the appender with nothing to append -- would silently
+    # rewrite the whole retained history (issue #365).
+    series = tmp_path / "series.parquet"
+    update_series.save_series(update_series.records_to_frame([_rec()]), series)
+    before = update_series.load_series(series)
+    update_series.main(
+        ["--series", str(series), "--records", _write(tmp_path, [_rec(obs=0, mem=None)])]
+    )
+    after = update_series.load_series(series)
+    assert after["total_obs"].dtype == before["total_obs"].dtype
+    assert after.equals(before)
+
+
 def test_mixed_batch_keeps_the_good_records(tmp_path):
     series = tmp_path / "series.parquet"
     update_series.main(

--- a/tests/test_benchmark_recording.py
+++ b/tests/test_benchmark_recording.py
@@ -1,0 +1,141 @@
+"""Record-before-assert for the per-merge benchmark (issue #365).
+
+A tripwire and a data-collection step must not be ordered so the tripwire
+destroys the collection. Pinned here: the retention boundary in
+``update_series.py`` -- an object-count mismatch is RETAINED (with its verdict
+on the row), an empty measurement is dropped -- which is what makes it safe for
+the merge workflow to append a point whatever the tripwire's verdict.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO / ".github" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import bench_metrics  # noqa: E402
+import update_series  # noqa: E402
+
+
+def _rec(commit="c1", target="t1", *, event="merge", obs=5_000_000, mem=1200.0, mismatch=None):
+    """A minimal merge record: the fields the retention filter and the dedup read."""
+    return {
+        "timestamp": "2026-01-01T00:00:00Z",
+        "commit": commit,
+        "ref": "main",
+        "event": event,
+        "target": target,
+        "total_obs": obs,
+        "runtime_s": 200.0,
+        "cost_per_shard_usd": 0.005,
+        "max_memory_mb": mem,
+        "objects_total": 12,
+        "objects_write_path": 12,
+        "objects_expected": 10,
+        "objects_mismatch": mismatch,
+    }
+
+
+def _write(tmp_path, records, name="metrics.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(records))
+    return str(path)
+
+
+# --- the anomaly rides the row ---------------------------------------------
+
+
+def test_objects_mismatch_is_a_retained_column():
+    # The verdict used to be JSON-only, so a run that tripped the tripwire left
+    # nothing in the series to explain itself -- and (before this issue) left no
+    # row at all. Now it survives the reindex.
+    assert "objects_mismatch" in bench_metrics.RECORD_COLUMNS
+    df = update_series.records_to_frame([_rec(mismatch="expected 10, measured 12")])
+    assert df["objects_mismatch"].tolist() == ["expected 10, measured 12"]
+    # Clean run -> null, so the column reads as "no anomaly", not "unknown".
+    assert update_series.records_to_frame([_rec()])["objects_mismatch"].tolist() == [None]
+
+
+def test_mismatched_run_is_retained_with_its_verdict(tmp_path):
+    # The point this issue exists for: a count mismatch is an anomaly worth
+    # having in the series NEXT to the numbers, not a reason to delete them.
+    series = tmp_path / "series.parquet"
+    update_series.main(
+        [
+            "--series",
+            str(series),
+            "--records",
+            _write(tmp_path, [_rec(mismatch="expected 10, measured 12")]),
+        ]
+    )
+    out = update_series.load_series(series)
+    assert out["commit"].tolist() == ["c1"]
+    assert out["objects_mismatch"].tolist() == ["expected 10, measured 12"]
+    assert out["total_obs"].tolist() == [5_000_000]
+
+
+# --- but junk is still rejected, at the retention boundary ------------------
+
+
+def test_has_empty_metrics_is_the_one_definition():
+    # Shared by run_benchmark's --fail-on-empty and the filter below, so the
+    # appender rejects exactly the rows the tripwire names (issues #145/#365).
+    assert bench_metrics.has_empty_metrics({"total_obs": 0, "max_memory_mb": 800.0})
+    assert bench_metrics.has_empty_metrics({"total_obs": 999, "max_memory_mb": None})
+    assert bench_metrics.has_empty_metrics({})
+    assert not bench_metrics.has_empty_metrics({"total_obs": 1, "max_memory_mb": 1.0})
+
+
+@pytest.mark.parametrize(
+    ("record", "why"),
+    [
+        (_rec(obs=0, mem=None), "empty metrics"),
+        (_rec(obs=999, mem=None), "empty metrics"),
+        (_rec(event="pr"), "non-merge"),
+    ],
+)
+def test_unretainable_records_are_dropped_and_reported(tmp_path, capsys, record, why):
+    # A silent OOM (obs=0 / no peak memory) would plot as a real dip to zero, so
+    # it must not ride the now-unconditional append. Reported, never silent.
+    series = tmp_path / "series.parquet"
+    update_series.main(["--series", str(series), "--records", _write(tmp_path, [record])])
+    assert update_series.load_series(series).empty
+    out = capsys.readouterr().out
+    assert "skipping record for 't1'" in out and why in out
+
+
+def test_a_dropped_record_cannot_evict_a_retained_one(tmp_path):
+    # Same (commit, target) as a good row: the dedup keeps the LAST write, so an
+    # unfiltered junk row would overwrite a real point on a re-dispatch.
+    series = tmp_path / "series.parquet"
+    update_series.save_series(update_series.records_to_frame([_rec()]), series)
+    update_series.main(
+        ["--series", str(series), "--records", _write(tmp_path, [_rec(obs=0, mem=None)])]
+    )
+    out = update_series.load_series(series)
+    assert out["total_obs"].tolist() == [5_000_000]
+
+
+def test_mixed_batch_keeps_the_good_records(tmp_path):
+    series = tmp_path / "series.parquet"
+    update_series.main(
+        [
+            "--series",
+            str(series),
+            "--records",
+            _write(
+                tmp_path,
+                [
+                    _rec(target="t1", mismatch="expected 10, measured 12"),
+                    _rec(target="t2", obs=0, mem=None),
+                    _rec(target="t3"),
+                ],
+            ),
+        ]
+    )
+    out = update_series.load_series(series)
+    assert sorted(out["target"]) == ["t1", "t3"]

--- a/tests/test_benchmark_recording.py
+++ b/tests/test_benchmark_recording.py
@@ -90,6 +90,22 @@ def test_has_empty_metrics_is_the_one_definition():
     assert not bench_metrics.has_empty_metrics({"total_obs": 1, "max_memory_mb": 1.0})
 
 
+def test_has_empty_metrics_treats_nan_as_missing(tmp_path):
+    # NaN, not None, is how a missing number arrives off parquet -- and json.dumps
+    # emits the bare ``NaN`` token, which json.loads reads straight back, so a
+    # metrics.json can carry one into the filter. ``not float("nan")`` is False,
+    # so an unguarded predicate would retain that row as a real measurement.
+    nan = float("nan")
+    assert bench_metrics.has_empty_metrics({"total_obs": 5_000_000, "max_memory_mb": nan})
+    assert bench_metrics.has_empty_metrics({"total_obs": nan, "max_memory_mb": 1200.0})
+    # End to end: the token survives the JSON round-trip and the row is dropped.
+    series = tmp_path / "series.parquet"
+    records = json.loads(json.dumps([_rec(mem=nan)]))
+    assert records[0]["max_memory_mb"] != records[0]["max_memory_mb"]  # NaN survived
+    update_series.main(["--series", str(series), "--records", _write(tmp_path, [_rec(mem=nan)])])
+    assert update_series.load_series(series).empty
+
+
 @pytest.mark.parametrize(
     ("record", "why"),
     [


### PR DESCRIPTION
Closes #365

## What this changes

The `merge-publish` job runs the object-count tripwire **inside** the "Run benchmark" step, so a mismatch exits 1 and aborts the job before the three steps that retain the point (checkout `benchmarks`, `update_series.py`, `plot_series.py` + push). The measurement exists — `metrics.json` is written *before* the tripwire is evaluated — and is thrown away.

The fix is ordering, not tripwire semantics: **record first, then let the red step stand.** Two halves:

**(1) The retention boundary decides what may be kept — landed.** Appending unconditionally would retain the one row the *other* tripwire exists to reject: a silent OOM (`obs=0` / null peak memory, issue #145) plots as a real dip to zero. So `update_series.main` now filters non-merge **and** empty-metrics records, reporting every drop. The predicate is one definition — `bench_metrics.has_empty_metrics` — shared with `run_benchmark`'s `--fail-on-empty`, so the appender rejects exactly the rows the tripwire names:

```python
retained, dropped = [], []
for r in records:
    if r.get("event") != "merge":
        dropped.append((r.get("target"), "non-merge run"))
    elif bench_metrics.has_empty_metrics(r):
        dropped.append((r.get("target"), "empty metrics (obs=0 / no peak memory)"))
    else:
        retained.append(r)
```

An object-count mismatch is deliberately **not** in that list — that run measured fine and is precisely the point worth keeping next to the anomaly. And the anomaly rides the row: `objects_mismatch` moves from JSON-only to a retained series column (appended last, per the stable-schema rule), so a mismatched point is explicable from `series.parquet` alone rather than only from a job log that ages out. Null on clean runs and on every row recorded before the column existed.

**(2) The retain steps stop being skipped — written, but NOT in this branch (see below).** Each of the three follow-on steps in `.github/workflows/lambda-benchmark.yml` gets `!cancelled() && hashFiles('metrics.json') != ''`. The job still goes red (the measuring step is untouched, no `continue-on-error`) — it just stops taking the data with it. Gating on the *artifact* rather than on the step's status is what makes this general: **any** tripwire that fires after `metrics.json` is written inherits the behavior, which is the property issue #365 asks for ("every future tripwire inherits the behavior" — the PR #356 overview-sidecar classifier gap would have been next). A run that died *before* writing metrics (login/dispatch failure) matches nothing and skips cleanly, mirroring the `comment.md` existence check in `lambda-benchmark-command.yml`.

> **This half is blocked on a push permission, not on a decision about the design.** The push of the workflow file was rejected: `refusing to allow an OAuth App to create or update workflow '.github/workflows/lambda-benchmark.yml' without 'workflow' scope`. The diff and its tests are written and green locally; they are posted in full on the thread below rather than pushed through another credential path. Issue #365 names the file, so the *policy* permits the edit — the token does not. See the thread for the options.

Not touched, deliberately: the composite action `.github/actions/run-benchmark/action.yml` (the tripwire keeps its current semantics for the PR/on-demand leg), the release/full-AOI leg (record-only there — it never fails on a mismatch, so it has no ordering problem), and backfilling the already-lost points (out of scope per the issue).

## Phases

- [x] Phase 1 — retention boundary + the recorded verdict: `has_empty_metrics` as the shared predicate, `update_series` filter, `objects_mismatch` as a series column, tests (`c4830e3`). Adversarial-review findings folded in `1a1cc96`, `80f6d4e`, `58e0d96`, `220498e`.
- [ ] Phase 2 — workflow ordering: `!cancelled() && hashFiles('metrics.json') != ''` on the three retain steps in `lambda-benchmark.yml`, plus structural tests over the parsed workflow. **Written and green locally; blocked on the `workflow` push scope** — full patch on the thread.
- [ ] Phase 3 — docs: `docs/deployment/benchmark.md` on what a red merge benchmark means for the series. Held until phase 2 lands, so the page never describes a half-applied behavior.

## How it was tested

- `uv run pytest -v` on the pushed branch: **3207 passed, 37 skipped** (full suite, ~9m50s).
- New `tests/test_benchmark_recording.py`: a mismatched record survives `update_series.main` **with** its verdict in the parquet; `obs=0` / null-memory / non-merge records are dropped and reported; a dropped record cannot evict a retained one through the `(commit, target)` dedup; a mixed batch keeps the good rows.
- Added while folding the adversarial review: `has_empty_metrics` treats `NaN` as missing on either field, including end-to-end through a `metrics.json` round-trip (`json.dumps` emits the bare `NaN` token and `json.loads` reads it back); appending onto a series that **predates** the `objects_mismatch` column — the real shape of `series.parquet` on the `benchmarks` branch — keeps column order, row order and the integer dtypes, with the pre-existing row reading null; and a *partially* dropped batch, which takes the `pd.concat` path rather than the empty-batch early return, likewise leaves the retained history's integer dtypes alone.
- The phase-2 half is CI-shaped and cannot be tested by execution — the job it lives in costs a live Lambda dispatch. Its tests assert it *structurally* over the parsed YAML: the retain steps come after the measuring step and in order, each carries both `!cancelled()` and the `hashFiles('metrics.json')` gate, and the measuring step is **not** `continue-on-error` (i.e. the alarm still fires). That is a regression pin on the ordering, not a claim that the job was executed. Precedent for parsing this workflow in tests: `tests/test_deploy_lambda.py`'s `--variants` drift guard.
- New tests live in their own module rather than in `tests/test_benchmark.py` (already 2,468 lines) — see the questions below.

Pre-existing, unrelated, **not** fixed here (both on files this PR does not touch, and both from local ruff 0.16.1 vs the `.pre-commit-config.yaml` pin at v0.14.10):

- `ruff check src tests` → `N818` on `src/zagg/registry.py:64` (`UnknownCapability`).
- `ruff format --check src tests` → `tests/data/benchmark/README.md` (0.16 formats python blocks inside markdown).

`ruff check` / `ruff format --check` are clean on every file this PR touches.

## Questions for review

1. **How should the workflow half land?** It is blocked on the `workflow` push scope, not on anything about the change. Options are on the thread — deliberately no attempt was made to route the same edit through a different credential.
2. **Gate on `hashFiles('metrics.json')`, or on an explicit run-benchmark output?** The artifact gate is why this generalizes to future tripwires, and it needs no change to the composite action — but it is an implicit contract ("metrics.json existing means the records are worth appending"). The explicit alternative is a step output from the composite action (or a distinct exit code for "tripwire fired after the data was written"), which is louder but special-cases each tripwire and leans on composite-action outputs surviving a failed step.
3. **Should the release/full-AOI leg get the `objects_mismatch` column too?** It is record-only there (never fails), so it has no ordering problem — but the column would make the two series read the same way. Left out as scope.
4. **New test module vs. growing `tests/test_benchmark.py`.** Added `tests/test_benchmark_recording.py` rather than pushing a 2,468-line module further past the ~1,200-line guidance.
