### PR TITLE
output.pyramid: per-field overview selection (issue #352)

### DIFF
--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -205,6 +205,30 @@ post-process sweep (D11), never at fan-out time, and the sweep adds its
 `materialized` actuals under the same key. Declaring it is not birth-only:
 see [Retrofitting the pyramid declaration](#retrofitting-the-pyramid-declaration).
 
+Which fields ride the schedule is a per-field knob (issue #352). The folds are
+not equally cheap — count/sum/min/max are dense merges, while a t-digest fold
+is a ragged read plus a k-way merge at every ancestor node — so
+`output.pyramid.fields` narrows an expensive field's schedule (or drops it)
+without coarsening the cheap ones:
+
+```yaml
+output:
+  pyramid:
+    orders: [7, 5, 3, 1]
+    fields:                       # optional; absent = every field at every order
+      h_tdigest: {orders: [7, 5]} # the costly fold, only near the top
+      photon_ids: false           # never in an overview
+```
+
+A per-field schedule may only **narrow** the block's `orders` (a wider one
+refuses at config-validation time — the sweep walks the block's orders, so a
+widening entry would silently do nothing). The narrowing is recorded in the
+manifest as the field's own `orders` list, so a reader learns the absence from
+the declaration alone — the same zero-open filtering D24 option A gives a
+`"class": "none"` field, never a probe. Fields the knob does not name carry no
+`orders` key and inherit the block schedule, so a config without the knob
+declares exactly as it did before the knob existed.
+
 A windowed store ([Time windows](#time-windows-morton-hive2)) additionally
 declares `spec: "morton-hive/2"` and a `temporal` block — schedule,
 `time_field`, `epoch`/`scale`/`units`/`calendar`, the explicit windows list,

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -893,7 +893,8 @@ gates (espg/moczarr#19/#20).
 
 Two tiny single-shard hive stores, both on the same deliberately small
 geometry — shard order 4, inner-chunk order 5, cell order 6 (16 cells,
-K = 4 inner chunks of 4 cells), sharded (the hive default):
+K = 4 inner chunks of 4 cells), sharded (the hive default) — plus one
+manifest-only fixture for the §4.5 declaration:
 
 - **`minimal/`** — one *unlocated* digest field (`h_tdigest`) plus `count`.
   The smallest thing that is a conforming store.
@@ -903,8 +904,20 @@ K = 4 inner chunks of 4 cells), sharded (the hive default):
   (including a single-photon cell packing the §3.1 golden word
   `0xFF000000FF0000FF` and a noise-only cell whose signal payload is the
   empty `(0, 2)` array), and `count`.
+- **`pyramid/`** — the §4.5 overview **declaration**, and nothing else: a
+  committed `morton_hive.json` carrying all four readings of a `fields` entry
+  in one block — a field that inherits the block schedule (`count`, no
+  `orders` key), one narrowed to a subset (`h_min`, `[3, 1]` of `[3, 2, 1]`),
+  one excluded outright but still declaring its fold law (`h_tdigest`,
+  `orders: []`), and a non-composable `"class": "none"` one (`h_mean`). The
+  block is a **template-time** artifact — it exists before the first leaf is
+  written and is decodable from the manifest alone — so this fixture carries
+  no store beneath it; a third leaf would pin nothing the other two do not.
+  Its sibling `pyramid.expected.json` records the declared knob and the
+  schedule each field resolves to under §4.5, so a reader's decoding of the
+  key is checkable without running zagg.
 
-Both stores pin the layout edge cases a reader must handle: inner chunk
+Both leaf stores pin the layout edge cases a reader must handle: inner chunk
 ordinal 2 is **empty** (absent from the shard index — the §1.5 sentinel, and
 that sparsity reaches the dense arrays too: the `morton` coordinate and
 `count` hold their fill across that chunk, so a reader MUST NOT assume the
@@ -912,7 +925,7 @@ coordinate is dense across a shard), populated chunks contain empty cells
 (the `b""` fill), and one cell's digest carries merged centroids (weight > 1)
 whose location words are common ancestors (§2.2).
 
-Both fixtures are **sharded**, so §7's conformance claim is scoped to the
+Both leaf fixtures are **sharded**, so §7's conformance claim is scoped to the
 §1.5 sharded geometry. The per-inner-chunk geometry — identical §1.4 framing,
 one object per inner chunk, no shard index — has no committed golden here; it
 is pinned zagg-side by
@@ -921,8 +934,8 @@ stored span from the array's own metadata, as §1.5 requires, reads both from
 one code path; a reader that hard-codes the shard-index suffix passes §7 and
 still fails on an unsharded store.
 
-Each fixture ships a sibling **`{name}.expected.json`** recording the shard
-key, leaf path, geometry, every populated cell's decoded values (digest
+Each leaf fixture ships a sibling **`{name}.expected.json`** recording the
+shard key, leaf path, geometry, every populated cell's decoded values (digest
 centroids, location words and composition words as decimal strings — JSON
 numbers cannot carry `uint64` faithfully), the per-stratum exact counts,
 and the §5 O11 `content_hashes` (per-array + combined). The expected

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -629,6 +629,16 @@ overview family under the versioned `pyramid` block:
   here?" question with zero opens and never a probe. Values outside the
   block's `orders` are not legal; a reader MAY ignore them (they name no
   overview the family walks).
+
+  **The declaration is authoritative over the objects.** Narrowing a schedule
+  does not delete the overviews written under the previous, wider one — like
+  shrinking `orders` itself, it leaves them as regenerable-cache debris (D9) —
+  so a stamped overview whose own `zagg_overview.fields` (§4.3) names a field
+  the manifest no longer schedules at that order MAY exist. A reader
+  encountering that contradiction MUST take the manifest's schedule as truth
+  and treat the extra array as stale; it is not evidence of a torn write, and
+  the array's *contents* remain a valid fold of whatever leaves existed when
+  it was written.
 - **`all_time`** — whether the `all.zarr` all-time fold is materialized at
   the declared orders (windowed stores only; a `schedule: none` store's
   single fold is already all-time).

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -503,9 +503,11 @@ regionally heterogeneous resolution).
   **`fields` enumerates the materialized fields only** — exactly the fields
   present as arrays in *this* overview, each recording the fold that was
   actually applied. A `none`-class field is absent from the zarr (§4.4) and so
-  MUST be absent from this map: its recorded absence lives in the manifest's
-  `pyramid.overview.fields` (§4.5), which is the map that enumerates **every**
-  declared field. Consequently a reader MAY treat this map as the overview's
+  MUST be absent from this map — as is a field whose own schedule
+  (§4.5 `fields[…].orders`) does not list this overview's `order`, which is
+  why this map may differ between two overviews of the same product. Recorded
+  absence lives in the manifest's `pyramid.overview.fields` (§4.5), which is
+  the map that enumerates **every** declared field. Consequently a reader MAY treat this map as the overview's
   variable list and MUST be able to open every array it names; cross-checking
   it against the arrays present is a valid integrity check. Each entry carries
   at least `class` and `method`, and MAY carry further fold provenance — an
@@ -535,12 +537,15 @@ is the store's resolution axis, partially materialized). Concretely:
   `2^24` observations, and there `sum(weights)` is the nearest float32 to the
   true count rather than the count itself;
 - field inclusion is gated by the field's **composability class** (§4.5):
-  `exact` and `approximate` fields appear, `none` fields are **absent**.
+  `exact` and `approximate` fields appear, `none` fields are **absent**;
+- inclusion is additionally gated by the field's own **schedule** when it
+  declares one (§4.5 `fields[…].orders`): a field may carry overviews at a
+  subset of the block's orders, or at none of them.
 
-An overview's variable set may therefore be a *subset* of the leaf's —
-heterogeneous variable sets across level nodes are in contract, and a reader
-MUST NOT assume every leaf field exists at every overview order (the
-manifest declaration below is the zero-open way to know).
+An overview's variable set may therefore be a *subset* of the leaf's, and may
+differ **between orders** — heterogeneous variable sets across level nodes are
+in contract, and a reader MUST NOT assume every leaf field exists at every
+overview order (the manifest declaration below is the zero-open way to know).
 
 ### 4.5 The manifest `pyramid` block
 
@@ -560,7 +565,8 @@ overview family under the versioned `pyramid` block:
       "count":     {"class": "exact", "method": "sum", "nan_policy": "skip",
                     "dtype": "int32", "fill_value": 0},
       "h_tdigest": {"class": "approximate", "method": "tdigest_kway",
-                    "dtype": "float32", "inner_shape": [2], "delta": 512},
+                    "dtype": "float32", "inner_shape": [2], "delta": 512,
+                    "orders": [3]},
       "photon_ids": {"class": "none"}
     }
   }
@@ -599,6 +605,30 @@ overview family under the versioned `pyramid` block:
   metadata to know the overview array's form up front. This map is the
   **all-fields** view; the per-overview `zagg_overview.fields` attrs map
   (§4.3) is the materialized subset.
+- **`fields[…].orders`** (optional, `exact`/`approximate` entries only) — the
+  field's **own** overview schedule, a subset of the block's `orders` in the
+  same descending order. It exists because the folds are not equally cheap:
+  the exact folds are dense merges, while an `approximate` fold is a ragged
+  read plus a k-way merge per ancestor node, so a product may carry `count` at
+  every order and `h_tdigest` at every other one. Semantics:
+
+  - **absent** — the field carries an overview at **every** order in the
+    block's `orders`. This is the default and the pre-existing behavior; a
+    declaration with no per-field schedules is byte-identical to one written
+    before this key existed;
+  - **present** — the field carries an overview at exactly the listed orders
+    and at no others. `[]` therefore excludes it from the whole pyramid while
+    still recording its class and fold law (which is what distinguishes it
+    from a `"class": "none"` field: that one *cannot* fold, this one is not
+    *scheduled* to).
+
+  A `none` entry never carries `orders` — it is absent everywhere already, so
+  the key would be redundant. A reader MUST NOT read an order outside a
+  field's declared schedule as an incomplete sweep: like `"class": "none"`,
+  this is **recorded absence** (D24 option A) and answers the "is this field
+  here?" question with zero opens and never a probe. Values outside the
+  block's `orders` are not legal; a reader MAY ignore them (they name no
+  overview the family walks).
 - **`all_time`** — whether the `all.zarr` all-time fold is materialized at
   the declared orders (windowed stores only; a `schedule: none` store's
   single fold is already all-time).

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -2456,8 +2456,12 @@ def _validate_pyramid_fields(knob: dict, declared: dict, parent_order: int) -> N
     are near-free dense merges, so ``h_tdigest`` may run every 4 orders while
     ``count`` stays at every one. A per-field order outside the block schedule
     refuses rather than widening it: the sweep only ever walks the block's own
-    orders, so a widening entry would silently do nothing.
+    orders, so a widening entry would silently do nothing. Scheduling a
+    ``none``-class field refuses for the same reason — D24 excludes it from
+    every order regardless — while ``false``/``[]`` over one stays legal, since
+    that only states the exclusion the block already records.
     """
+    from zagg.semantics import field_composability
     from zagg.sweep_overview import pyramid_orders
 
     fields = knob["fields"]
@@ -2489,6 +2493,18 @@ def _validate_pyramid_fields(knob: dict, declared: dict, parent_order: int) -> N
             raise ValueError(
                 f"output.pyramid.fields.{name}.orders {extra} are outside the pyramid "
                 f"schedule {schedule} — a per-field schedule may only narrow it"
+            )
+        if not orders:
+            continue
+        try:
+            composable = field_composability(declared[name]) != "none"
+        except Exception:
+            continue  # malformed meta: the kind/shape validators own that error
+        if not composable:
+            raise ValueError(
+                f"output.pyramid.fields.{name}.orders schedules overviews for a "
+                f"non-composable field (D24 class 'none'), which is excluded from every "
+                f"order regardless — drop the entry, or write `false` to say so explicitly"
             )
 
 

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -2370,7 +2370,10 @@ def get_pyramid(config: PipelineConfig) -> dict | None:
     store. An explicit mapping may carry ``spacing`` (int >= 1), ``orders``
     (explicit ancestor orders, winning over ``spacing``), ``all_time``
     (bool: also maintain the ``all.zarr`` cross-window fold on windowed
-    stores), and ``summarize`` (the D24 opt-in derived-summary declarations,
+    stores), ``fields`` (the issue #352 per-field overview schedules,
+    ``{field: {"orders": [...]}}`` or ``{field: false}`` — absent means every
+    composable field at every declared order, exactly the pre-#352 behavior),
+    and ``summarize`` (the D24 opt-in derived-summary declarations,
     ``{source_field: {"as": name, ...}}`` — recorded in the pyramid block,
     never the semantic core).
     """
@@ -2400,7 +2403,7 @@ def _validate_pyramid(config: PipelineConfig) -> None:
             "output.pyramid requires output.store_layout: hive (overviews live at "
             "hive-tree ancestor nodes; flat stores have no digit tree)"
         )
-    unknown = set(knob) - {"spacing", "orders", "all_time", "summarize"}
+    unknown = set(knob) - {"spacing", "orders", "all_time", "fields", "summarize"}
     if unknown:
         raise ValueError(f"output.pyramid has unknown keys {sorted(unknown)}")
     spacing = knob.get("spacing")
@@ -2418,6 +2421,8 @@ def _validate_pyramid(config: PipelineConfig) -> None:
     all_time = knob.get("all_time")
     if all_time is not None and not isinstance(all_time, bool):
         raise ValueError(f"output.pyramid.all_time must be a boolean (got {all_time!r})")
+    if knob.get("fields") is not None:
+        _validate_pyramid_fields(knob, get_agg_fields(config), parent_order)
     summarize = knob.get("summarize")
     if summarize is None:
         return
@@ -2438,6 +2443,52 @@ def _validate_pyramid(config: PipelineConfig) -> None:
                 f"output.pyramid.summarize.{source}.as = {target!r} collides with a "
                 f"declared field: derived summaries must use a DIFFERENT name so overview "
                 f"schema never silently differs from source (D24)"
+            )
+
+
+def _validate_pyramid_fields(knob: dict, declared: dict, parent_order: int) -> None:
+    """Validate ``output.pyramid.fields`` — the per-field schedules (issue #352).
+
+    Each entry is either ``false`` (exclude the field from every overview
+    order) or a mapping carrying ``orders``: a SUBSET of the block-wide
+    schedule, which is the cost lever the issue asks for — the t-digest fold
+    is a ragged read + k-way merge per ancestor node, while count/sum/min/max
+    are near-free dense merges, so ``h_tdigest`` may run every 4 orders while
+    ``count`` stays at every one. A per-field order outside the block schedule
+    refuses rather than widening it: the sweep only ever walks the block's own
+    orders, so a widening entry would silently do nothing.
+    """
+    from zagg.sweep_overview import pyramid_orders
+
+    fields = knob["fields"]
+    if not isinstance(fields, dict):
+        raise ValueError(f"output.pyramid.fields must be a mapping (got {fields!r})")
+    schedule = pyramid_orders(knob, parent_order)
+    for name, decl in fields.items():
+        if name not in declared:
+            raise ValueError(
+                f"output.pyramid.fields names unknown field {name!r} (declared: {sorted(declared)})"
+            )
+        if decl is False:
+            continue
+        if not isinstance(decl, dict):
+            raise ValueError(
+                f"output.pyramid.fields.{name} must be false or a mapping with 'orders' "
+                f"(got {decl!r})"
+            )
+        unknown = set(decl) - {"orders"}
+        if unknown:
+            raise ValueError(f"output.pyramid.fields.{name} has unknown keys {sorted(unknown)}")
+        orders = decl.get("orders")
+        if not isinstance(orders, list) or not all(isinstance(k, int) for k in orders):
+            raise ValueError(
+                f"output.pyramid.fields.{name}.orders must be a list of ints (got {orders!r})"
+            )
+        extra = sorted(set(orders) - set(schedule))
+        if extra:
+            raise ValueError(
+                f"output.pyramid.fields.{name}.orders {extra} are outside the pyramid "
+                f"schedule {schedule} — a per-field schedule may only narrow it"
             )
 
 

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -192,6 +192,22 @@ def fold_digests(cell_digests: list, *, delta: int, dtype="float32") -> bytes:
 # ---------------------------------------------------------------------------
 
 
+def pyramid_orders(knob: dict, shard_order: int) -> list:
+    """The block-wide overview schedule an ``output.pyramid`` knob declares.
+
+    Explicit ``orders`` win over ``spacing``; absent both, the default is
+    every :data:`DEFAULT_SPACING` orders below the shard order (the
+    espg-ratified display schedule). Shared with
+    :func:`zagg.config._validate_pyramid` so a per-field schedule (issue #352)
+    is checked against the very list the sweep walks, never a second
+    derivation of it.
+    """
+    if knob.get("orders") is not None:
+        return sorted({int(k) for k in knob["orders"]}, reverse=True)
+    spacing = int(knob.get("spacing") or DEFAULT_SPACING)
+    return list(range(int(shard_order) - spacing, -1, -spacing))
+
+
 def build_pyramid_block(config, shard_order: int) -> dict:
     """The manifest ``pyramid`` block: the template-time declaration (D22).
 
@@ -210,10 +226,7 @@ def build_pyramid_block(config, shard_order: int) -> dict:
     if knob is None:  # output.pyramid: false — declared off
         return {"spec": PYRAMID_SPEC, "overview": {"orders": []}}
     spacing = int(knob.get("spacing") or DEFAULT_SPACING)
-    if knob.get("orders") is not None:
-        orders = sorted({int(k) for k in knob["orders"]}, reverse=True)
-    else:
-        orders = list(range(int(shard_order) - spacing, -1, -spacing))
+    orders = pyramid_orders(knob, shard_order)
     agg = get_agg_fields(config)
     fields: dict = {}
     excluded = []

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -224,7 +224,11 @@ def build_pyramid_block(config, shard_order: int) -> dict:
     exclusion — so the per-(field, order) absence is recorded exactly as the
     block-wide one is: zero-open filtering, never a probe. Fields not named
     there carry no ``orders`` key and inherit the block schedule, so a config
-    without the knob declares byte-identically to pre-#352 zagg.
+    without the knob declares byte-identically to pre-#352 zagg. An empty
+    per-field schedule is warned about on the same footing as the D24 ``none``
+    exclusion below it — structurally the same outcome (a declared field that
+    is absent everywhere) — and excluding EVERY composable field says so
+    loudly: that declares a pyramid the sweep would never write.
     """
     from zagg.config import get_agg_fields, get_pyramid
     from zagg.semantics import EXACT_MERGE_LAWS, _fold_function_name, composability_classes
@@ -237,7 +241,8 @@ def build_pyramid_block(config, shard_order: int) -> dict:
     agg = get_agg_fields(config)
     selection = knob.get("fields") or {}
     fields: dict = {}
-    excluded = []
+    excluded: list = []
+    deselected: list = []
     for name, cls in composability_classes(config).items():
         meta = agg[name]
         if cls == "exact":
@@ -265,7 +270,22 @@ def build_pyramid_block(config, shard_order: int) -> dict:
             continue
         if name in selection:
             entry["orders"] = _field_orders(name, selection[name], orders)
+            if not entry["orders"]:
+                deselected.append(name)
         fields[name] = entry
+    if deselected and orders:
+        every = len(deselected) == len([e for e in fields.values() if e.get("class") != "none"])
+        logger.warning(
+            f"pyramid: fields {deselected} are excluded from every declared order by "
+            f"output.pyramid.fields — recorded absence (issue #352), not a missing sweep"
+            + (
+                f"; that is EVERY composable field, so the declared orders {orders} would "
+                f"materialize nothing — `output.pyramid: false` is how a store declares no "
+                f"pyramid at all"
+                if every
+                else ""
+            )
+        )
     if excluded and orders:
         logger.warning(
             f"pyramid: fields {excluded} are non-composable (D24 class 'none') and will "

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -264,7 +264,7 @@ def build_pyramid_block(config, shard_order: int) -> dict:
             excluded.append(name)
             continue
         if name in selection:
-            entry["orders"] = _field_orders(selection[name], orders)
+            entry["orders"] = _field_orders(name, selection[name], orders)
         fields[name] = entry
     if excluded and orders:
         logger.warning(
@@ -283,7 +283,7 @@ def build_pyramid_block(config, shard_order: int) -> dict:
     return {"spec": PYRAMID_SPEC, "overview": overview}
 
 
-def _field_orders(decl, orders: list) -> list:
+def _field_orders(name: str, decl, orders: list) -> list:
     """One field's declared overview schedule (issue #352), as a subset of ``orders``.
 
     ``false`` is the outright exclusion (the empty schedule); a mapping
@@ -293,11 +293,29 @@ def _field_orders(decl, orders: list) -> list:
     makes the invariant unfalsifiable for the unvalidated caller
     (``declare_pyramid`` against a manifest whose ``shard_order`` differs from
     the config's).
+
+    That caller is exactly why the drop is WARNED and names the field: a
+    validated ``[6, 4]`` retrofitted onto a store whose schedule is
+    ``[7, 5, 3, 1]`` intersects to nothing, and the summary reports classes
+    only — so a field the user asked for at two orders would otherwise be
+    dropped from the whole pyramid and reported as success.
     """
     if decl is False:
         return []
     want = {int(k) for k in ((decl or {}).get("orders") or [])}
-    return [k for k in orders if k in want]
+    kept = [k for k in orders if k in want]
+    dropped = sorted(want - set(orders), reverse=True)
+    if dropped:
+        logger.warning(
+            f"pyramid: field {name!r} schedules orders {dropped} outside the block schedule "
+            f"{orders}; they are dropped"
+            + (
+                " — NOTHING remains, so the field is excluded from the entire pyramid"
+                if not kept
+                else f", leaving {kept}"
+            )
+        )
+    return kept
 
 
 def _json_fill(fill_value):

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -218,6 +218,13 @@ def build_pyramid_block(config, shard_order: int) -> dict:
     that gives readers zero-open filtering (option A, the ruled default) —
     and warned about loudly at template time, per the D24 ruling. The sweep
     later adds ``materialized`` actuals; it never rewrites the declaration.
+
+    A composable field named in ``output.pyramid.fields`` (issue #352) also
+    records its own ``orders`` — the narrowed schedule, ``[]`` for an outright
+    exclusion — so the per-(field, order) absence is recorded exactly as the
+    block-wide one is: zero-open filtering, never a probe. Fields not named
+    there carry no ``orders`` key and inherit the block schedule, so a config
+    without the knob declares byte-identically to pre-#352 zagg.
     """
     from zagg.config import get_agg_fields, get_pyramid
     from zagg.semantics import EXACT_MERGE_LAWS, _fold_function_name, composability_classes
@@ -228,12 +235,13 @@ def build_pyramid_block(config, shard_order: int) -> dict:
     spacing = int(knob.get("spacing") or DEFAULT_SPACING)
     orders = pyramid_orders(knob, shard_order)
     agg = get_agg_fields(config)
+    selection = knob.get("fields") or {}
     fields: dict = {}
     excluded = []
     for name, cls in composability_classes(config).items():
         meta = agg[name]
         if cls == "exact":
-            fields[name] = {
+            entry = {
                 "class": "exact",
                 "method": EXACT_MERGE_LAWS[_fold_function_name(meta.get("function")) or ""],
                 "nan_policy": EXACT_NAN_POLICY,
@@ -242,7 +250,7 @@ def build_pyramid_block(config, shard_order: int) -> dict:
             }
         elif cls == "approximate":
             inner = meta.get("inner_shape") or (2,)
-            fields[name] = {
+            entry = {
                 "class": "approximate",
                 "method": TDIGEST_LAW,
                 "dtype": meta.get("dtype", "float32"),
@@ -250,8 +258,14 @@ def build_pyramid_block(config, shard_order: int) -> dict:
                 "delta": int((meta.get("params") or {}).get("delta", 512)),
             }
         else:
+            # A ``none`` entry carries ``class`` only (spec §4.5): it is already
+            # absent at every order, so a per-field schedule over it is moot.
             fields[name] = {"class": "none"}
             excluded.append(name)
+            continue
+        if name in selection:
+            entry["orders"] = _field_orders(selection[name], orders)
+        fields[name] = entry
     if excluded and orders:
         logger.warning(
             f"pyramid: fields {excluded} are non-composable (D24 class 'none') and will "
@@ -267,6 +281,22 @@ def build_pyramid_block(config, shard_order: int) -> dict:
     if knob.get("summarize"):
         overview["summarize"] = {str(k): dict(v) for k, v in knob["summarize"].items()}
     return {"spec": PYRAMID_SPEC, "overview": overview}
+
+
+def _field_orders(decl, orders: list) -> list:
+    """One field's declared overview schedule (issue #352), as a subset of ``orders``.
+
+    ``false`` is the outright exclusion (the empty schedule); a mapping
+    narrows to its ``orders``. Always intersected with the block schedule and
+    kept in the block's descending order: :func:`zagg.config._validate_pyramid`
+    refuses a widening entry up front, so the intersection here only makes the
+    invariant unfalsifiable for the unvalidated caller (``declare_pyramid``
+    against a manifest whose ``shard_order`` differs from the config's).
+    """
+    if decl is False:
+        return []
+    want = {int(k) for k in ((decl or {}).get("orders") or [])}
+    return [k for k in orders if k in want]
 
 
 def _json_fill(fill_value):

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -302,7 +302,9 @@ def _field_orders(name: str, decl, orders: list) -> list:
     """
     if decl is False:
         return []
-    want = {int(k) for k in ((decl or {}).get("orders") or [])}
+    want = _order_set(name, (decl or {}).get("orders") or [])
+    if want is None:  # unusable shape: inherit the block schedule, never narrow
+        return list(orders)
     kept = [k for k in orders if k in want]
     dropped = sorted(want - set(orders), reverse=True)
     if dropped:
@@ -316,6 +318,28 @@ def _field_orders(name: str, decl, orders: list) -> list:
             )
         )
     return kept
+
+
+def _order_set(name: str, sched) -> set | None:
+    """A declared per-field ``orders`` as a set of ints — ``None`` if unusable.
+
+    The shape is gated BEFORE iterating, because a ``str`` is iterable and its
+    digits parse: ``"13"`` would otherwise narrow the field to ``{1, 3}``, a
+    schedule nobody declared, instead of taking the fallback its callers
+    document. :func:`zagg.config._validate_pyramid_fields` refuses the same
+    shapes up front; this covers the callers that read a declaration back off
+    a manifest, which no validator has seen.
+    """
+    if isinstance(sched, list | tuple):
+        try:
+            return {int(k) for k in sched}
+        except (TypeError, ValueError):
+            pass
+    logger.warning(
+        f"pyramid: unusable per-field orders {sched!r} declared for field {name!r}; "
+        f"folding it at every declared order instead"
+    )
+    return None
 
 
 def _json_fill(fill_value):
@@ -725,7 +749,7 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
     store = open_object_store(store_root, **store_kwargs)
     materialized: set[int] = set()
     for k in orders:
-        order_fields = {n: m for n, m in fields.items() if _scheduled(m, k)}
+        order_fields = {n: m for n, m in fields.items() if _scheduled(n, m, k)}
         if not order_fields:
             logger.info(
                 f"sweep[overview]: no field is scheduled at order {k} (every declared field "
@@ -783,25 +807,20 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
     return counts
 
 
-def _scheduled(meta: dict, k: int) -> bool:
+def _scheduled(name: str, meta: dict, k: int) -> bool:
     """Whether a declared field carries an overview at order ``k`` (issue #352).
 
     No ``orders`` key is the pre-#352 default — the field runs at every order
     the block declares; a present one is its own narrowed schedule (``[]``
-    excludes it everywhere). Unparseable entries fall back to the default
-    rather than silently dropping a field the declaration promised.
+    excludes it everywhere). Unusable entries fall back to the default
+    (:func:`_order_set`) rather than silently dropping — or silently narrowing
+    — a field the declaration promised.
     """
     sched = meta.get("orders")
     if sched is None:
         return True
-    try:
-        return int(k) in {int(x) for x in sched}
-    except (TypeError, ValueError):
-        logger.warning(
-            f"sweep[overview]: unusable per-field orders {sched!r} in the pyramid "
-            f"declaration; folding the field at every declared order"
-        )
-        return True
+    want = _order_set(name, sched)
+    return True if want is None else int(k) in want
 
 
 def _sweep():

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -653,6 +653,11 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
     (run record + MOC — never a LIST); with the default family order the MOC
     family has just refreshed that root in the same pass.
 
+    Field inclusion is per ORDER, not per sweep: a declared field carrying its
+    own ``orders`` (the issue #352 cost lever) contributes only at those, so an
+    expensive t-digest fold can run every 4 orders while the near-free dense
+    folds run at every one. An order every field narrows out is skipped whole.
+
     Idempotent: a (node, window) whose stored generation stamp (merged-leaf
     count + max leaf stamp timestamp) AND content hash both match the freshly
     folded payload — and whose zarr is confirmed present and stamped, since the
@@ -701,6 +706,13 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
     store = open_object_store(store_root, **store_kwargs)
     materialized: set[int] = set()
     for k in orders:
+        order_fields = {n: m for n, m in fields.items() if _scheduled(m, k)}
+        if not order_fields:
+            logger.info(
+                f"sweep[overview]: no field is scheduled at order {k} (every declared field "
+                f"narrows it out — output.pyramid.fields, issue #352); nothing to generate there"
+            )
+            continue
         nodes = sorted({_node_at(d, k) for d in by_shard})
         for node in nodes:
             node_shards = sorted(d for d in candidates if d.startswith(node))
@@ -718,7 +730,7 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
                     key,
                     fold_windows,
                     node_shards,
-                    fields,
+                    order_fields,
                     cell_order,
                     shard_order,
                     windowed,
@@ -750,6 +762,27 @@ def sweep_overviews(store_root: str, manifest: dict, by_shard: dict, *, store_kw
             store_root, sorted(materialized), store_kwargs
         )
     return counts
+
+
+def _scheduled(meta: dict, k: int) -> bool:
+    """Whether a declared field carries an overview at order ``k`` (issue #352).
+
+    No ``orders`` key is the pre-#352 default — the field runs at every order
+    the block declares; a present one is its own narrowed schedule (``[]``
+    excludes it everywhere). Unparseable entries fall back to the default
+    rather than silently dropping a field the declaration promised.
+    """
+    sched = meta.get("orders")
+    if sched is None:
+        return True
+    try:
+        return int(k) in {int(x) for x in sched}
+    except (TypeError, ValueError):
+        logger.warning(
+            f"sweep[overview]: unusable per-field orders {sched!r} in the pyramid "
+            f"declaration; folding the field at every declared order"
+        )
+        return True
 
 
 def _sweep():

--- a/src/zagg/sweep_overview.py
+++ b/src/zagg/sweep_overview.py
@@ -288,10 +288,11 @@ def _field_orders(decl, orders: list) -> list:
 
     ``false`` is the outright exclusion (the empty schedule); a mapping
     narrows to its ``orders``. Always intersected with the block schedule and
-    kept in the block's descending order: :func:`zagg.config._validate_pyramid`
-    refuses a widening entry up front, so the intersection here only makes the
-    invariant unfalsifiable for the unvalidated caller (``declare_pyramid``
-    against a manifest whose ``shard_order`` differs from the config's).
+    kept in the block's descending order: the widening refusal lives in
+    :func:`zagg.config._validate_pyramid_fields`, so the intersection here only
+    makes the invariant unfalsifiable for the unvalidated caller
+    (``declare_pyramid`` against a manifest whose ``shard_order`` differs from
+    the config's).
     """
     if decl is False:
         return []

--- a/tests/data/spec/pyramid.expected.json
+++ b/tests/data/spec/pyramid.expected.json
@@ -1,0 +1,57 @@
+{
+ "shard_order": 4,
+ "declared": {
+  "orders": [
+   3,
+   2,
+   1
+  ],
+  "fields": {
+   "h_min": {
+    "orders": [
+     3,
+     1
+    ]
+   },
+   "h_tdigest": {
+    "orders": []
+   }
+  }
+ },
+ "orders": [
+  3,
+  2,
+  1
+ ],
+ "spacing": 2,
+ "all_time": false,
+ "fields": {
+  "count": {
+   "class": "exact",
+   "declares_orders": false,
+   "orders": [
+    3,
+    2,
+    1
+   ]
+  },
+  "h_tdigest": {
+   "class": "approximate",
+   "declares_orders": true,
+   "orders": []
+  },
+  "h_min": {
+   "class": "exact",
+   "declares_orders": true,
+   "orders": [
+    3,
+    1
+   ]
+  },
+  "h_mean": {
+   "class": "none",
+   "declares_orders": false,
+   "orders": []
+  }
+ }
+}

--- a/tests/data/spec/pyramid/morton_hive.json
+++ b/tests/data/spec/pyramid/morton_hive.json
@@ -1,0 +1,63 @@
+{
+ "spec": "morton-hive/1",
+ "dataset": {
+  "short_name": "SPEC_FIXTURE",
+  "version": "1"
+ },
+ "semantic_hash": "11351f9e8c8c79f5d0763ba026321132796948d579b21984fa82db179afce10b",
+ "cell_order": 6,
+ "shard_order": 4,
+ "split_schedule": [
+  1,
+  1,
+  1,
+  1
+ ],
+ "path_grouping": 1,
+ "pyramid": {
+  "spec": "zagg-pyramid/1",
+  "overview": {
+   "spacing": 2,
+   "orders": [
+    3,
+    2,
+    1
+   ],
+   "all_time": false,
+   "fields": {
+    "count": {
+     "class": "exact",
+     "method": "sum",
+     "nan_policy": "skip",
+     "dtype": "int32",
+     "fill_value": 0
+    },
+    "h_tdigest": {
+     "class": "approximate",
+     "method": "tdigest_kway",
+     "dtype": "float32",
+     "inner_shape": [
+      2
+     ],
+     "delta": 16,
+     "orders": []
+    },
+    "h_min": {
+     "class": "exact",
+     "method": "min",
+     "nan_policy": "skip",
+     "dtype": "float32",
+     "fill_value": 0,
+     "orders": [
+      3,
+      1
+     ]
+    },
+    "h_mean": {
+     "class": "none"
+    }
+   }
+  }
+ },
+ "generated_at": "2026-08-03T11:10:05+00:00"
+}

--- a/tests/test_spec_conformance.py
+++ b/tests/test_spec_conformance.py
@@ -1,9 +1,10 @@
 """Spec-conformance tests against the committed golden fixtures (issue #340).
 
 ``docs/specification.md`` §7: the fixtures under ``tests/data/spec/`` (two
-tiny hive stores written by ``tools/generate_spec_fixtures.py`` through the
-production write path) are part of the store contract. Every test here binds
-one of the spec's normative claims to those committed bytes, two ways:
+tiny hive stores plus one manifest-only declaration, all written by
+``tools/generate_spec_fixtures.py`` through the production write path) are
+part of the store contract. Every test here binds one of the spec's normative
+claims to those committed bytes, two ways:
 
 - **through the shipping readers** (``zagg.readers.tdigest_tensor`` +
   ``zagg.stats.composition``), so the reader cannot drift from the fixtures;
@@ -33,6 +34,9 @@ from zagg.stats.composition import counts_from_composition, unpack_composition
 
 SPEC_DATA = Path(__file__).parent / "data" / "spec"
 FIXTURES = ("minimal", "kitchen_sink")
+#: The manifest-only fixture (§4.5 declaration grammar) — no leaf, so it is
+#: deliberately NOT in ``FIXTURES``: nothing leaf-shaped applies to it.
+PYRAMID = "pyramid"
 #: (fixture, ragged field, element dtype, inner shape) — every committed
 #: ``zagg-ragged/1`` array, payload and located siblings alike.
 RAGGED_ARRAYS = [
@@ -538,3 +542,79 @@ class TestStoreEnvelope:
     def test_manifest_spec_marker(self, name):
         manifest = json.loads((SPEC_DATA / name / "morton_hive.json").read_text())
         assert manifest["spec"] == "morton-hive/1"
+
+
+def _pyramid_block():
+    """The ``pyramid/`` fixture's committed manifest declaration (§4.5)."""
+    manifest = json.loads((SPEC_DATA / PYRAMID / "morton_hive.json").read_text())
+    return manifest["pyramid"]
+
+
+def _declared_orders(entry: dict, block_orders: list) -> list:
+    """Decode ONE field's overview schedule from §4.5 text alone.
+
+    The three rules a reader must implement: a ``none`` class is absent
+    everywhere; an absent ``orders`` key inherits the block schedule; a present
+    one is exact (``[]`` excludes the field outright). Orders outside the
+    block's own list name no overview the family walks, so they drop.
+    """
+    if entry["class"] == "none":
+        return []
+    if "orders" not in entry:
+        return list(block_orders)
+    return [k for k in block_orders if k in set(entry["orders"])]
+
+
+class TestPyramidDeclaration:
+    """§4.5 — the manifest overview declaration, incl. per-field schedules (#352)."""
+
+    def test_block_shape_and_marker(self):
+        exp = _expected(PYRAMID)
+        block = _pyramid_block()
+        assert block["spec"] == "zagg-pyramid/1"
+        overview = block["overview"]
+        assert overview["orders"] == exp["orders"] == exp["declared"]["orders"]
+        # Non-empty orders: spacing/all_time/fields are all MUST-be-present.
+        assert overview["spacing"] == exp["spacing"]
+        assert overview["all_time"] is exp["all_time"]
+        assert set(overview["fields"]) == set(exp["fields"])
+
+    def test_field_schedules_decode_per_spec(self):
+        """Every §4.5 reading of ``fields[….].orders`` in one committed manifest."""
+        exp = _expected(PYRAMID)
+        overview = _pyramid_block()["overview"]
+        for name, want in exp["fields"].items():
+            entry = overview["fields"][name]
+            assert entry["class"] == want["class"]
+            # The key's PRESENCE is normative: absent means inherit, and a
+            # none-class entry never carries it.
+            assert ("orders" in entry) is want["declares_orders"]
+            assert _declared_orders(entry, overview["orders"]) == want["orders"]
+        # ...and the four readings really are distinct: inherit-all, narrowed,
+        # excluded-but-declared, and non-composable.
+        assert sorted(str(f["orders"]) for f in exp["fields"].values()) == sorted(
+            ["[3, 2, 1]", "[3, 1]", "[]", "[]"]
+        )
+
+    def test_declared_schedules_are_subsets_in_block_order(self):
+        overview = _pyramid_block()["overview"]
+        for entry in overview["fields"].values():
+            if "orders" in entry:
+                assert set(entry["orders"]) <= set(overview["orders"])
+                # Same descending order as the block's own list.
+                assert entry["orders"] == [k for k in overview["orders"] if k in entry["orders"]]
+
+    def test_excluded_field_still_declares_its_fold_law(self):
+        """``orders: []`` is not a dropped entry — class and fold law survive."""
+        entry = _pyramid_block()["overview"]["fields"]["h_tdigest"]
+        assert entry["orders"] == [] and entry["class"] == "approximate"
+        assert entry["method"] == "tdigest_kway" and entry["inner_shape"] == [2]
+
+    def test_none_class_entry_is_class_only(self):
+        """The recorded absence (D24 option A): no fold to name, no schedule."""
+        assert _pyramid_block()["overview"]["fields"]["h_mean"] == {"class": "none"}
+
+    def test_manifest_spec_marker(self):
+        manifest = json.loads((SPEC_DATA / PYRAMID / "morton_hive.json").read_text())
+        assert manifest["spec"] == "morton-hive/1"
+        assert manifest["shard_order"] == _expected(PYRAMID)["shard_order"]

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -620,6 +620,75 @@ class TestOverviewWriter:
         assert "h_mean" not in g
         assert "count" in g and "h_tdigest" in g
 
+    def test_per_field_schedule_drops_a_field_at_one_order(self, tmp_path):
+        """Issue #352: the expensive t-digest fold runs at order 1 only."""
+        fields = dict(FIELDS_DECL)
+        fields["h_tdigest"] = {**FIELDS_DECL["h_tdigest"], "orders": [1]}
+        _write_manifest(tmp_path, orders=(1, 0), fields=fields)
+        _make_leaf(tmp_path, "-311", {0: [1.0, 2.0]})
+        result = run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        assert result["families"]["overview"]["written"] == 2
+        # Order 1: scheduled -> the ragged array is materialized.
+        g1 = _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        assert "h_tdigest" in g1 and "count" in g1 and "h_min" in g1
+        # Order 0: narrowed out -> absent from the zarr AND from the overview's
+        # own materialized-fields attrs (spec §4.3), while the cheap exact
+        # folds still land.
+        g0 = _overview_group(tmp_path, "-3", "all.zarr", 2)
+        assert "h_tdigest" not in g0
+        np.testing.assert_array_equal(g0["count"][:1], [2])
+        info = _overview_root(tmp_path, "-3", "all.zarr").attrs[OVERVIEW_ATTR]
+        assert set(info["fields"]) == {"count", "h_min"}
+
+    def test_field_excluded_everywhere(self, tmp_path):
+        """``some_field: false`` — the empty schedule at every declared order."""
+        fields = dict(FIELDS_DECL)
+        fields["h_min"] = {**FIELDS_DECL["h_min"], "orders": []}
+        _write_manifest(tmp_path, orders=(1, 0), fields=fields)
+        _make_leaf(tmp_path, "-311", {0: [1.0, 2.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        for node_rel, order in (("-3/1", 3), ("-3", 2)):
+            g = _overview_group(tmp_path, node_rel, "all.zarr", order)
+            assert "h_min" not in g and "count" in g
+
+    def test_order_with_no_scheduled_field_is_skipped(self, tmp_path):
+        """An order every field narrows out writes nothing at all."""
+        fields = {n: {**m, "orders": [1]} for n, m in FIELDS_DECL.items() if n != "h_mean"}
+        fields["h_mean"] = FIELDS_DECL["h_mean"]
+        _write_manifest(tmp_path, orders=(1, 0), fields=fields)
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        result = run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        assert result["families"]["overview"]["written"] == 1
+        assert (tmp_path / "-3" / "1" / "all.zarr").exists()
+        assert not (tmp_path / "-3" / "all.zarr").exists()
+        # ...and only the order that produced an artifact is recorded materialized.
+        after = read_manifest(str(tmp_path))
+        assert after["pyramid"]["overview"]["materialized"]["orders"] == [1]
+
+    def test_unparseable_field_schedule_folds_everywhere(self, tmp_path, caplog):
+        """A malformed ``orders`` must not silently drop a declared field."""
+        fields = dict(FIELDS_DECL)
+        fields["h_min"] = {**FIELDS_DECL["h_min"], "orders": 1}  # a scalar, not a list
+        _write_manifest(tmp_path, orders=(1,), fields=fields)
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        assert "h_min" in _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        assert "unusable per-field orders" in caplog.text
+
+    def test_narrowed_schedule_regenerates_a_stale_overview(self, tmp_path):
+        """Narrowing a field's schedule is a content change, not a 'current' skip."""
+        _write_manifest(tmp_path, orders=(1,))
+        _make_leaf(tmp_path, "-311", {0: [1.0, 2.0]})
+        refs = [(morton_word("-311"), None)]
+        run_sweep(str(tmp_path), refs, families=("overview",))
+        assert "h_tdigest" in _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        fields = dict(FIELDS_DECL)
+        fields["h_tdigest"] = {**FIELDS_DECL["h_tdigest"], "orders": []}
+        _write_manifest(tmp_path, orders=(1,), fields=fields)
+        result = run_sweep(str(tmp_path), refs, families=("overview",))
+        assert result["families"]["overview"]["written"] == 1
+        assert "h_tdigest" not in _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+
     def test_no_declaration_is_a_noop(self, tmp_path):
         manifest = _write_manifest(tmp_path, orders=(1,))
         manifest["pyramid"] = {"orders": [], "aggregation": {}}  # the legacy block

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -571,6 +571,28 @@ class TestPyramidBlock:
         # The intersection is never silent: it names the field and what it dropped.
         assert "'h_min'" in caplog.text and "[5]" in caplog.text
 
+    def test_excluded_fields_warn_like_the_none_class_ones(self, caplog):
+        """An empty schedule is the same outcome as a ``none`` class — warn alike."""
+        from zagg.sweep_overview import build_pyramid_block
+
+        cfg = self._cfg(pyramid={"fields": {"h_min": False}})
+        overview = build_pyramid_block(cfg, shard_order=6)["overview"]
+        assert overview["fields"]["h_min"]["orders"] == []
+        assert "excluded from every declared order" in caplog.text and "h_min" in caplog.text
+        # Some composable fields remain, so this is NOT the whole-pyramid case.
+        assert "EVERY composable field" not in caplog.text
+
+    def test_excluding_every_composable_field_warns(self, caplog):
+        """`fields: {a: false, ...}` over the whole set declares a pyramid that writes nothing."""
+        from zagg.sweep_overview import build_pyramid_block
+
+        cfg = self._cfg(pyramid={"fields": {"count": False, "h_min": False, "h_max": False}})
+        overview = build_pyramid_block(cfg, shard_order=6)["overview"]
+        assert overview["orders"] == [4, 2, 0]  # declared...
+        assert all(overview["fields"][n]["orders"] == [] for n in ("count", "h_min", "h_max"))
+        assert "EVERY composable field" in caplog.text
+        assert "output.pyramid: false" in caplog.text  # the spelling that means this
+
     def test_unusable_field_schedule_inherits_the_block(self, caplog):
         """An unusable ``orders`` must not narrow: a str parses, so gate on shape."""
         from zagg.sweep_overview import build_pyramid_block

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -468,6 +468,58 @@ class TestPyramidBlock:
 
         validate_config(self._cfg(store_layout="hive"))  # absent knob is legal
 
+    def test_validate_field_schedules(self):
+        """The issue #352 per-field grammar: narrow, exclude, and the refusals."""
+        from zagg.config import validate_config
+
+        # A narrowing schedule and an exclusion, both against the default [4, 2, 0].
+        validate_config(
+            self._cfg(store_layout="hive", pyramid={"fields": {"h_min": {"orders": [4]}}})
+        )
+        validate_config(self._cfg(store_layout="hive", pyramid={"fields": {"h_min": False}}))
+        # An explicit block schedule is what a per-field schedule is checked against.
+        validate_config(
+            self._cfg(
+                store_layout="hive",
+                pyramid={"orders": [5, 3], "fields": {"count": {"orders": [5]}}},
+            )
+        )
+        with pytest.raises(ValueError, match="fields names unknown field"):
+            validate_config(self._cfg(store_layout="hive", pyramid={"fields": {"nope": False}}))
+        with pytest.raises(ValueError, match="must be false or a mapping"):
+            validate_config(self._cfg(store_layout="hive", pyramid={"fields": {"h_min": True}}))
+        with pytest.raises(ValueError, match="fields.h_min has unknown keys"):
+            validate_config(
+                self._cfg(store_layout="hive", pyramid={"fields": {"h_min": {"spacing": 2}}})
+            )
+        with pytest.raises(ValueError, match="orders must be a list of ints"):
+            validate_config(
+                self._cfg(store_layout="hive", pyramid={"fields": {"h_min": {"orders": 4}}})
+            )
+        with pytest.raises(ValueError, match=r"outside the pyramid schedule \[4, 2, 0\]"):
+            validate_config(
+                self._cfg(store_layout="hive", pyramid={"fields": {"h_min": {"orders": [3]}}})
+            )
+        # A per-field order may not widen an explicit block schedule either.
+        with pytest.raises(ValueError, match=r"outside the pyramid schedule \[5, 3\]"):
+            validate_config(
+                self._cfg(
+                    store_layout="hive",
+                    pyramid={"orders": [5, 3], "fields": {"count": {"orders": [4]}}},
+                )
+            )
+        with pytest.raises(ValueError, match="fields must be a mapping"):
+            validate_config(self._cfg(store_layout="hive", pyramid={"fields": ["h_min"]}))
+
+    def test_pyramid_orders_derivation(self):
+        """The shared schedule helper config validation and the block agree on."""
+        from zagg.sweep_overview import pyramid_orders
+
+        assert pyramid_orders({}, 6) == [4, 2, 0]
+        assert pyramid_orders({"spacing": 3}, 9) == [6, 3, 0]
+        assert pyramid_orders({"orders": [1, 5, 5]}, 6) == [5, 1]  # deduped, descending
+        assert pyramid_orders({"orders": [3], "spacing": 1}, 6) == [3]  # explicit wins
+
 
 class TestOverviewWriter:
     def test_folds_leaves_at_every_declared_order(self, tmp_path):

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -511,6 +511,44 @@ class TestPyramidBlock:
         with pytest.raises(ValueError, match="fields must be a mapping"):
             validate_config(self._cfg(store_layout="hive", pyramid={"fields": ["h_min"]}))
 
+    def test_field_schedule_recorded_in_block(self):
+        """The per-field schedule is manifest-recorded — D24 option A absence."""
+        from zagg.sweep_overview import build_pyramid_block
+
+        cfg = self._cfg(pyramid={"fields": {"h_min": {"orders": [4, 0]}, "h_max": False}})
+        overview = build_pyramid_block(cfg, shard_order=6)["overview"]
+        assert overview["orders"] == [4, 2, 0]
+        # Narrowed: descending, and only the block's own orders.
+        assert overview["fields"]["h_min"]["orders"] == [4, 0]
+        assert overview["fields"]["h_min"]["method"] == "min"  # fold law still declared
+        # Excluded: the empty schedule, not a dropped entry — the reader still
+        # learns the class and the fold it would have had.
+        assert overview["fields"]["h_max"]["orders"] == []
+        assert overview["fields"]["h_max"]["class"] == "exact"
+        # Unnamed fields carry NO orders key: they inherit the block schedule.
+        assert "orders" not in overview["fields"]["count"]
+        # A none-class entry stays class-only (spec §4.5) even when named.
+        assert overview["fields"]["h_mean"] == {"class": "none"}
+        json.dumps(overview)
+
+    def test_absent_field_knob_declares_identically(self):
+        """Absent ``fields:`` must be byte-identical to pre-#352 declarations."""
+        from zagg.sweep_overview import build_pyramid_block
+
+        block = build_pyramid_block(self._cfg(), shard_order=6)
+        assert all("orders" not in m for m in block["overview"]["fields"].values())
+        assert block == build_pyramid_block(self._cfg(pyramid={}), shard_order=6)
+
+    def test_field_schedule_never_widens_the_block(self):
+        """The unvalidated path (declare_pyramid) intersects, never widens."""
+        from zagg.sweep_overview import build_pyramid_block
+
+        # shard_order 4 => schedule [2, 0]; the knob asks for 5 as well.
+        cfg = self._cfg(pyramid={"fields": {"h_min": {"orders": [5, 2]}}})
+        overview = build_pyramid_block(cfg, shard_order=4)["overview"]
+        assert overview["orders"] == [2, 0]
+        assert overview["fields"]["h_min"]["orders"] == [2]
+
     def test_pyramid_orders_derivation(self):
         """The shared schedule helper config validation and the block agree on."""
         from zagg.sweep_overview import pyramid_orders

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -511,6 +511,20 @@ class TestPyramidBlock:
         with pytest.raises(ValueError, match="fields must be a mapping"):
             validate_config(self._cfg(store_layout="hive", pyramid={"fields": ["h_min"]}))
 
+    def test_validate_refuses_a_schedule_on_a_none_class_field(self):
+        """Scheduling a D24 ``none`` field would silently do nothing — so it refuses."""
+        from zagg.config import validate_config
+
+        with pytest.raises(ValueError, match="non-composable field"):
+            validate_config(
+                self._cfg(store_layout="hive", pyramid={"fields": {"h_mean": {"orders": [4]}}})
+            )
+        # Stating the exclusion the block already records stays legal.
+        validate_config(self._cfg(store_layout="hive", pyramid={"fields": {"h_mean": False}}))
+        validate_config(
+            self._cfg(store_layout="hive", pyramid={"fields": {"h_mean": {"orders": []}}})
+        )
+
     def test_field_schedule_recorded_in_block(self):
         """The per-field schedule is manifest-recorded — D24 option A absence."""
         from zagg.sweep_overview import build_pyramid_block

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -496,6 +496,12 @@ class TestPyramidBlock:
             validate_config(
                 self._cfg(store_layout="hive", pyramid={"fields": {"h_min": {"orders": 4}}})
             )
+        # A string is iterable and its digits parse, so it must be refused on
+        # SHAPE — otherwise "40" would quietly mean the orders [4, 0].
+        with pytest.raises(ValueError, match="orders must be a list of ints"):
+            validate_config(
+                self._cfg(store_layout="hive", pyramid={"fields": {"h_min": {"orders": "40"}}})
+            )
         with pytest.raises(ValueError, match=r"outside the pyramid schedule \[4, 2, 0\]"):
             validate_config(
                 self._cfg(store_layout="hive", pyramid={"fields": {"h_min": {"orders": [3]}}})
@@ -564,6 +570,16 @@ class TestPyramidBlock:
         assert overview["fields"]["h_min"]["orders"] == [2]
         # The intersection is never silent: it names the field and what it dropped.
         assert "'h_min'" in caplog.text and "[5]" in caplog.text
+
+    def test_unusable_field_schedule_inherits_the_block(self, caplog):
+        """An unusable ``orders`` must not narrow: a str parses, so gate on shape."""
+        from zagg.sweep_overview import build_pyramid_block
+
+        cfg = self._cfg(pyramid={"fields": {"h_min": {"orders": "40"}}})
+        overview = build_pyramid_block(cfg, shard_order=6)["overview"]
+        # NOT {4, 0} from the string's digits — the whole block schedule.
+        assert overview["fields"]["h_min"]["orders"] == [4, 2, 0]
+        assert "unusable per-field orders" in caplog.text and "'h_min'" in caplog.text
 
     def test_pyramid_orders_derivation(self):
         """The shared schedule helper config validation and the block agree on."""
@@ -690,6 +706,19 @@ class TestOverviewWriter:
         run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
         assert "h_min" in _overview_group(tmp_path, "-3/1", "all.zarr", 3)
         assert "unusable per-field orders" in caplog.text
+        assert "'h_min'" in caplog.text  # the warning names WHICH field is misdeclared
+
+    def test_string_field_schedule_folds_everywhere(self, tmp_path, caplog):
+        """A ``str`` orders iterates its digits — it must be refused on shape."""
+        fields = dict(FIELDS_DECL)
+        # "3" would parse to {3}: order 3 is not swept here, so a digit-wise
+        # reading would drop h_min from the only order that IS swept.
+        fields["h_min"] = {**FIELDS_DECL["h_min"], "orders": "3"}
+        _write_manifest(tmp_path, orders=(1,), fields=fields)
+        _make_leaf(tmp_path, "-311", {0: [1.0]})
+        run_sweep(str(tmp_path), [(morton_word("-311"), None)], families=("overview",))
+        assert "h_min" in _overview_group(tmp_path, "-3/1", "all.zarr", 3)
+        assert "unusable per-field orders" in caplog.text and "'h_min'" in caplog.text
 
     def test_narrowed_schedule_regenerates_a_stale_overview(self, tmp_path):
         """Narrowing a field's schedule is a content change, not a 'current' skip."""

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -553,7 +553,7 @@ class TestPyramidBlock:
         assert all("orders" not in m for m in block["overview"]["fields"].values())
         assert block == build_pyramid_block(self._cfg(pyramid={}), shard_order=6)
 
-    def test_field_schedule_never_widens_the_block(self):
+    def test_field_schedule_never_widens_the_block(self, caplog):
         """The unvalidated path (declare_pyramid) intersects, never widens."""
         from zagg.sweep_overview import build_pyramid_block
 
@@ -562,6 +562,8 @@ class TestPyramidBlock:
         overview = build_pyramid_block(cfg, shard_order=4)["overview"]
         assert overview["orders"] == [2, 0]
         assert overview["fields"]["h_min"]["orders"] == [2]
+        # The intersection is never silent: it names the field and what it dropped.
+        assert "'h_min'" in caplog.text and "[5]" in caplog.text
 
     def test_pyramid_orders_derivation(self):
         """The shared schedule helper config validation and the block agree on."""
@@ -1296,6 +1298,24 @@ class TestDeclarePyramid:
         again = declare_pyramid(str(tmp_path), cfg)
         assert again["previous"] == "identical" and again["updated"] is False
         assert puts == []
+
+    def test_retrofit_warns_when_a_field_schedule_empties(self, tmp_path, caplog):
+        """A schedule valid at the config's parent_order can empty at the store's."""
+        self._pre_declaration_store(tmp_path)
+        cfg = _leaf_cfg()
+        # Validated against a parent_order-3 config the derived schedule is [1];
+        # this store's shard_order is 2, so the block schedule is [0] and the
+        # requested order falls outside it entirely.
+        cfg.output["pyramid"] = {"spacing": 2, "fields": {"h_tdigest": {"orders": [1]}}}
+        summary = declare_pyramid(str(tmp_path), cfg)
+        assert summary["orders"] == [0]
+        block = read_manifest(str(tmp_path))["pyramid"]["overview"]
+        assert block["fields"]["h_tdigest"]["orders"] == []
+        # The summary reports the class only, so the warning is the ONLY signal
+        # that the field the user asked for is now in no overview at all.
+        assert summary["fields"]["h_tdigest"] == "approximate"
+        assert "'h_tdigest'" in caplog.text and "[1]" in caplog.text
+        assert "NOTHING remains" in caplog.text
 
     def test_second_call_is_idempotent_no_put(self, tmp_path, monkeypatch):
         self._pre_declaration_store(tmp_path)

--- a/tests/test_sweep_overview.py
+++ b/tests/test_sweep_overview.py
@@ -1271,6 +1271,32 @@ class TestDeclarePyramid:
         assert after["pyramid"] == build_pyramid_block(_leaf_cfg(), SHARD_ORDER)
         assert _frozen_matches(after, before)  # only the pyramid key moved
 
+    def test_retrofit_records_a_per_field_schedule(self, tmp_path, monkeypatch):
+        """The issue #352 knob through the issue #358 retrofit, round-trip included."""
+        self._pre_declaration_store(tmp_path)
+        cfg = _leaf_cfg()
+        cfg.output["pyramid"] = {
+            "orders": [1, 0],
+            "fields": {"h_tdigest": {"orders": [1]}, "h_min": False},
+        }
+        summary = declare_pyramid(str(tmp_path), cfg)
+        assert summary["updated"] is True and summary["orders"] == [1, 0]
+        # An excluded field is still validated against the leaf: it exists at
+        # native resolution, so its typing stays declared and checkable.
+        assert summary["validated"].startswith("leaf ")
+        block = read_manifest(str(tmp_path))["pyramid"]["overview"]
+        assert block["fields"]["h_tdigest"]["orders"] == [1]
+        assert block["fields"]["h_min"]["orders"] == []
+        assert "orders" not in block["fields"]["count"]  # unnamed: block schedule
+        # The schedules survive the canonical-JSON round-trip the idempotency
+        # compare runs on, so a knob-using config does not re-PUT every call.
+        puts = []
+        real_put = obstore.put
+        monkeypatch.setattr(obstore, "put", lambda *a, **k: (puts.append(a), real_put(*a, **k))[1])
+        again = declare_pyramid(str(tmp_path), cfg)
+        assert again["previous"] == "identical" and again["updated"] is False
+        assert puts == []
+
     def test_second_call_is_idempotent_no_put(self, tmp_path, monkeypatch):
         self._pre_declaration_store(tmp_path)
         declare_pyramid(str(tmp_path), _leaf_cfg())

--- a/tools/generate_spec_fixtures.py
+++ b/tools/generate_spec_fixtures.py
@@ -15,7 +15,7 @@ Run from a zagg checkout::
 
     uv run python tools/generate_spec_fixtures.py
 
-Geometry (both fixtures): parent order 4 / chunk order 5 / cell order 6 —
+Geometry (both leaf fixtures): parent order 4 / chunk order 5 / cell order 6 —
 16 cells per shard, K = 4 inner chunks of 4 cells, `sharded` (the D17 hive
 default), deliberately tiny. Chunk ordinal 2 is left EMPTY to pin the
 shard-index absence sentinel (§1.5); populated chunks carry empty cells to
@@ -29,6 +29,11 @@ conformance tests assert decoded values, never object bytes.
   (the `atl03_tdigest_strata_healpix.yaml` field shapes), including a
   single-photon cell that packs the §3.1 golden word `0xFF000000FF0000FF`
   and a noise-only cell whose signal payload is the empty ``(0, 2)`` array.
+- ``pyramid/`` — MANIFEST ONLY: the §4.5 overview declaration, including the
+  per-field schedules of issue #352 (a narrowed `orders`, an `orders: []`
+  exclusion, an inheriting field, and a `class: "none"` one). The block is a
+  template-time manifest artifact — it exists before any leaf and is decodable
+  from `morton_hive.json` alone — so this fixture writes no store beneath it.
 """
 
 from __future__ import annotations
@@ -52,6 +57,23 @@ DELTA = 16
 #: The §3.1 golden-word photon: per-surface confidences at threshold 2 pack
 #: lanes [255, 0, 0, 255, 0, 0, 0, 255] = 0xFF000000FF0000FF.
 GOLDEN_CONF = (4, -1, 0, 3, 1)
+#: The ``pyramid/`` fixture's declaration (§4.5): an explicit block schedule
+#: plus the issue #352 per-field grammar — one narrowed field, one excluded
+#: outright. ``count`` is deliberately left unnamed (it inherits the block
+#: schedule) and ``composition`` is a ``none``-class field, so one manifest
+#: carries all four readings a decoder must tell apart.
+PYRAMID_KNOB = {
+    "orders": [3, 2, 1],
+    "fields": {"h_min": {"orders": [3, 1]}, "h_tdigest": {"orders": []}},
+}
+#: Fields the ``pyramid/`` fixture declares beyond the ``minimal`` pair, so one
+#: manifest carries every §4.5 reading: an inheriting field (``count``), a
+#: narrowed one (``h_min``), an excluded one (``h_tdigest``), and a
+#: ``class: "none"`` one (``h_mean`` — no exact merge law, D24).
+PYRAMID_EXTRA_VARIABLES = {
+    "h_min": {"function": "nanmin", "source": "h", "dtype": "float32", "fill_value": 0},
+    "h_mean": {"function": "mean", "source": "h", "dtype": "float32", "fill_value": 0},
+}
 
 
 def _cell_photons(rng, n, *, signal_frac=0.6):
@@ -81,7 +103,7 @@ def _point_words(grid, cell_word, n, rng):
     return morton_words(MortonIndexArray.from_latlon(lats, lons, points=True))
 
 
-def _config(kitchen_sink: bool):
+def _config(kitchen_sink: bool, pyramid: dict | None = None):
     from zagg.config import PipelineConfig
 
     variables: dict = {
@@ -134,22 +156,25 @@ def _config(kitchen_sink: bool):
             "fill_value": 0,
             "params": {"delta": DELTA},
         }
+    output: dict = {
+        "store_layout": "hive",
+        "grid": {
+            "type": "healpix",
+            "parent_order": 4,
+            "child_order": 6,
+            "chunk_inner": 5,
+            "sharded": True,
+        },
+    }
+    if pyramid is not None:
+        output["pyramid"] = pyramid
     return PipelineConfig(
         data_source={"groups": ["g"]},
         aggregation={
             "coordinates": {"morton": {"dtype": "uint64", "fill_value": 0}},
             "variables": variables,
         },
-        output={
-            "store_layout": "hive",
-            "grid": {
-                "type": "healpix",
-                "parent_order": 4,
-                "child_order": 6,
-                "chunk_inner": 5,
-                "sharded": True,
-            },
-        },
+        output=output,
     )
 
 
@@ -366,6 +391,69 @@ def build(out: Path, kitchen_sink: bool) -> None:
     print(f"{out.name}: leaf {leaf_rel}, {len(expected_cells)} populated cells")
 
 
+def build_pyramid(out: Path) -> None:
+    """The manifest-only fixture: the §4.5 overview declaration grammar.
+
+    Written by the production path (``hive.build_manifest`` ->
+    ``sweep_overview.build_pyramid_block``), like the leaf fixtures. It carries
+    no store beneath it on purpose: the pyramid block is a TEMPLATE-time
+    manifest artifact — it exists before a single leaf is written — and
+    ``fields[….].orders`` is decodable from ``morton_hive.json`` alone, so a
+    third leaf would pin nothing the other two do not already pin.
+
+    The expectations are derived HERE from :data:`PYRAMID_KNOB` by the §4.5
+    rules (absent ``orders`` inherits the block schedule; a present one is
+    exact; a ``none`` class is absent everywhere and never carries the key),
+    never read back out of the written block — the same "expected values come
+    from the generator's INPUTS" discipline the cell values follow.
+    """
+    from zagg import hive
+    from zagg.grids import HealpixGrid
+
+    cfg = _config(False, pyramid=PYRAMID_KNOB)
+    cfg.aggregation["variables"].update(PYRAMID_EXTRA_VARIABLES)
+    grid = HealpixGrid(4, 6, layout="fullsphere", config=cfg, chunk_inner=5, sharded=True)
+    if out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True)
+    hive.ensure_manifest(
+        str(out),
+        hive.build_manifest(grid, dataset={"short_name": "SPEC_FIXTURE", "version": "1"}),
+    )
+    block_orders = list(PYRAMID_KNOB["orders"])
+    # class per field is a property of the declared reducer (D24), asserted
+    # here by construction: len/nanmin fold exactly, a t-digest approximately,
+    # a mean not at all.
+    classes = {
+        "count": "exact",
+        "h_tdigest": "approximate",
+        "h_min": "exact",
+        "h_mean": "none",
+    }
+    fields = {}
+    for name, cls in classes.items():
+        decl = PYRAMID_KNOB["fields"].get(name)
+        declares = cls != "none" and decl is not None
+        wanted = set(decl["orders"]) if declares else set(block_orders)
+        fields[name] = {
+            "class": cls,
+            # Whether the manifest entry carries its own ``orders`` key...
+            "declares_orders": declares,
+            # ...and the orders at which an overview exists either way.
+            "orders": [] if cls == "none" else [k for k in block_orders if k in wanted],
+        }
+    expected = {
+        "shard_order": 4,
+        "declared": PYRAMID_KNOB,
+        "orders": block_orders,
+        "spacing": 2,  # the default step, recorded even when orders are explicit
+        "all_time": False,
+        "fields": fields,
+    }
+    (out.parent / f"{out.name}.expected.json").write_text(json.dumps(expected, indent=1) + "\n")
+    print(f"{out.name}: manifest-only, orders {block_orders}, {len(fields)} declared fields")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -376,6 +464,7 @@ def main() -> None:
     args = parser.parse_args()
     build(args.out / "minimal", kitchen_sink=False)
     build(args.out / "kitchen_sink", kitchen_sink=True)
+    build_pyramid(args.out / "pyramid")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #352

## What this does

Adds the additive `output.pyramid.fields` grammar — a per-field overview schedule, so which fields ride the pyramid is no longer class-driven only. The cost asymmetry issue #352 names is real: `fold_dense` is a `reshape(-1, factor)` reduce, while the approximate fold is a full ragged decode plus `merge_tdigests_kway` per ancestor node (`fold_digests`). Before this change the only levers were all-or-nothing (`output.pyramid: false`) or coarsening the whole schedule, which penalizes the near-free dense folds too.

```yaml
output:
  pyramid:
    orders: [7, 5, 3, 1]
    fields:                       # optional; absent = exactly today's behavior
      h_tdigest: {orders: [7, 5]} # the costly fold, only near the top
      photon_ids: false           # never in an overview
```

### Approach

**The `fields:` mapping, not an `exclude:` list.** The issue left this open ("or an `exclude:` list, if per-field schedules prove overkill — decide at plan time"). The code makes the answer concrete:

1. The issue's own motivating example — "`count` at every order but `h_tdigest` only every 4" — is **inexpressible** with an exclude list. An exclude list only covers the degenerate all-orders case.
2. The manifest already expresses exclusion *field-wise*: the D24 `none`-class auto-exclusion writes `{"class": "none"}` into `pyramid.overview.fields`, and the spec (§4.5) calls that the recorded absence. A per-field `orders` key generalizes that same shape uniformly rather than adding a second, differently-shaped absence record next to it.
3. `exclude: [f]` is a strict subset of `fields: {f: false}`, and the implementation cost of the difference is one intersection helper (`_field_orders`) plus one predicate (`_scheduled`) — the sweep-side filter is the same one line either way.

See lettered question (a) below anyway, since the issue flagged the fork explicitly.

**Where the logic lives.**

- `zagg.sweep_overview.pyramid_orders(knob, shard_order)` — extracted the block-schedule derivation (explicit `orders` win over `spacing`, default `DEFAULT_SPACING`) so config validation checks a per-field schedule against *the very list the sweep walks*, not a second derivation of it. Pure refactor of code that was inline in `build_pyramid_block`.
- `zagg.config._validate_pyramid_fields` — grammar + refusals. A per-field order outside the block schedule **refuses** rather than widening: the sweep only walks the block's orders, so a widening entry would silently do nothing. Scheduling a `none`-class field refuses for the same reason, while `false`/`[]` over one stays legal. `orders` is shape-checked (a `list` of `int`), so a string never sneaks through as a digit-wise schedule.
- `build_pyramid_block` — records the narrowed schedule as the field entry's own `orders` (`[]` for an outright exclusion). Fields the knob does not name carry **no** `orders` key, so a config without `fields:` declares byte-identically to pre-#352 zagg. A `none` entry stays class-only per spec §4.5 — it is absent everywhere already. An empty per-field schedule warns at template time on the same footing as the D24 `none` exclusion, and excluding *every* composable field says so loudly: that declares a pyramid the sweep would never write, which `output.pyramid: false` is the spelling for.
- `sweep_overviews` — the field set is now computed **per order** inside the `for k in orders` loop and passed down to `_roll_node`/`_write_overview`, so a narrowed-out field is absent from that order's zarr *and* from its `zagg_overview.fields` attrs map (spec §4.3: that map is the materialized subset). An order every field narrows out is skipped whole, and does not enter `materialized`.

`_content_hash` already digests `sorted(slabs)`, so changing a field's schedule changes the hash and the affected overviews regenerate rather than reading as `current` — covered by a test.

**The unvalidated caller.** `declare_pyramid` (the issue #358 retrofit) re-derives the block at the *manifest's* `shard_order`, which need not equal the config's `parent_order`, and never runs `validate_config`. Both helpers therefore refuse to be silent there: `_field_orders` warns — naming the field and the orders it dropped, loudest when nothing remains and the field leaves the pyramid entirely — and `_order_set` gates a declaration read back off a manifest on shape before iterating it, falling back to the full block schedule rather than narrowing to a schedule nobody declared.

### Phases

- [x] **Phase 1** — config grammar + validation (`output.pyramid.fields`), plus the shared `pyramid_orders` schedule helper (`10b5593`)
- [x] **Phase 2** — `build_pyramid_block` records the per-field schedule in the manifest block (`849ac1e`)
- [x] **Phase 3** — `sweep_overviews` per-order field filtering (`e50ae13`)
- [x] **Phase 4** — normative `docs/specification.md` §4.3/§4.4/§4.5 + `docs/hive_layout.md` narrative (`673ce1c`)
- [x] **Self-review round 1, folded** — `c4aa32b` (refuse a schedule on a `none`-class field), `e066a9a` (spec: the declaration is authoritative over stale overview objects), `c65b775` (docstring named the wrong validator), `aa6fc77` (retrofit-path test coverage)
- [x] **Self-review round 2, folded** — `59aafc2` (warn when a per-field schedule empties on the retrofit path), `f4e534b` (gate `orders` on shape — a `str` is iterable and its digits parse), `99b8b6d` (warn when a per-field schedule excludes the whole pyramid), `81a8540` (a pyramid-declaring §7 conformance fixture)

### Spec impact (CLAUDE.md §4)

This **is** an attrs/manifest grammar change, so `docs/specification.md` and the §7 conformance fixtures are updated in the same PR:

- §4.3 — a narrowed-out field must also be absent from `zagg_overview.fields`, which is why that map may differ between two overviews of the same product;
- §4.4 — inclusion is gated by class **and** by the field's own schedule;
- §4.5 — the new optional `fields[….].orders` key, its absent/present semantics, the `[]`-vs-`"class": "none"` distinction (cannot fold vs. not scheduled to), the reader rule that this is recorded absence and never an incomplete sweep, and that the declaration is authoritative over overview objects left behind by a wider previous schedule;
- §7 — a **new `pyramid/` fixture** (`tools/generate_spec_fixtures.py` → `tests/data/spec/pyramid/`), so the new grammar ships with something to decode against rather than prose alone. It is manifest-only by design — the pyramid block is a template-time artifact, decodable from `morton_hive.json` before any leaf exists — and one committed block carries all four readings a decoder must tell apart: a field that inherits the block schedule (`count`, no `orders` key), one narrowed to a subset (`h_min`, `[3, 1]` of `[3, 2, 1]`), one excluded outright but still declaring its fold law (`h_tdigest`, `orders: []`), and a non-composable `"class": "none"` one (`h_mean`).

The `spec` marker stays `zagg-pyramid/1`: the key is optional and its absence is the pre-existing behavior, so no existing reader is invalidated. See question (c).

### How it was tested

`uv sync --extra test`, then `uv run pytest -v` — **3219 passed, 37 skipped**. `uv run ruff check src tests` and `uv run ruff format --check src tests` are clean apart from the two pre-existing failures in question (d).

New tests in `tests/test_sweep_overview.py`:

- `TestPyramidBlock` — `test_validate_field_schedules` (narrow / exclude / explicit-block-schedule + the refusals, including a string `orders`), `test_validate_refuses_a_schedule_on_a_none_class_field`, `test_field_schedule_recorded_in_block`, `test_absent_field_knob_declares_identically` (the non-breaking guarantee), `test_field_schedule_never_widens_the_block` (and that the drop is warned, naming the field), `test_excluded_fields_warn_like_the_none_class_ones`, `test_excluding_every_composable_field_warns`, `test_unusable_field_schedule_inherits_the_block`, `test_pyramid_orders_derivation`.
- `TestOverviewWriter` — `test_per_field_schedule_drops_a_field_at_one_order` (real leaves swept at two orders: the t-digest lands at order 1, is absent from the order-0 zarr and its attrs, and the exact folds still land), `test_field_excluded_everywhere`, `test_order_with_no_scheduled_field_is_skipped` (nothing written, nothing recorded `materialized`), `test_unparseable_field_schedule_folds_everywhere`, `test_string_field_schedule_folds_everywhere`, `test_narrowed_schedule_regenerates_a_stale_overview`.
- `TestDeclarePyramid` — `test_retrofit_records_a_per_field_schedule` (the knob through the issue #358 retrofit, JSON round-trip and no-re-PUT idempotency included), `test_retrofit_warns_when_a_field_schedule_empties` (a schedule valid at the config's `parent_order` that intersects to nothing at the store's `shard_order`).

And in `tests/test_spec_conformance.py`, a new `TestPyramidDeclaration` that decodes the `pyramid/` fixture's committed manifest by §4.5 text alone: block shape and `zagg-pyramid/1` marker, the four per-field readings against `pyramid.expected.json`, subset-and-descending-order, an excluded field still carrying its fold law, and a `none` entry staying class-only.

## Questions for review

**(a) The grammar fork the issue left open.** Implemented as `fields: {name: {orders: [...]} | false}` for the three reasons above. The alternative shape is `exclude: [name, ...]`, which is smaller but cannot express the issue's own motivating case. Pick one:

- **(a1)** keep `fields:` as implemented (recommended);
- **(a2)** ship `exclude:` only — I drop the `orders` half and the manifest records `"orders": []` for excluded fields only;
- **(a3)** ship both, with `exclude:` as sugar over `fields: {name: false}`.

**(b) `src/zagg/sweep_overview.py` is over the ~1,200-line limit.** It was **1,227 lines on `main` before this PR** and is **1,361** after (+134: the schedule helpers, the shape gate, the per-order filter, the template-time warnings, and their docstrings). CLAUDE.md §4 pre-approves overages *below* 1,200, so the file was already past the bar independently of this change. Per the routine's instruction I am **raising this rather than splitting** — splitting a module is a scope change and not mine to take.

**Correction.** An earlier version of this question said a split of this file "is already proposed under PR #349". That was **factually wrong**, and the option built on it was too. PR #349 splits five *other* modules — its own before/after table lists `hive.py`, `processing/raster.py`, `sweep.py`, `config.py`, `runner.py` — and its phase-3 rationale cites this file as the convention it is imitating, not as a target: "Sibling modules also match the tree's existing convention: `zagg/sweep_overview.py` is already the split-out overview family." So there is **no pending split to defer to**: landing as-is parks nothing behind another PR, it leaves `sweep_overview.py` at 1,361 lines with nothing queued to bring it down.

Two further facts for the call:

- the additions (`pyramid_orders`, `_field_orders`, `_order_set`, `_scheduled`) are pure predicates over a declaration dict — no store, no zarr, no manifest I/O — so they would move out cleanly rather than splitting the file arbitrarily;
- this PR introduces the **first runtime import from `zagg.config` into `zagg.sweep_overview`** (`_validate_pyramid_fields` calls `pyramid_orders` so validation and the sweep share one derivation; on `main`, `config.py` names `zagg.sweep_overview` only in a docstring). A neutral `zagg/pyramid.py` owning that helper would give both a common dependency instead of an inverted one. Note PR #349 phase 4 moves `_validate_pyramid` into `config/validate_output.py`, so this import lands there on merge — relevant to ordering the two.

Options: **(b1)** land as-is and raise the file size separately; **(b2)** I move `pyramid_orders`/`_field_orders`/`_order_set`/`_scheduled` (and possibly `build_pyramid_block`) out to a new `src/zagg/pyramid.py` in this PR; **(b3)** something else.

**(c) Should the per-field `orders` key bump `PYRAMID_SPEC` to `zagg-pyramid/2`?** I left it at `/1`: the key is optional, absent by default, and a `/1` reader that ignores it still gets a correct *superset* answer for "which fields might be here" — but it would over-promise on a narrowed field, and §4.5's conformance rule is strict-check-and-fail-loudly on an unknown revision. **(c1)** stay `/1` (recommended — bumping would make every existing reader refuse every manifest, including those with no per-field schedules); **(c2)** bump to `/2`.

**(d) Pre-existing failures I did not touch** (CLAUDE.md §4: flag, don't fix):

- `uv run ruff check src tests` fails on `main` with `N818 Exception name UnknownCapability should be named with an Error suffix` (`src/zagg/registry.py:64`). The PR lint bot's ruleset is `--select=E,F,W,I` so CI does not see it, but the pyproject `select` includes `N`, so the plain local command is red on `main`.
- `uv run ruff format --check src tests` flags `tests/data/benchmark/README.md` on `main` (a python code fence).
- Relatedly: the two **existing** spec fixtures (`tests/data/spec/{minimal,kitchen_sink}/morton_hive.json`) carry a **pre-#201** pyramid block, `{"orders": [], "aggregation": {}}`, not the `zagg-pyramid/1` block `build_manifest` writes today. That staleness is independent of this PR — this PR does not change what the generator emits for them, since neither fixture config declares `output.pyramid` — and the new `pyramid/` fixture above is what closes the §4 obligation for the new grammar. Refreshing the two stale ones is left as its own change; say the word if you want it here instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5GA2bvsvSXYMEx4yjiC5t)_