### PR TITLE
small fixes: event-transport pacing window, point-path observations-read counter

### DIFF
--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -61,7 +61,6 @@ from concurrent.futures import wait as futures_wait
 from dataclasses import asdict
 from typing import Any, Iterator
 
-from zagg.concurrency import fd_safe_max_workers
 from zagg.config import (
     PipelineConfig,
     get_child_order,
@@ -733,7 +732,7 @@ class Run:
             writes status objects (issue #327) and read access to the status
             prefix for the poll.
         """
-        from zagg import runner
+        from zagg import concurrency, runner
 
         if transport not in ("sync", "event"):
             raise ValueError(f'transport must be "sync" or "event", got {transport!r}')
@@ -767,6 +766,7 @@ class Run:
             # connection pool tracks the fan-out width, but must never exceed
             # the fd ceiling regardless of pacing window — the event window
             # may clear RLIMIT_NOFILE (issue #375), a pool of sockets may not.
+            # Through the module seam, so the fd ceiling has one patch point.
             client = session.client(
                 "lambda",
                 region_name=self.region,
@@ -774,7 +774,7 @@ class Run:
                     read_timeout=960,
                     connect_timeout=10,
                     retries={"max_attempts": 0},
-                    max_pool_connections=min(workers, fd_safe_max_workers()),
+                    max_pool_connections=min(workers, concurrency.fd_safe_max_workers()),
                 ),
             )
             invoked_by = runner._resolve_invoked_by(session, self.region)

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -709,7 +709,12 @@ class Run:
             held socket per in-flight shard), while the event window — which
             holds no connections — is sized by account headroom alone, so a
             low ``ulimit -n`` no longer strands concurrency the account has
-            already granted.
+            already granted. The window is fired serially by the poller thread
+            (:meth:`~zagg.client_transport.StatusPoller._dispatch_up_to_window`),
+            so a wider window also lengthens the opening dispatch ramp
+            proportionally — roughly 10 ms of invoke round-trip per shard, and
+            no LIST runs during it. Deliberate: the ramp grows by seconds while
+            the clamp cost whole 900 s waves (issue #375).
         transport : str
             ``"sync"`` (default, the v1 transport): a thread pool over
             synchronous ``RequestResponse`` invokes — one held connection per

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -631,7 +631,7 @@ class Run:
 
     # -- dispatch -----------------------------------------------------------
 
-    def _probe_workers(self, session, n: int) -> int:
+    def _probe_workers(self, session, n: int, *, fd_bound: bool = True) -> int:
         """Account-concurrency preflight, degrading to the default on denial.
 
         Runs ``agg``'s own :func:`~zagg.concurrency.compute_available_workers`
@@ -639,6 +639,11 @@ class Run:
         size, so a notebook fan-out is sized by what the account can actually
         take rather than by a hardcoded guess (espg ruling on PR #333: whoever
         can invoke the workers normally can read the concurrency too).
+
+        ``fd_bound`` carries the transport's connection model through to the
+        probe: the sync transport holds one socket per in-flight shard, so its
+        window is FD-bounded; the event transport holds none and passes
+        ``False`` (issue #375).
 
         Fail-open by design: ANY probe failure — ``AccessDenied`` under a
         narrow-permission deployment (the cryocloud case, where the worker role
@@ -656,6 +661,7 @@ class Run:
                 session.client("lambda", region_name=self.region),
                 session.client("cloudwatch", region_name=self.region),
                 self.function_name,
+                fd_bound=fd_bound,
             )
             runner._log_concurrency_report(report, workers)
             return workers
@@ -698,6 +704,12 @@ class Run:
             shards may be dispatched-but-unresolved at once, load-bearing
             because the fleet's 60 s ``MaximumEventAgeInSeconds`` silently
             drops an Event invoke the account has no concurrency to start.
+            The two transports therefore probe differently (issue #375): the
+            sync pool is clamped by the local ``RLIMIT_NOFILE`` ceiling (one
+            held socket per in-flight shard), while the event window — which
+            holds no connections — is sized by account headroom alone, so a
+            low ``ulimit -n`` no longer strands concurrency the account has
+            already granted.
         transport : str
             ``"sync"`` (default, the v1 transport): a thread pool over
             synchronous ``RequestResponse`` invokes — one held connection per
@@ -735,7 +747,14 @@ class Run:
             from botocore.config import Config
 
             session = boto3.Session()
-            requested = max_workers if max_workers is not None else self._probe_workers(session, n)
+            # The FD ceiling bounds the SYNC pool (one held socket per in-flight
+            # shard); the event transport holds no connections, so its pacing
+            # window comes from account headroom alone (issue #375).
+            requested = (
+                max_workers
+                if max_workers is not None
+                else self._probe_workers(session, n, fd_bound=transport == "sync")
+            )
             workers = max(1, min(requested, n))
             # read_timeout must exceed the 900 s function ceiling (same
             # rationale as agg's preflight-built client, issue #148); the

--- a/src/zagg/client.py
+++ b/src/zagg/client.py
@@ -61,6 +61,7 @@ from concurrent.futures import wait as futures_wait
 from dataclasses import asdict
 from typing import Any, Iterator
 
+from zagg.concurrency import fd_safe_max_workers
 from zagg.config import (
     PipelineConfig,
     get_child_order,
@@ -763,7 +764,9 @@ class Run:
             workers = max(1, min(requested, n))
             # read_timeout must exceed the 900 s function ceiling (same
             # rationale as agg's preflight-built client, issue #148); the
-            # connection pool tracks the fan-out width.
+            # connection pool tracks the fan-out width, but must never exceed
+            # the fd ceiling regardless of pacing window — the event window
+            # may clear RLIMIT_NOFILE (issue #375), a pool of sockets may not.
             client = session.client(
                 "lambda",
                 region_name=self.region,
@@ -771,7 +774,7 @@ class Run:
                     read_timeout=960,
                     connect_timeout=10,
                     retries={"max_attempts": 0},
-                    max_pool_connections=workers,
+                    max_pool_connections=min(workers, fd_safe_max_workers()),
                 ),
             )
             invoked_by = runner._resolve_invoked_by(session, self.region)

--- a/src/zagg/concurrency.py
+++ b/src/zagg/concurrency.py
@@ -11,7 +11,9 @@ fan-out, and this module surfaces both *before* dispatch:
   never sees, so those cells drop while the run still "completes".
   :func:`fd_safe_max_workers` derives a worker ceiling from
   ``RLIMIT_NOFILE``; :func:`raise_for_fd_exhaustion` turns a raw errno-24 into
-  an actionable message.
+  an actionable message. This limit is specific to the **sync** transport: a
+  carrier that holds no per-shard connection (the event transport, issue #375)
+  opts out via ``compute_available_workers(..., fd_bound=False)``.
 
 * **Account Lambda concurrency.** Saturating the account-wide concurrent
   execution pool throttles this run *and* any other Lambda activity in the
@@ -277,6 +279,7 @@ def compute_available_workers(
     *,
     padding_pct: float = _CONCURRENCY_PADDING_PCT,
     padding_floor: int = _CONCURRENCY_PADDING_FLOOR,
+    fd_bound: bool = True,
 ) -> tuple[int, ConcurrencyReport]:
     """Clamp ``requested`` workers to FD- and account-concurrency-safe bounds.
 
@@ -297,6 +300,19 @@ def compute_available_workers(
         Dispatch target (for the concurrency probe).
     padding_pct, padding_floor
         Forwarded to :func:`probe_concurrency`.
+    fd_bound : bool
+        Whether the local file-descriptor ceiling bounds the result. ``True``
+        (default) is the v1 sync transport, which holds one socket per
+        in-flight shard, so the ceiling is load-bearing. Pass ``False`` for a
+        caller that holds NO connection per unit of work — the event transport
+        (issue #375), whose window is pure dispatch pacing bounded by account
+        headroom, not client fds. Clamping it at ``RLIMIT_NOFILE`` strands paid
+        -for headroom (observed: window pinned to ~1,000 against ~1,898
+        available). The FD ceiling still applies as the fallback when account
+        headroom is UNREADABLE, since it is then the only bound left — an
+        unbounded window would fire the whole shard set at once and the fleet's
+        60 s ``MaximumEventAgeInSeconds`` would silently drop what it cannot
+        start.
 
     Returns
     -------
@@ -310,7 +326,10 @@ def compute_available_workers(
         padding_pct=padding_pct,
         padding_floor=padding_floor,
     )
-    workers = min(requested, fd_safe_max_workers())
     if report.available is not None:
-        workers = min(workers, report.available)
+        workers = min(requested, report.available)
+        if fd_bound:
+            workers = min(workers, fd_safe_max_workers())
+    else:
+        workers = min(requested, fd_safe_max_workers())
     return max(1, workers), report

--- a/src/zagg/index/__init__.py
+++ b/src/zagg/index/__init__.py
@@ -87,6 +87,7 @@ class VirtualIndex:
         grid,
         arrow: bool = False,
         granule_url: str | None = None,
+        io_stats: dict | None = None,
     ):
         """Read + spatially filter one HDF5 group for one shard.
 
@@ -96,6 +97,13 @@ class VirtualIndex:
         by the worker only when the a-priori chunk-boundary arm (issue #148
         arm 2a, ``read_plan.chunk_boundaries``) is configured — it locates the
         granule's boundary parquet on that route and is omitted otherwise.
+
+        ``io_stats`` (issue #374) is the optional read-counter sink: a dict the
+        backend's read routes accumulate ``obs_read`` (base-rate rows decoded,
+        BEFORE filtering and shard assignment) into. The worker allocates one
+        per granule, so a backend may write it without locking from the thread
+        that owns the granule. A backend that does not count leaves the key
+        absent, which reports as ``None`` (unmeasured) rather than zero.
         """
         raise NotImplementedError
 

--- a/src/zagg/index/hierarchical.py
+++ b/src/zagg/index/hierarchical.py
@@ -20,7 +20,17 @@ class HierarchicalIndex(VirtualIndex):
     # No backend-specific keys: today's path is configured by the existing
     # ``data_source.read_plan`` / ``levels`` surface, not the index block.
 
-    def read_group(self, h5obj, group, data_source, shard_key, grid, arrow=False, granule_url=None):
+    def read_group(
+        self,
+        h5obj,
+        group,
+        data_source,
+        shard_key,
+        grid,
+        arrow=False,
+        granule_url=None,
+        io_stats=None,
+    ):
         # Resolve through the package namespace at call time (not an import-time
         # binding) so tests that ``monkeypatch.setattr("zagg.processing._read_group",
         # ...)`` keep intercepting the worker's reads, exactly as before the seam.
@@ -29,7 +39,11 @@ class HierarchicalIndex(VirtualIndex):
         # ``granule_url`` is forwarded only when set (the a-priori arm), so
         # monkeypatched ``_read_group`` fakes keep their existing signature on
         # every other path -- mirroring the worker's presence-gated kwarg.
+        # ``io_stats`` (issue #374) is gated the same way, for the same reason:
+        # a fake that takes neither keeps working, and simply reports no count.
         kwargs = {"arrow": arrow}
         if granule_url is not None:
             kwargs["granule_url"] = granule_url
+        if io_stats is not None:
+            kwargs["io_stats"] = io_stats
         return _processing._read_group(h5obj, group, data_source, shard_key, grid, **kwargs)

--- a/src/zagg/index/hierarchical.py
+++ b/src/zagg/index/hierarchical.py
@@ -39,11 +39,13 @@ class HierarchicalIndex(VirtualIndex):
         # ``granule_url`` is forwarded only when set (the a-priori arm), so
         # monkeypatched ``_read_group`` fakes keep their existing signature on
         # every other path -- mirroring the worker's presence-gated kwarg.
-        # ``io_stats`` (issue #374) is gated the same way, for the same reason:
-        # a fake that takes neither keeps working, and simply reports no count.
-        kwargs = {"arrow": arrow}
+        # ``io_stats`` (issue #374) is NOT gated: it is always-on
+        # instrumentation, the worker always passes a dict (``worker.py:422``,
+        # ``worker.py:436``), and ``_record_obs_read`` no-ops on ``None`` for
+        # the direct callers that omit it -- so gating it would protect nothing
+        # while diverging from ``InlineIndex.read_group``, which forwards it
+        # unconditionally (review finding).
+        kwargs = {"arrow": arrow, "io_stats": io_stats}
         if granule_url is not None:
             kwargs["granule_url"] = granule_url
-        if io_stats is not None:
-            kwargs["io_stats"] = io_stats
         return _processing._read_group(h5obj, group, data_source, shard_key, grid, **kwargs)

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -608,7 +608,17 @@ class InlineIndex(VirtualIndex):
         key = write_manifest(granule_manifest(maps), self.store, _granule_id(granule_url))
         logger.info(f"  inline write-back: {len(maps)} dataset(s) -> {self.store}/{key}")
 
-    def read_group(self, h5obj, group, data_source, shard_key, grid, arrow=False, granule_url=None):
+    def read_group(
+        self,
+        h5obj,
+        group,
+        data_source,
+        shard_key,
+        grid,
+        arrow=False,
+        granule_url=None,
+        io_stats=None,
+    ):
         from zagg.processing.read import (
             _planned_read_group,
             _read_group_full,
@@ -635,10 +645,24 @@ class InlineIndex(VirtualIndex):
         read_fn = self._chunk_aligned_read_fn(h5obj, planned=planned)
         if planned:
             return _planned_read_group(
-                h5obj, group, data_source, shard_key, grid, arrow=arrow, read_fn=read_fn
+                h5obj,
+                group,
+                data_source,
+                shard_key,
+                grid,
+                arrow=arrow,
+                read_fn=read_fn,
+                io_stats=io_stats,
             )
         return _read_group_full(
-            h5obj, group, data_source, shard_key, grid, arrow=arrow, read_fn=read_fn
+            h5obj,
+            group,
+            data_source,
+            shard_key,
+            grid,
+            arrow=arrow,
+            read_fn=read_fn,
+            io_stats=io_stats,
         )
 
     def _chunk_aligned_read_fn(self, h5obj, *, planned=True):

--- a/src/zagg/processing/apriori.py
+++ b/src/zagg/processing/apriori.py
@@ -194,6 +194,7 @@ def _apriori_read_group(
     grid,
     arrow: bool = False,
     granule_url: str | None = None,
+    io_stats: dict | None = None,
 ):
     """A-priori (chunk-boundary) read of one HDF5 group — issue #148 arm 2a.
 
@@ -206,6 +207,9 @@ def _apriori_read_group(
     bit-identical to the production paths. Selectivity above
     ``full_read_threshold`` falls back to the full-coord read, mirroring
     :func:`~zagg.processing.read._planned_read_group`.
+
+    ``io_stats`` (issue #374) is forwarded to whichever arm decodes base-rate
+    rows, so this route reports ``obs_read`` like the others.
     """
     from zagg.processing.read import _execute_plan_group, _read_group_full
 
@@ -237,9 +241,20 @@ def _apriori_read_group(
     if not plan.parent_runs:
         return None  # no chunk's span touches this shard
     if plan.full_read:
-        return _read_group_full(h5obj, group, data_source, shard_key, grid, arrow=arrow)
+        return _read_group_full(
+            h5obj, group, data_source, shard_key, grid, arrow=arrow, io_stats=io_stats
+        )
 
     read_fn = _make_boundary_read_fn(h5obj)
     return _execute_plan_group(
-        h5obj, group, data_source, shard_key, grid, plan, n_base, arrow, read_fn=read_fn
+        h5obj,
+        group,
+        data_source,
+        shard_key,
+        grid,
+        plan,
+        n_base,
+        arrow,
+        read_fn=read_fn,
+        io_stats=io_stats,
     )

--- a/src/zagg/processing/apriori.py
+++ b/src/zagg/processing/apriori.py
@@ -211,7 +211,7 @@ def _apriori_read_group(
     ``io_stats`` (issue #374) is forwarded to whichever arm decodes base-rate
     rows, so this route reports ``obs_read`` like the others.
     """
-    from zagg.processing.read import _execute_plan_group, _read_group_full
+    from zagg.processing.read import _execute_plan_group, _read_group_full, _record_obs_read
 
     rp = data_source["read_plan"]
     cfg = rp["chunk_boundaries"]
@@ -228,6 +228,10 @@ def _apriori_read_group(
     beam = group.strip("/").split("/")[0]
     bdf = bdf[bdf["beam"] == beam]
     if bdf.empty:
+        # Pre-decode short-circuit: stamp a measured zero so the a-priori route
+        # agrees with the full-read one, where absence means "unmeasured", not
+        # "read nothing" (issue #374, review finding).
+        _record_obs_read(io_stats, 0)
         return None  # beam absent or photon-less at extraction time -> no data
 
     plan, n_base = _plan_from_boundaries(
@@ -239,6 +243,7 @@ def _apriori_read_group(
         samples_per_chunk=int(cfg.get("samples_per_chunk", DEFAULT_SAMPLES_PER_CHUNK)),
     )
     if not plan.parent_runs:
+        _record_obs_read(io_stats, 0)
         return None  # no chunk's span touches this shard
     if plan.full_read:
         return _read_group_full(

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -382,7 +382,9 @@ def _planned_read_group(
 
     ``io_stats`` (issue #374) is the optional read-counter sink, forwarded to
     whichever arm actually decodes base-rate rows — the full-read fallback or
-    :func:`_execute_plan_group` — so a group is counted exactly once.
+    :func:`_execute_plan_group` — so a group is counted exactly once. The
+    pre-decode short-circuits stamp a measured zero themselves, so this route
+    never reports "unmeasured" for a group it did look at.
     """
     levels = data_source["levels"]
     base_level_key = data_source["base_level"]
@@ -429,7 +431,14 @@ def _planned_read_group(
     ibeg_arr = coarse_data[ibeg_path]
     cnt_arr = coarse_data[cnt_path]
 
+    # The three short-circuits below return before any base-rate decode, so
+    # each stamps a measured zero (issue #374): without it the planned route --
+    # the production route for ATL03, where a granule assigned for one beam
+    # short-circuits on the other five -- reports ``n_obs_read = None``,
+    # indistinguishable from an uninstrumented read seam. That discrimination
+    # is the whole point of the nullable column (review finding).
     if len(coarse_lats) == 0:
+        _record_obs_read(io_stats, 0)
         return None
 
     # ``n_base`` under #43's contiguity assumption ("ranges do not overlap and
@@ -440,6 +449,7 @@ def _planned_read_group(
     # either form under- or over-estimates -- track via a follow-up to #43.
     n_base = int(np.asarray(cnt_arr).sum())
     if n_base <= 0:
+        _record_obs_read(io_stats, 0)
         return None
 
     # Match segments to this shard with the SAME mortie test the photon path
@@ -468,6 +478,7 @@ def _planned_read_group(
     )
 
     if not plan.parent_runs:
+        _record_obs_read(io_stats, 0)
         return None  # empty AOI -- no parent intersects, skip the group entirely
 
     if plan.full_read:
@@ -571,7 +582,9 @@ def _execute_plan_group(
     # straddling reads counted BEFORE the shard mask and filters below, so the
     # segment→photon indexed-IO efficiency (issue #43) is derivable from the
     # run parquet. Recorded ahead of the empty short-circuit so an instrumented
-    # route that decodes nothing still reads as measured-zero, not unmeasured.
+    # route that decodes nothing still reads as measured-zero, not unmeasured
+    # -- as do the pre-decode short-circuits in ``_planned_read_group`` and
+    # ``_apriori_read_group``, which never reach this line.
     _record_obs_read(io_stats, len(lats))
 
     if len(lats) == 0:

--- a/src/zagg/processing/read.py
+++ b/src/zagg/processing/read.py
@@ -321,6 +321,23 @@ def _level_coord_paths(level: dict, group: str) -> tuple[str, str]:
     return lat_path, lon_path
 
 
+def _record_obs_read(io_stats: dict | None, n: int) -> None:
+    """Accumulate base-rate rows DECODED (pre-filter) for the read counter.
+
+    The point-path counterpart of the raster ``io_stats`` counters (issue #374
+    / issue #297): rows fetched, before the shard mask, structured/expression
+    filters, and segment padding are applied — so ``n_obs_read / n_obs`` is the
+    read-vs-keep ratio, derived at read time and never stored.
+
+    PRESENCE of the key is the "measured" signal, not its value: a read seam
+    that never calls this (a stubbed ``_read_group``, or a worker predating the
+    field) leaves it absent, which the worker reports as ``None`` — unmeasured,
+    per the #297 nullable-column convention — rather than a real zero.
+    """
+    if io_stats is not None:
+        io_stats["obs_read"] = io_stats.get("obs_read", 0) + int(n)
+
+
 def _planned_read_group(
     h5obj,
     group: str,
@@ -329,6 +346,7 @@ def _planned_read_group(
     grid,
     arrow: bool = False,
     read_fn=None,
+    io_stats: dict | None = None,
 ):
     """Planned (AOI-bounded) read of one HDF5 group via the coarse spatial index.
 
@@ -361,6 +379,10 @@ def _planned_read_group(
     reads; ``None`` (default) uses the plain h5coro bridge — the hierarchical
     baseline. Selection semantics (the plan) and everything downstream of the
     returned columns are identical regardless.
+
+    ``io_stats`` (issue #374) is the optional read-counter sink, forwarded to
+    whichever arm actually decodes base-rate rows — the full-read fallback or
+    :func:`_execute_plan_group` — so a group is counted exactly once.
     """
     levels = data_source["levels"]
     base_level_key = data_source["base_level"]
@@ -454,11 +476,27 @@ def _planned_read_group(
         # ``read_fn`` rides along (issue #179): the fallback keeps the compiled
         # + pooled addressing instead of dropping to serial h5coro.
         return _read_group_full(
-            h5obj, group, data_source, shard_key, grid, arrow=arrow, read_fn=read_fn
+            h5obj,
+            group,
+            data_source,
+            shard_key,
+            grid,
+            arrow=arrow,
+            read_fn=read_fn,
+            io_stats=io_stats,
         )
 
     return _execute_plan_group(
-        h5obj, group, data_source, shard_key, grid, plan, n_base, arrow, read_fn=read_fn
+        h5obj,
+        group,
+        data_source,
+        shard_key,
+        grid,
+        plan,
+        n_base,
+        arrow,
+        read_fn=read_fn,
+        io_stats=io_stats,
     )
 
 
@@ -472,6 +510,7 @@ def _execute_plan_group(
     n_base,
     arrow=False,
     read_fn=None,
+    io_stats: dict | None = None,
 ):
     """Execute a computed :class:`~zagg.read_plan.ReadPlan` over one group.
 
@@ -527,6 +566,13 @@ def _execute_plan_group(
         workers,
     )
     lats, lons = coord_arrays[lat_path], coord_arrays[lon_path]
+
+    # Rows DECODED by this group's plan (issue #374): the padded, boundary-
+    # straddling reads counted BEFORE the shard mask and filters below, so the
+    # segment→photon indexed-IO efficiency (issue #43) is derivable from the
+    # run parquet. Recorded ahead of the empty short-circuit so an instrumented
+    # route that decodes nothing still reads as measured-zero, not unmeasured.
+    _record_obs_read(io_stats, len(lats))
 
     if len(lats) == 0:
         return None
@@ -671,6 +717,7 @@ def _read_group(
     grid,
     arrow: bool = False,
     granule_url: str | None = None,
+    io_stats: dict | None = None,
 ):
     """Read and spatially filter one HDF5 group.
 
@@ -706,6 +753,12 @@ def _read_group(
     Empty-AOI groups short-circuit to ``None``. Selectivity above the configured
     threshold falls back to the full-read path; the planned and full paths
     produce row-for-row identical output (#43 Phase C parity).
+
+    ``io_stats`` (issue #374) is an optional mutable dict the read routes
+    accumulate ``obs_read`` (rows decoded, pre-filter) into. The worker owns
+    one per granule, so it is written only by that granule's thread and read
+    by the dispatcher after the read completes — no lock (the point-path
+    analogue of the raster ``io_stats`` sink). ``None`` counts nothing.
     """
     rp = data_source.get("read_plan")
     # Presence check, not truthiness: an empty/misconfigured ``chunk_boundaries``
@@ -715,7 +768,14 @@ def _read_group(
         from zagg.processing.apriori import _apriori_read_group
 
         return _apriori_read_group(
-            h5obj, group, data_source, shard_key, grid, arrow=arrow, granule_url=granule_url
+            h5obj,
+            group,
+            data_source,
+            shard_key,
+            grid,
+            arrow=arrow,
+            granule_url=granule_url,
+            io_stats=io_stats,
         )
     # Truthy-checking ``levels``/``base_level`` would route an empty ``{}`` (a
     # config typo, easy to do) back to the full-read path silently. Reject
@@ -724,8 +784,12 @@ def _read_group(
     # multi-level structure to operate on.
     if isinstance(rp, dict) and rp.get("spatial_index"):
         _validate_planned_config(data_source)
-        return _planned_read_group(h5obj, group, data_source, shard_key, grid, arrow=arrow)
-    return _read_group_full(h5obj, group, data_source, shard_key, grid, arrow=arrow)
+        return _planned_read_group(
+            h5obj, group, data_source, shard_key, grid, arrow=arrow, io_stats=io_stats
+        )
+    return _read_group_full(
+        h5obj, group, data_source, shard_key, grid, arrow=arrow, io_stats=io_stats
+    )
 
 
 def _validate_planned_config(data_source: dict) -> None:
@@ -778,7 +842,14 @@ def _read_paths_pooled(entries, read_one, workers: int) -> dict:
 
 
 def _read_group_full(
-    h5obj, group: str, data_source: dict, shard_key: int, grid, arrow: bool = False, read_fn=None
+    h5obj,
+    group: str,
+    data_source: dict,
+    shard_key: int,
+    grid,
+    arrow: bool = False,
+    read_fn=None,
+    io_stats: dict | None = None,
 ):
     """Full-coord-read variant of :func:`_read_group` (the pre-#49-Phase-C path).
 
@@ -797,6 +868,10 @@ def _read_group_full(
     — so index backends (``inline``) can route this path's decode through the
     compiled reader too, giving read-plan-less (flat) data sources the fast
     decode. ``None`` keeps the batched h5coro reads byte-identical.
+
+    ``io_stats`` (issue #374) is the optional read-counter sink; this path
+    decodes the base-rate coordinates in FULL, so what it records is the whole
+    group's row count regardless of how few rows survive the shard mask.
     """
     coordinates = data_source["coordinates"]
     variables = data_source["variables"]
@@ -835,6 +910,10 @@ def _read_group_full(
     lon_path = coordinates["longitude"].format(group=group)
     lats = coord_data[lat_path]
     lons = coord_data[lon_path]
+
+    # Rows DECODED by this group (issue #374) — the full base-rate coordinate
+    # read, counted before the shard mask and filters below.
+    _record_obs_read(io_stats, len(lats))
 
     if len(lats) == 0:
         return None

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -235,8 +235,9 @@ def process_shard(
     -------
     (DataFrame, metadata)
         DataFrame in canonical chunk order; metadata dict with ``shard_key``,
-        ``cells_with_data``, ``total_obs``, ``granule_count``,
-        ``files_processed``, ``duration_s``, ``error``. Ragged fields are
+        ``cells_with_data``, ``total_obs``, ``total_obs_read`` (issue #374 —
+        rows decoded pre-filter, present only when a read route measured it),
+        ``granule_count``, ``files_processed``, ``duration_s``, ``error``. Ragged fields are
         delivered out-of-band via ``ragged_out`` (above), not in this tuple. At
         K>1 the per-chunk carriers + ragged are delivered via ``chunk_results``.
     """
@@ -403,17 +404,22 @@ def process_shard(
         → close, all in the calling thread (issue #180 — under the pool each
         granule gets its own ``H5Coro``, never shared across threads).
 
-        Returns ``(reads, group_errors)``: ``reads`` is the carriers of the
-        groups that returned data (group order, ``None`` — legitimately empty
-        — groups dropped); ``group_errors`` counts raised group reads, warned
-        here but folded into ``read_errors`` by the main thread (a shared
-        ``+= 1`` from worker threads could race). Raises when the granule
-        itself fails (e.g. the open) — the caller warns and skips it, shard
-        continues (issue #116 semantics).
+        Returns ``(reads, group_errors, io_stats)``: ``reads`` is the carriers
+        of the groups that returned data (group order, ``None`` — legitimately
+        empty — groups dropped); ``group_errors`` counts raised group reads,
+        warned here but folded into ``read_errors`` by the main thread (a
+        shared ``+= 1`` from worker threads could race); ``io_stats`` is this
+        granule's read counters (issue #374), allocated FRESH here so it is
+        written only by the thread that owns the granule and read by the main
+        thread after the result is handed back — the same no-lock argument as
+        ``group_errors``, rather than a shared dict the pool would race on.
+        Raises when the granule itself fails (e.g. the open) — the caller warns
+        and skips it, shard continues (issue #116 semantics).
         """
         h5obj = None
         reads: list = []
         group_errors = 0
+        io_stats: dict = {}
         try:
             resource_path = _rewrite_url(s3_url)
 
@@ -427,7 +433,7 @@ def process_shard(
 
             for g in data_source["groups"]:
                 try:
-                    read_kwargs = {"arrow": use_arrow}
+                    read_kwargs = {"arrow": use_arrow, "io_stats": io_stats}
                     if apriori:
                         read_kwargs["granule_url"] = s3_url
                     chunk = index_backend.read_group(
@@ -454,7 +460,7 @@ def process_shard(
                 # #175) on a path that never fails the read.
                 logger.warning(f"  index backend finish_granule failed for {s3_url}: {e}")
 
-            return reads, group_errors
+            return reads, group_errors, io_stats
         finally:
             # Release this granule's h5coro cache before the next one (issue #66):
             # without it each granule's unevicted cache stays resident for the whole
@@ -471,7 +477,7 @@ def process_shard(
                     logger.debug("h5coro cache release failed", exc_info=True)
 
     def _iter_granule_reads():
-        """Yield ``(s3_url, reads, group_errors)`` in original ``granule_urls`` order.
+        """Yield ``(s3_url, reads, group_errors, io_stats)`` in ``granule_urls`` order.
 
         ``granule_workers == 1`` reads each granule in this thread — the
         unchanged serial loop. Above 1, up to ``granule_workers`` granules are
@@ -502,7 +508,7 @@ def process_shard(
                 while in_flight:
                     s3_url, future = in_flight.popleft()
                     try:
-                        reads, group_errors = future.result()
+                        reads, group_errors, granule_io = future.result()
                     except Exception as e:
                         granule_errors += 1
                         _record_read_error(f"processing file {s3_url}", e)
@@ -515,11 +521,21 @@ def process_shard(
                     for u in islice(urls, 1):
                         in_flight.append((u, pool.submit(_read_granule, u)))
                     if reads is not None:
-                        yield s3_url, reads, group_errors
+                        yield s3_url, reads, group_errors, granule_io
+
+    # Observations READ (issue #374): base-rate rows decoded across every
+    # granule BEFORE the shard mask, filters, and read-plan segment padding
+    # cut them down — the numerator of the read-vs-keep ratio whose
+    # denominator is ``total_obs``. ``None`` until some read route reports a
+    # count, so a stubbed/older read seam reads as UNMEASURED rather than a
+    # real zero (the issue #297 nullable-counter convention).
+    obs_read_total: int | None = None
 
     # Read files and filter spatially, folding granules in original order.
-    for s3_url, reads, group_errors in _iter_granule_reads():
+    for s3_url, reads, group_errors, granule_io in _iter_granule_reads():
         read_errors += group_errors
+        if "obs_read" in granule_io:
+            obs_read_total = (obs_read_total or 0) + int(granule_io["obs_read"])
         try:
             for chunk in reads:
                 if buffered is not None:
@@ -804,6 +820,11 @@ def process_shard(
 
     metadata["cells_with_data"] = cells_with_data
     metadata["total_obs"] = n_obs_total
+    # Pre-filter read volume (issue #374), stamped only when a read route
+    # actually measured it — absence is "unmeasured", not zero.
+    if obs_read_total is not None:
+        metadata["total_obs_read"] = obs_read_total
+        logger.info(f"  Read {obs_read_total:,} observations, kept {n_obs_total:,}")
     metadata["duration_s"] = duration
 
     # K==1: deliver the lone chunk's carrier as the 2-tuple ``df_out`` and its

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -584,6 +584,14 @@ def process_shard(
         buffered.flush()
     phase_timings["read"] = time.time() - _read_t0
 
+    # Pre-filter read volume (issue #374), stamped as soon as the read loop is
+    # done so it survives the no-data early return below — a shard that decoded
+    # millions of photons and kept NONE is precisely the read-vs-keep case this
+    # counter exists to expose. Absent when no read route measured it, so
+    # absence stays "unmeasured" rather than a fabricated zero.
+    if obs_read_total is not None:
+        metadata["total_obs_read"] = obs_read_total
+
     if buffered.empty if buffered is not None else not all_reads:
         # Distinguish a genuinely-empty read from one where a group read raised
         # (issue #116): a raised read is a real error masquerading as "no data",
@@ -820,10 +828,7 @@ def process_shard(
 
     metadata["cells_with_data"] = cells_with_data
     metadata["total_obs"] = n_obs_total
-    # Pre-filter read volume (issue #374), stamped only when a read route
-    # actually measured it — absence is "unmeasured", not zero.
-    if obs_read_total is not None:
-        metadata["total_obs_read"] = obs_read_total
+    if obs_read_total is not None:  # stamped above, before the no-data return
         logger.info(f"  Read {obs_read_total:,} observations, kept {n_obs_total:,}")
     metadata["duration_s"] = duration
 

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -828,9 +828,12 @@ def process_shard(
 
     metadata["cells_with_data"] = cells_with_data
     metadata["total_obs"] = n_obs_total
-    if obs_read_total is not None:  # stamped above, before the no-data return
-        logger.info(f"  Read {obs_read_total:,} observations, kept {n_obs_total:,}")
     metadata["duration_s"] = duration
+    # "Read" already means "kept" in the two lines above (worker.py:673/:676),
+    # which is what CloudWatch greps for today, so this one says "Decoded" —
+    # one verb, one meaning (review finding, issue #374).
+    if obs_read_total is not None:
+        logger.info(f"  Decoded {obs_read_total:,} observations pre-filter, kept {n_obs_total:,}")
 
     # K==1: deliver the lone chunk's carrier as the 2-tuple ``df_out`` and its
     # ragged via ``ragged_out`` (unchanged contract). K>1: the carriers + ragged

--- a/src/zagg/schema.py
+++ b/src/zagg/schema.py
@@ -20,6 +20,13 @@ class ProcessingMetadata(TypedDict):
     cells_with_data: int
     total_obs: int
     granule_count: int
+    # Base-rate rows DECODED before filtering/assignment (issue #374), summed
+    # over the shard's granules — always >= ``total_obs``, whose difference is
+    # the read-plan padding, boundary-straddling segments, and filter rejects.
+    # ``NotRequired``: present only when a read route measured it, so absence
+    # reads as unmeasured (a stubbed read seam, or a worker predating the
+    # field) rather than a genuine zero.
+    total_obs_read: NotRequired[int]
     files_processed: int
     duration_s: float
     error: str | None

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -52,6 +52,7 @@ _SUM_KEYS = ("n_shards", "n_granules", "n_obs", "cells_with_data", "duration_s")
 _SUM_OR_NONE_KEYS = (
     "gb_seconds",
     "est_cost_usd",
+    "n_obs_read",
     "spill_bytes",
     "spill_blocks_closed",
     "raster_bytes_read",
@@ -131,6 +132,7 @@ def build_record(
 
     ``metadata`` is the existing worker result (``process_shard`` /
     ``process_and_write_hive`` / the raster metas): ``total_obs``,
+    ``total_obs_read`` (when the read path measured it — issue #374),
     ``cells_with_data``, ``duration_s``, ``phase_timings``, and the memory
     telemetry keys when the caller stamped them. ``invoked_by`` is copied
     VERBATIM from the invoke payload — the dispatcher resolves it via
@@ -202,6 +204,13 @@ def build_record(
         # reads as unverifiable, not tampered.
         "content_hashes": metadata.get("content_hashes"),
         "n_obs": int(metadata.get("total_obs") or 0),
+        # Point-path read volume (issue #374): observations DECODED before the
+        # shard mask / filters / read-plan padding cut them to ``n_obs``, so
+        # ``n_obs_read >= n_obs`` and the read-vs-keep ratio is derivable at
+        # read time (never stored — the raster ``px_decoded`` convention).
+        # Nullable: ``None`` on the raster path and on records from workers
+        # predating the field, where absence means unmeasured, not zero.
+        "n_obs_read": _opt_int(metadata.get("total_obs_read")),
         "cells_with_data": int(metadata.get("cells_with_data") or 0),
         "phase_timings": phase_timings,
         "duration_s": duration_s,
@@ -329,6 +338,7 @@ _ROW_SCALARS = (
     "n_granules",
     "granules_sha256",
     "n_obs",
+    "n_obs_read",
     "cells_with_data",
     "duration_s",
     "gb_seconds",

--- a/tests/test_apriori.py
+++ b/tests/test_apriori.py
@@ -348,8 +348,14 @@ class TestLoadBoundaries:
 
 class TestWorkerSeam:
     """The worker passes ``granule_url`` to ``_read_group`` only when the
-    feature is on, so monkeypatched fakes (and the flag-off production call)
-    keep their existing signature."""
+    a-priori feature is on, so the flag-off call carries no boundary-parquet
+    plumbing.
+
+    ``io_stats`` (issue #374) is by contrast passed ALWAYS — it is always-on
+    instrumentation, mirroring the raster ``io_stats`` sink — so the fakes
+    below take it explicitly. The gate these tests pin is ``granule_url``'s,
+    asserted directly on the received kwargs rather than indirectly via a
+    fake's signature arity."""
 
     def _run(self, monkeypatch, data_source, fake_read_group):
         cfg = PipelineConfig(
@@ -364,7 +370,7 @@ class TestWorkerSeam:
     def test_granule_url_passed_when_enabled(self, monkeypatch):
         captured = {}
 
-        def fake(h5obj, g, ds, sk, grid, arrow=False, granule_url=None):
+        def fake(h5obj, g, ds, sk, grid, arrow=False, granule_url=None, io_stats=None):
             captured["granule_url"] = granule_url
             return None
 
@@ -374,10 +380,16 @@ class TestWorkerSeam:
         assert captured["granule_url"] == "s3://b/g0.h5"
         assert meta["error"] == "No data after filtering"
 
-    def test_flag_off_call_signature_unchanged(self, monkeypatch):
-        # A fake WITHOUT granule_url in its signature must keep working when
-        # the feature is off (it would TypeError if the kwarg were passed).
-        def fake(h5obj, g, ds, sk, grid, arrow=False):
+    def test_granule_url_absent_when_flag_off(self, monkeypatch):
+        # The gate itself: with the feature off, ``granule_url`` must not be
+        # in the call at all (a fake lacking it would TypeError). Asserted on
+        # the received kwargs, so the invariant survives the addition of other
+        # always-on kwargs like ``io_stats``.
+        captured = {}
+
+        def fake(h5obj, g, ds, sk, grid, arrow=False, **kwargs):
+            captured.update(kwargs)
+            captured["seen"] = True
             return None
 
         ds = _data_source()
@@ -388,4 +400,6 @@ class TestWorkerSeam:
         # ``chunk_boundaries`` carve-out in ``index_from_config``).
         ds["index"] = {"backend": "hierarchical"}
         _, meta = self._run(monkeypatch, ds, fake)
+        assert captured["seen"] is True
+        assert "granule_url" not in captured
         assert meta["error"] == "No data after filtering"

--- a/tests/test_apriori.py
+++ b/tests/test_apriori.py
@@ -285,6 +285,33 @@ class TestAprioriReadGroup:
         )
         assert result is None
 
+    def test_short_circuits_read_as_measured_zero(self, tmp_path):
+        # Both a-priori exits above return before any base-rate decode, so
+        # neither reaches _execute_plan_group's counter. Each stamps a measured
+        # zero itself, or the route reports None -- "unmeasured", the signal
+        # reserved for a seam that was never instrumented (issue #374).
+        _write_parquet(tmp_path)
+        ds = _data_source(chunk_boundaries={"prefix": str(tmp_path)})
+        url = f"/data/{GRANULE}"
+
+        io_stats: dict = {}  # no chunk's span touches the shard
+        assert (
+            _read_group(
+                _Granule(), "gt1l", ds, 0, _BandGrid(80.0, 81.0), granule_url=url, io_stats=io_stats
+            )
+            is None
+        )
+        assert io_stats["obs_read"] == 0
+
+        io_stats = {}  # beam absent from the boundary parquet
+        assert (
+            _read_group(
+                _Granule(), "gt2r", ds, 0, _BandGrid(*BAND), granule_url=url, io_stats=io_stats
+            )
+            is None
+        )
+        assert io_stats["obs_read"] == 0
+
     def test_missing_parquet_raises(self, tmp_path):
         ds = _data_source(chunk_boundaries={"prefix": str(tmp_path)})
         with pytest.raises(FileNotFoundError, match="boundary parquet"):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -499,13 +499,16 @@ class TestConcurrencyPreflight:
         # lazily, but the declared cap is what turns into EMFILE if the loop
         # ever goes concurrent (PR #378, question (5) ruling).
         monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 2)
-        _, _, pool = self._dispatch(catalog, monkeypatch, max_workers=5)
-        assert pool == 2
+        width, _, pool = self._dispatch(catalog, monkeypatch, max_workers=5)
+        # The clamp stops at the DECLARED pool: the fan-out width is still the
+        # shard-count clamp of the requested 5, un-touched by the fd bound --
+        # re-clamping it there would undo issue #375.
+        assert (pool, width) == (2, 3)
 
     def test_pool_cap_unchanged_below_fd_bound(self, catalog, monkeypatch):
         monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 100)
-        _, _, pool = self._dispatch(catalog, monkeypatch, max_workers=2)
-        assert pool == 2
+        width, _, pool = self._dispatch(catalog, monkeypatch, max_workers=2)
+        assert (pool, width) == (2, 2)
 
     @staticmethod
     def _probe_fd_bound(catalog, monkeypatch, *, transport):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,6 +18,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 import zagg.client
+import zagg.concurrency
 from zagg.client import Run, RunHandle, ShardError
 from zagg.config import PipelineConfig, default_config
 
@@ -504,7 +505,7 @@ class TestConcurrencyPreflight:
         # `maxsize` to urllib3 (block=False), so an oversized declaration
         # allocates nothing on its own -- it is the number of sockets the
         # pool would KEEP once a concurrent dispatch loop opened them.
-        monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 2)
+        monkeypatch.setattr(zagg.concurrency, "fd_safe_max_workers", lambda: 2)
         width, _, pool = self._dispatch(catalog, monkeypatch, max_workers=5)
         # The clamp stops at the DECLARED pool: the fan-out width is still the
         # shard-count clamp of the requested 5, un-touched by the fd bound --
@@ -512,7 +513,7 @@ class TestConcurrencyPreflight:
         assert (pool, width) == (2, 3)
 
     def test_pool_cap_unchanged_below_fd_bound(self, catalog, monkeypatch):
-        monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 100)
+        monkeypatch.setattr(zagg.concurrency, "fd_safe_max_workers", lambda: 100)
         width, _, pool = self._dispatch(catalog, monkeypatch, max_workers=2)
         assert (pool, width) == (2, 2)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -493,11 +493,16 @@ class TestConcurrencyPreflight:
         assert seen == [False, True]
 
     def test_pool_cap_clamped_when_window_exceeds_fd_bound(self, catalog, monkeypatch):
-        # The pacing window may clear RLIMIT_NOFILE (fd_bound=False, issue
-        # #375), but the shared client's DECLARED pool never may: today the
-        # serial dispatch loop holds <=1 connection and urllib3 sizes pools
-        # lazily, but the declared cap is what turns into EMFILE if the loop
-        # ever goes concurrent (PR #378, question (5) ruling).
+        # A fan-out width above RLIMIT_NOFILE must not reach the shared
+        # client's DECLARED pool (PR #378, question (5) ruling). Forced here
+        # by an explicit max_workers, which skips the probe so `workers`
+        # carries no fd term at all -- the same shape the event transport
+        # reaches through the probe when it passes fd_bound=False (issue
+        # #375; that wiring is pinned by test_event_window_is_not_fd_bound,
+        # which this test deliberately does not re-derive). Today the serial
+        # dispatch loop holds <=1 connection and urllib3 sizes pools lazily,
+        # but the declared cap is what turns into EMFILE if the loop ever
+        # goes concurrent.
         monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 2)
         width, _, pool = self._dispatch(catalog, monkeypatch, max_workers=5)
         # The clamp stops at the DECLARED pool: the fan-out width is still the

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -357,7 +357,7 @@ class TestConcurrencyPreflight:
         if probe is not None:
 
             def _probe(requested, lambda_client, cloudwatch_client, function_name, **k):
-                calls.append((requested, function_name))
+                calls.append((requested, function_name, k.get("fd_bound")))
                 return probe(requested)
 
             monkeypatch.setattr(runner, "compute_available_workers", _probe)
@@ -398,7 +398,7 @@ class TestConcurrencyPreflight:
         )
         assert width == 2  # the probe's clamp, not _DEFAULT_MAX_WORKERS
         # It asks for the work size and names the dispatch target.
-        assert calls == [(3, "process-shard-test")]
+        assert calls == [(3, "process-shard-test", True)]
 
     def test_probe_denial_falls_back_with_a_warning(self, catalog, monkeypatch):
         # Distinguish the fallback from the shard-count clamp by shrinking the
@@ -416,7 +416,7 @@ class TestConcurrencyPreflight:
         with pytest.warns(RuntimeWarning, match="AccessDenied"):
             width, calls = self._dispatch(catalog, monkeypatch, probe=_denied)
         assert width == 2  # degraded to the default, run still dispatched
-        assert calls == [(3, "process-shard-test")]
+        assert calls == [(3, "process-shard-test", True)]
 
     def test_explicit_max_workers_skips_the_probe(self, catalog, monkeypatch):
         def _must_not_run(requested):
@@ -441,10 +441,6 @@ class TestConcurrencyPreflight:
 
     def test_sync_probes_fd_bound(self, catalog, monkeypatch):
         # The sync pool holds one socket per in-flight shard: FD-bounded.
-        width, calls = self._dispatch(
-            catalog, monkeypatch, probe=lambda requested: (2, self._report())
-        )
-        assert width == 2
         assert self._probe_fd_bound(catalog, monkeypatch, transport="sync") is True
 
     def test_event_window_is_not_fd_bound(self, catalog, monkeypatch):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -499,10 +499,11 @@ class TestConcurrencyPreflight:
         # carries no fd term at all -- the same shape the event transport
         # reaches through the probe when it passes fd_bound=False (issue
         # #375; that wiring is pinned by test_event_window_is_not_fd_bound,
-        # which this test deliberately does not re-derive). Today the serial
-        # dispatch loop holds <=1 connection and urllib3 sizes pools lazily,
-        # but the declared cap is what turns into EMFILE if the loop ever
-        # goes concurrent.
+        # which this test deliberately does not re-derive). The cap is a
+        # RETENTION bound, not an EMFILE guard: botocore passes only
+        # `maxsize` to urllib3 (block=False), so an oversized declaration
+        # allocates nothing on its own -- it is the number of sockets the
+        # pool would KEEP once a concurrent dispatch loop opened them.
         monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 2)
         width, _, pool = self._dispatch(catalog, monkeypatch, max_workers=5)
         # The clamp stops at the DECLARED pool: the fan-out width is still the

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -479,6 +479,48 @@ class TestConcurrencyPreflight:
         # caller's value, not `compute_available_workers`' own default.
         assert seen == [False, True]
 
+    def test_pool_cap_clamped_when_window_exceeds_fd_bound(self, catalog, monkeypatch):
+        # The pacing window may clear RLIMIT_NOFILE (fd_bound=False, issue
+        # #375), but the shared client's DECLARED pool never may: today the
+        # serial dispatch loop holds <=1 connection and urllib3 sizes pools
+        # lazily, but the declared cap is what turns into EMFILE if the loop
+        # ever goes concurrent (PR #378, question (5) ruling).
+        monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 2)
+        assert self._pool_cap(catalog, monkeypatch, max_workers=5) == 2
+
+    def test_pool_cap_unchanged_below_fd_bound(self, catalog, monkeypatch):
+        monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 100)
+        assert self._pool_cap(catalog, monkeypatch, max_workers=2) == 2
+
+    @staticmethod
+    def _pool_cap(catalog, monkeypatch, **dispatch_kwargs):
+        """The ``max_pool_connections`` handed to the shared client's Config."""
+        from unittest.mock import MagicMock
+
+        import boto3
+
+        stub = StubLambdaClient()
+        seen: dict = {}
+
+        def _client(service, **k):
+            if service != "lambda":
+                return MagicMock()
+            seen["pool"] = k["config"].max_pool_connections
+            return stub
+
+        session = MagicMock()
+        session.client.side_effect = _client
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: session)
+        run = Run.from_config(
+            default_config("atl06"),
+            shardmap=catalog,
+            store=_STORE,
+            function_name="process-shard-test",
+            source_credentials=_CREDS,
+        )
+        run.dispatch(**dispatch_kwargs).results()
+        return seen["pool"]
+
     @staticmethod
     def _probe_fd_bound(catalog, monkeypatch, *, transport):
         """The ``fd_bound`` ``dispatch`` hands the probe for ``transport``.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -339,7 +339,13 @@ class TestConcurrencyPreflight:
 
     @staticmethod
     def _dispatch(catalog, monkeypatch, *, probe=None, **dispatch_kwargs):
-        """Dispatch with NO injected client; return (pool_width, probe_calls)."""
+        """Dispatch with NO injected client.
+
+        Returns ``(pool_width, probe_calls, declared_pool)`` -- the fan-out
+        width the ``ThreadPoolExecutor`` was built with, the probe's call
+        record, and the ``max_pool_connections`` handed to the shared client's
+        ``Config`` (``None`` if no client was built).
+        """
         from unittest.mock import MagicMock
 
         import boto3
@@ -347,10 +353,17 @@ class TestConcurrencyPreflight:
         from zagg import runner
 
         stub = StubLambdaClient()
+        seen: dict = {}
+
+        def _client(service, **k):
+            if service != "lambda":
+                return MagicMock()
+            if "config" in k:  # the fan-out client; the probe's carries none
+                seen["pool"] = k["config"].max_pool_connections
+            return stub
+
         session = MagicMock()
-        session.client.side_effect = lambda service, **k: (
-            stub if service == "lambda" else MagicMock()
-        )
+        session.client.side_effect = _client
         monkeypatch.setattr(boto3, "Session", lambda *a, **k: session)
 
         calls: list = []
@@ -378,7 +391,7 @@ class TestConcurrencyPreflight:
             source_credentials=_CREDS,
         )
         run.dispatch(**dispatch_kwargs).results()
-        return widths[0], calls
+        return widths[0], calls, seen.get("pool")
 
     @staticmethod
     def _report():
@@ -393,7 +406,7 @@ class TestConcurrencyPreflight:
         )
 
     def test_probe_sizes_the_pool(self, catalog, monkeypatch):
-        width, calls = self._dispatch(
+        width, calls, _ = self._dispatch(
             catalog, monkeypatch, probe=lambda requested: (2, self._report())
         )
         assert width == 2  # the probe's clamp, not _DEFAULT_MAX_WORKERS
@@ -414,7 +427,7 @@ class TestConcurrencyPreflight:
             )
 
         with pytest.warns(RuntimeWarning, match="AccessDenied"):
-            width, calls = self._dispatch(catalog, monkeypatch, probe=_denied)
+            width, calls, _ = self._dispatch(catalog, monkeypatch, probe=_denied)
         assert width == 2  # degraded to the default, run still dispatched
         assert calls == [(3, "process-shard-test", True)]
 
@@ -422,7 +435,7 @@ class TestConcurrencyPreflight:
         def _must_not_run(requested):
             raise AssertionError("probe ran despite an explicit max_workers")
 
-        width, calls = self._dispatch(catalog, monkeypatch, probe=_must_not_run, max_workers=1)
+        width, calls, _ = self._dispatch(catalog, monkeypatch, probe=_must_not_run, max_workers=1)
         assert width == 1
         assert calls == []
 
@@ -486,40 +499,13 @@ class TestConcurrencyPreflight:
         # lazily, but the declared cap is what turns into EMFILE if the loop
         # ever goes concurrent (PR #378, question (5) ruling).
         monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 2)
-        assert self._pool_cap(catalog, monkeypatch, max_workers=5) == 2
+        _, _, pool = self._dispatch(catalog, monkeypatch, max_workers=5)
+        assert pool == 2
 
     def test_pool_cap_unchanged_below_fd_bound(self, catalog, monkeypatch):
         monkeypatch.setattr(zagg.client, "fd_safe_max_workers", lambda: 100)
-        assert self._pool_cap(catalog, monkeypatch, max_workers=2) == 2
-
-    @staticmethod
-    def _pool_cap(catalog, monkeypatch, **dispatch_kwargs):
-        """The ``max_pool_connections`` handed to the shared client's Config."""
-        from unittest.mock import MagicMock
-
-        import boto3
-
-        stub = StubLambdaClient()
-        seen: dict = {}
-
-        def _client(service, **k):
-            if service != "lambda":
-                return MagicMock()
-            seen["pool"] = k["config"].max_pool_connections
-            return stub
-
-        session = MagicMock()
-        session.client.side_effect = _client
-        monkeypatch.setattr(boto3, "Session", lambda *a, **k: session)
-        run = Run.from_config(
-            default_config("atl06"),
-            shardmap=catalog,
-            store=_STORE,
-            function_name="process-shard-test",
-            source_credentials=_CREDS,
-        )
-        run.dispatch(**dispatch_kwargs).results()
-        return seen["pool"]
+        _, _, pool = self._dispatch(catalog, monkeypatch, max_workers=2)
+        assert pool == 2
 
     @staticmethod
     def _probe_fd_bound(catalog, monkeypatch, *, transport):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -439,6 +439,57 @@ class TestConcurrencyPreflight:
         handle.results()
         assert len(handle) == 3
 
+    def test_sync_probes_fd_bound(self, catalog, monkeypatch):
+        # The sync pool holds one socket per in-flight shard: FD-bounded.
+        width, calls = self._dispatch(
+            catalog, monkeypatch, probe=lambda requested: (2, self._report())
+        )
+        assert width == 2
+        assert self._probe_fd_bound(catalog, monkeypatch, transport="sync") is True
+
+    def test_event_window_is_not_fd_bound(self, catalog, monkeypatch):
+        # The event transport holds no connections, so its pacing window is
+        # sized by account headroom alone (issue #375).
+        assert self._probe_fd_bound(catalog, monkeypatch, transport="event") is False
+
+    @staticmethod
+    def _probe_fd_bound(catalog, monkeypatch, *, transport):
+        """The ``fd_bound`` ``dispatch`` hands the probe for ``transport``.
+
+        Intercepts at ``_probe_workers`` and aborts the dispatch there with a
+        sentinel: the wiring under test is decided before any invoke, so the
+        event transport's runtime (status store + poller) need not be stood up
+        to observe it.
+        """
+        from unittest.mock import MagicMock
+
+        import boto3
+
+        class _ProbeReachedError(Exception):
+            pass
+
+        session = MagicMock()
+        session.client.side_effect = lambda service, **k: MagicMock()
+        monkeypatch.setattr(boto3, "Session", lambda *a, **k: session)
+
+        seen: dict = {}
+
+        def _probe(self, session, n, *, fd_bound=True):
+            seen["fd_bound"] = fd_bound
+            raise _ProbeReachedError
+
+        monkeypatch.setattr(Run, "_probe_workers", _probe)
+        run = Run.from_config(
+            default_config("atl06"),
+            shardmap=catalog,
+            store=_STORE,
+            function_name="process-shard-test",
+            source_credentials=_CREDS,
+        )
+        with pytest.raises(_ProbeReachedError):
+            run.dispatch(transport=transport)
+        return seen["fd_bound"]
+
 
 # -- parity with the runner's lambda path -------------------------------------
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -452,6 +452,37 @@ class TestConcurrencyPreflight:
         # sized by account headroom alone (issue #375).
         assert self._probe_fd_bound(catalog, monkeypatch, transport="event") is False
 
+    def test_probe_body_forwards_fd_bound(self, catalog, monkeypatch):
+        # The seam the two tests above bracket without crossing: they pin what
+        # `dispatch` hands `_probe_workers`, and `TestFdBound` pins what
+        # `compute_available_workers` does with it -- but neither runs the real
+        # `_probe_workers` body, so deleting `fd_bound=fd_bound` at
+        # `client.py:664` left the suite green (review finding). Drive the real
+        # body and assert the value it forwards.
+        from unittest.mock import MagicMock
+
+        from zagg import runner
+
+        seen: list = []
+
+        def _probe(requested, lambda_client, cloudwatch_client, function_name, **k):
+            seen.append(k.get("fd_bound"))
+            return 7, self._report()
+
+        run = Run.from_config(
+            default_config("atl06"),
+            shardmap=catalog,
+            store=_STORE,
+            function_name="process-shard-test",
+            source_credentials=_CREDS,
+        )
+        monkeypatch.setattr(runner, "compute_available_workers", _probe)
+        assert run._probe_workers(MagicMock(), 3, fd_bound=False) == 7
+        assert run._probe_workers(MagicMock(), 3, fd_bound=True) == 7
+        # Not `[None, None]`: the kwarg reaches the probe, and it is the
+        # caller's value, not `compute_available_workers`' own default.
+        assert seen == [False, True]
+
     @staticmethod
     def _probe_fd_bound(catalog, monkeypatch, *, transport):
         """The ``fd_bound`` ``dispatch`` hands the probe for ``transport``.

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -236,3 +236,58 @@ class TestComputeAvailableWorkers:
         cw = _cloudwatch_client(current_max=200)
         workers, _ = concurrency.compute_available_workers(1700, lam, cw, "fn")
         assert workers == 1
+
+
+class TestFdBound:
+    """``fd_bound=False`` drops the FD term for connection-less carriers (#375).
+
+    The event transport holds no socket per in-flight shard, so clamping its
+    pacing window at ``RLIMIT_NOFILE`` strands account headroom that has
+    already been granted (observed: ~1,000 window against ~1,898 available).
+    """
+
+    def test_event_window_ignores_the_fd_ceiling(self, fake_rlimit):
+        fake_rlimit(1024, 1024)  # fd ceiling 992, well below account headroom
+        lam = _lambda_client(account_limit=2000)
+        cw = _cloudwatch_client(current_max=0)
+        workers, report = concurrency.compute_available_workers(2721, lam, cw, "fn", fd_bound=False)
+        # account available = 2000 - 0 - 100 padding; the fd ceiling does not bite
+        assert report.available == 1900
+        assert workers == 1900
+
+    def test_sync_stays_fd_clamped_on_the_same_inputs(self, fake_rlimit):
+        # Same probe, same request: the default (sync) path still clamps, so the
+        # divergence is attributable to fd_bound alone.
+        fake_rlimit(1024, 1024)
+        lam = _lambda_client(account_limit=2000)
+        cw = _cloudwatch_client(current_max=0)
+        workers, _ = concurrency.compute_available_workers(2721, lam, cw, "fn")
+        assert workers == 1024 - concurrency._FD_HEADROOM
+
+    def test_account_headroom_still_clamps_without_the_fd_term(self, fake_rlimit):
+        # Dropping the FD term must not drop the account bound too.
+        fake_rlimit(65536, 65536)
+        lam = _lambda_client(account_limit=1000)
+        cw = _cloudwatch_client(current_max=200)
+        workers, _ = concurrency.compute_available_workers(1700, lam, cw, "fn", fd_bound=False)
+        assert workers == 700
+
+    def test_requested_still_wins_when_below_headroom(self, fake_rlimit):
+        fake_rlimit(1024, 1024)
+        lam = _lambda_client(account_limit=10000)
+        cw = _cloudwatch_client(current_max=0)
+        workers, _ = concurrency.compute_available_workers(50, lam, cw, "fn", fd_bound=False)
+        assert workers == 50
+
+    def test_unreadable_account_falls_back_to_fd_even_unbound(self, fake_rlimit):
+        # With no account headroom to size from, the FD ceiling is the only
+        # bound left — an unbounded window would fire the whole shard set at
+        # once and the 60 s MaximumEventAgeInSeconds would drop the overflow.
+        fake_rlimit(1024, 1024)
+        lam = MagicMock()
+        lam.get_account_settings.side_effect = Exception("AccessDenied")
+        lam.get_function_concurrency.return_value = {}
+        cw = _cloudwatch_client(current_max=0)
+        workers, report = concurrency.compute_available_workers(2721, lam, cw, "fn", fd_bound=False)
+        assert report.available is None
+        assert workers == 1024 - concurrency._FD_HEADROOM

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -332,6 +332,19 @@ class TestHierarchicalDelegation:
         out = HierarchicalIndex().read_group(object(), "gt1l", {}, 0, None)
         assert out is sentinel
 
+    def test_io_stats_forwarded_unconditionally(self, monkeypatch):
+        # ``io_stats`` (issue #374) is always-on instrumentation, not a gated
+        # kwarg: the sink reaches ``_read_group`` on every call, and a caller
+        # that omits it forwards ``None`` rather than dropping the kwarg — the
+        # same contract ``InlineIndex.read_group`` already honours, so the two
+        # backends present one signature to the read seam (review finding).
+        seen: list = []
+        monkeypatch.setattr("zagg.processing._read_group", lambda *a, **k: seen.append(k) or None)
+        sink: dict = {}
+        HierarchicalIndex().read_group(object(), "gt1l", {}, 0, None, io_stats=sink)
+        HierarchicalIndex().read_group(object(), "gt1l", {}, 0, None)
+        assert [k["io_stats"] for k in seen] == [sink, None]
+
     def test_finish_granule_is_noop(self):
         HierarchicalIndex().finish_granule(object(), "s3://bucket/granule.h5")
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5014,6 +5014,54 @@ class TestPlannedReadGroup:
         assert _read_group(h5, "gt1l", ds_full, 0, grid, io_stats=io_stats) is None
         assert io_stats["obs_read"] == 12  # decoded, then all masked out
 
+    def test_planned_short_circuits_read_as_measured_zero(self):
+        # The planned route's three exits BEFORE any base-rate decode never
+        # reach _execute_plan_group's counter, so each has to stamp the zero
+        # itself (review finding). Without it a beam that short-circuits --
+        # the common per-beam outcome on the spatial-index route, where a
+        # granule is assigned for one beam and the other five miss -- reports
+        # None, indistinguishable from an uninstrumented seam.
+        ds = _planned_read_data_source()
+        seg = {
+            "/seg/lat": np.array([0.0, 100.0]),
+            "/seg/lon": np.zeros(2),
+            "/heights/lat_ph": np.array([0.0, 100.0]),
+            "/heights/lon_ph": np.zeros(2),
+            "/heights/h": np.zeros(2, dtype=np.float32),
+        }
+        cases = {
+            # empty AOI: no segment rep-point intersects the shard
+            "empty_aoi": (_planned_read_h5(), _LatBboxGrid((-0.1, 100000.0, 0.1, 100001.0))),
+            # coarse level carries no segments at all
+            "empty_coarse": (
+                _FakeH5(
+                    {
+                        **seg,
+                        "/seg/lat": np.array([]),
+                        "/seg/lon": np.array([]),
+                        "/seg/ph_index_beg": np.array([], dtype=np.int64),
+                        "/seg/segment_ph_cnt": np.array([], dtype=np.int64),
+                    }
+                ),
+                _LatBboxGrid((-0.1, -1.0, 0.1, 1000.0)),
+            ),
+            # segments present but link counts sum to zero base rows
+            "no_base_rows": (
+                _FakeH5(
+                    {
+                        **seg,
+                        "/seg/ph_index_beg": np.zeros(2, dtype=np.int64),
+                        "/seg/segment_ph_cnt": np.zeros(2, dtype=np.int64),
+                    }
+                ),
+                _LatBboxGrid((-0.1, -1.0, 0.1, 1000.0)),
+            ),
+        }
+        for name, (h5, grid) in cases.items():
+            io_stats: dict = {}
+            assert _read_group(h5, "gt1l", ds, 0, grid, io_stats=io_stats) is None, name
+            assert io_stats["obs_read"] == 0, name
+
     def test_multi_slice_plan_global_idx_alignment(self):
         # Force a plan with two disjoint base-slices (one ATL03 track that
         # crosses the shard lat band twice). Fixture: 10 segments × 1 photon

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2110,6 +2110,21 @@ class TestObsReadMetadata:
         assert metadata["total_obs"] == 3
         assert "total_obs_read" not in metadata
 
+    def test_stamped_on_the_no_data_shard(self, monkeypatch):
+        # The highest-signal case for issue #374: every photon was decoded and
+        # every one filtered out. The shard takes the "No data after filtering"
+        # early return, which must still carry the read volume — otherwise the
+        # run parquet reports nothing for exactly the shards whose read was
+        # pure waste.
+        def read_group(h5obj, group, ds, sk, grid, arrow=False, io_stats=None, **k):
+            io_stats["obs_read"] = io_stats.get("obs_read", 0) + 1000
+            return None  # legitimately empty after filtering
+
+        metadata, _grid, _sk = self._run(monkeypatch, read_group, ["s3://a"])
+        assert metadata["error"] == "No data after filtering"
+        assert metadata["total_obs_read"] == 1000
+        assert metadata["total_obs"] == 0
+
     def test_each_granule_gets_its_own_sink(self, monkeypatch):
         # The no-lock argument: the worker must not hand the same dict to two
         # granules (they may be read concurrently under granule_workers > 1).

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2030,6 +2030,101 @@ class TestRaggedChunkCompanion:
         np.testing.assert_array_equal(np.frombuffer(raw, "<f4"), [1.0, 2.0])
 
 
+class TestObsReadMetadata:
+    """Issue #374: the worker sums the per-granule read sink into
+    ``metadata["total_obs_read"]`` — observations READ, alongside the kept
+    ``total_obs`` — so the run parquet can carry the read-vs-keep ratio.
+
+    The decode-side counting is pinned in ``TestPlannedReadGroup``; what these
+    pin is the worker's half: it hands each granule its OWN sink, sums them,
+    and reports nothing at all when the read seam never measured.
+    """
+
+    @staticmethod
+    def _cfg():
+        from zagg.config import default_config
+
+        cfg = default_config("atl06")
+        cfg.output["grid"] = {
+            "type": "healpix",
+            "parent_order": 6,
+            "child_order": 8,
+            "sharded": False,
+        }
+        cfg.aggregation["variables"] = {"count": {"function": "len", "source": "h_li"}}
+        # One beam group, so "rows per granule" is exactly one read_group call
+        # and the arithmetic below is readable (atl06 declares six beams).
+        cfg.data_source["groups"] = ["gt1l"]
+        return cfg
+
+    def _run(self, monkeypatch, read_group, granules):
+        from mortie import geo2mort
+
+        from zagg.index.hierarchical import HierarchicalIndex
+
+        cfg = self._cfg()
+        grid = HealpixGrid(6, 8, layout="fullsphere", config=cfg, sharded=False)
+        shard_key = int(geo2mort(-78.5, -132.0, order=6)[0])
+
+        monkeypatch.setattr("zagg.processing._read_group", read_group)
+        monkeypatch.setattr("zagg.processing.h5coro.H5Coro", lambda *a, **k: object())
+        monkeypatch.setattr("zagg.processing._make_url_rewriter", lambda driver: lambda u: u)
+        monkeypatch.setattr(
+            "zagg.processing.worker.index_from_config", lambda cfg: HierarchicalIndex()
+        )
+        _df, metadata = process_shard(
+            grid, shard_key, granules, s3_credentials={}, config=cfg, chunk_results=[]
+        )
+        return metadata, grid, shard_key
+
+    @staticmethod
+    def _carrier(grid, shard_key, n):
+        leaf = int(grid.children(shard_key)[0])
+        return pd.DataFrame(
+            {
+                "h_li": np.arange(n, dtype=np.float32),
+                "leaf_id": np.full(n, leaf, dtype=np.uint64),
+            }
+        )
+
+    def test_sums_the_sink_across_granules_and_exceeds_kept(self, monkeypatch):
+        # Each granule decodes 10 rows and keeps 3, across two granules: the
+        # worker reports 20 read against 6 kept.
+        def read_group(h5obj, group, ds, sk, grid, arrow=False, io_stats=None, **k):
+            io_stats["obs_read"] = io_stats.get("obs_read", 0) + 10
+            return self._carrier(grid, sk, 3)
+
+        metadata, _grid, _sk = self._run(monkeypatch, read_group, ["s3://a", "s3://b"])
+        assert metadata["total_obs"] == 6
+        assert metadata["total_obs_read"] == 20
+        assert metadata["total_obs_read"] > metadata["total_obs"]
+
+    def test_unmeasured_seam_omits_the_key(self, monkeypatch):
+        # A read seam that never touches the sink (a stub, or a backend
+        # predating the field) must leave the key ABSENT, so the record reads
+        # as unmeasured rather than a fabricated zero.
+        def read_group(h5obj, group, ds, sk, grid, arrow=False, io_stats=None, **k):
+            return self._carrier(grid, sk, 3)
+
+        metadata, _grid, _sk = self._run(monkeypatch, read_group, ["s3://a"])
+        assert metadata["total_obs"] == 3
+        assert "total_obs_read" not in metadata
+
+    def test_each_granule_gets_its_own_sink(self, monkeypatch):
+        # The no-lock argument: the worker must not hand the same dict to two
+        # granules (they may be read concurrently under granule_workers > 1).
+        seen: list = []
+
+        def read_group(h5obj, group, ds, sk, grid, arrow=False, io_stats=None, **k):
+            seen.append(id(io_stats))
+            io_stats["obs_read"] = io_stats.get("obs_read", 0) + 5
+            return self._carrier(grid, sk, 1)
+
+        metadata, _grid, _sk = self._run(monkeypatch, read_group, ["s3://a", "s3://b", "s3://c"])
+        assert len(set(seen)) == len(seen) == 3  # three distinct dicts
+        assert metadata["total_obs_read"] == 15
+
+
 class TestMultiChunkWorker:
     """Issue #30 item 3: one worker (one shard) owns K = grid.chunks_per_shard finer
     Zarr chunks. process_shard reads granules once and returns one carrier + ragged
@@ -4822,6 +4917,87 @@ class TestPlannedReadGroup:
         grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
         with pytest.raises(ValueError, match="must link directly to base level"):
             _read_group(h5, "gt1l", ds, 0, grid)
+
+    def test_obs_read_counts_padded_decode_above_kept(self):
+        # Issue #374: the read counter is rows DECODED, so the read-plan's
+        # pad — which pulls whole neighbouring segments in to recover boundary
+        # photons — shows up as obs_read > kept. Same fixture and band as
+        # test_pad_recovers_boundary_segment_and_matches_full: the mask picks
+        # segments 2,3 (rep-points 200,300); pad=1 widens the run to segments
+        # 1..4, i.e. photons [2, 10) = 8 decoded, of which 4 survive the band.
+        h5 = _planned_read_h5()
+        grid = _LatBboxGrid((-0.1, 150.0, 0.1, 310.0))
+        ds = _planned_read_data_source()
+        ds["read_plan"]["pad"] = 1
+
+        io_stats: dict = {}
+        df = _read_group(h5, "gt1l", ds, 0, grid, io_stats=io_stats)
+
+        assert df["h"].tolist() == [30.0, 40.0, 50.0, 60.0]
+        assert io_stats["obs_read"] == 8
+        assert io_stats["obs_read"] > len(df)
+
+    def test_obs_read_accumulates_across_groups(self):
+        # The sink is per-GRANULE, so successive group reads add into it — the
+        # worker sums one dict per granule rather than one per group.
+        h5 = _planned_read_h5()
+        grid = _LatBboxGrid((-0.1, 150.0, 0.1, 310.0))
+        ds = _planned_read_data_source()
+        ds["read_plan"]["pad"] = 1
+
+        io_stats: dict = {}
+        _read_group(h5, "gt1l", ds, 0, grid, io_stats=io_stats)
+        _read_group(h5, "gt1l", ds, 0, grid, io_stats=io_stats)
+        assert io_stats["obs_read"] == 16
+
+    def test_full_read_path_counts_the_whole_group(self):
+        # The flat/full route decodes the base coords entirely, so obs_read is
+        # the group's whole photon count however few survive the shard mask.
+        h5 = _planned_read_h5()
+        grid = _LatBboxGrid((-0.1, 175.0, 0.1, 225.0))
+        ds_full = {
+            "coordinates": {"latitude": "/heights/lat_ph", "longitude": "/heights/lon_ph"},
+            "variables": {"h": "/heights/h"},
+        }
+        io_stats: dict = {}
+        df = _read_group(h5, "gt1l", ds_full, 0, grid, io_stats=io_stats)
+        assert df["h"].tolist() == [40.0]
+        assert io_stats["obs_read"] == 12  # all 12 photons decoded to keep 1
+
+    def test_full_read_fallback_counts_once_not_twice(self):
+        # The selectivity fallback re-enters _read_group_full from inside the
+        # planned path. Only the arm that actually decodes may count, or the
+        # ratio would double-count the fallback.
+        ds = _planned_read_data_source()
+        ds["read_plan"]["full_read_threshold"] = 0.1  # force the fallback
+        h5 = _planned_read_h5()
+        grid = _BboxGrid((-0.1, 175.0, 0.1, 225.0))
+        io_stats: dict = {}
+        _read_group(h5, "gt1l", ds, 0, grid, io_stats=io_stats)
+        assert io_stats["obs_read"] == 12
+
+    def test_no_sink_counts_nothing(self):
+        # Default (None) is the unchanged path: no counting, no crash.
+        h5 = _planned_read_h5()
+        grid = _LatBboxGrid((-0.1, 150.0, 0.1, 310.0))
+        ds = _planned_read_data_source()
+        ds["read_plan"]["pad"] = 1
+        # Identical rows to the counted run above — the sink is observation-only.
+        assert _read_group(h5, "gt1l", ds, 0, grid)["h"].tolist() == [30.0, 40.0, 50.0, 60.0]
+
+    def test_empty_decode_reads_as_measured_zero(self):
+        # An instrumented route that decodes nothing must SET the key (measured
+        # zero), so it stays distinguishable from an uninstrumented seam, which
+        # leaves it absent and reports None.
+        h5 = _planned_read_h5()
+        ds_full = {
+            "coordinates": {"latitude": "/heights/lat_ph", "longitude": "/heights/lon_ph"},
+            "variables": {"h": "/heights/h"},
+        }
+        grid = _LatBboxGrid((-0.1, 100000.0, 0.1, 100001.0))  # matches nothing
+        io_stats: dict = {}
+        assert _read_group(h5, "gt1l", ds_full, 0, grid, io_stats=io_stats) is None
+        assert io_stats["obs_read"] == 12  # decoded, then all masked out
 
     def test_multi_slice_plan_global_idx_alignment(self):
         # Force a plan with two disjoint base-slices (one ATL03 track that

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2139,6 +2139,23 @@ class TestObsReadMetadata:
         assert len(set(seen)) == len(seen) == 3  # three distinct dicts
         assert metadata["total_obs_read"] == 15
 
+    def test_one_read_log_line_per_shard(self, monkeypatch, caplog):
+        # "Read N observations" is how a shard's KEPT tally is grepped out of
+        # CloudWatch today. Emitting the pre-filter count under the same verb
+        # gave two contradictory hits per shard, so the new line says "Decoded"
+        # (review finding): one verb, one meaning.
+        import logging
+
+        def read_group(h5obj, group, ds, sk, grid, arrow=False, io_stats=None, **k):
+            io_stats["obs_read"] = io_stats.get("obs_read", 0) + 10
+            return self._carrier(grid, sk, 3)
+
+        with caplog.at_level(logging.INFO, logger="zagg.processing.worker"):
+            self._run(monkeypatch, read_group, ["s3://a"])
+        lines = [r.getMessage() for r in caplog.records]
+        assert sum("Read " in ln and "observations" in ln for ln in lines) == 1
+        assert "  Decoded 10 observations pre-filter, kept 3" in lines
+
 
 class TestMultiChunkWorker:
     """Issue #30 item 3: one worker (one shard) owns K = grid.chunks_per_shard finer

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -132,6 +132,29 @@ class TestBuildRecord:
         # through the invoke payload, copied verbatim into the record.
         assert _record(run_id="deadbeef")["run_id"] == "deadbeef"
 
+    def test_n_obs_read_absent_reads_as_unmeasured(self):
+        # Issue #374: no ``total_obs_read`` in the worker metadata — a raster
+        # record, or one from a worker predating the field — reads as None
+        # (unmeasured), NOT as zero, so a rollup can't dilute the ratio with
+        # rows nobody counted.
+        assert _record()["n_obs_read"] is None
+
+    def test_n_obs_read_rides_worker_metadata(self):
+        rec = build_record(
+            shard_key=1,
+            metadata={"duration_s": 1.0, "total_obs": 400, "total_obs_read": 1000},
+        )
+        assert rec["n_obs"] == 400
+        assert rec["n_obs_read"] == 1000
+        # The ratio is derived at read time, never stored (the #297 convention).
+        assert "read_keep_ratio" not in rec
+
+    def test_n_obs_read_zero_is_distinct_from_absent(self):
+        rec = build_record(
+            shard_key=1, metadata={"duration_s": 1.0, "total_obs": 0, "total_obs_read": 0}
+        )
+        assert rec["n_obs_read"] == 0  # measured zero, not None
+
     def test_raster_counters_default_none_and_populate(self):
         # Off-raster records carry the read-volume fields as None (issue #297).
         rec = _record()
@@ -219,6 +242,33 @@ class TestMerge:
         assert m["phase_timings"]["read"] == pytest.approx(16.0)
         assert m["timestamp"] == max(a["timestamp"], b["timestamp"])
         assert m["success"] is True
+
+    def test_n_obs_read_sums_over_the_fold(self):
+        # Issue #374: mergeable by construction, like the raster counters —
+        # the up-tree rollup sums reads and keeps, and the ratio is taken
+        # after the fold rather than averaged across leaves.
+        a = build_record(
+            shard_key=1, metadata={"duration_s": 1.0, "total_obs": 40, "total_obs_read": 100}
+        )
+        b = build_record(
+            shard_key=2, metadata={"duration_s": 1.0, "total_obs": 60, "total_obs_read": 300}
+        )
+        m = merge([a, b])
+        assert m["n_obs"] == 100
+        assert m["n_obs_read"] == 400
+
+    def test_n_obs_read_back_compat_row_folds(self):
+        # A record predating the field (None) must not poison the fold: the
+        # _SUM_OR_NONE disposition skips it, so a mixed rollup reports the
+        # measured part rather than collapsing to None.
+        measured = build_record(
+            shard_key=1, metadata={"duration_s": 1.0, "total_obs": 40, "total_obs_read": 100}
+        )
+        legacy = build_record(shard_key=2, metadata={"duration_s": 1.0, "total_obs": 60})
+        assert legacy["n_obs_read"] is None
+        assert merge([measured, legacy])["n_obs_read"] == 100
+        # All-unmeasured stays unmeasured.
+        assert merge([legacy, legacy])["n_obs_read"] is None
 
     def test_content_hashes_merge_equal_or_none(self):
         # Per-leaf identity (issue #342): shared value survives a fold,
@@ -446,7 +496,19 @@ class TestRunParquet:
         assert row["invoked_by"] == ident["arn"]
         assert row["invoked_by_userid"] == ident["userid"]
         assert "raster_bytes_read" in row  # read-volume columns always present
+        # The point-path read counter is a column of every run parquet too, so
+        # the read-vs-keep ratio is queryable alongside n_obs (issue #374).
+        assert "n_obs_read" in row
         assert "phase_timings" not in row and "lambda" not in row  # flattened away
+
+    def test_n_obs_read_flattens_to_a_column(self):
+        rec = build_record(
+            shard_key=3, metadata={"duration_s": 1.0, "total_obs": 40, "total_obs_read": 100}
+        )
+        row = flatten_record(rec)
+        assert row["n_obs"] == 40 and row["n_obs_read"] == 100
+        # Unmeasured stays null in the column rather than defaulting to 0.
+        assert flatten_record(_record())["n_obs_read"] is None
 
     def test_failure_record_and_error_class(self):
         rec = failure_record(


### PR DESCRIPTION
Bundled `small-fix` PR for the 2026-08-04 sweep.

Refs #372
Closes #374
Closes #375

## Phases

- [x] **Phase 1 — #375**: event-transport dispatch pacing no longer inherits the v1 fd ceiling.
- [x] **Phase 2 — #374**: point path records observations READ (pre-filter) alongside `n_obs`.
- [x] **Fold round (adversarial self-review of `e67edd8`)**: all six findings folded, one commit each — `8fc63b0`, `3473fe3`, `893f062`, `a977723`, `4177cff`, `f72e706`. Detail in the fold status comment on this thread.
- [ ] **#372** — conus shardmap builder count mislabel. **Cannot be implemented as written**; see "Questions for review" (1). No commit here touches it.
- [x] **Question (5) ruling**: shared-client `max_pool_connections` capped at the fd-safe bound regardless of transport — `058b9cb`.
- [x] **Fold round 2 (adversarial self-review of `058b9cb`)**: all six findings addressed — five commits (`8d47425`, `89c8009`, `4b609d2`, `28f9b31`, `1f297b5`) plus the question (5) scoping below. Detail in the inline replies.

## Phase 1 — #375: event-transport pacing window

`Run.dispatch(transport="event")` sized its pacing window through the same `_probe_workers` → `compute_available_workers` path as the sync transport, so the window was `min(n, fd_ceiling, account_headroom)`. The fd term exists because the v1 sync transport holds one socket per in-flight shard; the event transport holds **no** connections, so `RLIMIT_NOFILE` was clamping pure dispatch pacing.

**Approach.** The clamp composition stays in one place — `concurrency.compute_available_workers` grows a `fd_bound: bool = True` keyword rather than the caller re-deriving the window:

```python
if report.available is not None:
    workers = min(requested, report.available)
    if fd_bound:
        workers = min(workers, fd_safe_max_workers())
else:
    workers = min(requested, fd_safe_max_workers())
```

`Run.dispatch` threads the transport's connection model through `_probe_workers(session, n, fd_bound=transport == "sync")`. An explicit `max_workers` still wins verbatim and skips the probe, and the sync path is byte-identical.

**One judgement call, deliberately conservative:** when account headroom is **unreadable** (denied `GetAccountSettings`), the fd ceiling still applies even under `fd_bound=False`. It is then the only bound left, and an unbounded window would fire the whole shard set at once — exactly what the fleet's 60 s `MaximumEventAgeInSeconds` drops. Pinned by `test_unreadable_account_falls_back_to_fd_even_unbound`. Raised as question (2).

**Second-order effect, now documented** (fold `f72e706`): the event window is fired **serially** by the poller thread (`StatusPoller._dispatch_up_to_window`, `client_transport.py:901-903`), so a wider window lengthens the opening dispatch ramp proportionally — order 10 ms of invoke round-trip per shard, ~10 s → ~19 s in this issue's scenario, with no LIST running during it. That is the intended trade (the ramp grows by seconds; the clamp cost whole 900 s waves), and `dispatch`'s `max_workers` docstring now says so.

**Tests.** `tests/test_concurrency.py::TestFdBound` — the event window clears the fd ceiling (1900 vs a 992 ceiling) while the sync path on *identical* inputs stays clamped, so the divergence is attributable to `fd_bound` alone; account headroom still clamps without the fd term; `requested` still wins below headroom; the unreadable-account fallback above. `tests/test_client.py` pins the wiring itself, in two links that meet at the seam: `_probe_fd_bound` pins what `dispatch(transport=…)` hands `_probe_workers` (`False` for event, `True` for sync), and `test_probe_body_forwards_fd_bound` drives the **real** `_probe_workers` body and asserts the value it forwards to `compute_available_workers` is `[False, True]`, not the callee's default. The `_dispatch` helper's probe stub records the kwarg too, so `test_probe_sizes_the_pool` covers the sync direction end-to-end.

## Phase 2 — #374: observations READ on the point path

`n_obs` is the worker's `total_obs` — photons that survived the filters and landed in the shard. Photons fetched-but-discarded (read-plan `pad` segment padding, segments straddling the shard boundary, filter rejects) left no trace, so the read-vs-keep ratio — the direct measure of the #43 segment→photon indexed-IO efficiency — was not derivable from the run parquet.

**Approach — mirror the raster counters (issue #297), including their thread-safety argument.** The raster path threads a mutable `io_stats` dict down the read and accumulates in place. The point path does the same, with one adaptation: the granule fan-out is a `ThreadPoolExecutor` (issue #180), not an event loop, so a single shared dict would race. Instead **each granule gets its own sink**, allocated inside `_read_granule` and returned alongside its reads; the main thread sums them as it folds granules in order. Same no-lock argument the existing `group_errors` counter already relies on — written by the owning thread, read after the result is handed back.

Counting happens at the two places that actually decode base-rate rows, before any mask is applied:

| route | counted at | value |
|---|---|---|
| planned (`read_plan.spatial_index`) | `_execute_plan_group` | rows the plan decoded, including `pad` |
| full / flat, and the selectivity fallback | `_read_group_full` | the whole group |
| a-priori (`chunk_boundaries`) | whichever of the two it delegates to | as above |

Exactly one arm counts per group — `test_full_read_fallback_counts_once_not_twice` pins that the selectivity fallback does not double-count when it re-enters `_read_group_full` from inside the planned path.

**Absence means unmeasured, not zero** (the #297 nullable convention). `_record_obs_read` makes the *presence of the key* the "measured" signal, so a stubbed read seam or a worker predating the field reports `None` rather than a fabricated `0`, and `telemetry.merge`'s `_SUM_OR_NONE` disposition skips it instead of poisoning a mixed rollup.

That contract only held on the full-read path in the first cut. The planned and a-priori routes have **five exits before any base-rate decode** — `read.py:432`/`:442`/`:470` and `apriori.py:230`/`:241` — and none touched the sink, so a beam that short-circuits (the *common* per-beam outcome on the spatial-index route: a granule assigned for one beam misses on the other five) reported `None`, indistinguishable from an uninstrumented seam. Each now stamps `_record_obs_read(io_stats, 0)` (fold `893f062`); the numeric rollup is unchanged, since `_SUM_OR_NONE` skipping a `None` and summing a `0` agree.

Plumbing: `metadata["total_obs_read"]` (worker) → `n_obs_read` in `build_record`, `_SUM_OR_NONE_KEYS`, and `_ROW_SCALARS`. `deployment/aws/lambda_handler.py` already forwards worker metadata verbatim to `build_record`, so the field reaches the sidecar and run parquet with **no change to any deploy/infra file**.

**The stamp lands before the no-data early return** — a shard that decoded millions of photons and kept none is precisely the case the counter exists to expose, and stamping it only at the normal exit would have lost it. Caught in self-review (commit `e67edd8`), pinned by `test_stamped_on_the_no_data_shard`.

**`io_stats` is forwarded unconditionally by both index backends.** `HierarchicalIndex.read_group` briefly presence-gated it the way it gates `granule_url`; that gate protected nothing (the worker always passes a dict — `worker.py:422`/`:436`) and diverged from `InlineIndex`, which forwards it always. Dropped in fold `a977723`; `granule_url`'s gate is genuinely load-bearing and stays.

**One verb, one meaning in the shard log.** The new pre-filter count first shipped as a second `Read N observations` line, colliding with the pre-existing `worker.py:673`/`:676` lines that mean *kept* and are what CloudWatch is grepped for today. It now reads `Decoded {n} observations pre-filter, kept {m}` (fold `4177cff`).

**Tests.** `tests/test_processing.py::TestPlannedReadGroup` — padded decode counts 8 read against 4 kept on the existing 6-segment/12-photon fixture; per-granule accumulation across groups; the full-read route counting the whole group (12 decoded to keep 1); the fallback counting once; `None` sink counting nothing; an instrumented route that decodes-then-masks-everything reporting measured zero; and `test_planned_short_circuits_read_as_measured_zero` over all three pre-decode exits (empty AOI, empty coarse level, link counts summing to zero base rows). `tests/test_apriori.py::TestAprioriReadGroup::test_short_circuits_read_as_measured_zero` does the same for the a-priori pair. `tests/test_processing.py::TestObsReadMetadata` — the worker's half: sums across granules and exceeds kept, omits the key when the seam never measured, hands each granule a distinct sink, stamps the no-data shard, and emits exactly one `Read … observations` line per shard. `tests/test_index.py::TestHierarchicalDelegation::test_io_stats_forwarded_unconditionally` — the sink reaches `_read_group` on every call, `None` included. `tests/test_telemetry.py` — record field, measured-zero vs absent, merge sums, back-compat row folds without poisoning, parquet column.

## How it was tested

Full local gate on the final commit (`1f297b5`):

- `uv run pytest -q` → **3290 passed, 38 skipped**, 0 failures (`test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` deselected — it fails identically on the base commit `f72e706` in this environment, env-dependent Docker build, untouched by this PR).
- `uv run ruff check src tests` → clean except the **pre-existing** `N818` on `src/zagg/registry.py:64` (`UnknownCapability`), untouched by this PR.
- `uv run ruff format --check src tests` → clean except the **pre-existing** diff on `tests/data/benchmark/README.md`, untouched by this PR.

Both pre-existing failures reproduce on `main` at 66cb111 and are deliberately left alone per the "don't fix unrelated CI failures" rule.

Every fold commit that changed behavior was **mutation-verified**: the fix reverted locally, the new test observed to fail, the fix restored. Per-finding detail in the inline replies.

## Questions for review

1. **#372 cannot be implemented on `main` as written — it is the reason this PR is `waiting`.** The issue names `data/conus/build_conus_shardmap.py:254` and `data/build_aoi_shardmap.py`, but at `main` (66cb111) there is **no `data/` directory in the repository at all** — and it is not gitignored (`.gitignore` has no `data/` entry, so the files are genuinely absent, not merely untracked). The premise field is missing too: the issue says the fix is "one-line now that `ShardMap.build` records the distinct assigned count (landed with the demo-week `granules_assigned` metadata addition)", but `granules_assigned` appears nowhere in the tree — `ShardMap.build` writes `total_granules`/`total_shards`/`total_pairs`/`build_wall_s` only (`src/zagg/catalog/shardmap.py:534-542`), and a repo-wide search for `granules_assigned` and `granules_intersecting_conus` returns nothing. The closest live analogue to the hand-computed distinct set is `src/zagg/sweep.py:447` (`meta["total_granules"] = len({e["id"] for g in granules for e in g})`), which is not what the issue asks to change. Which do you want?
   - (1) The scripts live outside this repo (a demo/scratch tree) — close #372 here, or move it to that repo.
   - (2) They are meant to land here and haven't yet — #372 waits on the PR that adds them.
   - (3) You actually want `ShardMap.build` to record a `granules_assigned` distinct count first (the prerequisite the issue assumes) — a behavioral change to the shardmap builder, well beyond `small-fix`, so it wants its own issue/PR rather than being folded in here.

   Referenced with `Refs`, not `Closes`, so merging will not silently close it.

2. **#375, the unreadable-account fallback.** Keeping the fd clamp when the probe is denied is my call, not the issue's text (which says "compute the window from the account-concurrency probe without the `fd_safe_max_workers` term"). The literal reading gives a denied probe under `transport="event"` a window of `n` — dispatching every shard at once on exactly the runs where headroom is unknown. Self-review confirmed the code does what this says and let the call stand, with one caveat worth recording: on that branch the FD ceiling is no longer bounding anything physical (the event transport holds no sockets), so it is an **arbitrary-but-bounded pacing proxy** — the right shape of answer, but the number itself carries no meaning. Say the word if you want the literal reading instead, or a named pacing constant in place of the FD ceiling.

3. **#374 changes the `_read_group` call contract: `io_stats` is passed ALWAYS, not feature-gated** — and both index backends now agree on that. `granule_url` stays gated on the a-priori feature being configured; `tests/test_apriori.py::TestWorkerSeam::test_granule_url_absent_when_flag_off` pins that gate on the *received kwargs*, so it survives future always-on kwargs (mutation-verified in review: removing the gate still fails it). `io_stats` is always-on instrumentation matching the raster sink, so `HierarchicalIndex.read_group` now forwards it unconditionally like `InlineIndex` always did — the presence-gate it briefly carried protected nothing, since the worker always passes a dict (`worker.py:422`/`:436`), and `_record_obs_read` already no-ops on `None` for direct callers. Nothing to decide here unless you disagree that the sink should be always-on.

4. **`src/zagg/client.py` is over the §4 size limit — pre-existing, and I did not split it.** It was **1211** lines at 66cb111 (already past ~1,200); this PR adds 24, almost all docstring on the existing `_probe_workers`/`dispatch`, taking it to **1235**. §4 says raise it rather than split, so: flagging, not splitting. A split is its own PR.

5. **Resolved — ruled "fix it here, now" ([ruling](https://github.com/englacial/zagg/pull/378#issuecomment-5185073447), row (5)); landed in `058b9cb`.** The shared client's declared pool is now `max_pool_connections=min(workers, concurrency.fd_safe_max_workers())` regardless of transport, so it can never exceed `RLIMIT_NOFILE` even when the event pacing window legitimately does (`fd_bound=False`). What it declares is a **retention** bound, not an EMFILE guard: botocore passes only `maxsize` to urllib3 (`block=False`), so an oversized declaration allocates nothing by itself — it is the number of sockets the pool would keep once a concurrent dispatch loop opened them.

   **Scope of "no behavioral change" (review finding, fold round 2).** Inert on both **probe-driven** paths: the sync probe already applies the fd term inside `compute_available_workers`, so `min()` is a no-op, and today's serial event dispatch loop holds at most one connection. It is **not** literally inert on the **explicit `max_workers`** path, which skips the probe on either transport and so carries no fd term: `dispatch(max_workers=300)` under `ulimit -n 256` now declares a 224-connection pool against a 300-wide thread pool, i.e. urllib3 "Connection pool is full, discarding connection" churn where it previously retained one connection per thread. That is exactly what the ruling asks for ("regardless of transport") and is arguably the better behavior — recording it here because it is a change, not nothing.

   Pinned by `tests/test_client.py::TestConcurrencyPreflight::test_pool_cap_clamped_when_window_exceeds_fd_bound` and `test_pool_cap_unchanged_below_fd_bound`, which assert the declared pool **and** the fan-out width together (`(pool, width) == (2, 3)`): the clamp must stop at the pool and must not re-clamp the pacing window, which would undo #375. Mutation-verified both ways — reverting the cap to `max_pool_connections=workers` fails the clamp test, and moving the fd term up into `workers` fails the width assertion.

