### PR TITLE
spill: cross-block merge for located / strata / composition fields (issue #370)

### DIFF
--- a/docs/signal_strata.md
+++ b/docs/signal_strata.md
@@ -66,12 +66,16 @@ part of the store contract, not a zagg implementation detail).
 
 ## Operational caveat
 
-Strata and composition run on the **pooled path and the single-block spill
-regime** (exact, via the pooled replay). The streaming merge surface rejects
-them: its fold rebuilds digests from the raw source column and would silently
-ignore the `where` mask, and the composition fold is not wired into the
-streaming state. Heavy multi-block shards need the fold-law follow-up
-(issue #321).
+Strata and composition run on the **pooled path and the spill path** — exact
+via the pooled replay in the single-block regime, and folding across block
+closes on overflow shards (issue #370): per-block stratum digests merge like
+any digest (row selection precedes the build), and the composition words
+collapse in one k-way weighted lane mean (presence exact via the floor,
+counts within the documented quantization bound — the folded word is not
+byte-stable against the single-block result). The streaming **merge** surface
+still rejects them: its per-flush fold rebuilds digests from the raw source
+column (no `where` state) and would re-quantize composition lanes on every
+flush.
 
 ## What the mask channel gains
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -276,6 +276,11 @@ with the payload:
   (a fresh point word folded with an earlier merge's coarser area word)
   compose under the same rule.
 
+A writer-side spill-block close (`aggregation.streaming.mode: spill` crossing
+its block threshold, issue #370) is an additional merge source under the same
+rule: an overflow shard's centroids may carry coarser common-ancestor words,
+with the stored layout and byte-level contract above unchanged.
+
 Word semantics (bit layout, kind marking, coarsening) are mortie's
 specification §1/§4, not restated here.
 

--- a/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
+++ b/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
@@ -34,7 +34,8 @@
 # Strata + composition run pooled, or under ``mode: spill`` including the
 # multi-block regime (issue #370): a block close folds per-block stratum
 # digests (row selection precedes the build) and composition words
-# (``merge_composition`` — presence exact, counts within O(n/510) per fold).
+# (``merge_composition_kway`` — presence exact, counts within one
+# quantization however many blocks close).
 # ``mode: merge`` still rejects them (its per-flush fold would degrade
 # locations continuously and has no ``where`` state).
 # Grid geometry matches atl03_tdigest_healpix.yaml (o11 shard / o13 inner

--- a/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
+++ b/src/zagg/configs/atl03_tdigest_strata_healpix.yaml
@@ -31,9 +31,12 @@
 # order-29 morton word (exact photon position at weight 1) in the row-aligned
 # ``{field}_locations`` sibling arrays.
 #
-# Strata + composition are pooled / single-block-spill only for now: the
-# streaming merge surface rejects them (the fold would ignore the ``where``
-# mask), so heavy multi-block shards need the fold-law follow-up (issue #321).
+# Strata + composition run pooled, or under ``mode: spill`` including the
+# multi-block regime (issue #370): a block close folds per-block stratum
+# digests (row selection precedes the build) and composition words
+# (``merge_composition`` — presence exact, counts within O(n/510) per fold).
+# ``mode: merge`` still rejects them (its per-flush fold would degrade
+# locations continuously and has no ``where`` state).
 # Grid geometry matches atl03_tdigest_healpix.yaml (o11 shard / o13 inner
 # chunk / o19 cells).
 data_source:

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -74,7 +74,8 @@ class SpillOverflowError(RuntimeError):
     """A spill block hit its threshold under a config with no merge law.
 
     Raised the moment a second block would open (never on single-block
-    shards, where every reducer is exact); the message names the remedies.
+    shards, where every reducer is exact); the message carries the probe's
+    per-field verdict (``validate_spill_fold``) and the remedies.
     Deliberately a distinct type so the worker's tolerated per-granule
     ``except`` can re-raise it instead of warn-and-continue.
     """
@@ -496,11 +497,17 @@ class SpillAggregator:
         # block close (SpillOverflowError).
         from zagg.processing.streaming import validate_spill_fold
 
+        # The probe names every offending field; keep its text so the overflow
+        # raised at the first block close can say WHICH reducer has no fold law
+        # (this is its only call site — dropping the message left an operator
+        # re-deriving it from a 900 s Lambda they cannot reproduce locally).
+        self._fold_problems: str | None = None
         try:
             validate_spill_fold(config)
             self._mergeable = True
-        except ValueError:
+        except ValueError as e:
             self._mergeable = False
+            self._fold_problems = str(e)
         self._count_fields: list[str] = []
         self._digest_fields: dict[str, _DigestField] = {}
         # name -> (source, params): scalar pack_composition fields (issue #370
@@ -688,6 +695,7 @@ class SpillAggregator:
                 f"results cannot combine (the fold covers 'len'/'count', tdigest "
                 f"fields — located, where-strata, pairwise — and the packed "
                 f"composition word; single-block spill is exact for every reducer). "
+                f"{self._fold_problems}. "
                 f"Remedies: a bigger memory tier, a '-disk' function variant with "
                 f"more ephemeral storage, or a finer parent_order (smaller shards)."
             )

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -43,6 +43,7 @@ naming the ``-disk`` function-variant fix.
 from __future__ import annotations
 
 import ast
+import logging
 import os
 import tempfile
 import threading
@@ -65,6 +66,8 @@ from zagg.stats.tdigest import (
     merge_tdigests,
     merge_tdigests_kway,
 )
+
+logger = logging.getLogger(__name__)
 
 #: Floor for the spill-enable /tmp check: below this, even a degraded
 #: many-block run is pointless — fail at config time instead of thrashing.
@@ -706,6 +709,16 @@ class SpillAggregator:
         """True when no observation ever survived filtering."""
         return self.n_obs_total == 0 and not self._buffer
 
+    @property
+    def closed_blocks(self) -> int:
+        """Blocks closed at the threshold; 0 = exact single-block regime.
+
+        Ridden into the worker's ``phase_timings`` as ``spill_blocks_closed``
+        (issue #370) so an overflow-folded leaf is queryable in the run
+        telemetry, the same route ``spill_bytes`` takes.
+        """
+        return self._closed_blocks
+
     def occupied_cells(self) -> np.ndarray:
         """Distinct populated cell words (issue #200 coverage sink), sorted."""
         if not self._occupied:
@@ -736,6 +749,17 @@ class SpillAggregator:
                 f"{self._fold_problems}. "
                 f"Remedies: a bigger memory tier, a '-disk' function variant with "
                 f"more ephemeral storage, or a finer parent_order (smaller shards)."
+            )
+        if self._closed_blocks == 0:
+            # Once per shard, at the moment the exact regime is left (issue
+            # #370): from here on outputs FOLD across blocks — an overflow
+            # leaf is not byte-identical to its single-block result.
+            logger.warning(
+                f"spill block threshold ({self.block_bytes:,} bytes) crossed: this "
+                f"shard leaves the exact single-block regime and its outputs now "
+                f"fold across blocks — digests merge under t-digest semantics, "
+                f"located centroids coarsen to common ancestors, composition takes "
+                f"one k-way re-quantization; counts stay exact."
             )
         block = self._block
         self._block = SpillBlock(self.tmp_dir)

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -56,6 +56,7 @@ from zagg.config import (
     get_data_vars,
     get_output_signature,
 )
+from zagg.stats.composition import merge_composition, pack_composition_n
 from zagg.stats.tdigest import (
     _DEFAULT_DELTA,
     build_tdigest,
@@ -339,15 +340,16 @@ class _DigestField(NamedTuple):
     where: object | None
 
 
-def _resolve_where(param, col_arrays: dict[str, np.ndarray], start: int, end: int):
-    """Resolve one cell's ``where`` param over its block rows, the pooled way.
+def _resolve_param(param, col_arrays: dict[str, np.ndarray], start: int, end: int):
+    """Resolve one cell's param over its block rows, the pooled path's way.
 
     Mirrors ``calculate_cell_statistics``'s params resolution exactly (bare
     column name -> that column's rows; a string naming columns -> eval'd over
     the cell's rows with the same cached code object; anything else passes
-    through), so a stratum's per-block membership is computed by the identical
-    rule the pooled/single-block replay applies per cell — block boundaries
-    cannot shift a photon between strata.
+    through), so a stratum's per-block ``where`` membership and a composition
+    field's conf columns are computed by the identical rule the pooled/
+    single-block replay applies per cell — block boundaries cannot shift a
+    photon between strata or lanes.
     """
     from zagg.processing.aggregate import _compile_param_expr
 
@@ -440,7 +442,8 @@ class SpillAggregator:
       partition-by-partition into running mergeable state (counts by
       summation, tdigests via ``merge_tdigests``/``merge_tdigests_kway`` —
       including located fields and ``build_tdigest_where`` strata, whose
-      per-block builds fold under the located overloads, issue #370),
+      per-block builds fold under the located overloads — and composition
+      words via ``merge_composition``, issue #370),
       collapsing merge rounds from N/buffer to ~spill/threshold. A
       config with any reducer outside the ``validate_spill_fold`` surface
       raises :class:`SpillOverflowError` at the first crossing instead of
@@ -483,8 +486,12 @@ class SpillAggregator:
             self._mergeable = False
         self._count_fields: list[str] = []
         self._digest_fields: dict[str, _DigestField] = {}
+        # name -> (source, params): scalar pack_composition fields (issue #370
+        # option (a)); params carry the conf column names + threshold, resolved
+        # per cell at fold time exactly like the pooled path.
+        self._composition_fields: dict[str, tuple[str, dict]] = {}
         if self._mergeable:
-            from zagg.processing.streaming import _TDIGEST_PAIRWISE_FUNCTION
+            from zagg.processing.streaming import _COMPOSITION_FUNCTION, _TDIGEST_PAIRWISE_FUNCTION
 
             for name, meta in agg_fields.items():
                 sig = get_output_signature(meta)
@@ -497,6 +504,11 @@ class SpillAggregator:
                         pairwise=meta.get("function") == _TDIGEST_PAIRWISE_FUNCTION,
                         location=sig["location"],
                         where=params.get("where"),
+                    )
+                elif meta.get("function") == _COMPOSITION_FUNCTION:
+                    self._composition_fields[name] = (
+                        meta.get("source") or "h_li",
+                        dict(meta.get("params") or {}),
                     )
                 else:
                     self._count_fields.append(name)
@@ -531,6 +543,14 @@ class SpillAggregator:
         # merge_tdigests / merge_tdigests_kway overloads.
         self._digest_locs: dict[str, dict[int, np.ndarray]] = {
             n: {} for n, f in self._digest_fields.items() if f.location
+        }
+        # Composition running state (issue #370): per-cell (word, n_signal),
+        # folded pairwise in block-close order via merge_composition — presence
+        # exact (the floor survives re-quantization), counts within the
+        # documented O(n/510)-per-fold bound, so an overflow shard's word is
+        # NOT byte-stable against the single-block result (option (a)).
+        self._compositions: dict[str, dict[int, tuple[int, int]]] = {
+            n: {} for n in self._composition_fields
         }
         # k-way fold accumulator: for order-independent fields, each block's
         # per-cell digest is stashed here and collapsed once at finalize
@@ -691,13 +711,16 @@ class SpillAggregator:
         ``leaf_id`` column is a spilled read column, so the block holds the
         exact order-29 point words), a ``where`` stratum field (issue #321)
         via ``build_tdigest_where`` with its mask resolved per cell over the
-        block's spilled columns (:func:`_resolve_where` — row selection
+        block's spilled columns (:func:`_resolve_param` — row selection
         precedes the build, so block boundaries cannot shift a photon between
         strata, issue #370) — and then, per the field's fold law: **k-way**
         fields stash the block digest (+ locations) for one order-independent
         collapse at finalize (:meth:`_finalize_kway`); **pairwise** fields
         merge it into the running digest here, the located overload carrying
-        the location channel. Either way it is one build round per block
+        the location channel. Composition fields pack a per-block ``(word,
+        n_signal)`` pair (``pack_composition_n`` — the same predicate and
+        bytes as the pooled reducer) and fold it via ``merge_composition`` in
+        block-close order. Either way it is one build round per block
         instead of per buffer — the ~6x merge-CPU collapse the design targets
         (issue #279).
         """
@@ -715,7 +738,7 @@ class SpillAggregator:
                     values = col_arrays[f.source][start:end]
                     locs = col_arrays[f.location][start:end] if f.location else None
                     if f.where is not None:
-                        where = _resolve_where(f.where, col_arrays, start, end)
+                        where = _resolve_param(f.where, col_arrays, start, end)
                         built = build_tdigest_where(
                             values, delta=f.delta, where=where, locations=locs
                         )
@@ -744,6 +767,21 @@ class SpillAggregator:
                         self._digest_locs[name][cell] = merged_locs
                     else:
                         self._digests[name][cell] = merge_tdigests(held, fresh, delta=f.delta)
+                for name, (source, params) in self._composition_fields.items():
+                    values = col_arrays[source][start:end]
+                    kwargs = {
+                        k: _resolve_param(v, col_arrays, start, end) for k, v in params.items()
+                    }
+                    word, n = pack_composition_n(values, **kwargs)
+                    held_comp = self._compositions[name].get(cell)
+                    if held_comp is None:
+                        self._compositions[name][cell] = (word, n)
+                    else:
+                        held_word, held_n = held_comp
+                        self._compositions[name][cell] = (
+                            merge_composition(held_word, held_n, word, n),
+                            held_n + n,
+                        )
 
     def _finalize_kway(self) -> None:
         """Collapse each k-way field's per-block parts into one digest per cell.
@@ -859,6 +897,12 @@ class SpillAggregator:
                 stats_arrays[name] = np.full(n_cells, np.nan, dtype=dtype)
             else:
                 stats_arrays[name] = np.zeros(n_cells, dtype=dtype)
+        for name in self._composition_fields:
+            # The packed word (issue #321): integer dtype, numeric fill — the
+            # spec mandates fill_value 0 so unwritten cells read as "no lanes".
+            meta = agg_fields[name]
+            dtype = np.dtype(meta.get("dtype", "uint64"))
+            stats_arrays[name] = np.full(n_cells, meta.get("fill_value", 0), dtype=dtype)
         ragged_payloads: dict[str, list] = {n: [] for n in self._digest_fields}
         ragged_cell_indices: dict[str, list[int]] = {n: [] for n in self._digest_fields}
         # Located fields only (issue #87): keyed presence tells the worker to
@@ -875,6 +919,10 @@ class SpillAggregator:
             cells_with_data += 1
             for name in self._count_fields:
                 stats_arrays[name][i] = count
+            for name in self._composition_fields:
+                # Every occupied cell has an entry (the fold writes one per
+                # cell per block); the word may legitimately be 0 (no signal).
+                stats_arrays[name][i] = self._compositions[name][cell][0]
             for name in self._digest_fields:
                 digest = self._digests[name].get(cell)
                 if digest is not None and digest.size > 0:

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -954,6 +954,8 @@ class SpillAggregator:
 
     def _chunk_outputs_merged(self, children, agg_fields: dict):
         """Multi-block regime: emit from the cross-block mergeable state."""
+        from zagg.processing.aggregate import _field_sentinel, _integer_fill
+
         if not self._finalized:
             # Join the in-flight overlap reduce (its failure re-raises here),
             # then fold the final (still-open, never threshold-closed) block
@@ -977,11 +979,21 @@ class SpillAggregator:
             else:
                 stats_arrays[name] = np.zeros(n_cells, dtype=dtype)
         for name in self._composition_fields:
-            # The packed word (issue #321): integer dtype, numeric fill — the
-            # spec mandates fill_value 0 so unwritten cells read as "no lanes".
+            # The packed word (issue #321). Same dtype default as every other
+            # emission path (`_aggregate_chunk_cells`, the count loop above) and
+            # the same fill derivation the pooled path uses for an empty cell
+            # (`_integer_fill` for integer dtypes — it names a non-numeric
+            # sentinel instead of letting it reach numpy — else
+            # `_field_sentinel`): a dtype-omitted composition field must not
+            # store float32 single-block and uint64 multi-block.
             meta = agg_fields[name]
-            dtype = np.dtype(meta.get("dtype", "uint64"))
-            stats_arrays[name] = np.full(n_cells, meta.get("fill_value", 0), dtype=dtype)
+            dtype = np.dtype(meta.get("dtype", "float32"))
+            fill = (
+                _integer_fill(meta, dtype)
+                if np.issubdtype(dtype, np.integer)
+                else _field_sentinel(meta)
+            )
+            stats_arrays[name] = np.full(n_cells, fill, dtype=dtype)
         ragged_payloads: dict[str, list] = {n: [] for n in self._digest_fields}
         ragged_cell_indices: dict[str, list[int]] = {n: [] for n in self._digest_fields}
         # Located fields only (issue #87): keyed presence tells the worker to

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -747,6 +747,7 @@ class SpillAggregator:
         """
         from zagg.processing.aggregate import _group_columns
 
+        self._check_fold_columns(block.schema)
         for key in block.partition_keys():
             t0 = time.perf_counter()
             cells, cols = block.read_partition(key, close=True)
@@ -803,6 +804,42 @@ class SpillAggregator:
                             merge_composition(held_word, held_n, word, n),
                             held_n + n,
                         )
+
+    def _check_fold_columns(self, schema) -> None:
+        """Name a missing source/location column, as the pooled path does.
+
+        The fold indexes ``col_arrays`` by each field's declared ``source`` and
+        ``location``; a column the block never carried would surface as a bare
+        ``KeyError`` raised on the overlap reducer thread, which
+        :meth:`_join_reducer` re-wraps as :class:`SpillReduceError` with the real
+        cause reachable only via ``__cause__`` — a materially worse diagnostic
+        than ``calculate_cell_statistics``'s named ``ValueError`` for the same
+        config error, and one that only appears on shards big enough to close a
+        block. Checked once per block against the block schema, off the per-cell
+        loop. An empty block (nothing appended, so no schema) has nothing to
+        fold and nothing to check.
+        """
+        available = sorted(name for name, _ in schema or [])
+        if not available:
+            return
+        for name, f in self._digest_fields.items():
+            if f.source not in available:
+                raise ValueError(
+                    f"ragged field {name!r} declares source: {f.source!r} but that "
+                    f"column is not in the spilled block (available: {available})"
+                )
+            if f.location is not None and f.location not in available:
+                raise ValueError(
+                    f"ragged field {name!r} declares location: {f.location!r} but that "
+                    f"column is not in the spilled block (available: {available}); "
+                    f"per-observation mortons require a HEALPix grid"
+                )
+        for name, (source, _) in self._composition_fields.items():
+            if source not in available:
+                raise ValueError(
+                    f"field {name!r} declares source: {source!r} but that column is "
+                    f"not in the spilled block (available: {available})"
+                )
 
     def _finalize_kway(self) -> None:
         """Collapse each k-way field's per-block parts into one digest per cell.

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -46,6 +46,7 @@ import os
 import tempfile
 import threading
 import time
+from typing import NamedTuple
 
 import numpy as np
 
@@ -58,6 +59,7 @@ from zagg.config import (
 from zagg.stats.tdigest import (
     _DEFAULT_DELTA,
     build_tdigest,
+    build_tdigest_where,
     merge_tdigests,
     merge_tdigests_kway,
 )
@@ -319,6 +321,45 @@ class SpillBlock:
         self._partitions.clear()
 
 
+class _DigestField(NamedTuple):
+    """One ragged tdigest field's fold-relevant declaration (issues #279/#370).
+
+    ``pairwise`` selects the cross-block fold law: ``False`` — order-independent
+    k-way collapse at finalize (``build_tdigest``/``build_tdigest_where``, the
+    default); ``True`` — pairwise left-fold per block (``build_tdigest_pairwise``).
+    ``location`` is the per-observation morton column (issue #87) or ``None``;
+    ``where`` the field's raw ``where`` param (a column name or expression the
+    fold resolves per cell, exactly like the pooled path) or ``None``.
+    """
+
+    source: str
+    delta: int
+    pairwise: bool
+    location: str | None
+    where: object | None
+
+
+def _resolve_where(param, col_arrays: dict[str, np.ndarray], start: int, end: int):
+    """Resolve one cell's ``where`` param over its block rows, the pooled way.
+
+    Mirrors ``calculate_cell_statistics``'s params resolution exactly (bare
+    column name -> that column's rows; a string naming columns -> eval'd over
+    the cell's rows with the same cached code object; anything else passes
+    through), so a stratum's per-block membership is computed by the identical
+    rule the pooled/single-block replay applies per cell — block boundaries
+    cannot shift a photon between strata.
+    """
+    from zagg.processing.aggregate import _compile_param_expr
+
+    if isinstance(param, str) and param in col_arrays:
+        return col_arrays[param][start:end]
+    if isinstance(param, str) and any(c in param for c in col_arrays):
+        cell_data = {col: arr[start:end] for col, arr in col_arrays.items()}
+        ns = {"__builtins__": {}, "np": np, "numpy": np, **cell_data}
+        return eval(_compile_param_expr(param), ns)  # noqa: S307
+    return param
+
+
 def _memory_budget_bytes() -> int:
     """Worker memory budget: Lambda env, else cgroup v2 limit, else RAM."""
     mb = os.environ.get("AWS_LAMBDA_FUNCTION_MEMORY_SIZE")
@@ -397,11 +438,13 @@ class SpillAggregator:
     - **Multi block** (bytes hit the threshold — see
       :func:`_default_block_bytes`): each closing block is reduced
       partition-by-partition into running mergeable state (counts by
-      summation, tdigests via ``merge_tdigests`` — the StreamingAggregator
-      laws), collapsing merge rounds from N/buffer to ~spill/threshold. A
-      config with any non-mergeable reducer raises
-      :class:`SpillOverflowError` at the first crossing instead of silently
-      approximating.
+      summation, tdigests via ``merge_tdigests``/``merge_tdigests_kway`` —
+      including located fields and ``build_tdigest_where`` strata, whose
+      per-block builds fold under the located overloads, issue #370),
+      collapsing merge rounds from N/buffer to ~spill/threshold. A
+      config with any reducer outside the ``validate_spill_fold`` surface
+      raises :class:`SpillOverflowError` at the first crossing instead of
+      silently approximating.
 
     ``chunk_outputs`` returns the 5-tuple ``_aggregate_chunk_cells`` contract
     (``stats_arrays, ragged_payloads, ragged_cell_indices, ragged_locations,
@@ -426,30 +469,35 @@ class SpillAggregator:
         self.tmp_dir = tmp_dir or tempfile.gettempdir()
         agg_fields = get_agg_fields(config)
         self._data_vars = get_data_vars(config)
-        # Mergeable iff the merge-mode validator accepts the config: those are
-        # exactly the reducers with a cross-block combine law. Non-mergeable
-        # configs are still accepted — they are exact in the single-block
-        # regime — but cannot survive a block close (SpillOverflowError).
-        from zagg.processing.streaming import validate_streaming
+        # Mergeable iff the spill fold probe accepts the config (issue #370):
+        # wider than merge mode — located ragged fields and build_tdigest_where
+        # strata fold on block closes. Non-mergeable configs are still accepted
+        # — they are exact in the single-block regime — but cannot survive a
+        # block close (SpillOverflowError).
+        from zagg.processing.streaming import validate_spill_fold
 
         try:
-            validate_streaming(config)
+            validate_spill_fold(config)
             self._mergeable = True
         except ValueError:
             self._mergeable = False
         self._count_fields: list[str] = []
-        # name -> (source, delta, pairwise). ``pairwise`` selects the cross-block
-        # fold law: False -> order-independent k-way (build_tdigest, the default),
-        # True -> pairwise left-fold (build_tdigest_pairwise). See issue #279.
-        self._digest_fields: dict[str, tuple[str, int, bool]] = {}
+        self._digest_fields: dict[str, _DigestField] = {}
         if self._mergeable:
             from zagg.processing.streaming import _TDIGEST_PAIRWISE_FUNCTION
 
             for name, meta in agg_fields.items():
-                if get_output_signature(meta)["kind"] == "ragged":
-                    delta = int((meta.get("params") or {}).get("delta", _DEFAULT_DELTA))
-                    pairwise = meta.get("function") == _TDIGEST_PAIRWISE_FUNCTION
-                    self._digest_fields[name] = (meta.get("source") or "h_li", delta, pairwise)
+                sig = get_output_signature(meta)
+                if sig["kind"] == "ragged":
+                    params = meta.get("params") or {}
+                    self._digest_fields[name] = _DigestField(
+                        # Mirror the pooled path's source default (aggregate.py).
+                        source=meta.get("source") or "h_li",
+                        delta=int(params.get("delta", _DEFAULT_DELTA)),
+                        pairwise=meta.get("function") == _TDIGEST_PAIRWISE_FUNCTION,
+                        location=sig["location"],
+                        where=params.get("where"),
+                    )
                 else:
                     self._count_fields.append(name)
         if hasattr(grid, "chunk_order") and int(getattr(grid, "chunks_per_shard", 1)) > 1:
@@ -476,6 +524,14 @@ class SpillAggregator:
         # Cross-block mergeable running state (only ever fed on block close).
         self._counts: dict[int, int] = {}
         self._digests: dict[str, dict[int, np.ndarray]] = {n: {} for n in self._digest_fields}
+        # Located channel running state (issue #370): per-cell uint64 location
+        # vectors row-aligned with the running digests, for fields declaring
+        # ``location:`` only — the per-block build returns (digest, locations)
+        # pairs and the fold laws carry the channel through the located
+        # merge_tdigests / merge_tdigests_kway overloads.
+        self._digest_locs: dict[str, dict[int, np.ndarray]] = {
+            n: {} for n, f in self._digest_fields.items() if f.location
+        }
         # k-way fold accumulator: for order-independent fields, each block's
         # per-cell digest is stashed here and collapsed once at finalize
         # (merge_tdigests_kway), rather than pairwise-folded per block. Holding
@@ -489,7 +545,13 @@ class SpillAggregator:
         # reserves. Tighter memory-budget accounting against that reservation is
         # owned by the #280 parallel-reduce work.
         self._digest_parts: dict[str, dict[int, list[np.ndarray]]] = {
-            n: {} for n, (_, _, pairwise) in self._digest_fields.items() if not pairwise
+            n: {} for n, f in self._digest_fields.items() if not f.pairwise
+        }
+        # Location parts stashed alongside (issue #370), index-aligned with
+        # ``_digest_parts`` so the finalize k-way collapse folds both channels
+        # in the same order-independent pass.
+        self._digest_loc_parts: dict[str, dict[int, list[np.ndarray]]] = {
+            n: {} for n, f in self._digest_fields.items() if not f.pairwise and f.location
         }
         # Per-flush unique cell words; unioned lazily by occupied_cells().
         self._occupied: list[np.ndarray] = []
@@ -624,12 +686,20 @@ class SpillAggregator:
     def _fold_block(self, block: SpillBlock) -> None:
         """Fold one block into the running mergeable state, per partition.
 
-        Counts fold by summation (exact). tdigests are built fresh per cell and
-        then, per the field's fold law: **k-way** fields stash the block digest
-        for one order-independent collapse at finalize (:meth:`_finalize_kway`);
-        **pairwise** fields merge it into the running digest here. Either way it
-        is one build round per block instead of per buffer — the ~6x merge-CPU
-        collapse the design targets (issue #279).
+        Counts fold by summation (exact). tdigests are built fresh per cell —
+        a located field (issue #87) via the located ``build_tdigest`` (its
+        ``leaf_id`` column is a spilled read column, so the block holds the
+        exact order-29 point words), a ``where`` stratum field (issue #321)
+        via ``build_tdigest_where`` with its mask resolved per cell over the
+        block's spilled columns (:func:`_resolve_where` — row selection
+        precedes the build, so block boundaries cannot shift a photon between
+        strata, issue #370) — and then, per the field's fold law: **k-way**
+        fields stash the block digest (+ locations) for one order-independent
+        collapse at finalize (:meth:`_finalize_kway`); **pairwise** fields
+        merge it into the running digest here, the located overload carrying
+        the location channel. Either way it is one build round per block
+        instead of per buffer — the ~6x merge-CPU collapse the design targets
+        (issue #279).
         """
         from zagg.processing.aggregate import _group_columns
 
@@ -641,15 +711,39 @@ class SpillAggregator:
             del cells, cols
             for cell, (start, end) in cell_to_slice.items():
                 self._counts[cell] = self._counts.get(cell, 0) + (end - start)
-                for name, (source, delta, pairwise) in self._digest_fields.items():
-                    fresh = build_tdigest(col_arrays[source][start:end], delta=delta)
-                    if pairwise:
-                        held = self._digests[name].get(cell)
-                        self._digests[name][cell] = (
-                            fresh if held is None else merge_tdigests(held, fresh, delta=delta)
+                for name, f in self._digest_fields.items():
+                    values = col_arrays[f.source][start:end]
+                    locs = col_arrays[f.location][start:end] if f.location else None
+                    if f.where is not None:
+                        where = _resolve_where(f.where, col_arrays, start, end)
+                        built = build_tdigest_where(
+                            values, delta=f.delta, where=where, locations=locs
                         )
                     else:
+                        built = build_tdigest(values, delta=f.delta, locations=locs)
+                    fresh, fresh_locs = built if f.location else (built, None)
+                    if not f.pairwise:
                         self._digest_parts[name].setdefault(cell, []).append(fresh)
+                        if f.location:
+                            self._digest_loc_parts[name].setdefault(cell, []).append(fresh_locs)
+                        continue
+                    held = self._digests[name].get(cell)
+                    if held is None:
+                        self._digests[name][cell] = fresh
+                        if f.location:
+                            self._digest_locs[name][cell] = fresh_locs
+                    elif f.location:
+                        merged, merged_locs = merge_tdigests(
+                            held,
+                            fresh,
+                            delta=f.delta,
+                            locations1=self._digest_locs[name][cell],
+                            locations2=fresh_locs,
+                        )
+                        self._digests[name][cell] = merged
+                        self._digest_locs[name][cell] = merged_locs
+                    else:
+                        self._digests[name][cell] = merge_tdigests(held, fresh, delta=f.delta)
 
     def _finalize_kway(self) -> None:
         """Collapse each k-way field's per-block parts into one digest per cell.
@@ -657,13 +751,24 @@ class SpillAggregator:
         Runs once, after the final block is folded and before the first emission.
         The single-pass k-way merge is order-independent (t-digest merge is not
         associative), so the result does not depend on block reduce order — the
-        property #280 relies on to parallelize the reducer.
+        property #280 relies on to parallelize the reducer. A located field's
+        location parts collapse in the same pass (the located
+        ``merge_tdigests_kway`` overload), keeping both channels row-aligned.
         """
         for name, cell_parts in self._digest_parts.items():
-            delta = self._digest_fields[name][1]
+            f = self._digest_fields[name]
             dest = self._digests[name]
-            for cell, parts in cell_parts.items():
-                dest[cell] = merge_tdigests_kway(parts, delta=delta)
+            if f.location:
+                loc_parts = self._digest_loc_parts[name]
+                dest_locs = self._digest_locs[name]
+                for cell, parts in cell_parts.items():
+                    dest[cell], dest_locs[cell] = merge_tdigests_kway(
+                        parts, delta=f.delta, locations=loc_parts[cell]
+                    )
+                loc_parts.clear()
+            else:
+                for cell, parts in cell_parts.items():
+                    dest[cell] = merge_tdigests_kway(parts, delta=f.delta)
             cell_parts.clear()
 
     # -- post-read emission ----------------------------------------------------
@@ -756,6 +861,9 @@ class SpillAggregator:
                 stats_arrays[name] = np.zeros(n_cells, dtype=dtype)
         ragged_payloads: dict[str, list] = {n: [] for n in self._digest_fields}
         ragged_cell_indices: dict[str, list[int]] = {n: [] for n in self._digest_fields}
+        # Located fields only (issue #87): keyed presence tells the worker to
+        # deliver the 3-tuple ragged contract, mirroring _aggregate_chunk_cells.
+        ragged_locs: dict[str, list] = {n: [] for n, f in self._digest_fields.items() if f.location}
         cells_with_data = 0
         for i, child in enumerate(children):
             cell = int(child)
@@ -772,7 +880,9 @@ class SpillAggregator:
                 if digest is not None and digest.size > 0:
                     ragged_payloads[name].append(digest)
                     ragged_cell_indices[name].append(i)
-        return stats_arrays, ragged_payloads, ragged_cell_indices, {}, cells_with_data
+                    if name in ragged_locs:
+                        ragged_locs[name].append(self._digest_locs[name][cell])
+        return stats_arrays, ragged_payloads, ragged_cell_indices, ragged_locs, cells_with_data
 
     def close(self) -> None:
         """Release every spill fd and the cached partition (idempotent).

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -57,7 +57,7 @@ from zagg.config import (
     get_data_vars,
     get_output_signature,
 )
-from zagg.stats.composition import merge_composition, pack_composition_n
+from zagg.stats.composition import merge_composition_kway, pack_composition_n
 from zagg.stats.tdigest import (
     _DEFAULT_DELTA,
     build_tdigest,
@@ -489,7 +489,7 @@ class SpillAggregator:
       summation, tdigests via ``merge_tdigests``/``merge_tdigests_kway`` —
       including located fields and ``build_tdigest_where`` strata, whose
       per-block builds fold under the located overloads — and composition
-      words via ``merge_composition``, issue #370),
+      words via ``merge_composition_kway``, issue #370),
       collapsing merge rounds from N/buffer to ~spill/threshold. A
       config with any reducer outside the ``validate_spill_fold`` surface
       raises :class:`SpillOverflowError` at the first crossing instead of
@@ -601,12 +601,22 @@ class SpillAggregator:
         self._digest_locs: dict[str, dict[int, np.ndarray]] = {
             n: {} for n, f in self._digest_fields.items() if f.location
         }
-        # Composition running state (issue #370): per-cell (word, n_signal),
-        # folded pairwise in block-close order via merge_composition — presence
-        # exact (the floor survives re-quantization), counts within the
-        # documented O(n/510)-per-fold bound, so an overflow shard's word is
-        # NOT byte-stable against the single-block result (option (a)).
+        # Composition state (issue #370): per-cell (word, n_signal), written
+        # once at finalize from the per-block parts below.
         self._compositions: dict[str, dict[int, tuple[int, int]]] = {
+            n: {} for n in self._composition_fields
+        }
+        # Per-block (word, n_signal) parts, stashed like ``_digest_parts`` and
+        # collapsed in ONE weighted-mean pass at finalize
+        # (``merge_composition_kway``): quantizing once instead of once per
+        # block close keeps the stored word independent of block-close order —
+        # the property the k-way digest fold already has, and the one #280's
+        # parallel reduce would otherwise silently break here — and holds the
+        # count error at one quantization instead of compounding with the block
+        # count. Still option (a): the word is not byte-stable against the
+        # single-block result, presence is exact via the floor. Two ints per
+        # cell per block, negligible beside the digest parts.
+        self._composition_parts: dict[str, dict[int, list[tuple[int, int]]]] = {
             n: {} for n in self._composition_fields
         }
         # k-way fold accumulator: for order-independent fields, each block's
@@ -783,9 +793,9 @@ class SpillAggregator:
         merge it into the running digest here, the located overload carrying
         the location channel. Composition fields pack a per-block ``(word,
         n_signal)`` pair (``pack_composition_n`` — the same predicate and
-        bytes as the pooled reducer) and fold it via ``merge_composition`` in
-        block-close order. Either way it is one build round per block
-        instead of per buffer — the ~6x merge-CPU collapse the design targets
+        bytes as the pooled reducer) and stash it for the same finalize
+        collapse (``merge_composition_kway``). Either way it is one build round
+        per block instead of per buffer — the ~6x merge-CPU collapse the design targets
         (issue #279).
         """
         from zagg.processing.aggregate import _group_columns
@@ -840,16 +850,9 @@ class SpillAggregator:
                 for name, (source, params) in self._composition_fields.items():
                     values = cell_data[source]
                     kwargs = {k: _resolve_param(v, cell_data) for k, v in params.items()}
-                    word, n = pack_composition_n(values, **kwargs)
-                    held_comp = self._compositions[name].get(cell)
-                    if held_comp is None:
-                        self._compositions[name][cell] = (word, n)
-                    else:
-                        held_word, held_n = held_comp
-                        self._compositions[name][cell] = (
-                            merge_composition(held_word, held_n, word, n),
-                            held_n + n,
-                        )
+                    self._composition_parts[name].setdefault(cell, []).append(
+                        pack_composition_n(values, **kwargs)
+                    )
 
     def _check_fold_columns(self, schema) -> None:
         """Name a missing source/location/param column, as the pooled path does.
@@ -911,7 +914,7 @@ class SpillAggregator:
                     )
 
     def _finalize_kway(self) -> None:
-        """Collapse each k-way field's per-block parts into one digest per cell.
+        """Collapse every k-way channel's per-block parts, once per cell.
 
         Runs once, after the final block is folded and before the first emission.
         The single-pass k-way merge is order-independent (t-digest merge is not
@@ -921,7 +924,11 @@ class SpillAggregator:
         ``merge_tdigests_kway`` overload), keeping both channels row-aligned —
         and the location channel is order-independent too, since the located
         merge breaks ``(mean, weight)`` ties on the location word itself
-        (issue #370); a reducer parallelized under #280 inherits both.
+        (issue #370). Composition parts collapse the same way
+        (``merge_composition_kway`` over the block ``(word, n_signal)`` pairs:
+        one weighted lane mean, quantized once), so a reducer parallelized
+        under #280 inherits the property on all three channels rather than
+        finding composition silently excluded.
         """
         for name, cell_parts in self._digest_parts.items():
             f = self._digest_fields[name]
@@ -938,6 +945,14 @@ class SpillAggregator:
                 for cell, parts in cell_parts.items():
                     dest[cell] = merge_tdigests_kway(parts, delta=f.delta)
             cell_parts.clear()
+        for name, comp_parts in self._composition_parts.items():
+            comp_dest = self._compositions[name]
+            for cell, pairs in comp_parts.items():
+                comp_dest[cell] = (
+                    merge_composition_kway(pairs),
+                    sum(n for _, n in pairs),
+                )
+            comp_parts.clear()
 
     # -- post-read emission ----------------------------------------------------
 

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -42,6 +42,7 @@ naming the ``-disk`` function-variant fix.
 
 from __future__ import annotations
 
+import ast
 import os
 import tempfile
 import threading
@@ -378,6 +379,33 @@ def _resolve_param(param, cell_data: dict[str, np.ndarray]):
         ns = {"__builtins__": {}, "np": np, "numpy": np, **cell_data}
         return eval(_compile_param_expr(param), ns)  # noqa: S307
     return param
+
+
+def _unresolvable_names(param, available) -> tuple[str, ...]:
+    """Identifiers ``param`` needs that :func:`_resolve_param` could not supply.
+
+    The eval namespace is exactly the cell's columns plus ``np``/``numpy``
+    (``__builtins__`` stripped), so an expression's free names are checkable
+    against the block schema without running it — which is the only way to name
+    the field AND the column for a param that today either falls through as a
+    literal string (nothing in it matches a column: the failure surfaces as a
+    shape mismatch deep inside the reducer) or reaches ``eval`` and raises a
+    ``NameError`` naming the identifier but not the field. Bare column names
+    parse as a single :class:`ast.Name`, so one rule covers both forms.
+
+    Non-strings and strings that are not parseable expressions are genuine
+    literals for their reducer and yield ``()`` — the check never widens
+    :func:`_resolve_param`'s pass-through rule beyond what the caller declared
+    must be a column.
+    """
+    if not isinstance(param, str):
+        return ()
+    try:
+        tree = ast.parse(param, mode="eval")
+    except SyntaxError:
+        return ()
+    allowed = set(available) | {"np", "numpy"}
+    return tuple(sorted({n.id for n in ast.walk(tree) if isinstance(n, ast.Name)} - allowed))
 
 
 def _memory_budget_bytes() -> int:
@@ -824,10 +852,13 @@ class SpillAggregator:
                         )
 
     def _check_fold_columns(self, schema) -> None:
-        """Name a missing source/location column, as the pooled path does.
+        """Name a missing source/location/param column, as the pooled path does.
 
-        The fold indexes ``col_arrays`` by each field's declared ``source`` and
-        ``location``; a column the block never carried would surface as a bare
+        Covers every column the fold resolves out of the block: a field's
+        ``source`` and ``location``, a stratum's ``where``, and a composition
+        field's ``conf_*`` params (the hand-written ones — five per field — and
+        the ones whose failure mode is worst; see :func:`_unresolvable_names`).
+        A column the block never carried would surface as a bare
         ``KeyError`` raised on the overlap reducer thread, which
         :meth:`_join_reducer` re-wraps as :class:`SpillReduceError` with the real
         cause reachable only via ``__cause__`` — a materially worse diagnostic
@@ -852,12 +883,32 @@ class SpillAggregator:
                     f"column is not in the spilled block (available: {available}); "
                     f"per-observation mortons require a HEALPix grid"
                 )
-        for name, (source, _) in self._composition_fields.items():
+            missing = _unresolvable_names(f.where, available)
+            if missing:
+                raise ValueError(
+                    f"ragged field {name!r} declares where: {f.where!r}, which names "
+                    f"{list(missing)} — not in the spilled block (available: "
+                    f"{available}); the stratum mask is resolved per cell over the "
+                    f"block's columns"
+                )
+        for name, (source, params) in self._composition_fields.items():
             if source not in available:
                 raise ValueError(
                     f"field {name!r} declares source: {source!r} but that column is "
                     f"not in the spilled block (available: {available})"
                 )
+            # The five conf_* params MUST resolve to row-aligned columns (they
+            # are stacked in pack_composition_n): a typo falls through
+            # _resolve_param as a literal string and dies inside
+            # np.column_stack naming neither the field nor the column.
+            for pname, pval in params.items():
+                missing = _unresolvable_names(pval, available) if pname.startswith("conf_") else ()
+                if missing:
+                    raise ValueError(
+                        f"field {name!r} param {pname}: {pval!r} names {list(missing)}, "
+                        f"not in the spilled block (available: {available}); the conf "
+                        f"params must resolve to row-aligned columns"
+                    )
 
     def _finalize_kway(self) -> None:
         """Collapse each k-way field's per-block parts into one digest per cell.

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -350,8 +350,13 @@ class _DigestField(NamedTuple):
     stratum: bool
 
 
-def _resolve_param(param, col_arrays: dict[str, np.ndarray], start: int, end: int):
-    """Resolve one cell's param over its block rows, the pooled path's way.
+def _resolve_param(param, cell_data: dict[str, np.ndarray]):
+    """Resolve one param over one cell's rows, the pooled path's way.
+
+    ``cell_data`` is the cell's already-sliced column views — built once per
+    cell by :meth:`SpillAggregator._fold_block`, exactly as the pooled path
+    builds it once per cell before resolving every field's params
+    (``_aggregate_chunk_cells`` -> ``calculate_cell_statistics``).
 
     Mirrors ``calculate_cell_statistics``'s params resolution exactly (bare
     column name -> that column's rows; a string naming columns -> eval'd over
@@ -359,14 +364,16 @@ def _resolve_param(param, col_arrays: dict[str, np.ndarray], start: int, end: in
     through), so a stratum's per-block ``where`` membership and a composition
     field's conf columns are computed by the identical rule the pooled/
     single-block replay applies per cell — block boundaries cannot shift a
-    photon between strata or lanes.
+    photon between strata or lanes. The two namespaces are identical only
+    because ``validate_spill_fold`` rejects ``chunk_precompute`` outright: the
+    pooled namespace's one extra ingredient is its ``chunk_scalars``, which no
+    config reaching this fold can carry.
     """
     from zagg.processing.aggregate import _compile_param_expr
 
-    if isinstance(param, str) and param in col_arrays:
-        return col_arrays[param][start:end]
-    if isinstance(param, str) and any(c in param for c in col_arrays):
-        cell_data = {col: arr[start:end] for col, arr in col_arrays.items()}
+    if isinstance(param, str) and param in cell_data:
+        return cell_data[param]
+    if isinstance(param, str) and any(c in param for c in cell_data):
         ns = {"__builtins__": {}, "np": np, "numpy": np, **cell_data}
         return eval(_compile_param_expr(param), ns)  # noqa: S307
     return param
@@ -756,11 +763,16 @@ class SpillAggregator:
             del cells, cols
             for cell, (start, end) in cell_to_slice.items():
                 self._counts[cell] = self._counts.get(cell, 0) + (end - start)
+                # One namespace per cell, not per field — the pooled path's
+                # shape (`calculate_cell_statistics` gets one `cell_data`),
+                # and the strata config declares two complementary `where`
+                # fields over the same source.
+                cell_data = {col: arr[start:end] for col, arr in col_arrays.items()}
                 for name, f in self._digest_fields.items():
-                    values = col_arrays[f.source][start:end]
-                    locs = col_arrays[f.location][start:end] if f.location else None
+                    values = cell_data[f.source]
+                    locs = cell_data[f.location] if f.location else None
                     if f.stratum:
-                        where = _resolve_param(f.where, col_arrays, start, end)
+                        where = _resolve_param(f.where, cell_data)
                         built = build_tdigest_where(
                             values, delta=f.delta, where=where, locations=locs
                         )
@@ -790,10 +802,8 @@ class SpillAggregator:
                     else:
                         self._digests[name][cell] = merge_tdigests(held, fresh, delta=f.delta)
                 for name, (source, params) in self._composition_fields.items():
-                    values = col_arrays[source][start:end]
-                    kwargs = {
-                        k: _resolve_param(v, col_arrays, start, end) for k, v in params.items()
-                    }
+                    values = cell_data[source]
+                    kwargs = {k: _resolve_param(v, cell_data) for k, v in params.items()}
                     word, n = pack_composition_n(values, **kwargs)
                     held_comp = self._compositions[name].get(cell)
                     if held_comp is None:

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -331,6 +331,15 @@ class _DigestField(NamedTuple):
     ``location`` is the per-observation morton column (issue #87) or ``None``;
     ``where`` the field's raw ``where`` param (a column name or expression the
     fold resolves per cell, exactly like the pooled path) or ``None``.
+
+    ``stratum`` records that the DECLARED function is ``build_tdigest_where``
+    and is what selects the reducer in :meth:`SpillAggregator._fold_block` —
+    never ``where``'s presence. Keying on the param would let a config drop
+    ``where`` and silently get the unmasked population, or add one to a plain
+    ``build_tdigest`` and silently get a masked digest, in either case
+    disagreeing with the pooled replay (which raises ``TypeError``).
+    ``validate_spill_fold`` rejects both mis-declarations up front, so
+    ``stratum`` implies ``where is not None`` and vice versa.
     """
 
     source: str
@@ -338,6 +347,7 @@ class _DigestField(NamedTuple):
     pairwise: bool
     location: str | None
     where: object | None
+    stratum: bool
 
 
 def _resolve_param(param, col_arrays: dict[str, np.ndarray], start: int, end: int):
@@ -491,7 +501,11 @@ class SpillAggregator:
         # per cell at fold time exactly like the pooled path.
         self._composition_fields: dict[str, tuple[str, dict]] = {}
         if self._mergeable:
-            from zagg.processing.streaming import _COMPOSITION_FUNCTION, _TDIGEST_PAIRWISE_FUNCTION
+            from zagg.processing.streaming import (
+                _COMPOSITION_FUNCTION,
+                _TDIGEST_PAIRWISE_FUNCTION,
+                _TDIGEST_WHERE_FUNCTION,
+            )
 
             for name, meta in agg_fields.items():
                 sig = get_output_signature(meta)
@@ -504,6 +518,7 @@ class SpillAggregator:
                         pairwise=meta.get("function") == _TDIGEST_PAIRWISE_FUNCTION,
                         location=sig["location"],
                         where=params.get("where"),
+                        stratum=meta.get("function") == _TDIGEST_WHERE_FUNCTION,
                     )
                 elif meta.get("function") == _COMPOSITION_FUNCTION:
                     self._composition_fields[name] = (
@@ -715,7 +730,11 @@ class SpillAggregator:
         via ``build_tdigest_where`` with its mask resolved per cell over the
         block's spilled columns (:func:`_resolve_param` — row selection
         precedes the build, so block boundaries cannot shift a photon between
-        strata, issue #370) — and then, per the field's fold law: **k-way**
+        strata, issue #370). Which of the two reducers runs is decided by the
+        field's **declared function** (``_DigestField.stratum``), never by
+        whether a ``where`` param happens to be present, so the fold can never
+        substitute a reducer the config did not declare — and then, per the
+        field's fold law: **k-way**
         fields stash the block digest (+ locations) for one order-independent
         collapse at finalize (:meth:`_finalize_kway`); **pairwise** fields
         merge it into the running digest here, the located overload carrying
@@ -739,7 +758,7 @@ class SpillAggregator:
                 for name, f in self._digest_fields.items():
                     values = col_arrays[f.source][start:end]
                     locs = col_arrays[f.location][start:end] if f.location else None
-                    if f.where is not None:
+                    if f.stratum:
                         where = _resolve_param(f.where, col_arrays, start, end)
                         built = build_tdigest_where(
                             values, delta=f.delta, where=where, locations=locs

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -662,8 +662,10 @@ class SpillAggregator:
         if not self._mergeable:
             raise SpillOverflowError(
                 f"spill block hit the {self.block_bytes:,}-byte threshold but the "
-                f"config carries reducers with no merge law, so per-block results "
-                f"cannot combine (single-block spill is exact for every reducer). "
+                f"config carries reducers with no cross-block fold law, so per-block "
+                f"results cannot combine (the fold covers 'len'/'count', tdigest "
+                f"fields — located, where-strata, pairwise — and the packed "
+                f"composition word; single-block spill is exact for every reducer). "
                 f"Remedies: a bigger memory tier, a '-disk' function variant with "
                 f"more ephemeral storage, or a finer parent_order (smaller shards)."
             )

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -812,7 +812,10 @@ class SpillAggregator:
         associative), so the result does not depend on block reduce order — the
         property #280 relies on to parallelize the reducer. A located field's
         location parts collapse in the same pass (the located
-        ``merge_tdigests_kway`` overload), keeping both channels row-aligned.
+        ``merge_tdigests_kway`` overload), keeping both channels row-aligned —
+        and the location channel is order-independent too, since the located
+        merge breaks ``(mean, weight)`` ties on the location word itself
+        (issue #370); a reducer parallelized under #280 inherits both.
         """
         for name, cell_parts in self._digest_parts.items():
             f = self._digest_fields[name]

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -47,6 +47,14 @@ _TDIGEST_FUNCTION = "zagg.stats.tdigest.build_tdigest"
 _TDIGEST_PAIRWISE_FUNCTION = "zagg.stats.tdigest.build_tdigest_pairwise"
 _TDIGEST_FUNCTIONS = (_TDIGEST_FUNCTION, _TDIGEST_PAIRWISE_FUNCTION)
 
+#: Ragged reducers the SPILL fold additionally accepts (issue #370): stratum
+#: membership (``build_tdigest_where``) is per-photon row selection *before*
+#: the build — independent of block boundaries — so per-block strata digests
+#: merge like any digest. It folds k-way, like the ``build_tdigest`` it
+#: delegates to.
+_TDIGEST_WHERE_FUNCTION = "zagg.stats.tdigest.build_tdigest_where"
+_TDIGEST_SPILL_FUNCTIONS = (*_TDIGEST_FUNCTIONS, _TDIGEST_WHERE_FUNCTION)
+
 
 def get_streaming(config: PipelineConfig) -> dict | None:
     """Return the ``aggregation.streaming`` block, or ``None`` (pooled path).
@@ -143,6 +151,62 @@ def validate_streaming(config: PipelineConfig) -> None:
         raise ValueError(
             "aggregation.streaming is on but the config is not streamable: " + "; ".join(problems)
         )
+
+
+def validate_spill_fold(config: PipelineConfig) -> None:
+    """Reject configs whose reducers have no CROSS-BLOCK fold law (issue #370).
+
+    The spill-path mergeability probe — deliberately wider than
+    :func:`validate_streaming` (``mode: merge``): merge mode folds every
+    ``buffer_granules`` flush, so a located field's centroid locations would
+    coarsen continuously, whereas spill folds only on the rare block close.
+    Accepted here beyond the merge-mode set: **located** ragged fields (the
+    located ``merge_tdigests``/``merge_tdigests_kway`` overloads carry the
+    channel) and **``build_tdigest_where`` strata** (row selection precedes
+    the build, so per-block stratum digests merge like any digest).
+
+    A config this rejects is still accepted by ``mode: spill`` — every
+    reducer is exact in the single-block regime — but cannot survive a block
+    close (:class:`~zagg.processing.spill.SpillOverflowError`).
+
+    Raises ``ValueError`` naming every offending field, mirroring
+    :func:`validate_streaming`.
+    """
+    problems: list[str] = []
+    if get_chunk_precompute(config):
+        problems.append("chunk_precompute is chunk-scoped and has no cross-block fold")
+    for name, meta in get_agg_fields(config).items():
+        sig = get_output_signature(meta)
+        if "expression" in meta:
+            problems.append(f"field '{name}': expression fields have no cross-block fold")
+        elif sig["resolution"] != "cell":
+            problems.append(
+                f"field '{name}': resolution '{sig['resolution']}' has no cross-block fold"
+            )
+        elif sig["kind"] == "ragged":
+            if meta.get("function") not in _TDIGEST_SPILL_FUNCTIONS:
+                problems.append(
+                    f"field '{name}': ragged function {meta.get('function')!r} has no "
+                    f"fold law (only {' or '.join(_TDIGEST_SPILL_FUNCTIONS)})"
+                )
+            elif tuple(sig["inner_shape"]) != (2,):
+                # Same posture as validate_streaming: the fold stores merged
+                # digests directly, so a mis-declared inner_shape must fail
+                # here, not silently disagree with the store schema.
+                problems.append(
+                    f"field '{name}': tdigest payloads are (k, 2) centroids; "
+                    f"declared inner_shape {list(sig['inner_shape'])} has no cross-block fold"
+                )
+        elif sig["kind"] == "scalar":
+            if meta.get("function") not in ("len", "count"):
+                problems.append(
+                    f"field '{name}': scalar function {meta.get('function')!r} has no "
+                    "cross-block fold (only 'len'/'count')"
+                )
+        else:
+            problems.append(f"field '{name}': kind '{sig['kind']}' has no cross-block fold")
+    if problems:
+        raise ValueError("spill blocks cannot cross-block fold this config: " + "; ".join(problems))
 
 
 class StreamingAggregator:

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -205,6 +205,11 @@ def validate_spill_fold(config: PipelineConfig) -> None:
     O(n/510)-per-fold bound; see :data:`_COMPOSITION_FUNCTION` for the
     option (a)/(b) flip point).
 
+    ``where`` and ``build_tdigest_where`` must be declared **together**: either
+    one alone is a config error here, mirroring the ``TypeError`` the pooled
+    replay raises for the same config, so the fold's reducer choice can never
+    diverge from the declared one.
+
     A config this rejects is still accepted by ``mode: spill`` — every
     reducer is exact in the single-block regime — but cannot survive a block
     close (:class:`~zagg.processing.spill.SpillOverflowError`).
@@ -228,6 +233,23 @@ def validate_spill_fold(config: PipelineConfig) -> None:
                 problems.append(
                     f"field '{name}': ragged function {meta.get('function')!r} has no "
                     f"fold law (only {' or '.join(_TDIGEST_SPILL_FUNCTIONS)})"
+                )
+            elif ("where" in (meta.get("params") or {})) != (
+                meta.get("function") == _TDIGEST_WHERE_FUNCTION
+            ):
+                # The declared function and the where param must agree, in both
+                # directions — the pooled path raises TypeError for each
+                # (missing / unexpected keyword argument), and the spill fold
+                # must not be quieter: without this the fold would digest the
+                # whole population under a stratum name, or mask a field the
+                # config declared unmasked.
+                problems.append(
+                    f"field '{name}': {_TDIGEST_WHERE_FUNCTION} requires a 'where' param"
+                    if meta.get("function") == _TDIGEST_WHERE_FUNCTION
+                    else (
+                        f"field '{name}': 'where' is only meaningful for "
+                        f"{_TDIGEST_WHERE_FUNCTION} (declared {meta.get('function')!r})"
+                    )
                 )
             elif tuple(sig["inner_shape"]) != (2,):
                 # Same posture as validate_streaming: the fold stores merged

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -20,7 +20,11 @@ validated up front (:func:`validate_streaming`):
   the shard fits in a single buffer, since one flush == one pooled build).
 
 Everything else (expressions, vector fields, ``resolution: chunk`` companions,
-``chunk_precompute``) has no incremental-merge story and raises. A fixed-size
+``chunk_precompute``) has no incremental-merge story and raises. Located
+ragged fields, ``build_tdigest_where`` strata, and the packed composition word
+also raise **here** (per-flush folding would degrade locations continuously /
+re-quantize lanes per flush) but fold on the spill path's rare block closes —
+:func:`validate_spill_fold`, issue #370. A fixed-size
 buffer is used rather than pure granule-by-granule updates because each flush
 costs one merge round over the touched cells (~10 µs/cell, see
 ``zagg/stats/tdigest.py``): near 88S a tangent-running granule touches most of
@@ -124,13 +128,27 @@ def validate_streaming(config: PipelineConfig) -> None:
             problems.append(f"field '{name}': resolution '{sig['resolution']}' cannot stream")
         elif sig["kind"] == "ragged":
             if sig["location"] is not None:
-                # The located channel (issue #87) has a merge law (located
-                # merge_tdigests), but the streaming state does not thread
-                # per-cell locations yet — reject rather than silently dropping
-                # the channel from the store.
+                # The located channel (issue #87) has a merge law (the located
+                # merge_tdigests overloads), but merge mode folds every
+                # buffer_granules flush — each fold coarsens merged centroids'
+                # locations toward common ancestors, so per-flush folding
+                # degrades the channel continuously. Spill folds only on the
+                # rare block close (issue #370), so route located configs there.
                 problems.append(
                     f"field '{name}': located ragged fields (location: "
-                    f"{sig['location']!r}) cannot stream yet"
+                    f"{sig['location']!r}) cannot stream under mode: merge — every "
+                    f"flush folds the running digest, coarsening centroid locations "
+                    f"continuously; use mode: spill, which folds only on block "
+                    f"closes (issue #370)"
+                )
+            elif meta.get("function") == _TDIGEST_WHERE_FUNCTION:
+                # Stratum membership needs the raw rows at build time; merge
+                # mode has no where state, but the spill fold evaluates the
+                # mask per block before each build (issue #370).
+                problems.append(
+                    f"field '{name}': build_tdigest_where has no per-flush merge law "
+                    f"(the where stratum folds only on the spill path — use "
+                    f"mode: spill, issue #370)"
                 )
             elif meta.get("function") not in _TDIGEST_FUNCTIONS:
                 problems.append(
@@ -149,7 +167,16 @@ def validate_streaming(config: PipelineConfig) -> None:
         elif sig["kind"] == "scalar":
             # ``count`` is the pooled path's alias of ``len`` (aggregate.py);
             # both merge by summation.
-            if meta.get("function") not in ("len", "count"):
+            if meta.get("function") == _COMPOSITION_FUNCTION:
+                # The packed word folds via merge_composition on the spill
+                # path (issue #370 option (a)); merge mode would re-quantize
+                # the lanes on every flush, compounding the O(n/510) error.
+                problems.append(
+                    f"field '{name}': the packed composition word is not per-flush "
+                    f"mergeable (each fold re-quantizes the lanes); it folds only on "
+                    f"the spill path — use mode: spill, issue #370"
+                )
+            elif meta.get("function") not in ("len", "count"):
                 problems.append(
                     f"field '{name}': scalar function {meta.get('function')!r} is not "
                     "mergeable (only 'len'/'count')"

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -55,6 +55,15 @@ _TDIGEST_FUNCTIONS = (_TDIGEST_FUNCTION, _TDIGEST_PAIRWISE_FUNCTION)
 _TDIGEST_WHERE_FUNCTION = "zagg.stats.tdigest.build_tdigest_where"
 _TDIGEST_SPILL_FUNCTIONS = (*_TDIGEST_FUNCTIONS, _TDIGEST_WHERE_FUNCTION)
 
+#: The packed composition reducer (issue #321): the SPILL fold combines its
+#: per-block ``(word, n_signal)`` pairs via ``merge_composition`` — issue #370
+#: option (a), accepting the documented O(n/510)-per-fold lane-quantization
+#: error (presence exact via the floor). Flipping to option (b) — composition
+#: stays non-mergeable, so a strata-with-composition config fails loudly on a
+#: block close — is the one-line removal of this function from the
+#: ``validate_spill_fold`` scalar branch below.
+_COMPOSITION_FUNCTION = "zagg.stats.composition.pack_composition"
+
 
 def get_streaming(config: PipelineConfig) -> dict | None:
     """Return the ``aggregation.streaming`` block, or ``None`` (pooled path).
@@ -162,8 +171,12 @@ def validate_spill_fold(config: PipelineConfig) -> None:
     coarsen continuously, whereas spill folds only on the rare block close.
     Accepted here beyond the merge-mode set: **located** ragged fields (the
     located ``merge_tdigests``/``merge_tdigests_kway`` overloads carry the
-    channel) and **``build_tdigest_where`` strata** (row selection precedes
-    the build, so per-block stratum digests merge like any digest).
+    channel), **``build_tdigest_where`` strata** (row selection precedes
+    the build, so per-block stratum digests merge like any digest), and the
+    **packed composition word** (``merge_composition`` over per-block
+    ``(word, n_signal)`` pairs — presence exact, counts within the documented
+    O(n/510)-per-fold bound; see :data:`_COMPOSITION_FUNCTION` for the
+    option (a)/(b) flip point).
 
     A config this rejects is still accepted by ``mode: spill`` — every
     reducer is exact in the single-block regime — but cannot survive a block
@@ -198,10 +211,10 @@ def validate_spill_fold(config: PipelineConfig) -> None:
                     f"declared inner_shape {list(sig['inner_shape'])} has no cross-block fold"
                 )
         elif sig["kind"] == "scalar":
-            if meta.get("function") not in ("len", "count"):
+            if meta.get("function") not in ("len", "count", _COMPOSITION_FUNCTION):
                 problems.append(
                     f"field '{name}': scalar function {meta.get('function')!r} has no "
-                    "cross-block fold (only 'len'/'count')"
+                    f"cross-block fold (only 'len'/'count'/{_COMPOSITION_FUNCTION!r})"
                 )
         else:
             problems.append(f"field '{name}': kind '{sig['kind']}' has no cross-block fold")

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -59,10 +59,11 @@ _TDIGEST_FUNCTIONS = (_TDIGEST_FUNCTION, _TDIGEST_PAIRWISE_FUNCTION)
 _TDIGEST_WHERE_FUNCTION = "zagg.stats.tdigest.build_tdigest_where"
 _TDIGEST_SPILL_FUNCTIONS = (*_TDIGEST_FUNCTIONS, _TDIGEST_WHERE_FUNCTION)
 
-#: The packed composition reducer (issue #321): the SPILL fold combines its
-#: per-block ``(word, n_signal)`` pairs via ``merge_composition`` — issue #370
-#: option (a), accepting the documented O(n/510)-per-fold lane-quantization
-#: error (presence exact via the floor). Flipping to option (b) — composition
+#: The packed composition reducer (issue #321): the SPILL fold collapses its
+#: per-block ``(word, n_signal)`` pairs in one pass via
+#: ``merge_composition_kway`` — issue #370 option (a), accepting the documented
+#: lane-quantization error (one quantization over the parts, presence exact via
+#: the floor) rather than a byte-stable word. Flipping to option (b) — composition
 #: stays non-mergeable, so a strata-with-composition config fails loudly on a
 #: block close — is the one-line removal of this function from the
 #: ``validate_spill_fold`` scalar branch below.
@@ -168,9 +169,9 @@ def validate_streaming(config: PipelineConfig) -> None:
             # ``count`` is the pooled path's alias of ``len`` (aggregate.py);
             # both merge by summation.
             if meta.get("function") == _COMPOSITION_FUNCTION:
-                # The packed word folds via merge_composition on the spill
-                # path (issue #370 option (a)); merge mode would re-quantize
-                # the lanes on every flush, compounding the O(n/510) error.
+                # The packed word folds k-way at finalize on the spill path
+                # (issue #370 option (a)); merge mode would re-quantize the
+                # lanes on every flush, compounding the O(n/510) error.
                 problems.append(
                     f"field '{name}': the packed composition word is not per-flush "
                     f"mergeable (each fold re-quantizes the lanes); it folds only on "
@@ -200,10 +201,10 @@ def validate_spill_fold(config: PipelineConfig) -> None:
     located ``merge_tdigests``/``merge_tdigests_kway`` overloads carry the
     channel), **``build_tdigest_where`` strata** (row selection precedes
     the build, so per-block stratum digests merge like any digest), and the
-    **packed composition word** (``merge_composition`` over per-block
-    ``(word, n_signal)`` pairs — presence exact, counts within the documented
-    O(n/510)-per-fold bound; see :data:`_COMPOSITION_FUNCTION` for the
-    option (a)/(b) flip point).
+    **packed composition word** (``merge_composition_kway`` over the per-block
+    ``(word, n_signal)`` pairs — presence exact, counts within one
+    quantization; see :data:`_COMPOSITION_FUNCTION` for the option (a)/(b)
+    flip point).
 
     ``where`` and ``build_tdigest_where`` must be declared **together**: either
     one alone is a config error here, mirroring the ``TypeError`` the pooled

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -792,6 +792,11 @@ def process_shard(
         phase_timings["spill_write_s"] = buffered.spill_write_s
         phase_timings["spill_read_s"] = buffered.spill_read_s
         phase_timings["spill_bytes"] = buffered.spill_bytes
+        # Fold-regime marker (issue #370): blocks closed at the threshold.
+        # 0 = exact single-block regime; > 0 = this leaf's outputs were folded
+        # across blocks. Split out of the seconds-only timings by build_record,
+        # like spill_bytes.
+        phase_timings["spill_blocks_closed"] = buffered.closed_blocks
     metadata["phase_timings"] = phase_timings
 
     duration = (datetime.now() - start_time).total_seconds()

--- a/src/zagg/stats/composition.py
+++ b/src/zagg/stats/composition.py
@@ -38,7 +38,10 @@ only within ``O(n/510)``, so folds are not byte-stable across orders)::
     lane_merged = quantize((n_a * lane_a + n_b * lane_b) / (n_a + n_b))
 
 with the same presence floor, so presence survives re-quantization exactly and
-count error stays O(n/510) per merge.
+count error stays O(n/510) per merge. :func:`merge_composition_kway` folds a
+whole set of parts in one pass instead — same law, quantized once, so it is
+order-independent and does not compound with the part count (the writer's
+spill fold, issue #370); the binary law above stays the reader-facing contract.
 """
 
 from __future__ import annotations
@@ -52,6 +55,7 @@ __all__ = [
     "composition_attrs_block",
     "counts_from_composition",
     "merge_composition",
+    "merge_composition_kway",
     "pack_composition",
     "pack_composition_n",
     "unpack_composition",
@@ -238,4 +242,40 @@ def merge_composition(word_a: int, n_a: int, word_b: int, n_b: int) -> int:
     merged = (n_a * la + n_b * lb) / n
     k = np.rint(merged)
     k = np.where(((la > 0) | (lb > 0)) & (k == 0), 1.0, k)
+    return _pack(np.clip(k, 0, 255).astype(np.uint64))
+
+
+def merge_composition_kway(parts: list[tuple[int, int]]) -> int:
+    """Fold many ``(word, n_signal)`` pairs in ONE pass — **order-independent**.
+
+    The merge law is a weighted mean, so ``k`` parts collapse directly:
+    ``lane = quantize(Σ nᵢ·laneᵢ / Σ nᵢ)`` with the same presence floor. A
+    left-fold of :func:`merge_composition` re-quantizes ``k-1`` times and the
+    result depends on the fold order; this quantizes **once**, so the count
+    error stays one quantization wide (≤ 1 lane step over the parts' own,
+    i.e. O(n/255) recovered counts) no matter how many parts there are, and a
+    permutation of ``parts`` returns identical bytes. That is the writer's
+    fold law on the spill path (issue #370), where the parts are per-block
+    words and the block count is small; :func:`merge_composition` remains the
+    reader-facing binary law of spec §3.4 — folding k-way is inside its
+    documented "associative up to the bounded re-quantization error" tolerance
+    and strictly tighter than the binary chain.
+
+    Parts with ``n <= 0`` are skipped (the ``(0, 0)`` identity), and an empty
+    or all-empty ``parts`` returns ``0`` — an empty signal stratum.
+    """
+    lanes = np.zeros(len(LANES), dtype=np.float64)
+    present = np.zeros(len(LANES), dtype=bool)
+    total = 0
+    for word, n in parts:
+        if n <= 0:
+            continue
+        la = unpack_composition(word).astype(np.float64)
+        lanes += n * la
+        present |= la > 0
+        total += int(n)
+    if total <= 0:
+        return 0
+    k = np.rint(lanes / total)
+    k = np.where(present & (k == 0), 1.0, k)
     return _pack(np.clip(k, 0, 255).astype(np.uint64))

--- a/src/zagg/stats/composition.py
+++ b/src/zagg/stats/composition.py
@@ -53,6 +53,7 @@ __all__ = [
     "counts_from_composition",
     "merge_composition",
     "pack_composition",
+    "pack_composition_n",
     "unpack_composition",
 ]
 
@@ -165,6 +166,37 @@ def pack_composition(
     stayed populated — out of contract for this spec rather than defended
     against here.
     """
+    return pack_composition_n(
+        values,
+        conf_land=conf_land,
+        conf_ocean=conf_ocean,
+        conf_sea_ice=conf_sea_ice,
+        conf_land_ice=conf_land_ice,
+        conf_inland_water=conf_inland_water,
+        threshold=threshold,
+    )[0]
+
+
+def pack_composition_n(
+    values: np.ndarray,
+    *,
+    conf_land: np.ndarray,
+    conf_ocean: np.ndarray,
+    conf_sea_ice: np.ndarray,
+    conf_land_ice: np.ndarray,
+    conf_inland_water: np.ndarray,
+    threshold: int = 2,
+) -> tuple[int, int]:
+    """:func:`pack_composition` returning the ``(word, n_signal)`` pair.
+
+    The spill cross-block fold (issue #370) needs each block's stratum size
+    beside its word — :func:`merge_composition` is a fold over ``(word, n)``
+    pairs — and ``n_signal`` is computed here anyway (the signal predicate over
+    the finite rows). Exposing the pair keeps the predicate in ONE place: a
+    fold that re-derived ``n`` from the conf columns could silently drift from
+    the packing cut. ``pack_composition`` (the config-facing reducer, word
+    only) delegates here, so both entry points share the identical bytes.
+    """
     values = np.asarray(values, dtype=np.float64)
     conf = np.column_stack(
         [conf_land, conf_ocean, conf_sea_ice, conf_land_ice, conf_inland_water]
@@ -177,7 +209,7 @@ def pack_composition(
     signal = (conf >= threshold).any(axis=1)
     n = int(signal.sum())
     if n == 0:
-        return 0
+        return 0, 0
     csig = conf[signal]
 
     counts = np.empty(8, dtype=np.int64)
@@ -185,7 +217,7 @@ def pack_composition(
     strongest = csig.max(axis=1)
     for i, level in enumerate((2, 3, 4)):
         counts[_SURFACES + i] = int((strongest == level).sum())
-    return _pack(_quantize(counts, n))
+    return _pack(_quantize(counts, n)), n
 
 
 def merge_composition(word_a: int, n_a: int, word_b: int, n_b: int) -> int:

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -451,6 +451,10 @@ def merge_tdigests_kway(
     standard ``build_tdigest`` reducer on the spill path, where each input is a
     saturated per-block digest and the block count is small.
 
+    Order-independence covers **both** channels: with ``locations``, the sort
+    breaks ``(mean, weight)`` ties on the location word, so a permutation of the
+    inputs returns the same location vector as well as the same digest.
+
     Parameters
     ----------
     digests : list of ndarray
@@ -507,16 +511,25 @@ def merge_tdigests_kway(
     # digest order. A stable argsort on mean alone breaks ties by concatenation
     # position (i.e. input order), which makes the k-way fold permutation-
     # dependent when means tie across digests (discrete/quantized sources).
-    # Sub-centroids with identical (mean, weight) are interchangeable, so their
-    # residual order does not affect the result (issue #279).
-    order = np.lexsort((combined[:, 1], combined[:, 0]))
+    # Sub-centroids with identical (mean, weight) are interchangeable *for the
+    # digest*, but not for the location channel: a tie straddling a compression
+    # boundary would send different location words into different output
+    # centroids depending on input order. So the located branch adds the
+    # location word as a tertiary (least-significant) key — it changes no digest
+    # byte (the tied rows carry identical means and weights) and makes the
+    # companion channel permutation-independent too (issues #279/#370).
+    if located:
+        combined_locs = np.concatenate(locs)
+        order = np.lexsort((combined_locs, combined[:, 1], combined[:, 0]))
+        combined_locs = combined_locs[order]
+    else:
+        order = np.lexsort((combined[:, 1], combined[:, 0]))
     combined = combined[order]
     out_means, out_weights, starts = _compress(combined[:, 0], combined[:, 1], float(delta))
     out = np.empty((len(out_means), 2), dtype=np.float32)
     out[:, 0] = out_means
     out[:, 1] = out_weights
     if located:
-        combined_locs = np.concatenate(locs)[order]
         return out, _centroid_ancestors(combined_locs, starts, len(combined))
     return out
 

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -53,6 +53,7 @@ _SUM_OR_NONE_KEYS = (
     "gb_seconds",
     "est_cost_usd",
     "spill_bytes",
+    "spill_blocks_closed",
     "raster_bytes_read",
     "raster_px_decoded",
     "raster_px_sampled",
@@ -167,9 +168,16 @@ def build_record(
     # in the seconds-only phase block: the run parquet flattens phase_timings to
     # seconds-typed columns, where a byte count would mislead cost/latency
     # queries. Split any ``*_bytes`` entries out; surface spill volume on its own
-    # summed field (issue #297).
+    # summed field (issue #297). ``spill_blocks_closed`` (issue #370) is split
+    # the same way: the fold-regime marker (0/absent = exact single-block leaf)
+    # is a count, not seconds.
     spill_bytes = phase_entries.get("spill_bytes")
-    phase_timings = {k: v for k, v in phase_entries.items() if not k.endswith("_bytes")}
+    spill_blocks_closed = _opt_int(phase_entries.get("spill_blocks_closed"))
+    phase_timings = {
+        k: v
+        for k, v in phase_entries.items()
+        if not k.endswith("_bytes") and k != "spill_blocks_closed"
+    }
     granule_ids = list(granule_ids) if granule_ids is not None else None
     n_granules = metadata.get("granule_count")
     if n_granules is None:
@@ -198,6 +206,11 @@ def build_record(
         "phase_timings": phase_timings,
         "duration_s": duration_s,
         "spill_bytes": spill_bytes,
+        # Fold-regime marker (issue #370): blocks closed at the spill threshold.
+        # 0/absent = exact single-block leaf; > 0 = the leaf's outputs were
+        # folded across blocks (digest merge semantics, coarsened locations,
+        # one composition re-quantization).
+        "spill_blocks_closed": spill_blocks_closed,
         # Raster read-volume counters (issue #297): compressed bytes fetched,
         # pixels decoded (whole tiles), cell samples gathered. Stored raw — the
         # px_decoded / px_sampled ratio is derived at read, never stored
@@ -321,6 +334,7 @@ _ROW_SCALARS = (
     "gb_seconds",
     "est_cost_usd",
     "spill_bytes",
+    "spill_blocks_closed",
     "raster_bytes_read",
     "raster_px_decoded",
     "raster_px_sampled",

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -7,6 +7,7 @@ from zagg.stats.composition import (
     LANES,
     counts_from_composition,
     merge_composition,
+    merge_composition_kway,
     pack_composition,
     unpack_composition,
 )
@@ -182,6 +183,83 @@ class TestMergeComposition:
         wa = pack_composition(np.zeros(30), **_conf_kwargs(conf_a))
         wb = pack_composition(np.zeros(50), **_conf_kwargs(conf_b))
         assert merge_composition(wa, 30, wb, 50) == merge_composition(wb, 50, wa, 30)
+
+
+class TestMergeCompositionKway:
+    """One-pass k-way fold: order-independent and tighter than the chain."""
+
+    @staticmethod
+    def _parts(rng, sizes, signal_col=1):
+        """``(parts, pooled_word, n_total, conf)`` for blocks of ``sizes`` rows."""
+        conf = rng.integers(-2, 5, size=(sum(sizes), 5))
+        conf[:, signal_col] = 4  # everything signal, so n == len(rows)
+        parts, off = [], 0
+        for size in sizes:
+            block = conf[off : off + size]
+            parts.append((pack_composition(np.zeros(size), **_conf_kwargs(block)), size))
+            off += size
+        pooled = pack_composition(np.zeros(len(conf)), **_conf_kwargs(conf))
+        return parts, pooled, len(conf), conf
+
+    def test_identity_and_empty(self):
+        conf = np.array([[4, -1, -1, 2, -1]])
+        w = pack_composition(np.array([1.0]), **_conf_kwargs(conf))
+        assert merge_composition_kway([]) == 0
+        assert merge_composition_kway([(0, 0), (0, 0)]) == 0
+        assert merge_composition_kway([(w, 1), (0, 0)]) == w
+        assert merge_composition_kway([(w, 1)]) == w
+
+    def test_order_independent(self):
+        rng = np.random.default_rng(4)
+        parts, _, _, _ = self._parts(rng, [7, 40, 13, 60, 5, 90])
+        word = merge_composition_kway(parts)
+        for seed in range(5):
+            shuffled = list(parts)
+            np.random.default_rng(seed).shuffle(shuffled)
+            assert merge_composition_kway(shuffled) == word
+
+    def test_tighter_than_the_pairwise_chain(self):
+        # 12 blocks: the chain re-quantizes 11 times and drifts; one pass
+        # quantizes once, so its recovered counts sit within a single step of
+        # the pooled word however many parts there are.
+        rng = np.random.default_rng(87)
+        parts, pooled, n, _ = self._parts(rng, [40] * 12)
+        chained, held_n = parts[0]
+        for word, n_i in parts[1:]:
+            chained = merge_composition(chained, held_n, word, n_i)
+            held_n += n_i
+        assert held_n == n
+        kway = merge_composition_kway(parts)
+        truth = counts_from_composition(pooled, n)
+        assert np.max(np.abs(counts_from_composition(kway, n) - truth)) <= 1 + n / 255.0
+        assert np.max(np.abs(counts_from_composition(kway, n) - truth)) <= np.max(
+            np.abs(counts_from_composition(chained, n) - truth)
+        )
+        assert np.array_equal(unpack_composition(kway) > 0, unpack_composition(pooled) > 0)
+
+    def test_presence_floor_survives_many_parts(self):
+        # One rare flag in one part must stay nonzero against 20 parts that
+        # never carry it, exactly as the binary law guarantees.
+        conf0 = np.full((10, 5), -1)
+        conf0[:, 0] = 4
+        conf0[0, 4] = 3  # rare inland_water flag
+        confk = np.full((100, 5), -1)
+        confk[:, 0] = 4
+        parts = [(pack_composition(np.zeros(10), **_conf_kwargs(conf0)), 10)]
+        wk = pack_composition(np.zeros(100), **_conf_kwargs(confk))
+        parts += [(wk, 100)] * 20
+        assert unpack_composition(merge_composition_kway(parts))[4] >= 1
+
+    def test_weighted_by_n_not_part_count(self):
+        # A 1-row part must not pull the mean like a 200-row one.
+        big = np.full((200, 5), -1)
+        big[:, 0] = 4
+        small = np.array([[-1, -1, -1, -1, 4]])
+        wb = pack_composition(np.zeros(200), **_conf_kwargs(big))
+        ws = pack_composition(np.zeros(1), **_conf_kwargs(small))
+        lanes = unpack_composition(merge_composition_kway([(wb, 200), (ws, 1)]))
+        assert lanes[0] == 254  # 200/201 of the stratum
+        assert lanes[4] == 1  # present, floored
 
 
 class TestBuildTdigestWhere:

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -727,10 +727,13 @@ class TestSpillWorkerSingleBlock:
             "spill_write_s",
             "spill_read_s",
             "spill_bytes",
+            "spill_blocks_closed",
         }
         assert timings["spill_bytes"] > 0
         assert timings["spill_write_s"] >= 0
         assert timings["spill_read_s"] >= 0
+        # Single-block run: the fold-regime marker reads 0 (exact regime).
+        assert timings["spill_blocks_closed"] == 0
 
 
 class TestSpillWorkerMultiBlock:

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -471,10 +471,12 @@ class TestSpillConfig:
         assert not agg._mergeable
         agg.close()
 
-    def test_stratified_config_single_block_only(self):
-        # Signal/noise strata + composition (issue #321): accepted by spill,
-        # pinned non-mergeable (single-block regime, exact via the pooled
-        # replay) — the fold surface would silently drop the ``where`` mask.
+    def test_stratified_config_is_mergeable(self):
+        # Signal/noise strata + composition (issue #321): accepted by spill
+        # AND mergeable across blocks since issue #370 — strata fold via
+        # build_tdigest_where per block, composition via merge_composition
+        # (option (a)). Cross-block behavior is pinned in
+        # test_spill_crossblock.py.
         variables = _base_variables()
         variables["h_sig"] = {
             "kind": "ragged",
@@ -493,7 +495,9 @@ class TestSpillConfig:
         }
         cfg = _config(streaming={"mode": "spill"}, variables=variables)
         agg = SpillAggregator(cfg, _grid(cfg), "pandas", 25)
-        assert not agg._mergeable
+        assert agg._mergeable
+        assert "composition" in agg._composition_fields
+        assert "count" in agg._count_fields
         agg.close()
 
     def test_guard_fires_at_construction(self, monkeypatch):

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -637,6 +637,62 @@ class TestCompositionMultiBlock:
                 assert ls.shape == (len(ds),)
 
 
+class TestFoldColumnDiagnostics:
+    """A declared column the block never carried fails with the pooled path's
+    named ValueError, not a bare KeyError re-wrapped as SpillReduceError."""
+
+    @staticmethod
+    def _agg_with_block(variables, cols):
+        cfg = _config(variables, streaming=_SPILL)
+        grid = _grid(cfg)
+        agg = SpillAggregator(cfg, grid, "pandas", 1)
+        assert agg._mergeable
+        cells = np.asarray(grid.children(_shard_key()), dtype=np.uint64)[:1]
+        agg._block.append(np.zeros(1, dtype=np.uint64), cells, cols)
+        return agg
+
+    def test_missing_location_column_named(self):
+        agg = self._agg_with_block(_variables(located=True), {"h_ph": np.zeros(1, np.float32)})
+        with pytest.raises(ValueError, match="h_tdigest.*location: 'leaf_id'.*spilled block"):
+            agg._fold_block(agg._block)
+        agg.close()
+
+    def test_missing_source_column_named(self):
+        agg = self._agg_with_block(_variables(located=True), {"leaf_id": np.zeros(1, np.uint64)})
+        with pytest.raises(ValueError, match="h_tdigest.*source: 'h_ph'.*spilled block"):
+            agg._fold_block(agg._block)
+        agg.close()
+
+    def test_missing_composition_source_named(self):
+        variables = _variables()
+        variables["composition"] = {**_composition_field(), "source": "h_absent"}
+        agg = self._agg_with_block(variables, {"h_ph": np.zeros(1, np.float32)})
+        with pytest.raises(ValueError, match="'composition'.*source: 'h_absent'.*spilled block"):
+            agg._fold_block(agg._block)
+        agg.close()
+
+    def test_reducer_thread_surfaces_the_named_cause(self):
+        # On the overlap path the fold runs off-thread; _join_reducer wraps the
+        # failure, so the named ValueError must be the cause (not a KeyError).
+        from zagg.processing.spill import SpillReduceError
+
+        agg = self._agg_with_block(_variables(located=True), {"h_ph": np.zeros(1, np.float32)})
+        agg._reduce_one(agg._block)
+        with pytest.raises(SpillReduceError) as exc:
+            agg._join_reducer()
+        assert isinstance(exc.value.__cause__, ValueError)
+        assert "location: 'leaf_id'" in str(exc.value.__cause__)
+        agg.close()
+
+    def test_empty_block_needs_no_columns(self):
+        # A block that was never appended to (the final open block of a shard
+        # whose last flush closed one) has no schema and nothing to check.
+        cfg = _config(_variables(located=True), streaming=_SPILL)
+        agg = SpillAggregator(cfg, _grid(cfg), "pandas", 1)
+        agg._fold_block(agg._block)  # no raise
+        agg.close()
+
+
 class TestUnlocatedUnchanged:
     """Issue #370 adds nothing to the spill record — the fold reads the
     already-spilled read-carrier columns — so unlocated configs' spilled

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -214,6 +214,26 @@ def _assert_ancestor_or_equal(locs, contributors):
         )
 
 
+def _pooled_build(meta, n=8):
+    """Call one ragged field's declared reducer exactly as the pooled path does.
+
+    Mirrors ``calculate_cell_statistics``: resolve the declared params over the
+    cell's columns, then call ``resolve_function(meta['function'])(values,
+    **params)``. Used to pin that a mis-declared ``where`` fails the same way on
+    both paths.
+    """
+    from zagg.config import resolve_function
+    from zagg.processing.aggregate import _compile_param_expr
+
+    cell_data = {"h_ph": np.linspace(-1.0, 1.0, n, dtype=np.float32)}
+    ns = {"__builtins__": {}, "np": np, "numpy": np, **cell_data}
+    params = {
+        k: (eval(_compile_param_expr(v), ns) if isinstance(v, str) else v)
+        for k, v in (meta.get("params") or {}).items()
+    }
+    return resolve_function(meta["function"])(cell_data["h_ph"], **params)
+
+
 class TestSpillFoldProbe:
     """The spill mergeability probe (validate_spill_fold) vs merge mode."""
 
@@ -253,6 +273,39 @@ class TestSpillFoldProbe:
         }
         with pytest.raises(ValueError, match="h_raw.*fold law"):
             validate_spill_fold(_config(variables))
+
+    def test_where_function_without_where_param_rejected(self):
+        # A stratum field that lost its `where` (copy-paste drop) must fail at
+        # the probe, not silently fold the WHOLE population into the stratum's
+        # name. The pooled replay raises TypeError for the same config.
+        variables = _variables(strata=True)
+        variables["h_sig"]["params"] = {"delta": 16}
+        with pytest.raises(ValueError, match="h_sig.*build_tdigest_where requires a 'where'"):
+            validate_spill_fold(_config(variables))
+        with pytest.raises(TypeError, match="missing 1 required keyword-only argument: 'where'"):
+            _pooled_build(variables["h_sig"])
+
+    def test_where_param_on_plain_tdigest_rejected(self):
+        # The other direction: a `where` on a non-where reducer must not make
+        # the fold silently mask — the pooled replay raises TypeError.
+        variables = _variables()
+        variables["h_tdigest"]["params"] = {"delta": 16, "where": _SIGNAL}
+        with pytest.raises(ValueError, match="h_tdigest.*'where' is only meaningful"):
+            validate_spill_fold(_config(variables))
+        with pytest.raises(TypeError, match="unexpected keyword argument 'where'"):
+            _pooled_build(variables["h_tdigest"])
+
+    def test_mis_declared_where_config_is_not_mergeable(self):
+        # Belt and braces: the probe's rejection is what keeps the fold from
+        # ever classifying such a field, so _fold_block cannot pick a reducer
+        # the config did not declare.
+        variables = _variables()
+        variables["h_tdigest"]["params"] = {"delta": 16, "where": _SIGNAL}
+        cfg = _config(variables, streaming=_SPILL)
+        agg = SpillAggregator(cfg, _grid(cfg), "pandas", 1)
+        assert not agg._mergeable
+        assert agg._digest_fields == {}
+        agg.close()
 
     def test_mode_merge_validation_unchanged(self):
         # The spill probe widening must not leak into mode: merge — its

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -126,11 +126,14 @@ def _point_leafs(grid, cell, n, rng):
     return out[:n]
 
 
-def _granule_dfs(grid, shard_key, cell_idx_lists, obs_per_cell=60, seed=0, conf=False):
+def _granule_dfs(
+    grid, shard_key, cell_idx_lists, obs_per_cell=60, seed=0, conf=False, nan_cells=()
+):
     """One DataFrame per granule; real order-29 point leafs per chosen cell.
 
     ``conf=True`` adds the five ``signal_conf_*`` columns (ATL03's ``-1..4``
-    range) for composition tests.
+    range) for composition tests. Cells in ``nan_cells`` get all-NaN heights
+    (an empty digest but a nonzero count).
     """
     rng = np.random.default_rng(seed)
     children = np.asarray(grid.children(shard_key), dtype=np.uint64)
@@ -139,7 +142,10 @@ def _granule_dfs(grid, shard_key, cell_idx_lists, obs_per_cell=60, seed=0, conf=
         n = obs_per_cell * len(idxs)
         h, leaf = [], []
         for ci in idxs:
-            h.append(rng.normal(0.0, 10.0, obs_per_cell).astype(np.float32))
+            vals = rng.normal(0.0, 10.0, obs_per_cell).astype(np.float32)
+            if ci in nan_cells:
+                vals[:] = np.nan
+            h.append(vals)
             leaf.append(_point_leafs(grid, int(children[ci]), obs_per_cell, rng))
         cols = {"h_ph": np.concatenate(h), "leaf_id": np.concatenate(leaf)}
         if conf:
@@ -558,3 +564,54 @@ class TestCompositionMultiBlock:
             for dp, ds, ls in zip(vals_p, vals_s, locs_s, strict=True):
                 assert float(dp[:, 1].sum()) == float(ds[:, 1].sum())
                 assert ls.shape == (len(ds),)
+
+
+class TestUnlocatedUnchanged:
+    """Issue #370 adds nothing to the spill record — the fold reads the
+    already-spilled read-carrier columns — so unlocated configs' spilled
+    bytes are unchanged by construction."""
+
+    def test_spill_record_schema_is_the_read_carrier(self):
+        # Same schema whether or not the config declares location: the
+        # location channel is served from the existing leaf_id column, never
+        # an appended one; an unlocated spill record gains no column.
+        df = None
+        schemas = {}
+        for located in (False, True):
+            cfg = _config(_variables(located=located), streaming=_SPILL)
+            grid = _grid(cfg)
+            if df is None:
+                df = _granule_dfs(grid, _shard_key(), [[0, 4]], obs_per_cell=5, seed=1)[0]
+            agg = SpillAggregator(cfg, grid, "pandas", 1)
+            agg.add_read(df.copy())
+            agg.flush()
+            schemas[located] = [name for name, _ in agg._block.schema]
+            agg.close()
+        assert schemas[False] == schemas[True] == ["h_ph", "leaf_id"]
+
+    def test_nan_cell_multi_block_empty_digest_real_count(self, monkeypatch):
+        # An all-NaN cell across blocks: exact count, no digest and no
+        # locations entry emitted — matching pooled behavior.
+        key = _shard_key()
+        pooled_cfg = _config(_variables(located=True))
+        spill_cfg = _config(_variables(located=True), streaming=_SPILL)
+        grid = _grid(pooled_cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=30, seed=14, nan_cells={4})
+        df_p, ragged_p, _ = _run(monkeypatch, pooled_cfg, grid, key, list(dfs))
+        _force_tiny_blocks(monkeypatch)
+        df_s, ragged_s, _ = _run(monkeypatch, spill_cfg, _grid(spill_cfg), key, list(dfs))
+        pd.testing.assert_series_equal(df_p["count"], df_s["count"])
+        vals_p, idx_p, locs_p = ragged_p["h_tdigest"]
+        vals_s, idx_s, locs_s = ragged_s["h_tdigest"]
+        assert idx_p == idx_s  # the NaN cell is absent from both
+        assert len(locs_s) == len(vals_s)
+        children = np.asarray(grid.children(key), dtype=np.uint64)
+        nan_cell = int(children[4])
+        counted = df_s["count"].values[4] if len(df_s) > 4 else None
+        # The NaN cell holds observations (count > 0) yet emits no payload.
+        nan_rows = sum(
+            int((np.asarray(grid.cells_of(df["leaf_id"].values)) == nan_cell).sum()) for df in dfs
+        )
+        assert nan_rows > 0
+        assert 4 not in idx_s
+        assert counted == nan_rows

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -1,0 +1,385 @@
+"""Cross-block spill folds for located / strata / composition fields (issue #370).
+
+Phase 1 — located ragged fields and ``build_tdigest_where`` strata survive a
+block close: ``_fold_block`` builds per-block ``(digest, locations)`` partials
+with the same reducers the pooled path uses (the ``leaf_id`` point words are
+already spilled — they are a read-carrier column) and folds them under the
+located ``merge_tdigests`` / ``merge_tdigests_kway`` overloads, so overflow
+shards trade location resolution (merged centroids coarsen to common
+ancestors — the located channel's defined behavior above weight 1) instead of
+raising ``SpillOverflowError``.
+
+Byte-equality tests pin ``shard_workers: 1`` (see ``test_spill.py``).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from zagg.config import PipelineConfig
+from zagg.grids import HealpixGrid
+from zagg.processing import process_shard
+from zagg.processing.spill import SpillAggregator
+from zagg.processing.streaming import validate_spill_fold, validate_streaming
+from zagg.stats.tdigest import quantile_from_tdigest
+
+_CREDS = {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"}
+
+_SIGNAL = "h_ph > 0"
+_NOISE = "~(h_ph > 0)"
+
+
+def _variables(located=False, strata=False, pairwise=False, delta=16):
+    fn = "zagg.stats.tdigest.build_tdigest" + ("_pairwise" if pairwise else "")
+    base = {
+        "kind": "ragged",
+        "function": fn,
+        "source": "h_ph",
+        "inner_shape": [2],
+        "params": {"delta": delta},
+        "dtype": "float32",
+        "fill_value": 0,
+    }
+    if located:
+        base["location"] = "leaf_id"
+    variables = {
+        "count": {"function": "len", "source": "h_ph", "dtype": "int32", "fill_value": 0},
+    }
+    if strata:
+        for name, where in (("h_sig", _SIGNAL), ("h_noise", _NOISE)):
+            f = {**base, "function": "zagg.stats.tdigest.build_tdigest_where"}
+            f["params"] = {**base["params"], "where": where}
+            variables[name] = f
+    else:
+        variables["h_tdigest"] = base
+    return variables
+
+
+def _config(variables, streaming=None):
+    agg = {"variables": variables}
+    if streaming is not None:
+        agg["streaming"] = streaming
+    return PipelineConfig(
+        data_source={
+            "reader": "h5coro",
+            "driver": "s3",
+            "groups": ["gt1l"],
+            "index": {"backend": "hierarchical"},
+            "shard_workers": 1,
+        },
+        aggregation=agg,
+    )
+
+
+_SPILL = {"buffer_granules": 1, "mode": "spill"}
+
+
+def _grid(cfg):
+    return HealpixGrid(6, 8, layout="fullsphere", config=cfg)
+
+
+def _shard_key():
+    from mortie import geo2mort
+
+    return int(geo2mort(-78.5, -132.0, order=6)[0])
+
+
+def _point_leafs(grid, cell, n, rng):
+    """``n`` order-29 point words strictly inside child cell ``cell``."""
+    from mortie import mort2geo
+
+    lat, lon = mort2geo(np.array([cell], dtype=np.uint64))
+    out = np.empty(0, dtype=np.uint64)
+    scale = 0.2
+    while len(out) < n:
+        lats = float(lat) + rng.uniform(-scale, scale, 4 * n)
+        lons = float(lon) + rng.uniform(-scale, scale, 4 * n)
+        leafs = np.asarray(grid.assign(lats, lons))
+        out = np.concatenate([out, leafs[np.asarray(grid.cells_of(leafs)) == cell]])
+        scale *= 0.5
+    return out[:n]
+
+
+def _granule_dfs(grid, shard_key, cell_idx_lists, obs_per_cell=60, seed=0):
+    """One DataFrame per granule; real order-29 point leafs per chosen cell."""
+    rng = np.random.default_rng(seed)
+    children = np.asarray(grid.children(shard_key), dtype=np.uint64)
+    dfs = []
+    for idxs in cell_idx_lists:
+        h, leaf = [], []
+        for ci in idxs:
+            h.append(rng.normal(0.0, 10.0, obs_per_cell).astype(np.float32))
+            leaf.append(_point_leafs(grid, int(children[ci]), obs_per_cell, rng))
+        dfs.append(pd.DataFrame({"h_ph": np.concatenate(h), "leaf_id": np.concatenate(leaf)}))
+    return dfs
+
+
+def _run(monkeypatch, cfg, grid, shard_key, dfs):
+    reads = iter(dfs)
+    monkeypatch.setattr("zagg.processing._read_group", lambda *a, **k: next(reads))
+    monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
+    monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+    ragged: dict = {}
+    df_out, meta = process_shard(
+        grid,
+        shard_key,
+        [f"s3://b/g{i}.h5" for i in range(len(dfs))],
+        s3_credentials=_CREDS,
+        config=cfg,
+        ragged_out=ragged,
+    )
+    return df_out, ragged, meta
+
+
+def _force_tiny_blocks(monkeypatch):
+    monkeypatch.setattr("zagg.processing.spill._default_block_bytes", lambda k, tmp_dir=None: 1)
+
+
+_CELL_LISTS = [[0, 4, 8], [2, 4, 10], [1, 8, 9], [0, 10, 15], [4, 8, 10]]
+
+
+def _contributors(dfs, grid, cell, mask_fn=None):
+    """Every leaf word the granules contribute to child cell ``cell``."""
+    words = []
+    for df in dfs:
+        in_cell = np.asarray(grid.cells_of(df["leaf_id"].values)) == cell
+        keep = in_cell
+        if mask_fn is not None:
+            keep = in_cell & mask_fn(df)
+        words.append(df["leaf_id"].values[keep])
+    return np.concatenate(words)
+
+
+def _assert_ancestor_or_equal(locs, contributors):
+    """Each merged location lies between the contributor hull and a member.
+
+    Membership per centroid is not observable from the output, so pin both
+    bounds: every location is (a) the ancestor-or-equal of at least one
+    contributor word (it sits on a member's path) and (b) a descendant-or-equal
+    of the common ancestor of ALL contributors (it cannot escape the hull).
+    """
+    from mortie import clip2order, common_ancestor, orders_of
+
+    contributors = np.asarray(contributors, dtype=np.uint64)
+    hull = np.uint64(common_ancestor(contributors))
+    hull_order = int(orders_of(np.array([hull], dtype=np.uint64))[0])
+    loc_orders = np.asarray(orders_of(locs))
+    for loc, order in zip(locs, loc_orders):
+        assert np.any(clip2order(int(order), contributors) == loc), (
+            f"location {loc} is no contributor's ancestor"
+        )
+        assert np.uint64(clip2order(hull_order, np.array([loc], dtype=np.uint64))[0]) == hull, (
+            f"location {loc} escapes the contributor hull {hull}"
+        )
+
+
+class TestSpillFoldProbe:
+    """The spill mergeability probe (validate_spill_fold) vs merge mode."""
+
+    def test_located_config_is_mergeable(self):
+        cfg = _config(_variables(located=True), streaming=_SPILL)
+        agg = SpillAggregator(cfg, _grid(cfg), "pandas", 1)
+        assert agg._mergeable
+        assert agg._digest_fields["h_tdigest"].location == "leaf_id"
+        agg.close()
+
+    def test_strata_config_is_mergeable(self):
+        cfg = _config(_variables(strata=True), streaming=_SPILL)
+        agg = SpillAggregator(cfg, _grid(cfg), "pandas", 1)
+        assert agg._mergeable
+        assert agg._digest_fields["h_sig"].where == _SIGNAL
+        agg.close()
+
+    def test_located_strata_config_is_mergeable(self):
+        cfg = _config(_variables(located=True, strata=True), streaming=_SPILL)
+        agg = SpillAggregator(cfg, _grid(cfg), "pandas", 1)
+        assert agg._mergeable
+        agg.close()
+
+    def test_expression_field_still_has_no_fold(self):
+        variables = _variables()
+        variables["h_spread"] = {"expression": "np.nanmax(h_ph) - np.nanmin(h_ph)"}
+        with pytest.raises(ValueError, match="expression fields have no cross-block fold"):
+            validate_spill_fold(_config(variables))
+
+    def test_non_tdigest_ragged_still_has_no_fold(self):
+        variables = _variables()
+        variables["h_raw"] = {
+            "function": "np.sort",
+            "source": "h_ph",
+            "kind": "ragged",
+            "inner_shape": [1],
+        }
+        with pytest.raises(ValueError, match="h_raw.*fold law"):
+            validate_spill_fold(_config(variables))
+
+    def test_mode_merge_validation_unchanged(self):
+        # The spill probe widening must not leak into mode: merge — its
+        # per-flush fold degrades locations continuously and ignores where.
+        with pytest.raises(ValueError, match="located ragged"):
+            validate_streaming(_config(_variables(located=True)))
+        with pytest.raises(ValueError, match="h_sig"):
+            validate_streaming(_config(_variables(strata=True)))
+
+
+class TestLocatedMultiBlock:
+    """Located fields across forced block closes: digests exact vs unlocated,
+    locations bounded by the contributor hull."""
+
+    @pytest.mark.parametrize("pairwise", [False, True])
+    def test_digest_bytes_match_unlocated_and_locations_bounded(self, monkeypatch, pairwise):
+        _force_tiny_blocks(monkeypatch)
+        key = _shard_key()
+        out = {}
+        dfs_cache = None
+        for located in (False, True):
+            cfg = _config(_variables(located=located, pairwise=pairwise), streaming=_SPILL)
+            grid = _grid(cfg)
+            if dfs_cache is None:
+                dfs_cache = _granule_dfs(grid, key, _CELL_LISTS, seed=11)
+            out[located] = _run(monkeypatch, cfg, grid, key, list(dfs_cache))
+        (df_u, ragged_u, _), (df_l, ragged_l, _) = out[False], out[True]
+        pd.testing.assert_frame_equal(df_u, df_l)
+        vals_u, idx_u = ragged_u["h_tdigest"]
+        vals_l, idx_l, locs_l = ragged_l["h_tdigest"]
+        assert idx_u == idx_l
+        # The digest channel is identical with or without locations (the
+        # located build/merge overloads change only the companion channel).
+        for a, b in zip(vals_u, vals_l, strict=True):
+            np.testing.assert_array_equal(a, b)
+        # Locations row-aligned with the payloads, uint64, hull-bounded.
+        grid = _grid(_config(_variables(located=True), streaming=_SPILL))
+        children = np.asarray(grid.children(key), dtype=np.uint64)
+        assert len(locs_l) == len(vals_l)
+        for cell_i, digest, locs in zip(idx_l, vals_l, locs_l, strict=True):
+            assert locs.dtype == np.uint64
+            assert locs.shape == (len(digest),)
+            _assert_ancestor_or_equal(locs, _contributors(dfs_cache, grid, int(children[cell_i])))
+
+    def test_counts_and_weights_exact_vs_pooled(self, monkeypatch):
+        _force_tiny_blocks(monkeypatch)
+        key = _shard_key()
+        pooled_cfg = _config(_variables(located=True))
+        spill_cfg = _config(_variables(located=True), streaming=_SPILL)
+        grid = _grid(pooled_cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=100, seed=4)
+        df_p, ragged_p, _ = _run(monkeypatch, pooled_cfg, grid, key, list(dfs))
+        df_s, ragged_s, _ = _run(monkeypatch, spill_cfg, _grid(spill_cfg), key, list(dfs))
+        pd.testing.assert_series_equal(df_p["count"], df_s["count"])
+        vals_p, idx_p, _ = ragged_p["h_tdigest"]
+        vals_s, idx_s, _ = ragged_s["h_tdigest"]
+        assert idx_p == idx_s
+        for dp, ds in zip(vals_p, vals_s, strict=True):
+            # Total weight is the exact observation count either way.
+            assert float(dp[:, 1].sum()) == float(ds[:, 1].sum())
+            for q in (0.1, 0.5, 0.9):
+                assert abs(quantile_from_tdigest(ds, q) - quantile_from_tdigest(dp, q)) < 1.0
+
+    def test_below_knee_locations_are_exact_point_words(self, monkeypatch):
+        # n <= delta across every block: the fold stays loss-free, every
+        # centroid is weight 1, and its location is the exact order-29 point
+        # word — the multiset of locations equals the contributor words.
+        _force_tiny_blocks(monkeypatch)
+        key = _shard_key()
+        cfg = _config(_variables(located=True, delta=512), streaming=_SPILL)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=20, seed=8)
+        _, ragged, _ = _run(monkeypatch, cfg, grid, key, list(dfs))
+        vals, idx, locs = ragged["h_tdigest"]
+        children = np.asarray(grid.children(key), dtype=np.uint64)
+        assert len(vals) > 0
+        for cell_i, digest, cell_locs in zip(idx, vals, locs, strict=True):
+            assert (digest[:, 1] == 1.0).all()
+            contributors = _contributors(dfs, grid, int(children[cell_i]))
+            np.testing.assert_array_equal(np.sort(cell_locs), np.sort(contributors))
+
+    def test_multi_block_actually_engaged(self, monkeypatch):
+        _force_tiny_blocks(monkeypatch)
+        closes = {"n": 0}
+        orig = SpillAggregator._close_block
+
+        def counting(self):
+            closes["n"] += 1
+            orig(self)
+
+        monkeypatch.setattr(SpillAggregator, "_close_block", counting)
+        key = _shard_key()
+        cfg = _config(_variables(located=True), streaming=_SPILL)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, seed=2)
+        _, ragged, meta = _run(monkeypatch, cfg, grid, key, dfs)
+        assert closes["n"] >= len(_CELL_LISTS)
+        assert meta["total_obs"] > 0
+        assert len(ragged["h_tdigest"]) == 3  # located 3-tuple delivered
+
+
+class TestStrataMultiBlock:
+    """build_tdigest_where strata across forced block closes."""
+
+    def _pooled_and_spill(self, monkeypatch, located=False, seed=4):
+        key = _shard_key()
+        pooled_cfg = _config(_variables(strata=True, located=located))
+        spill_cfg = _config(_variables(strata=True, located=located), streaming=_SPILL)
+        grid = _grid(pooled_cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=100, seed=seed)
+        pooled = _run(monkeypatch, pooled_cfg, grid, key, list(dfs))
+        _force_tiny_blocks(monkeypatch)
+        spilled = _run(monkeypatch, spill_cfg, _grid(spill_cfg), key, list(dfs))
+        return key, grid, dfs, pooled, spilled
+
+    def test_stratum_weights_exact_and_quantiles_close_vs_pooled(self, monkeypatch):
+        _, _, _, (df_p, ragged_p, _), (df_s, ragged_s, _) = self._pooled_and_spill(monkeypatch)
+        pd.testing.assert_series_equal(df_p["count"], df_s["count"])
+        for name in ("h_sig", "h_noise"):
+            vals_p, idx_p = ragged_p[name]
+            vals_s, idx_s = ragged_s[name]
+            assert idx_p == idx_s
+            for dp, ds in zip(vals_p, vals_s, strict=True):
+                # Stratum membership is decided per row before the build, so
+                # the stratum count (total weight) is exact across blocks.
+                assert float(dp[:, 1].sum()) == float(ds[:, 1].sum())
+                for q in (0.1, 0.5, 0.9):
+                    assert abs(quantile_from_tdigest(ds, q) - quantile_from_tdigest(dp, q)) < 1.5
+
+    def test_located_strata_locations_bounded_per_stratum(self, monkeypatch):
+        key, grid, dfs, _, (_, ragged_s, _) = self._pooled_and_spill(
+            monkeypatch, located=True, seed=6
+        )
+        children = np.asarray(grid.children(key), dtype=np.uint64)
+        masks = {
+            "h_sig": lambda df: df["h_ph"].values > 0,
+            "h_noise": lambda df: ~(df["h_ph"].values > 0),
+        }
+        for name, mask_fn in masks.items():
+            vals, idx, locs = ragged_s[name]
+            assert len(vals) > 0
+            for cell_i, digest, cell_locs in zip(idx, vals, locs, strict=True):
+                assert cell_locs.shape == (len(digest),)
+                contributors = _contributors(dfs, grid, int(children[cell_i]), mask_fn)
+                # Only the stratum's own rows contribute to its locations.
+                _assert_ancestor_or_equal(cell_locs, contributors)
+
+    def test_strata_invariant_to_block_placement(self, monkeypatch):
+        # The same rows split into different granules (hence different block
+        # boundaries under buffer_granules=1 + tiny blocks) must land the
+        # exact same per-cell stratum weights, and close quantiles.
+        _force_tiny_blocks(monkeypatch)
+        key = _shard_key()
+        cfg_a = _config(_variables(strata=True), streaming=_SPILL)
+        grid = _grid(cfg_a)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=80, seed=3)
+        # Placement B: the same rows, re-partitioned into two granules.
+        pooled_rows = pd.concat(dfs, ignore_index=True)
+        half = len(pooled_rows) // 2
+        dfs_b = [pooled_rows.iloc[:half].copy(), pooled_rows.iloc[half:].copy()]
+        cfg_b = _config(_variables(strata=True), streaming=_SPILL)
+        _, ragged_a, _ = _run(monkeypatch, cfg_a, grid, key, dfs)
+        _, ragged_b, _ = _run(monkeypatch, cfg_b, _grid(cfg_b), key, dfs_b)
+        for name in ("h_sig", "h_noise"):
+            vals_a, idx_a = ragged_a[name]
+            vals_b, idx_b = ragged_b[name]
+            assert idx_a == idx_b
+            for da, db in zip(vals_a, vals_b, strict=True):
+                assert float(da[:, 1].sum()) == float(db[:, 1].sum())
+                for q in (0.1, 0.5, 0.9):
+                    assert abs(quantile_from_tdigest(da, q) - quantile_from_tdigest(db, q)) < 1.5

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -744,6 +744,45 @@ class TestFoldColumnDiagnostics:
             agg._fold_block(agg._block)
         agg.close()
 
+    def test_missing_composition_param_column_named(self):
+        # A typo'd conf column used to fall through _resolve_param as a literal
+        # string and die inside np.column_stack, naming neither the field nor
+        # the column ("the array at index 4 has size 1").
+        variables = _variables()
+        field = _composition_field()
+        field["params"] = {**field["params"], "conf_ocean": "signal_conf_ocaen"}
+        variables["composition"] = field
+        cols = {c: np.zeros(1, np.int64) for c in _CONF_COLS}
+        cols["h_ph"] = np.zeros(1, np.float32)
+        agg = self._agg_with_block(variables, cols)
+        with pytest.raises(
+            ValueError, match="'composition'.*conf_ocean.*signal_conf_ocaen.*spilled block"
+        ):
+            agg._fold_block(agg._block)
+        agg.close()
+
+    def test_missing_where_column_named(self):
+        # A where expression over an unread column reached build_tdigest_where
+        # and raised "where shape () does not match values shape (n,)".
+        variables = _variables(strata=True)
+        variables["h_sig"]["params"] = {**variables["h_sig"]["params"], "where": "flag > 0"}
+        agg = self._agg_with_block(variables, {"h_ph": np.zeros(1, np.float32)})
+        with pytest.raises(ValueError, match="h_sig.*where: 'flag > 0'.*\\['flag'\\]"):
+            agg._fold_block(agg._block)
+        agg.close()
+
+    def test_expression_over_spilled_columns_passes(self):
+        # np/numpy and the block's own columns are the whole namespace, so a
+        # real expression over them must not trip the check.
+        variables = _variables(strata=True)
+        variables["h_sig"]["params"] = {
+            **variables["h_sig"]["params"],
+            "where": "np.isfinite(h_ph) & (h_ph > 0)",
+        }
+        agg = self._agg_with_block(variables, {"h_ph": np.ones(1, np.float32)})
+        agg._fold_block(agg._block)  # no raise
+        agg.close()
+
     def test_reducer_thread_surfaces_the_named_cause(self):
         # On the overlap path the fold runs off-thread; _join_reducer wraps the
         # failure, so the named ValueError must be the cause (not a KeyError).

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -593,6 +593,56 @@ def _true_lane_counts(dfs, grid, cell, threshold=2):
 class TestCompositionMultiBlock:
     """merge_composition across forced block closes (issue #370 option (a))."""
 
+    @pytest.mark.parametrize("declared", [None, "uint64"])
+    def test_prealloc_dtype_and_fill_match_single_block(self, monkeypatch, declared):
+        # The two spill regimes must agree on the stored dtype and on an empty
+        # cell's fill. Nothing forces a composition field to declare `dtype`,
+        # and the merged prealloc used to default it to uint64 while every
+        # other emission path (and the single-block replay) defaults float32.
+        key = _shard_key()
+        field = _composition_field()
+        if declared is None:
+            del field["dtype"], field["fill_value"]
+        else:
+            field["dtype"] = declared
+        variables = {
+            "count": {"function": "len", "source": "h_ph", "dtype": "int32", "fill_value": 0},
+            "composition": field,
+        }
+        cfg = _config(dict(variables), streaming=_SPILL)
+        dfs = _granule_dfs(_grid(cfg), key, _CELL_LISTS[:2], obs_per_cell=8, seed=5, conf=True)
+        df_1, _, _ = _run(monkeypatch, cfg, _grid(cfg), key, list(dfs))
+        multi_cfg = _config(dict(variables), streaming=_SPILL)
+        _force_tiny_blocks(monkeypatch)
+        df_m, _, _ = _run(monkeypatch, multi_cfg, _grid(multi_cfg), key, list(dfs))
+        expected = np.dtype("float32" if declared is None else declared)
+        assert df_1["composition"].dtype == expected
+        assert df_m["composition"].dtype == expected
+        # Empty cells (no observation at all) take the same sentinel in both
+        # regimes: NaN for the float default, the declared 0 for the word.
+        empty = df_1["count"].values == 0
+        assert empty.any()
+        w1, wm = df_1["composition"].values[empty], df_m["composition"].values[empty]
+        if declared is None:
+            assert np.isnan(w1).all() and np.isnan(wm).all()
+        else:
+            assert (w1 == 0).all() and (wm == 0).all()
+
+    def test_non_numeric_fill_on_the_word_is_named(self, monkeypatch):
+        # An integer-dtype field with a string sentinel is rejected by name
+        # (_integer_fill), not by numpy's int('NaN') deep in the prealloc.
+        key = _shard_key()
+        variables = {
+            "count": {"function": "len", "source": "h_ph", "dtype": "int32", "fill_value": 0},
+            "composition": {**_composition_field(), "fill_value": "NaN"},
+        }
+        cfg = _config(dict(variables), streaming=_SPILL)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS[:2], obs_per_cell=8, seed=6, conf=True)
+        _force_tiny_blocks(monkeypatch)
+        with pytest.raises(ValueError, match="cannot hold a non-numeric sentinel"):
+            _run(monkeypatch, cfg, grid, key, list(dfs))
+
     def test_presence_exact_counts_within_fold_bound(self, monkeypatch):
         key = _shard_key()
         variables = {

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -855,3 +855,34 @@ class TestUnlocatedUnchanged:
         assert nan_rows > 0
         assert 4 not in idx_s
         assert counted == nan_rows
+
+
+class TestFoldRegimeVisibility:
+    """The fold regime must be loud (one warning) and queryable
+    (``spill_blocks_closed`` in the stats metadata) — issue #370."""
+
+    _MSG = "leaves the exact single-block regime"
+
+    def test_first_block_close_warns_once_and_counts_land(self, monkeypatch, caplog):
+        _force_tiny_blocks(monkeypatch)
+        key = _shard_key()
+        cfg = _config(_variables(located=True), streaming=_SPILL)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=20, seed=5)
+        with caplog.at_level("WARNING", logger="zagg.processing.spill"):
+            _, _, meta = _run(monkeypatch, cfg, grid, key, dfs)
+        warned = [r for r in caplog.records if self._MSG in r.message]
+        assert len(warned) == 1  # once per shard, not once per close
+        assert warned[0].levelname == "WARNING"
+        # buffer_granules=1 + 1-byte threshold: every flush closes a block.
+        assert meta["phase_timings"]["spill_blocks_closed"] == len(_CELL_LISTS)
+
+    def test_single_block_run_is_silent_and_reads_zero(self, monkeypatch, caplog):
+        key = _shard_key()
+        cfg = _config(_variables(located=True), streaming=_SPILL)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=20, seed=5)
+        with caplog.at_level("WARNING", logger="zagg.processing.spill"):
+            _, _, meta = _run(monkeypatch, cfg, grid, key, dfs)
+        assert not any(self._MSG in r.message for r in caplog.records)
+        assert meta["phase_timings"]["spill_blocks_closed"] == 0

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -591,7 +591,7 @@ def _true_lane_counts(dfs, grid, cell, threshold=2):
 
 
 class TestCompositionMultiBlock:
-    """merge_composition across forced block closes (issue #370 option (a))."""
+    """merge_composition_kway across forced block closes (issue #370 option (a))."""
 
     @pytest.mark.parametrize("declared", [None, "uint64"])
     def test_prealloc_dtype_and_fill_match_single_block(self, monkeypatch, declared):
@@ -670,11 +670,12 @@ class TestCompositionMultiBlock:
             np.testing.assert_array_equal(unpack_composition(word_p) > 0, truth > 0)
             np.testing.assert_array_equal(unpack_composition(word_s) > 0, truth > 0)
             # Below n=254 the pooled word recovers counts exactly; the folded
-            # word stays within the documented O(n/510)-per-fold error over
-            # at most len(dfs) folds (one block per granule here).
+            # word stays within ONE quantization of it — the k-way collapse
+            # quantizes once over every block's part, so the bound does not
+            # grow with the block count (a pairwise chain's would).
             assert n <= 254
             np.testing.assert_array_equal(counts_from_composition(word_p, n), truth)
-            tol = 1 + len(dfs) * n / 510.0
+            tol = 1 + n / 255.0
             assert np.abs(counts_from_composition(word_s, n) - truth).max() <= tol
             checked += 1
         assert checked >= 3

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -179,16 +179,22 @@ def _force_tiny_blocks(monkeypatch):
 _CELL_LISTS = [[0, 4, 8], [2, 4, 10], [1, 8, 9], [0, 10, 15], [4, 8, 10]]
 
 
-def _contributors(dfs, grid, cell, mask_fn=None):
-    """Every leaf word the granules contribute to child cell ``cell``."""
-    words = []
+def _contributor_rows(dfs, grid, cell, mask_fn=None):
+    """Every ``(h_ph value, leaf word)`` row the granules contribute to ``cell``."""
+    values, words = [], []
     for df in dfs:
         in_cell = np.asarray(grid.cells_of(df["leaf_id"].values)) == cell
         keep = in_cell
         if mask_fn is not None:
             keep = in_cell & mask_fn(df)
+        values.append(df["h_ph"].values[keep])
         words.append(df["leaf_id"].values[keep])
-    return np.concatenate(words)
+    return np.concatenate(values), np.concatenate(words)
+
+
+def _contributors(dfs, grid, cell, mask_fn=None):
+    """Every leaf word the granules contribute to child cell ``cell``."""
+    return _contributor_rows(dfs, grid, cell, mask_fn)[1]
 
 
 def _assert_ancestor_or_equal(locs, contributors):
@@ -406,7 +412,10 @@ class TestLocatedMultiBlock:
     def test_below_knee_locations_are_exact_point_words(self, monkeypatch):
         # n <= delta across every block: the fold stays loss-free, every
         # centroid is weight 1, and its location is the exact order-29 point
-        # word — the multiset of locations equals the contributor words.
+        # word — the multiset of locations equals the contributor words, AND
+        # each digest row's location is that row's own leaf. The multiset check
+        # alone is permutation-invariant, so it would pass a shuffled location
+        # channel; the per-row map below is what pins the alignment.
         _force_tiny_blocks(monkeypatch)
         key = _shard_key()
         cfg = _config(_variables(located=True, delta=512), streaming=_SPILL)
@@ -418,8 +427,17 @@ class TestLocatedMultiBlock:
         assert len(vals) > 0
         for cell_i, digest, cell_locs in zip(idx, vals, locs, strict=True):
             assert (digest[:, 1] == 1.0).all()
-            contributors = _contributors(dfs, grid, int(children[cell_i]))
+            values, contributors = _contributor_rows(dfs, grid, int(children[cell_i]))
             np.testing.assert_array_equal(np.sort(cell_locs), np.sort(contributors))
+            # Weight-1 centroids: digest[i, 0] IS an observation value (float32,
+            # the payload dtype), so the value identifies its row. Heights are
+            # drawn from a continuous normal, so ties are measure-zero — assert
+            # uniqueness rather than assume it.
+            keys = values.astype(np.float32)
+            assert len(np.unique(keys)) == len(keys)
+            value_to_leaf = dict(zip(keys.tolist(), contributors.tolist(), strict=True))
+            for centroid, loc in zip(digest, cell_locs, strict=True):
+                assert value_to_leaf[float(centroid[0])] == int(loc)
 
     def test_multi_block_actually_engaged(self, monkeypatch):
         _force_tiny_blocks(monkeypatch)

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -21,12 +21,38 @@ from zagg.grids import HealpixGrid
 from zagg.processing import process_shard
 from zagg.processing.spill import SpillAggregator
 from zagg.processing.streaming import validate_spill_fold, validate_streaming
+from zagg.stats.composition import counts_from_composition, unpack_composition
 from zagg.stats.tdigest import quantile_from_tdigest
 
 _CREDS = {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"}
 
 _SIGNAL = "h_ph > 0"
 _NOISE = "~(h_ph > 0)"
+
+_CONF_COLS = (
+    "signal_conf_land",
+    "signal_conf_ocean",
+    "signal_conf_sea_ice",
+    "signal_conf_land_ice",
+    "signal_conf_inland_water",
+)
+
+
+def _composition_field(threshold=2):
+    return {
+        "function": "zagg.stats.composition.pack_composition",
+        "source": "h_ph",
+        "dtype": "uint64",
+        "fill_value": 0,
+        "params": {
+            "conf_land": "signal_conf_land",
+            "conf_ocean": "signal_conf_ocean",
+            "conf_sea_ice": "signal_conf_sea_ice",
+            "conf_land_ice": "signal_conf_land_ice",
+            "conf_inland_water": "signal_conf_inland_water",
+            "threshold": threshold,
+        },
+    }
 
 
 def _variables(located=False, strata=False, pairwise=False, delta=16):
@@ -100,17 +126,26 @@ def _point_leafs(grid, cell, n, rng):
     return out[:n]
 
 
-def _granule_dfs(grid, shard_key, cell_idx_lists, obs_per_cell=60, seed=0):
-    """One DataFrame per granule; real order-29 point leafs per chosen cell."""
+def _granule_dfs(grid, shard_key, cell_idx_lists, obs_per_cell=60, seed=0, conf=False):
+    """One DataFrame per granule; real order-29 point leafs per chosen cell.
+
+    ``conf=True`` adds the five ``signal_conf_*`` columns (ATL03's ``-1..4``
+    range) for composition tests.
+    """
     rng = np.random.default_rng(seed)
     children = np.asarray(grid.children(shard_key), dtype=np.uint64)
     dfs = []
     for idxs in cell_idx_lists:
+        n = obs_per_cell * len(idxs)
         h, leaf = [], []
         for ci in idxs:
             h.append(rng.normal(0.0, 10.0, obs_per_cell).astype(np.float32))
             leaf.append(_point_leafs(grid, int(children[ci]), obs_per_cell, rng))
-        dfs.append(pd.DataFrame({"h_ph": np.concatenate(h), "leaf_id": np.concatenate(leaf)}))
+        cols = {"h_ph": np.concatenate(h), "leaf_id": np.concatenate(leaf)}
+        if conf:
+            for name in _CONF_COLS:
+                cols[name] = rng.integers(-1, 5, n).astype(np.int8)
+        dfs.append(pd.DataFrame(cols))
     return dfs
 
 
@@ -359,6 +394,22 @@ class TestStrataMultiBlock:
                 # Only the stratum's own rows contribute to its locations.
                 _assert_ancestor_or_equal(cell_locs, contributors)
 
+    def test_strata_and_composition_config_is_mergeable(self):
+        # The full stratified-product shape (issue #321 exemplar): strata +
+        # composition + count, accepted by the spill fold probe (issue #370
+        # option (a)). A non-fold scalar stays rejected alongside.
+        variables = _variables(located=True, strata=True)
+        variables["composition"] = _composition_field()
+        cfg = _config(variables, streaming=_SPILL)
+        validate_spill_fold(cfg)
+        agg = SpillAggregator(cfg, _grid(cfg), "pandas", 1)
+        assert agg._mergeable
+        assert "composition" in agg._composition_fields
+        agg.close()
+        variables["h_mean"] = {"function": "mean", "source": "h_ph"}
+        with pytest.raises(ValueError, match="h_mean.*no.*cross-block fold"):
+            validate_spill_fold(_config(variables))
+
     def test_strata_invariant_to_block_placement(self, monkeypatch):
         # The same rows split into different granules (hence different block
         # boundaries under buffer_granules=1 + tiny blocks) must land the
@@ -383,3 +434,93 @@ class TestStrataMultiBlock:
                 assert float(da[:, 1].sum()) == float(db[:, 1].sum())
                 for q in (0.1, 0.5, 0.9):
                     assert abs(quantile_from_tdigest(da, q) - quantile_from_tdigest(db, q)) < 1.5
+
+
+def _true_lane_counts(dfs, grid, cell, threshold=2):
+    """Ground-truth composition lane counts + n_signal for one cell's rows."""
+    conf_rows, finite_rows = [], []
+    for df in dfs:
+        in_cell = np.asarray(grid.cells_of(df["leaf_id"].values)) == cell
+        conf_rows.append(df.loc[in_cell, list(_CONF_COLS)].to_numpy(np.int64))
+        finite_rows.append(np.isfinite(df.loc[in_cell, "h_ph"].to_numpy(np.float64)))
+    conf = np.concatenate(conf_rows)[np.concatenate(finite_rows)]
+    signal = (conf >= threshold).any(axis=1)
+    n = int(signal.sum())
+    counts = np.zeros(8, dtype=np.int64)
+    if n:
+        csig = conf[signal]
+        counts[:5] = (csig >= threshold).sum(axis=0)
+        strongest = csig.max(axis=1)
+        for i, level in enumerate((2, 3, 4)):
+            counts[5 + i] = int((strongest == level).sum())
+    return counts, n
+
+
+class TestCompositionMultiBlock:
+    """merge_composition across forced block closes (issue #370 option (a))."""
+
+    def test_presence_exact_counts_within_fold_bound(self, monkeypatch):
+        key = _shard_key()
+        variables = {
+            "count": {"function": "len", "source": "h_ph", "dtype": "int32", "fill_value": 0},
+            "composition": _composition_field(),
+        }
+        pooled_cfg = _config(dict(variables))
+        spill_cfg = _config(dict(variables), streaming=_SPILL)
+        grid = _grid(pooled_cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=60, seed=21, conf=True)
+        df_p, _, _ = _run(monkeypatch, pooled_cfg, grid, key, list(dfs))
+        _force_tiny_blocks(monkeypatch)
+        df_s, _, _ = _run(monkeypatch, spill_cfg, _grid(spill_cfg), key, list(dfs))
+        np.testing.assert_array_equal(df_p["count"].values, df_s["count"].values)
+        children = np.asarray(grid.children(key), dtype=np.uint64)
+        checked = 0
+        for i, cell in enumerate(children):
+            word_p, word_s = int(df_p["composition"].values[i]), int(df_s["composition"].values[i])
+            truth, n = _true_lane_counts(dfs, grid, int(cell))
+            if n == 0:
+                assert word_p == 0 and word_s == 0
+                continue
+            # Presence (lane > 0) survives every fold exactly — that is the
+            # spec's floor guarantee — and matches the pooled word's presence.
+            np.testing.assert_array_equal(unpack_composition(word_p) > 0, truth > 0)
+            np.testing.assert_array_equal(unpack_composition(word_s) > 0, truth > 0)
+            # Below n=254 the pooled word recovers counts exactly; the folded
+            # word stays within the documented O(n/510)-per-fold error over
+            # at most len(dfs) folds (one block per granule here).
+            assert n <= 254
+            np.testing.assert_array_equal(counts_from_composition(word_p, n), truth)
+            tol = 1 + len(dfs) * n / 510.0
+            assert np.abs(counts_from_composition(word_s, n) - truth).max() <= tol
+            checked += 1
+        assert checked >= 3
+
+    def test_full_stratified_product_survives_block_closes(self, monkeypatch):
+        # The issue #370 acceptance shape: located strata + composition +
+        # count through a forced multi-block run lands every channel.
+        key = _shard_key()
+        variables = _variables(located=True, strata=True)
+        variables["composition"] = _composition_field()
+        pooled_cfg = _config(dict(variables))
+        spill_cfg = _config(dict(variables), streaming=_SPILL)
+        grid = _grid(pooled_cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=80, seed=9, conf=True)
+        df_p, ragged_p, _ = _run(monkeypatch, pooled_cfg, grid, key, list(dfs))
+        _force_tiny_blocks(monkeypatch)
+        df_s, ragged_s, meta_s = _run(monkeypatch, spill_cfg, _grid(spill_cfg), key, list(dfs))
+        assert meta_s["total_obs"] > 0
+        np.testing.assert_array_equal(df_p["count"].values, df_s["count"].values)
+        # Composition present and presence-consistent with pooled.
+        for wp, ws in zip(df_p["composition"].values, df_s["composition"].values, strict=True):
+            np.testing.assert_array_equal(
+                unpack_composition(int(wp)) > 0, unpack_composition(int(ws)) > 0
+            )
+        # Both strata deliver the located 3-tuple with exact stratum weights.
+        for name in ("h_sig", "h_noise"):
+            vals_p, idx_p, _ = ragged_p[name]
+            vals_s, idx_s, locs_s = ragged_s[name]
+            assert idx_p == idx_s
+            assert len(locs_s) == len(vals_s)
+            for dp, ds, ls in zip(vals_p, vals_s, locs_s, strict=True):
+                assert float(dp[:, 1].sum()) == float(ds[:, 1].sum())
+                assert ls.shape == (len(ds),)

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -280,6 +280,25 @@ class TestSpillFoldProbe:
         with pytest.raises(ValueError, match="h_raw.*fold law"):
             validate_spill_fold(_config(variables))
 
+    def test_chunk_precompute_still_has_no_fold(self):
+        # Chunk-scoped scalars are computed over the whole shard's pooled rows,
+        # which no per-block fold can reconstruct. Rejecting them is also what
+        # makes _resolve_param's namespace identical to the pooled one (no
+        # chunk_scalars ingredient), so the branch is load-bearing.
+        cfg = _config(_variables(), streaming=_SPILL)
+        cfg.aggregation["chunk_precompute"] = {"anchor": {"function": "mean", "source": "h_ph"}}
+        with pytest.raises(ValueError, match="chunk_precompute.*no cross-block fold"):
+            validate_spill_fold(cfg)
+
+    def test_mis_declared_inner_shape_still_has_no_fold(self):
+        # The fold stores merged (k, 2) digests directly, so a mis-declared
+        # inner_shape must fail here rather than disagree with the store schema
+        # readers key on.
+        variables = _variables()
+        variables["h_tdigest"]["inner_shape"] = [3]
+        with pytest.raises(ValueError, match="h_tdigest.*inner_shape.*no cross-block fold"):
+            validate_spill_fold(_config(variables))
+
     def test_where_function_without_where_param_rejected(self):
         # A stratum field that lost its `where` (copy-paste drop) must fail at
         # the probe, not silently fold the WHOLE population into the stratum's

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -362,7 +362,8 @@ class TestSpillFoldProbe:
 
     def test_overflow_message_names_the_fold_surface(self, monkeypatch):
         # A genuinely non-foldable config crossing the threshold names what
-        # the fold DOES cover (and still names the remedies).
+        # the fold DOES cover, WHICH field put it outside that surface (the
+        # probe's verdict, spliced in), and the remedies.
         from zagg.processing.spill import SpillOverflowError
 
         _force_tiny_blocks(monkeypatch)
@@ -371,7 +372,10 @@ class TestSpillFoldProbe:
         cfg = _config(variables, streaming=_SPILL)
         grid = _grid(cfg)
         dfs = _granule_dfs(grid, _shard_key(), _CELL_LISTS[:2], obs_per_cell=10, seed=1)
-        with pytest.raises(SpillOverflowError, match="cross-block fold law.*memory tier"):
+        with pytest.raises(
+            SpillOverflowError,
+            match="cross-block fold law.*'h_spread': expression fields.*memory tier",
+        ):
             _run(monkeypatch, cfg, grid, _shard_key(), dfs)
 
 

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -250,11 +250,45 @@ class TestSpillFoldProbe:
 
     def test_mode_merge_validation_unchanged(self):
         # The spill probe widening must not leak into mode: merge — its
-        # per-flush fold degrades locations continuously and ignores where.
+        # per-flush fold degrades locations continuously, ignores where, and
+        # would re-quantize composition lanes every flush.
         with pytest.raises(ValueError, match="located ragged"):
             validate_streaming(_config(_variables(located=True)))
         with pytest.raises(ValueError, match="h_sig"):
             validate_streaming(_config(_variables(strata=True)))
+        variables = _variables()
+        variables["composition"] = _composition_field()
+        with pytest.raises(ValueError, match="composition.*not.*mergeable"):
+            validate_streaming(_config(variables))
+
+    def test_merge_mode_messages_route_to_spill(self):
+        # Phase 3 (issue #370): the merge-mode rejections keep their
+        # strictness but now name the fold behavior and the mode: spill
+        # remedy, so a config author lands on the working mode in one read.
+        for variables in (
+            _variables(located=True),
+            _variables(strata=True),
+        ):
+            with pytest.raises(ValueError, match="mode: spill"):
+                validate_streaming(_config(variables))
+        variables = _variables()
+        variables["composition"] = _composition_field()
+        with pytest.raises(ValueError, match="mode: spill"):
+            validate_streaming(_config(variables))
+
+    def test_overflow_message_names_the_fold_surface(self, monkeypatch):
+        # A genuinely non-foldable config crossing the threshold names what
+        # the fold DOES cover (and still names the remedies).
+        from zagg.processing.spill import SpillOverflowError
+
+        _force_tiny_blocks(monkeypatch)
+        variables = _variables()
+        variables["h_spread"] = {"expression": "np.nanmax(h_ph) - np.nanmin(h_ph)"}
+        cfg = _config(variables, streaming=_SPILL)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, _shard_key(), _CELL_LISTS[:2], obs_per_cell=10, seed=1)
+        with pytest.raises(SpillOverflowError, match="cross-block fold law.*memory tier"):
+            _run(monkeypatch, cfg, grid, _shard_key(), dfs)
 
 
 class TestLocatedMultiBlock:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -109,10 +109,10 @@ class TestStreamingConfig:
             validate_streaming(cfg)
 
     def test_stratified_where_reducer_rejected(self):
-        # Streaming/spill-fold rebuilds digests from the raw source column
-        # ((source, delta) only), so the ``where`` mask would be silently
-        # ignored — the merge surface must reject it until a masked fold law
-        # exists (issue #321).
+        # The merge-mode fold rebuilds digests from the raw source column
+        # ((source, delta) only) and has no ``where`` state — it must keep
+        # rejecting strata even though the spill fold now evaluates the mask
+        # per block (issue #370); the message routes authors to mode: spill.
         cfg = _config()
         cfg.aggregation["variables"]["h_sig"] = {
             "kind": "ragged",
@@ -125,8 +125,9 @@ class TestStreamingConfig:
             validate_streaming(cfg)
 
     def test_composition_scalar_rejected(self):
-        # The packed composition word's fold (digest-weighted lane mean, issue
-        # #321) is not wired into the streaming state — reject, don't corrupt.
+        # The packed composition word folds only on the spill path (issue
+        # #370): a per-flush merge-mode fold would re-quantize the lanes on
+        # every flush, compounding the O(n/510) error — reject, don't corrupt.
         cfg = _config()
         cfg.aggregation["variables"]["composition"] = {
             "function": "zagg.stats.composition.pack_composition",
@@ -159,8 +160,9 @@ class TestStreamingConfig:
         validate_streaming(cfg)
 
     def test_located_ragged_rejected(self):
-        # The located channel (issue #87) is not threaded through the
-        # streaming state yet; reject rather than silently drop it.
+        # The located channel (issue #87) folds on the spill path's block
+        # closes (issue #370); merge mode folds every flush, which would
+        # coarsen centroid locations continuously — keep rejecting it here.
         cfg = _config()
         cfg.aggregation["variables"]["h_tdigest"]["location"] = "leaf_id"
         with pytest.raises(ValueError, match="located ragged fields .* cannot stream"):

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -664,6 +664,31 @@ class TestMergeTDigestsKway:
         for perm in ([2, 0, 4, 1, 5, 3], [5, 4, 3, 2, 1, 0], [1, 3, 5, 0, 2, 4]):
             assert np.array_equal(ref, merge_tdigests_kway([ds[i] for i in perm], delta=256))
 
+    def test_located_order_independent_with_tied_means(self):
+        """The LOCATION channel is permutation-invariant too (issue #370).
+
+        Tied ``(mean, weight)`` sub-centroids are interchangeable for the digest
+        but carry different location words; a tie straddling a compression
+        boundary used to hand the output centroid a different ancestor depending
+        on part order. The location word is now the tertiary lexsort key, so both
+        channels agree under permutation — and the digest bytes are unchanged
+        (they equal the unlocated fold of the same inputs).
+        """
+        vals = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+        built = [
+            build_tdigest(vals, delta=4, locations=_point_words(6, seed=s)) for s in (11, 12, 13)
+        ]
+        ds = [d for d, _ in built]
+        ls = [ln for _, ln in built]
+        ref, ref_locs = merge_tdigests_kway(ds, delta=4, locations=ls)
+        assert np.array_equal(ref, merge_tdigests_kway(ds, delta=4))
+        for perm in ([2, 0, 1], [1, 2, 0], [2, 1, 0]):
+            out, out_locs = merge_tdigests_kway(
+                [ds[i] for i in perm], delta=4, locations=[ls[i] for i in perm]
+            )
+            assert np.array_equal(ref, out)
+            assert np.array_equal(ref_locs, out_locs)
+
     def test_pairwise_fold_is_order_dependent(self):
         """Contrast: the pairwise left-fold is NOT associative (issue #279)."""
         ds = self._digests(2, 6)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -159,6 +159,8 @@ class TestBuildRecord:
         # The spill instrumentation (issue #217) stamps byte counts alongside
         # the ``*_s`` seconds in ``phase_timings``; the record keeps timings
         # seconds-only and surfaces the volume on its own top-level field.
+        # The issue #370 fold-regime marker splits out the same way (a count,
+        # not seconds).
         rec = _record(
             phases={
                 "read": 8.0,
@@ -166,6 +168,7 @@ class TestBuildRecord:
                 "spill_write_s": 0.5,
                 "spill_read_s": 0.25,
                 "spill_bytes": 4096.0,
+                "spill_blocks_closed": 3,
             }
         )
         assert rec["phase_timings"] == {
@@ -175,6 +178,21 @@ class TestBuildRecord:
             "spill_read_s": 0.25,
         }
         assert rec["spill_bytes"] == pytest.approx(4096.0)
+        assert rec["spill_blocks_closed"] == 3
+
+    def test_spill_blocks_closed_absent_reads_none(self):
+        # 0/absent = exact regime; a record without the marker carries None.
+        assert _record()["spill_blocks_closed"] is None
+
+    def test_spill_blocks_closed_merges_by_sum_and_flattens(self):
+        # Rollups sum the fold counts (like spill_bytes); the run parquet gets
+        # a real column so folded leaves are queryable after the fact.
+        a = _record(phases={"read": 1.0, "spill_blocks_closed": 2})
+        b = _record(phases={"read": 1.0, "spill_blocks_closed": 3})
+        assert merge([a, b])["spill_blocks_closed"] == 5
+        row = flatten_record(a)
+        assert row["spill_blocks_closed"] == 2
+        assert "phase_spill_blocks_closed" not in row
 
     def test_granules_sha256_order_independent(self):
         assert granules_sha256(["b", "a"]) == granules_sha256(["a", "b"])


### PR DESCRIPTION
Closes #370

## What

Lifts the single-block restriction for located ragged fields, `build_tdigest_where` strata, and the packed composition word on the spill path (`aggregation.streaming.mode: spill`). Today `SpillAggregator` classifies these non-mergeable (`_mergeable` via bare `validate_streaming`) and raises `SpillOverflowError` the moment a second block opens — exactly on the densest shards (88S crossover belt, fat-tail Sierra shards on a California o8 strata run) that both want strata+location and risk a block close. Per the issue, the blocking is plumbing, not algebra: `merge_tdigests` already implements the located pairwise merge (`locations1=`/`locations2=`, `src/zagg/stats/tdigest.py`), `merge_tdigests_kway` the located k-way merge, stratum membership is per-photon row selection before the build (independent of block boundaries), and `merge_composition` exists with documented error bounds.

## Approach

- **No spill-record schema change turned out to be needed.** The plan's phase 1 anticipated appending the order-29 point-word column to the spill record gated on `location:`; on inspection the flush already spills **every** read-carrier column wholesale (`SpillAggregator.flush` → `_concat_and_group` → `SpillBlock.append`), and `leaf_id` is a read-carrier column (`read.py` materializes it for cell assignment). The single-block exact replay already depends on it — located fields work single-block today. So phase 1 reduces to the block-close build, the flush/append path is untouched, and unlocated spill records are byte-identical by construction (zero diff on the write path).
- **Block close** (`_fold_block`): located fields build `(digest, locations)` partials per cell via the same `build_tdigest(values, locations=...)` the pooled path uses; strata fields resolve their `where` param per cell over the spilled columns (same bare-column/expression resolution as `calculate_cell_statistics`, sharing `_compile_param_expr`) and delegate to `build_tdigest_where`.
- **Cross-block fold**: located pairwise via `merge_tdigests(..., locations1=, locations2=)`, located k-way via `merge_tdigests_kway(..., locations=)` at finalize — k-way vs pairwise follows the field's function exactly as the plain-digest fold does today (issue #279). Composition folds under option (a) — per-block `(word, n_signal)` parts collapse in ONE k-way weighted lane mean at finalize (`merge_composition_kway`, added on review to make the fold order-independent and single-quantization; `merge_composition` itself is untouched as the spec §3.4 binary law). See Questions for review.
- **Validation split**: spill's mergeability probe is the new `validate_spill_fold` (`streaming.py`) — wider than `validate_streaming`, which stays exactly as strict: `mode: merge` folds every `buffer_granules` flush, degrading locations continuously, so it keeps rejecting located/strata/composition; phase 3 only updates its messages to name the fold behavior and the `mode: spill` remedy.
- **Spec**: one descriptive sentence in `docs/specification.md` §2.2 naming spill-block closes as an additional merge source for the located channel. **No wire-format change and no fixture change** — cross-block-folded payloads are already conformant `zagg-ragged/1` + locations (a fold coarsens merged centroids' locations to common ancestors, the located channel's defined behavior above weight 1).

## Phases

- [x] Phase 1 — located + strata cross-block folds: `validate_spill_fold` probe (located + `build_tdigest_where`; composition still excluded), `_DigestField` classification, `_fold_block` builds located `(digest, locations)` / stratum partials, pairwise + k-way located folds, merged emission carries the located channel. (The probe move was planned for phase 2 but the pairwise fold happens inside `_fold_block`, so landing build-without-fold would have been incoherent; phase 2 is composition.)
- [x] Phase 2 — composition cross-block fold: per-block `(word, n_signal)` build, composition fold (k-way collapse at finalize after the round-2 review fold), probe accepts `pack_composition`, merged emission of the packed word.
- [x] Phase 3 — validation split + guardrails: `mode: merge` messages name the fold behavior and the spill remedy (strictness unchanged); `SpillOverflowError` message names what still has no fold law.
- [x] Phase 4 — spec sentence + acceptance battery: located+strata+composition config through a forced multi-block run end-to-end; unlocated spill unchanged; composition within the documented O(n/510)-per-fold bound.

## How tested

New battery in `tests/test_spill_crossblock.py` (phase 1: probe classification; located multi-block digests byte-identical to the unlocated fold with locations bounded — every merged location is an ancestor-or-equal of a contributor word and a descendant of the contributors' common ancestor; below-compression-knee locations are the exact order-29 point words; stratum weights exact vs pooled and invariant to block placement; quantiles within t-digest tolerance vs pooled). Plus `uv run pytest tests/test_spill.py tests/test_streaming.py` (all pre-existing spill/streaming tests green, unchanged), `ruff check` / `ruff format --check`, and the full suite before ready-for-review.

Full-suite status: `uv run pytest` (minus `tests/test_lambda_build.py`, environmental) is 3200 passed / 37 skipped locally. Known pre-existing local issues, not touched here: `ruff check src` flags `N818` on `src/zagg/registry.py` (`UnknownCapability`) on a clean main checkout, and `ruff format --check` flags `tests/data/benchmark/README.md` (both reproduce with this PR's changes stashed); `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` fails locally for environmental reasons.

## Questions for review

- **Composition multi-block fold — needs a ruling (the question #321 deferred).** Phase 2 implements **option (a)**: fold composition words across blocks via `merge_composition`, accepting the documented lane-quantization error (O(n/510) per fold; presence exact via the floor) — an overflow shard's composition word is *not byte-stable* against the single-block result. Option (b) would leave composition non-mergeable so a strata-with-composition config still fails loudly on a block close. Flipping to (b) is a one-line change: remove the `pack_composition` acceptance branch in `validate_spill_fold` (`src/zagg/processing/streaming.py`). Working assumption is (a) per the issue; awaiting ratification.

- **Follow-up flagged during review (pre-existing, outside this diff):** `validate_streaming` (mode: merge) accepts a `build_tdigest` field carrying a stray `where` param and would silently ignore the mask in its fold — the spill probe now rejects that mismatch, but the merge-mode validator has the same hole on main. Standing on the review thread; happy to file it as a small-fix issue if wanted.
