### PR TITLE
small fixes 2026-08-05: refuse a sub-second windowing epoch (issue #390)

### DIFF
--- a/demo/05_california_read.ipynb
+++ b/demo/05_california_read.ipynb
@@ -193,7 +193,7 @@
     "print(f\"order-{overview_order} overview: {ov.sizes['cells']} cells; \"\n",
     "      f\"count sum {int(ov['count'].sum()):,} (leaves: exactness check vs the run total)\")\n",
     "\n",
-    "from mortie.tools import mort2polygon\n",
+    "from mortie import mort2polygon\n",
     "\n",
     "words = [int(w) for w in ov[\"morton\"].values]\n",
     "lat = np.array([np.mean([p[0] for p in mort2polygon(w, step=4)]) for w in words])\n",

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -193,7 +193,13 @@ same second (say `12:00:01.0Z` → `12:00:01.4Z`) the window dispatches as an
 empty `ge x`/`lt x` pair, so it is rejected — the point form is the spelling
 for one-second intent. A sub-second range that *straddles* a second boundary
 (`12:00:01.9Z` → `12:00:02.1Z`) is still valid; it renders to the one-second
-window its truncated bounds describe. On the raster path
+window its truncated bounds describe. The `epoch` is the one time value held
+to a stricter rule ([issue #390](https://github.com/englacial/zagg/issues/390)):
+it too renders at whole-second granularity, but it defines *every* window
+conversion rather than one edge of one window, so a sub-second `epoch` is
+**refused** rather than truncated — `2018-01-01T00:00:00.5Z` would shift every
+boundary by half a second, invisibly. Declare it at second precision. On the
+raster path
 ([issue #247](https://github.com/englacial/zagg/issues/247)) membership is
 the acquisition's STAC `datetime`: `time_field` is optional (fixed to
 `datetime`) and the `epoch`/`scale`/`units` conversion knobs are rejected.

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -166,7 +166,9 @@ output:
   need `bounds.temporal` to enumerate generative windows.
 - **Stamps carry the truth, the manifest the schema** (D15): each windowed
   leaf's commit stamp records its `window` label and the ACTUAL written
-  `time_range` as ISO-8601 UTC strings; the root `coverage.moc` summary
+  `time_range` as ISO-8601 UTC strings (both ends at whole-second
+  granularity, which narrows the tail by up to 1 s — see
+  [The commit stamp](#the-commit-stamp)); the root `coverage.moc` summary
   carries the run's time-range union (cache, regenerable); temporal *extent*
   never lives in the manifest, which stays write-once. Appending a new year
   to a `yearly` store adds leaves the schedule already describes — no
@@ -489,6 +491,26 @@ stamp, so coverage shares the debris semantics: no stamp, no visible coverage.
 A windowed leaf's stamp ([Time windows](#time-windows-morton-hive2)) declares
 `spec: "morton-hive/2"` and adds `window` (the label) plus `time_range` — the
 actual `[t_min, t_max]` written, as ISO-8601 UTC strings.
+
+**Reader caveat — `t_max` floors, so the recorded range can end up to 1 s
+early.** Both ends render through `windows.iso_utc`'s whole-second
+granularity (`isoformat(timespec="seconds")`), so each truncates to the second
+*containing* it. On `t_min` that is harmless: the recorded start is at or
+before the true first observation. On `t_max` it is not — a last observation
+at `12:00:00.7` is recorded as `12:00:00`, so the closed `[t_min, t_max]` is
+a slight **under**-estimate of the extent written, not an envelope around it.
+**A consumer that prunes leaves on the stamp must treat `t_max` as inclusive
+with 1 s of slack** (test the query against `t_max + 1 s`); pruning on the
+recorded value alone can skip a leaf that genuinely holds data in the queried
+interval. Sub-second inputs reach the rendering on both pipelines — a float
+`delta_time` column on the point path (`windows.iso_time_range`), a
+millisecond-bearing STAC `datetime` on the raster path
+(`processing/raster._us_iso`). The narrowing is recorded rather than fixed
+(ruled on [PR #398](https://github.com/englacial/zagg/pull/398)): no in-tree
+consumer prunes on `time_range` — every use is a union into the regenerable
+root `coverage.moc` summary or the overview rollup — and rendering the range
+outward instead would change the bytes of a stamp field external readers
+decode.
 
 ## Coverage
 

--- a/notebooks/aoi_mask.ipynb
+++ b/notebooks/aoi_mask.ipynb
@@ -66,7 +66,7 @@
     "# 3) Visualize the in-AOI cells by their HEALPix center (decode only for the\n",
     "#    picture — the mask itself never decodes centers).\n",
     "import matplotlib.pyplot as plt\n",
-    "from mortie.tools import mort2geo\n",
+    "from mortie import mort2geo\n",
     "\n",
     "clat, clon = mort2geo(np.asarray(children))\n",
     "fig, ax = plt.subplots(figsize=(5, 5))\n",

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1056,17 +1056,17 @@ def _validate_windowing(config: PipelineConfig) -> None:
     # The message renders parsed_epoch rather than repr-ing the declared value:
     # yaml.safe_load types an ISO timestamp scalar as a datetime, which parse_utc
     # passes through, so repr would hand the author a stdlib constructor call
-    # instead of the value they wrote.
+    # instead of the value they wrote. The drop is reported in microseconds
+    # because that is exactly what iso_utc discards and nothing else: an integer,
+    # so no scientific notation for the 1 µs case, and never negative.
     rendered_epoch = _windows.iso_utc(parsed_epoch)
     if _windows.parse_utc(rendered_epoch) != parsed_epoch:
         raise ValueError(
             f"output.windowing.epoch {parsed_epoch.isoformat()!r} carries sub-second "
             f"precision that the canonical whole-second rendering drops: it is "
             f"recorded as {rendered_epoch!r}, which would shift every window "
-            f"conversion by "
-            f"{(parsed_epoch - _windows.parse_utc(rendered_epoch)).total_seconds()} s. "
-            f"Window granularity is whole seconds, so a finer epoch is a config "
-            f"error, never a silent shift — declare the epoch at second precision"
+            f"conversion by {parsed_epoch.microsecond} µs — declare the epoch at "
+            f"second precision"
         )
     scale = block.get("scale") or "utc"
     if scale not in _windows.EPOCH_SCALES:

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1053,12 +1053,17 @@ def _validate_windowing(config: PipelineConfig) -> None:
     # is consumed — shifting EVERY window conversion by the dropped fraction. The
     # predicate calls the renderer and round-trips it rather than repeating the
     # truncation rule, so the two cannot drift (the PR #367 pattern).
+    # The message renders parsed_epoch rather than repr-ing the declared value:
+    # yaml.safe_load types an ISO timestamp scalar as a datetime, which parse_utc
+    # passes through, so repr would hand the author a stdlib constructor call
+    # instead of the value they wrote.
     rendered_epoch = _windows.iso_utc(parsed_epoch)
     if _windows.parse_utc(rendered_epoch) != parsed_epoch:
         raise ValueError(
-            f"output.windowing.epoch {epoch!r} carries sub-second precision that the "
-            f"canonical whole-second rendering drops: it is recorded as "
-            f"{rendered_epoch!r}, which would shift every window conversion by "
+            f"output.windowing.epoch {parsed_epoch.isoformat()!r} carries sub-second "
+            f"precision that the canonical whole-second rendering drops: it is "
+            f"recorded as {rendered_epoch!r}, which would shift every window "
+            f"conversion by "
             f"{(parsed_epoch - _windows.parse_utc(rendered_epoch)).total_seconds()} s. "
             f"Window granularity is whole seconds, so a finer epoch is a config "
             f"error, never a silent shift — declare the epoch at second precision"

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -6,7 +6,7 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from importlib import resources
 from typing import Any, NotRequired, TypedDict
 
@@ -2681,6 +2681,16 @@ def _is_nan_fill(meta: dict) -> bool:
     return isinstance(fill, float) and np.isnan(fill)
 
 
+#: The raster branch's fixed windowing epoch (issue #247, ratified): raster
+#: window membership is the acquisition's STAC ``datetime``, already an ISO-8601
+#: UTC instant, so the encoding is the identity one and is never author-declared.
+#: Held as an *instant*, not a spelling — ``get_windowing`` renders it through
+#: ``windows.iso_utc``, the same renderer its point branch canonicalizes the
+#: declared epoch with, so the two branches cannot write different spellings of
+#: the same instant if that rendering ever changes (issue #390).
+_UNIX_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
 def get_windowing(config: PipelineConfig) -> dict | None:
     """The normalized temporal windowing declaration, or ``None`` (issue #246).
 
@@ -2702,12 +2712,14 @@ def get_windowing(config: PipelineConfig) -> dict | None:
     entry is desugared to its second-wide range (issue #355) so the normalized
     list is uniformly ``{label, start, end}``.
     On the raster branch (``reader: raster``) ``time_field`` is the fixed STAC
-    ``datetime`` and ``epoch``/``scale``/``units`` are hardcoded to the
-    Unix-epoch UTC-seconds encoding any ISO instant normalizes to, rather than
+    ``datetime`` and ``epoch``/``scale``/``units`` are fixed to the Unix-epoch
+    UTC-seconds encoding any ISO instant normalizes to, rather than
     canonicalizing a declared ``epoch`` off the block (``_validate_windowing``
-    rejects those conversion knobs there). The same dict feeds the manifest
-    temporal block (:func:`zagg.hive.build_manifest`) and the dispatch fan-out,
-    so the two can never disagree.
+    rejects those conversion knobs there); the fixed epoch is still rendered
+    through the same ``windows.iso_utc`` as the declared one, so the branches
+    cannot spell one instant two ways (issue #390). The same dict feeds the
+    manifest temporal block (:func:`zagg.hive.build_manifest`) and the dispatch
+    fan-out, so the two can never disagree.
     """
     from zagg import windows as _windows
 
@@ -2731,11 +2743,16 @@ def get_windowing(config: PipelineConfig) -> dict | None:
         # #247, ratified): the manifest records the resolved field plus the
         # fixed encoding any ISO-8601 UTC instant normalizes to (UTC seconds
         # since the Unix epoch). _validate_windowing rejects the conversion
-        # knobs on raster configs, so nothing here can disagree with it.
+        # knobs on raster configs, so nothing here can disagree with it. The
+        # epoch is *rendered* through iso_utc rather than spelled out, for the
+        # reason _validate_windowing's #390 guard calls the renderer instead of
+        # restating its truncation rule: a literal here would be a copy of
+        # iso_utc's output format, free to drift from the spelling the point
+        # branch below gives the very same instant (see _UNIX_EPOCH).
         return {
             "schedule": block["schedule"],
             "time_field": "datetime",
-            "epoch": "1970-01-01T00:00:00+00:00",
+            "epoch": _windows.iso_utc(_UNIX_EPOCH),
             "scale": "utc",
             "units": "seconds",
             "windows": declared,

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -2691,15 +2691,16 @@ def get_windowing(config: PipelineConfig) -> dict | None:
         {"schedule", "time_field", "epoch", "scale", "units", "windows"}
 
     ``epoch`` and explicit-window boundaries are canonicalized to ISO-8601
-    UTC strings. The ``epoch`` canonicalization is lossless — ``timespec=
-    "seconds"`` would otherwise truncate a sub-second epoch and shift every
-    window conversion, so :func:`_validate_windowing` refuses one outright
-    (issue #390); explicit bounds do truncate, documented on
-    :func:`_explicit_window_bounds`. ``windows`` is ``None`` except for
-    ``schedule: explicit``,
-    where a ``{label, timestamp}`` point entry is desugared to its second-wide
-    range (issue #355) so the normalized list is uniformly ``{label, start,
-    end}``.
+    UTC strings. The ``epoch`` canonicalization is lossless on any config that
+    passed ``validate_config`` — ``timespec="seconds"`` would otherwise truncate
+    a sub-second epoch and shift every window conversion, so
+    :func:`_validate_windowing` refuses one outright (issue #390). A config
+    built without that check (``load_config_from_dict``, a hand-rolled worker
+    payload) still truncates here; explicit bounds truncate either way,
+    documented on :func:`_explicit_window_bounds`. ``windows`` is ``None``
+    except for ``schedule: explicit``, where a ``{label, timestamp}`` point
+    entry is desugared to its second-wide range (issue #355) so the normalized
+    list is uniformly ``{label, start, end}``.
     On the raster branch (``reader: raster``) ``time_field`` is the fixed STAC
     ``datetime`` and ``epoch``/``scale``/``units`` are hardcoded to the
     Unix-epoch UTC-seconds encoding any ISO instant normalizes to, rather than

--- a/src/zagg/config.py
+++ b/src/zagg/config.py
@@ -1044,9 +1044,25 @@ def _validate_windowing(config: PipelineConfig) -> None:
             "delta_time)"
         )
     try:
-        _windows.parse_utc(epoch)
+        parsed_epoch = _windows.parse_utc(epoch)
     except ValueError as e:
         raise ValueError(f"output.windowing.epoch: {e}") from e
+    # Validate the RENDERED epoch, not the parsed one (issue #390). get_windowing
+    # canonicalizes through windows.iso_utc (timespec="seconds"), so a sub-second
+    # epoch parses clean here and is then silently truncated at the one place it
+    # is consumed — shifting EVERY window conversion by the dropped fraction. The
+    # predicate calls the renderer and round-trips it rather than repeating the
+    # truncation rule, so the two cannot drift (the PR #367 pattern).
+    rendered_epoch = _windows.iso_utc(parsed_epoch)
+    if _windows.parse_utc(rendered_epoch) != parsed_epoch:
+        raise ValueError(
+            f"output.windowing.epoch {epoch!r} carries sub-second precision that the "
+            f"canonical whole-second rendering drops: it is recorded as "
+            f"{rendered_epoch!r}, which would shift every window conversion by "
+            f"{(parsed_epoch - _windows.parse_utc(rendered_epoch)).total_seconds()} s. "
+            f"Window granularity is whole seconds, so a finer epoch is a config "
+            f"error, never a silent shift — declare the epoch at second precision"
+        )
     scale = block.get("scale") or "utc"
     if scale not in _windows.EPOCH_SCALES:
         raise ValueError(
@@ -2670,7 +2686,12 @@ def get_windowing(config: PipelineConfig) -> dict | None:
         {"schedule", "time_field", "epoch", "scale", "units", "windows"}
 
     ``epoch`` and explicit-window boundaries are canonicalized to ISO-8601
-    UTC strings; ``windows`` is ``None`` except for ``schedule: explicit``,
+    UTC strings. The ``epoch`` canonicalization is lossless — ``timespec=
+    "seconds"`` would otherwise truncate a sub-second epoch and shift every
+    window conversion, so :func:`_validate_windowing` refuses one outright
+    (issue #390); explicit bounds do truncate, documented on
+    :func:`_explicit_window_bounds`. ``windows`` is ``None`` except for
+    ``schedule: explicit``,
     where a ``{label, timestamp}`` point entry is desugared to its second-wide
     range (issue #355) so the normalized list is uniformly ``{label, start,
     end}``.

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -249,7 +249,7 @@ class HealpixGrid:
         crossing the antimeridian or enclosing a pole, where a lon/lat box is
         the wrong shape entirely.
         """
-        from mortie.tools import mort2polygon
+        from mortie import mort2polygon
 
         lats: list[float] = []
         lons: list[float] = []
@@ -433,7 +433,7 @@ class HealpixGrid:
 
     def shard_footprint(self, shard_key):
         """Parent-cell polygon in WGS84 (lon, lat)."""
-        from mortie.tools import mort2polygon
+        from mortie import mort2polygon
         from shapely.geometry import Polygon
 
         verts = mort2polygon(int(shard_key), step=32)

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -8,6 +8,7 @@ on the mortie spec page (mortie#62).
 """
 
 import re
+from datetime import datetime, timezone
 
 import pytest
 
@@ -237,25 +238,45 @@ class TestWindowingConfig:
             validate_config(cfg)
 
     @pytest.mark.parametrize(
-        "epoch, rendered, shift",
+        "epoch, declared, rendered, shift",
         [
-            ("2018-01-01T00:00:00.5Z", "2018-01-01T00:00:00+00:00", "0.5"),
+            (
+                "2018-01-01T00:00:00.5Z",
+                "2018-01-01T00:00:00.500000+00:00",
+                "2018-01-01T00:00:00+00:00",
+                "0.5",
+            ),
             # The fraction survives a non-UTC declaration: the offset is whole
             # minutes, so only the sub-second part is ever what iso_utc drops.
-            ("2018-01-01T05:30:00.001+05:30", "2018-01-01T00:00:00+00:00", "0.001"),
+            (
+                "2018-01-01T05:30:00.001+05:30",
+                "2018-01-01T00:00:00.001000+00:00",
+                "2018-01-01T00:00:00+00:00",
+                "0.001",
+            ),
+            # The production path is datetime-typed, not str: yaml.safe_load
+            # resolves an ISO timestamp scalar to an aware datetime and
+            # windows.parse_utc passes it through, so the message must render
+            # the author's value rather than repr a stdlib constructor call.
+            (
+                datetime(2018, 1, 1, 0, 0, 0, 500000, tzinfo=timezone.utc),
+                "2018-01-01T00:00:00.500000+00:00",
+                "2018-01-01T00:00:00+00:00",
+                "0.5",
+            ),
         ],
     )
-    def test_subsecond_epoch_rejected(self, cfg, epoch, rendered, shift):
+    def test_subsecond_epoch_rejected(self, cfg, epoch, declared, rendered, shift):
         # The epoch parses at full precision but is CONSUMED through
         # windows.iso_utc (timespec="seconds"), so a sub-second epoch used to
         # validate clean and then shift every window conversion by the dropped
         # fraction (issue #390 — the PR #367 validate-vs-render mismatch class).
-        # The message quotes the rendered value and the shift, so the refusal is
-        # tied to what get_windowing would actually emit.
+        # The message quotes the declared instant, the rendered value and the
+        # shift, so the refusal is tied to what get_windowing would actually emit.
         _windowed(cfg, epoch=epoch)
         with pytest.raises(
             ValueError,
-            match=rf"epoch {re.escape(repr(epoch))} carries sub-second precision.*"
+            match=rf"epoch {re.escape(repr(declared))} carries sub-second precision.*"
             rf"recorded as {re.escape(repr(rendered))}.*shift every window "
             rf"conversion by {shift} s",
         ):

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -44,6 +44,21 @@ def _windowed(cfg, schedule="yearly", **over):
     return cfg
 
 
+def _raster_windowed(schedule="yearly"):
+    """A minimal raster + hive + windowing config (issue #247)."""
+    c = default_config("atl06")
+    c.data_source = {
+        "reader": "raster",
+        "bands": {"red": {"asset": "red", "dtype": "uint16"}},
+    }
+    c.aggregation = {}
+    c.output["grid"] = {"type": "healpix", "parent_order": 6, "child_order": 12}
+    c.output["store_layout"] = "hive"
+    c.output["windowing"] = {"schedule": schedule}
+    validate_config(c)
+    return c
+
+
 # ── config block (phase 2) ───────────────────────────────────────────────────
 
 
@@ -683,6 +698,20 @@ class TestWindowingConfig:
         validate_config(c)
         assert get_windowing(c)["time_field"] == "datetime"
 
+    def test_raster_epoch_renders_through_iso_utc(self):
+        # Issue #390: the raster epoch is FIXED (issue #247) but not SPELLED —
+        # get_windowing renders it with windows.iso_utc like every other
+        # instant it emits. Asserting against the renderer's own output rather
+        # than a literal is the point: this stays true through a change to
+        # iso_utc's precision or offset form, and only a re-introduced literal
+        # in config.py can break it.
+        from zagg import windows as _windows
+
+        c = _raster_windowed()
+        assert get_windowing(c)["epoch"] == _windows.iso_utc(
+            _windows.parse_utc(datetime(1970, 1, 1, tzinfo=timezone.utc))
+        )
+
 
 # ── manifest temporal block + spec bump (phase 2) ────────────────────────────
 
@@ -722,6 +751,21 @@ class TestManifestTemporal:
             "calendar": "proleptic_gregorian",
             "append_policy": "new-window",
         }
+
+    def test_raster_and_point_epochs_spell_one_instant_alike(self, cfg):
+        # The drift the rendered raster epoch prevents (issue #390): both
+        # branches of get_windowing feed the SAME manifest field, so a given
+        # instant has to reach it spelled one way. A point config declaring
+        # the Unix epoch and a raster config (whose epoch is fixed to it)
+        # therefore must produce byte-identical temporal epochs — this is the
+        # assertion a re-introduced literal on either branch breaks, since a
+        # literal is free to disagree with whatever iso_utc emits.
+        _windowed(cfg, epoch="1970-01-01T00:00:00Z", scale="utc")
+        validate_config(cfg)
+        point = hive.build_manifest(self._grid(cfg), windowing=get_windowing(cfg))
+        rcfg = _raster_windowed()
+        raster = hive.build_manifest(self._grid(rcfg), windowing=get_windowing(rcfg))
+        assert raster["temporal"]["epoch"] == point["temporal"]["epoch"]
 
     def test_explicit_manifest_carries_windows_and_retemplate_policy(self, cfg):
         _windowed(cfg, schedule="explicit")

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -244,7 +244,7 @@ class TestWindowingConfig:
                 "2018-01-01T00:00:00.5Z",
                 "2018-01-01T00:00:00.500000+00:00",
                 "2018-01-01T00:00:00+00:00",
-                "0.5",
+                "500000",
             ),
             # The fraction survives a non-UTC declaration: the offset is whole
             # minutes, so only the sub-second part is ever what iso_utc drops.
@@ -252,7 +252,16 @@ class TestWindowingConfig:
                 "2018-01-01T05:30:00.001+05:30",
                 "2018-01-01T00:00:00.001000+00:00",
                 "2018-01-01T00:00:00+00:00",
-                "0.001",
+                "1000",
+            ),
+            # The smallest representable violation — a microsecond-precision
+            # timestamp pasted in from a data file — reads as an integer count,
+            # not as 1e-06.
+            (
+                "2018-01-01T00:00:00.000001Z",
+                "2018-01-01T00:00:00.000001+00:00",
+                "2018-01-01T00:00:00+00:00",
+                "1",
             ),
             # The production path is datetime-typed, not str: yaml.safe_load
             # resolves an ISO timestamp scalar to an aware datetime and
@@ -262,7 +271,7 @@ class TestWindowingConfig:
                 datetime(2018, 1, 1, 0, 0, 0, 500000, tzinfo=timezone.utc),
                 "2018-01-01T00:00:00.500000+00:00",
                 "2018-01-01T00:00:00+00:00",
-                "0.5",
+                "500000",
             ),
         ],
     )
@@ -278,7 +287,7 @@ class TestWindowingConfig:
             ValueError,
             match=rf"epoch {re.escape(repr(declared))} carries sub-second precision.*"
             rf"recorded as {re.escape(repr(rendered))}.*shift every window "
-            rf"conversion by {shift} s",
+            rf"conversion by {shift} µs",
         ):
             validate_config(cfg)
 

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -246,8 +246,10 @@ class TestWindowingConfig:
                 "2018-01-01T00:00:00+00:00",
                 "500000",
             ),
-            # The fraction survives a non-UTC declaration: the offset is whole
-            # minutes, so only the sub-second part is ever what iso_utc drops.
+            # The fraction survives a non-UTC declaration: the guard compares
+            # INSTANTS, not spellings, so it is the dropped fraction that
+            # refuses this — never the offset (Python accepts sub-minute
+            # offsets, and a whole-second one of those round-trips clean).
             (
                 "2018-01-01T05:30:00.001+05:30",
                 "2018-01-01T00:00:00.001000+00:00",
@@ -309,6 +311,21 @@ class TestWindowingConfig:
         _windowed(cfg, epoch=epoch)
         validate_config(cfg)
         assert get_windowing(cfg)["epoch"] == "2018-01-01T00:00:00+00:00"
+
+    def test_schedule_none_keeps_subsecond_epoch(self, cfg):
+        # The guard sits AFTER the ``schedule: none`` early return, and must:
+        # an inert block is equivalent to an absent one (test_absent_is_none),
+        # get_windowing returns None, and the epoch is never rendered — so
+        # there is no conversion to shift and nothing to refuse.
+        cfg.output["store_layout"] = "hive"
+        cfg.output["windowing"] = {
+            "schedule": "none",
+            "time_field": "delta_time",
+            "epoch": "2018-01-01T00:00:00.5Z",
+            "scale": "gps",
+        }
+        validate_config(cfg)
+        assert get_windowing(cfg) is None
 
     def test_bad_scale_and_units(self, cfg):
         _windowed(cfg, scale="tt")

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -7,6 +7,8 @@ themselves are pinned in ``tests/test_windows.py``; the frozen grammar lives
 on the mortie spec page (mortie#62).
 """
 
+import re
+
 import pytest
 
 from zagg import hive
@@ -233,6 +235,50 @@ class TestWindowingConfig:
         _windowed(cfg, epoch="the beginning")
         with pytest.raises(ValueError, match="ISO-8601"):
             validate_config(cfg)
+
+    @pytest.mark.parametrize(
+        "epoch, rendered, shift",
+        [
+            ("2018-01-01T00:00:00.5Z", "2018-01-01T00:00:00+00:00", "0.5"),
+            # The fraction survives a non-UTC declaration: the offset is whole
+            # minutes, so only the sub-second part is ever what iso_utc drops.
+            ("2018-01-01T05:30:00.001+05:30", "2018-01-01T00:00:00+00:00", "0.001"),
+        ],
+    )
+    def test_subsecond_epoch_rejected(self, cfg, epoch, rendered, shift):
+        # The epoch parses at full precision but is CONSUMED through
+        # windows.iso_utc (timespec="seconds"), so a sub-second epoch used to
+        # validate clean and then shift every window conversion by the dropped
+        # fraction (issue #390 — the PR #367 validate-vs-render mismatch class).
+        # The message quotes the rendered value and the shift, so the refusal is
+        # tied to what get_windowing would actually emit.
+        _windowed(cfg, epoch=epoch)
+        with pytest.raises(
+            ValueError,
+            match=rf"epoch {re.escape(repr(epoch))} carries sub-second precision.*"
+            rf"recorded as {re.escape(repr(rendered))}.*shift every window "
+            rf"conversion by {shift} s",
+        ):
+            validate_config(cfg)
+
+    @pytest.mark.parametrize(
+        "epoch",
+        [
+            "2018-01-01T00:00:00Z",
+            "2018-01-01T00:00:00+00:00",
+            # Naive input is taken AS UTC (windows.parse_utc), and a whole-second
+            # offset-bearing epoch still round-trips — only the fraction is lost.
+            "2018-01-01T00:00:00",
+            "2018-01-01T05:30:00+05:30",
+        ],
+    )
+    def test_whole_second_epoch_accepted(self, cfg, epoch):
+        # The guard is exactly "the rendering is lossless", not "the declaration
+        # is spelled canonically": every whole-second spelling stays legal and
+        # canonicalizes to the same instant.
+        _windowed(cfg, epoch=epoch)
+        validate_config(cfg)
+        assert get_windowing(cfg)["epoch"] == "2018-01-01T00:00:00+00:00"
 
     def test_bad_scale_and_units(self, cfg):
         _windowed(cfg, scale="tt")


### PR DESCRIPTION
Closes #390. Closes #406. Refs PR #367 (the validate-vs-render pattern the #390 entries mirror), espg/mortie#159 (the module split the #406 entry de-risks).

## Checklist (one entry per bundled small-fix)

- [x] **#390** — `output.windowing.epoch`: validate the *rendered* value, so a sub-second epoch is refused instead of silently shifting every window conversion.
- [x] **#390 (second small-fix)** — apply the same principle to `get_windowing`'s **raster** branch: render the fixed epoch through `windows.iso_utc` instead of spelling its output format out as a literal, so the two branches cannot disagree on how one instant is written.
- [x] **#406** — import `mort2polygon` / `mort2geo` from `mortie` directly instead of reaching through the undocumented `mortie.tools` submodule path.
- [x] **Reviewer finding on this PR (no issue — see "Questions for review" (1))** — document the ≤ 1 s downward narrowing of the recorded `time_range` upper bound as a reader caveat in `docs/hive_layout.md`, per the ruling on option (b). Docs-only; the stamp bytes are unchanged.

The first two entries are the same insight applied twice, which is why the second rides this branch rather than a follow-up: #390's fix exists because *restating* a renderer's rule lets the restatement drift from the renderer, and the raster branch three lines away was doing exactly that. The third entry is unrelated to them and rides the bundle purely as a same-day `small-fix` (CLAUDE.md §5). The branch keeps the dated `claude/small-fixes-` name.

## What this does

`output.windowing.epoch` was validated at full parsed precision (`_validate_windowing`) but rendered through whole-second truncation — `get_windowing` canonicalizes it with `windows.iso_utc`, which is `timespec="seconds"`. A sub-second epoch such as `2018-01-01T00:00:00.5Z` therefore passed validation and then shifted **every** window boundary conversion by the dropped fraction, invisibly.

Precisely: there is one *render* site — `get_windowing` at `config.py:2746`, `iso_utc(parse_utc(block["epoch"]))` — but several consumers of the value it renders: the manifest temporal block (`hive.build_manifest`, `hive.py:330-350`) and every stamp conversion through `windows.iso_time_range`. The truncation happens once and propagates to all of them.

The fix mirrors the merged #367 pattern (`f06a1e7` refinement — *make the predicate the renderer*): validate the rendered form by round-tripping it, and refuse when it is not the declared instant.

```python
rendered_epoch = _windows.iso_utc(parsed_epoch)
if _windows.parse_utc(rendered_epoch) != parsed_epoch:
    raise ValueError(...)
```

Calling the renderer rather than restating its truncation rule is the point: the guard cannot drift from `get_windowing` if the rendering precision ever changes. The refusal names the declared instant, the rendered value and the exact drop:

```
output.windowing.epoch '2018-01-01T00:00:00.000001+00:00' carries sub-second precision
that the canonical whole-second rendering drops: it is recorded as
'2018-01-01T00:00:00+00:00', which would shift every window conversion by 1 µs —
declare the epoch at second precision
```

**Refuse, not widen** — consistent with the merged range ruling on #367: 1 s granularity means finer intent is a config error, not something to round for the author. The guard is "the rendering is lossless", *not* "the declaration is spelled canonically", so every whole-second spelling stays legal (`…00:00Z`, `…00:00+00:00`, naive `…00:00`, and offset-bearing `2018-01-01T05:30:00+05:30`) and canonicalizes to the same instant. The comparison is between *instants*, not spellings, so a whole-second sub-minute offset (`…00:00:30+00:00:30`, which Python accepts) round-trips clean too.

Scope note: `_validate_windowing` rejects the conversion knobs on raster configs, so this guard is on the point-pipeline branch only, where the epoch is author-declared. The raster branch's own hardcoded rendering is the second entry, below.

## What the second entry does (the raster branch)

`get_windowing`'s raster branch returned the epoch as a string literal:

```python
"epoch": "1970-01-01T00:00:00+00:00",
```

That literal is not a value — it is a **restatement of `windows.iso_utc`'s output format** (`windows.py:122-124`: seconds precision, `+00:00` offset). Three lines below, the point branch renders through `_windows.iso_utc(_windows.parse_utc(block["epoch"]))` and follows `iso_utc` automatically. So if `iso_utc`'s spelling or precision ever changed — `Z` instead of `+00:00`, say — the two branches would write **different spellings of the same instant** into their manifests' `temporal.epoch`. That is the #390 drift class, one level up: the same reason the guard calls the renderer rather than restating its truncation rule.

The fix hoists the epoch to a module-level constant held as an **instant**, not a spelling, and renders it at use:

```python
#: The raster branch's fixed windowing epoch (issue #247, ratified): raster
#: window membership is the acquisition's STAC ``datetime`` ...
#: Held as an *instant*, not a spelling — ``get_windowing`` renders it through
#: ``windows.iso_utc`` ... (issue #390).
_UNIX_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
```
```python
"epoch": _windows.iso_utc(_UNIX_EPOCH),
```

A `datetime` rather than an ISO string was chosen because a string constant — even one spelled `...Z` — still *is* a rendering, so it keeps a second spelling in the file for the renderer to drift from; the `datetime` leaves the module with exactly one place that decides how an instant is written. The call shape `iso_utc(<datetime>)` also matches how the explicit-window bounds are already rendered just above in the same function (`config.py:2737-2738`, `_windows.iso_utc(start)`), so no new shape is introduced. `parse_utc` is not wrapped around it: it is the declared-input normalizer, and an already-aware constant has nothing to normalize (`iso_utc` calls `.astimezone(timezone.utc)` itself). Placement follows `_POINT_WINDOW_WIDTH` (`config.py:1087`) — a `#:` constant immediately above its only consumer.

**The #390 sub-second guard itself does *not* extend to raster, deliberately.** There is no author-declared value on that branch to guard: `_validate_windowing` refuses `epoch`/`scale`/`units` outright on raster configs (`config.py:993-999`, ratified #247 — window membership is the acquisition's STAC `datetime`, already an ISO-8601 UTC instant, so there is nothing to convert). A round-trip check there would be validating a constant the code had just written one line earlier — it can never fail, so it would test nothing and only suggest a knob exists. The validation asymmetry is left exactly as it is; only the hardcoded *rendering* was at issue.

Also updated: the `get_windowing` docstring (the epoch canonicalization is lossless *on any config that passed `validate_config`*, unlike explicit-window bounds, which truncate either way) and the `docs/hive_layout.md` validation paragraph, which already documented the bound-truncation edge and now records the epoch as the one time value held to the stricter rule.

## Adversarial review fold

- `1bca2f1` — the refusal now renders `parsed_epoch.isoformat()` instead of `repr(epoch)`. `yaml.safe_load` types an ISO timestamp scalar as a `datetime` (YAML 1.1 timestamp resolution) and `windows.parse_utc` passes a `datetime` through, so on the path a real config takes the author got a stdlib constructor call back rather than their own value. `test_subsecond_epoch_rejected` gains a `datetime`-typed param so the loader-shaped input is pinned.
- `fd2fdd0` — the dropped amount is reported as `parsed_epoch.microsecond` (an integer count of µs) rather than `total_seconds()`, which rendered the smallest and most plausible violation — a microsecond-precision timestamp pasted from a data file — as `1e-06 s`. The comment above the guard now states that the drop is exactly the microseconds field, hence integral and never negative, instead of leaving that to be re-derived. The message's closing sentence (*"Window granularity is whole seconds, so a finer epoch is a config error, never a silent shift"*) is dropped as a verbatim restatement of the code comment and the `docs/hive_layout.md` paragraph — CLAUDE.md §4 terseness, and the neighbouring refusals in this file state the rule and the fix and stop. A `.000001Z` param pins the new rendering.
- `c33b0f1` — the `get_windowing` docstring no longer asserts losslessness unconditionally. It holds only for the validated path: `validate_config` never appears in `runner.py`, which calls `get_windowing` at `:809`, `:2793` and `:3227`, and `load_config_from_dict` is documented as skipping validation. The docstring now scopes the claim and names the unvalidated paths that still truncate. No second guard was added at the render site — in the shipped flows the dispatcher validates before it builds the worker event, so this is not a hole the PR opens.
- `dd5ed4d` — `test_schedule_none_keeps_subsecond_epoch` pins the deliberate carve-out: the guard sits after the `schedule: none` early return (`config.py:962`), so an inert block with a sub-second epoch validates and `get_windowing` returns `None`. That is the case the refusal would false-positive on if the guard were ever hoisted, and it is the `schedule: none` ≡ absent-block equivalence the surrounding tests already treat as load-bearing (`test_absent_is_none`). The raster carve-out is left to the existing raster-knob rejection test, which refuses `epoch` being present at all and so subsumes the sub-second case.

## Assessment of the three flagged sites (issue #390, "assess while in there")

The issue asked whether the render-only downward truncation of *recorded* range ends is the same class, and to fix only if so. **Assessment: none of the three is the #390 class, so none is fixed here** — but the three do not share one rationale, so they are taken per site.

The #390 defect is a **validate-vs-render mismatch**: a *declared* value is accepted at one precision and then *computed with* at another, so the store's behavior silently disagrees with the config the author wrote.

**(1) `windows.union_time_range` (`windows.py:302`).** No declared input, and in practice no truncation at all: the inputs are leaf D15 `time_range` stamps, already seconds-precision ISO strings, so `iso_utc(parse_utc(x))` over them is idempotent. Nothing is dropped here; the site only re-renders values another site already truncated.

**(2) `windows.iso_time_range` (`windows.py:313`).** No declared input. It renders a **measured** extent — the worker's `[float(col.min()), float(col.max())]` over data actually written (`processing/worker.py:684`) — converted through the (now-guarded) epoch and truncated to the seconds precision convention documents for every ISO instant in the store (`docs/hive_layout.md`, "Stamps carry the truth"). There is no author-declared instant for the rendering to contradict, and the truncation is uniform across both ends and every consumer, including the idempotence compare at `sweep.py:234` that skips a root-summary rewrite when the union renders unchanged. Correct recording at a documented precision, not a silent shift of a declared conversion. It *is* one of the two paths into question (1) below.

**(3) `raster._us_iso` (`raster.py:494`, truncating at `:502`).** The provenance here is **not** the point worker's, and an earlier revision of this section wrongly gave it that one. This site is fed at `raster.py:1334`:

```python
instants = [_iso_us(e["datetime"]) for e in granules if e.get("assets")]
if instants:
    time_range = [_us_iso(min(instants)), _us_iso(max(instants))]
```

`e["datetime"]` is the acquisition's STAC `datetime` — a **declared** ISO instant carried in the catalog, not a float measured off the data — and sub-second STAC datetimes are routine (Sentinel-2 and Landsat items commonly carry milliseconds). So "no declared input" is simply false here, and the ruling has to rest on something else.

Redone on its own facts, the conclusion holds for a different reason: **nothing is computed from the truncated value.** Raster window membership is decided at dispatch on the parsed instant — `runner.py:2285-2288` takes `min(parse_utc(e["datetime"]))` per acquisition group and hands it to `windows_intersecting` — and the leaf's own time axis is the microsecond int64 `times_us` built by `raster_time_index` (`raster.py:534`, consumed at `:1250`), also full precision. `_us_iso` is reached only at `raster.py:1336`, writing the D15 stamp. The truncation therefore changes what is **recorded**, never what is **computed**: no window assignment, no time coordinate and no filter moves by it. That is materially different from the epoch defect, where the truncated value *is* the conversion every window boundary is computed through.

One consequence worth recording rather than closing silently: because the raster stamp's input is a declared STAC datetime that routinely carries milliseconds, the ≤ 1 s narrowing in question (1) is reachable through the **raster** path too, not only through a float `delta_time` column.

A separate raster/point asymmetry surfaced while making the change above and is filed as **#404**, not fixed here: the raster branch records `units: "seconds"` in the manifest temporal block (`config.py:2757`) while the raster store's `time` coordinate array carries CF attrs `units: "microseconds since 1970-01-01T00:00:00"` (`processing/raster.py:835`). Tracing confirms these are **different contracts, not an inconsistency in code** — the manifest triple describes a *source* `time_field` conversion, and no consumer applies it to the stored array. Both readers of `windowing["units"]` are point-only: `windows.iso_time_range` (`windows.py:315`) is reached solely from `hive.process_and_write_hive` (`hive.py:1299`), and `runner._windowed_units` (`runner.py:2219`) solely from `SpatialStrategy`'s `_run_local`/`_run_lambda`. The raster fan-out uses `_raster_windowed_units` (`runner.py:2245`), which reads only `schedule`/`windows` and decides membership from `parse_utc(e["datetime"])` (`runner.py:2286-2288`), and the raster worker renders its own D15 stamp at `raster.py:1332-1336`. So on raster the triple is write-only. #404 owns the question of whether to drop it or document it.

## What the third entry does (issue #406 — mortie's flat exports)

Four import sites reached `mort2polygon` / `mort2geo` through mortie's **submodule** path when both names are already exported flat from `mortie/__init__.py`:

```python
from mortie.tools import mort2polygon   # before
from mortie import mort2polygon         # after
```

`mortie.tools` is not an advertised submodule — `mortie/__init__.py` re-exports these names flat (both are in its `__all__`), and only `arrow` and `morton_index` are exposed as submodules via `from . import …`. So the submodule spelling was an implementation detail being reached through, and a private path can break on any mortie release without a deprecation cycle.

The immediate motivation is espg/mortie#159, which splits mortie's `tools.py` into domain modules and moves `mort2polygon` into `convert.py`. These sites were that split's entire external blast radius in zagg; after this commit it is zero. The change is mechanical — same function object, same call, different import path — and works on every mortie version that has the flat export, so **the `mortie>=0.7.2` floor in `pyproject.toml` is untouched**.

Sites changed (`ae408ea`, +4/−4 across three files):

| file | symbol |
| --- | --- |
| `src/zagg/grids/healpix.py:252` (`shards_bbox`) | `mort2polygon` |
| `src/zagg/grids/healpix.py:436` (`shard_footprint`) | `mort2polygon` |
| `demo/05_california_read.ipynb` (cell 12) | `mort2polygon` |
| `notebooks/aoi_mask.ipynb` (cell 3) | `mort2geo` |

The two `src/` sites are the ones that matter for the package; both are function-local imports and stay in place (`shard_footprint`'s neighbouring `from shapely.geometry import Polygon` still sorts after `mortie`, so ruff's `I` rules are unaffected).

Two corrections to the site list as filed on #406, both found by re-running the issue's own `grep -rn "mortie.tools" .` against the tree:

1. **`notebooks/aoi_mask.ipynb` imports `mort2geo`, not `mort2polygon`.** Same treatment — `mort2geo` is flat-exported and in `__all__` too, and `mortie.mort2geo is mortie.tools.mort2geo` — but worth recording, since #159's split moves the two names independently. That notebook already imported `moc_to_order` flat two cells earlier, so the file is now internally consistent.
2. **The three `data/` scripts named on the issue are not in the repo.** `data/build_aoi_shardmap.py`, `data/conus/build_conus_shardmap.py` and `data/conus/plot_conus_shardmap.py` are untracked working files (`git ls-files data` is empty on `main` and on this branch), so there is nothing for a commit here to change. They still carry the old import locally and will need the same one-word swap out-of-tree if #159 lands; that is not this PR's to make, and #406 can close on the in-tree sites.

Notebook edits touch the **import line only** — neither notebook was re-executed, and both carry zero stored outputs already, so the two `.ipynb` diffs are one line each (`git diff --stat`: `demo/05_california_read.ipynb | 2 +-`, `notebooks/aoi_mask.ipynb | 2 +-`). Binder runnability (CLAUDE.md §4) is unaffected: the import path change requires no new dependency and no version floor move.

## What the fourth entry does (the `time_range` tail narrowing — ruled (b))

Question (1) below asked which of three arms to take on the ≤ 1 s downward narrowing of the recorded `time_range` upper bound. **The ruling is (b): document the narrowing as a reader caveat and keep the stamp bytes stable** — not (a) render-outward and not (c) sub-second precision, both of which change the bytes of a stamp field external decoders read and so pull the change inside CLAUDE.md §4's normative-store-contract rule (`docs/specification.md` plus the `tools/generate_spec_fixtures.py` → `tests/data/spec/` fixtures in the same PR).

`ce7d033` is docs-only: **no rendering code, no stamp bytes, and no test's expected values change** (`git show --stat ce7d033` is `docs/hive_layout.md | 24 +++-`). The caveat lands in **The commit stamp** section, immediately after the sentence that defines `time_range` as "the actual `[t_min, t_max]` written":

> **Reader caveat — `t_max` floors, so the recorded range can end up to 1 s early.** Both ends render through `windows.iso_utc`'s whole-second granularity (`isoformat(timespec="seconds")`), so each truncates to the second *containing* it. On `t_min` that is harmless: the recorded start is at or before the true first observation. On `t_max` it is not — a last observation at `12:00:00.7` is recorded as `12:00:00`, so the closed `[t_min, t_max]` is a slight **under**-estimate of the extent written, not an envelope around it. **A consumer that prunes leaves on the stamp must treat `t_max` as inclusive with 1 s of slack** (test the query against `t_max + 1 s`); pruning on the recorded value alone can skip a leaf that genuinely holds data in the queried interval. […]

The **Time windows** section's "Stamps carry the truth" bullet (D15), which is where a reader first meets the field, gains a one-clause pointer to it rather than a second copy of the text — normative-ish prose duplicated across sections drifts:

```diff
-  `time_range` as ISO-8601 UTC strings; the root `coverage.moc` summary
+  `time_range` as ISO-8601 UTC strings (both ends at whole-second
+  granularity, which narrows the tail by up to 1 s — see
+  [The commit stamp](#the-commit-stamp)); the root `coverage.moc` summary
```

**No fixture regeneration is required, and this was verified rather than assumed.** CLAUDE.md §4 triggers the fixture rule on a change to *a wire format, an attrs grammar, or a versioned `spec` marker*; a sentence describing behavior that already ships changes none of the three. Concretely, at `ce7d033`:

- `grep -c time_range docs/specification.md` → **0**, and `grep -c time_range tools/generate_spec_fixtures.py` → **0**;
- `grep -rl time_range tests/data/spec/` → **no files** (the three fixture pairs `minimal`, `pyramid`, `kitchen_sink` never carry the field);
- the diff touches no `spec` marker: `morton-hive/1`/`/2` are written unchanged by `hive.stamp_commit`, and no `zagg-*/N` string appears in the diff.

So the spec page and the fixtures are untouched **and owe no update** — a reviewer does not have to re-derive that.

**But (see question (2)) the spec page had no home for the normative half of this caveat, so that half did not land.** The hazard is specifically aimed at "a consumer that prunes on the stamp — an external reader decoding from the spec", and such a reader never opens `docs/hive_layout.md`; the intent was to land a short normative sentence in `docs/specification.md` as well. `time_range` turns out not to be described there **at all**, so there was nothing to qualify and no section it belongs to — inventing one was judged worse than reporting the gap.

## Questions for review

1. **The recorded `time_range` upper bound floors downward, narrowing the envelope. — RULED (b), landed in `ce7d033`.** `time_range` is documented as the closed `[t_min, t_max]` *actually written*, and both ends floor to the second containing them. Flooring `t_min` is harmless (the recorded start is at or before the true first observation), but flooring `t_max` makes the recorded end up to 1 s **earlier** than the true last observation: data at `12:00:00.7` is recorded as ending at `12:00:00`. A consumer that prunes on the stamp — an external reader decoding from the spec, per CLAUDE.md §4 — can therefore prune a leaf that genuinely holds data in the queried interval. No in-tree consumer prunes on `time_range` today (every use is a union into the regenerable root `coverage.moc` summary or the overview rollup), so nothing is broken now. Reachable on both pipelines: via a float `delta_time` column (point) and via a millisecond-bearing STAC `datetime` (raster — see (3) above).

   The three arms as posed: (a) render the envelope outward — floor `t_min`, ceil `t_max` — which makes the stamp a guaranteed superset and never prunes real data, but redefines a field documented as the *actual* value into an envelope and changes the stamp bytes every store writes; (b) leave it and document the ≤ 1 s narrowing as a reader caveat, keeping "actual" literally true and the bytes stable; (c) record `t_max` at sub-second precision, which breaks the store-wide "every ISO instant is seconds-precision" convention for one field.

   **Cost asymmetry that decided it:** (a) changes the bytes of a stamp field external decoders read, which puts it inside CLAUDE.md §4's normative-store-contract rule — it would require `docs/specification.md` **and** the `tools/generate_spec_fixtures.py` → `tests/data/spec/` fixtures updated in the same PR. (c) changes those bytes too. (b) does not. **Ruling: (b)** — the exposure is bounded, no in-tree reader is affected, and byte-stability of a stamp field external decoders already read is worth more than the ≤ 1 s tightening. Implemented in the section above; the ≤ 1 s narrowing is now recorded behavior, not an unflagged trap.

2. **`time_range` is not described in `docs/specification.md` at all — so the caveat could not reach the reader it is aimed at.** Reporting rather than acting, because the fix is a scope call, not a docs edit.

   The caveat's whole subject is an external reader that decodes from the spec and the fixtures alone (CLAUDE.md §4) — precisely the reader that #404 records a docstring cannot protect. That reader never opens `docs/hive_layout.md`. Landing a normative sentence in `docs/specification.md` was therefore the intent, and it did not land because there is nothing there to qualify:

   - `grep -c time_range docs/specification.md` → **0**; likewise `t_min`/`t_max`/`morton-hive/2`, and the only "commit stamp" mentions (`:589`, `:1078`) say the stamp is written *last* and never describe its contents.
   - The page's sections are §1–3 array byte layouts, §4 pyramid/overview declarations (the `role`/`zagg_overview` attrs grammar), §5 O11 hashes, §6 `zagg-ragged/2`, §7 fixtures. None is a home for a leaf-stamp field, and the page states its own scope explicitly: it "owns the **array-level** contracts inside a leaf; it cites mortie's page for path and word semantics and never restates them", because "duplicated normative text drifts".
   - The stamp grammar is ceded to **mortie's** spec page — which describes `morton-hive/2` leaf *naming* and the schedule grammar (§6.3) and the stamp's *coverage* envelope (§7.1), but **not** the D15 `time_range`. Its only `time_range` mention is §7.3, as an *informative carrier field* on the **root** coverage MOC — a different object from the leaf stamp.

   So the leaf stamp's `window`/`time_range` pair appears to have **no normative description on either page**: an external decoder learns the field exists only from `docs/hive_layout.md`, a narrative page explicitly not the contract. That is a larger gap than this small-fix, and where it should be closed is a fork: (a) add a leaf-stamp section to zagg's `docs/specification.md` (contradicts its stated scope split, and would need the fixture question answered — today's fixtures carry no stamp `time_range`); (b) extend **mortie's** §6.3 to describe the `/2` stamp fields, since that page already owns `morton-hive/N` (cross-repo, so out of this PR either way); or (c) rule the field deliberately informative and say so once, in whichever page owns it. **No issue filed and no spec edit made** — filing is a side-effecting directive per CLAUDE.md §6, and inventing a section in the normative page to hang one sentence on seemed clearly worse than surfacing the gap.

## Testing

- `uv run pytest -q` at head `ce7d033` (the caveat commit): **3,508 passed / 16 skipped / 1 failed** in 240 s — the same counts as the `ae408ea` run below, as a docs-only diff must produce. The one failure is the pre-existing, flagged-not-fixed `test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`. `uv run ruff check src tests` → the one pre-existing `N818` at `src/zagg/registry.py:64`; `uv run ruff format --check src tests` → the one pre-existing `tests/data/benchmark/README.md` diff. Nothing new from this commit, and **no test's expected values were touched** — the ruling (b) is explicitly the arm that leaves the stamp bytes alone. No test was added: there is no behavioral surface to pin, since the commit adds prose describing rendering that already ships and is already covered (`windows.iso_utc`'s seconds precision is asserted by the existing windowing tests).
- `uv run pytest -q` at head `ae408ea` (the #406 commit): **3,508 passed / 16 skipped / 1 failed**. The one failure is the pre-existing, flagged-not-fixed `test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`; the flaky `test_client_transport.py::TestStatusPoller` test that also failed in the `b95ac50` run below passed this time, which is the whole of the +1 in the pass count over the same 3,525 collected. `uv run ruff check src tests` / `uv run ruff format --check src tests` are byte-for-byte unchanged from `b95ac50` — the same two pre-existing items (`N818` at `src/zagg/registry.py:64`, the `tests/data/benchmark/README.md` format diff) and nothing new from this diff.
- For #406 specifically: `grep -rn "mortie.tools\|from mortie import tools" . --exclude-dir=.git` returned the four sites in the table before the change and **nothing** after (the acceptance check the issue names). No test was added — the change is import-path-only with no behavioral surface to pin, so the existing coverage of `shards_bbox` / `shard_footprint` is the test, and both were additionally exercised end-to-end against a real California shard key (`3800171670338011145`: a 129-vertex footprint and bbox `[-118.3887, 33.8687, -118.2129, 34.0486]`) to confirm the rebound name resolves and returns the same shapes. Verified in the resolved env that `mortie.mort2polygon is mortie.tools.mort2polygon` and likewise for `mort2geo` (mortie 0.9.4), so the swap is object-identical and not merely name-compatible.
- `uv run pytest -q` at head `b95ac50`: **3,507 passed / 16 skipped / 2 failed**, both pre-existing and flagged-not-fixed — `test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` (environment-dependent, flagged on #391/#397) and the flaky `test_client_transport.py::TestStatusPoller::test_invoke_fault_burns_an_attempt_and_retries` poller test. (Counts differ from the earlier `dd5ed4d` run of 3,485/38 because this environment has the `catalog`/`analysis` extras installed, which un-skips those suites.) Targeted: `tests/test_hive_windows.py tests/test_raster_pipeline.py tests/test_config.py tests/test_windows.py tests/test_hive.py` — **629 passed**, with every pre-existing raster windowing test (`test_raster_pipeline.py::TestRasterConfig::test_windowing_validates_and_normalizes` and the knob-rejection matrix) passing **unchanged**.
- New coverage in `tests/test_hive_windows.py`: `test_subsecond_epoch_rejected` (parametrized over a plain `.5Z` epoch, an offset-bearing `.001+05:30` one, a `.000001Z` microsecond one and a `datetime`-typed one as `yaml.safe_load` produces, asserting the message quotes the declared instant, the rendered value and the µs drop, so the refusal stays tied to what `get_windowing` emits), `test_whole_second_epoch_accepted` (parametrized over four legal spellings, asserting each canonicalizes to `2018-01-01T00:00:00+00:00`) and `test_schedule_none_keeps_subsecond_epoch` (the inert-block carve-out).
- `uv run ruff check src tests` / `uv run ruff format --check src tests`: clean on the diff. Two pre-existing items flagged, not fixed: `N818` at `src/zagg/registry.py:64` and the format diff on `tests/data/benchmark/README.md` (both predate this branch and are already flagged on #391/#397).
- Checked that no shipped config, doc example, or test fixture declares a sub-second epoch, so nothing existing is newly refused.
- For the raster entry, two new tests in `tests/test_hive_windows.py` pin the drift-proofing rather than today's string:
  - `TestWindowingConfig::test_raster_epoch_renders_through_iso_utc` — asserts the rendered raster epoch equals `windows.iso_utc(windows.parse_utc(datetime(1970, 1, 1, tzinfo=utc)))`, i.e. against the **renderer's own output**, not a literal. It therefore survives a change to `iso_utc`'s precision or offset form and can only be broken by a literal re-entering `config.py`.
  - `TestManifestTemporal::test_raster_and_point_epochs_spell_one_instant_alike` — builds a point config declaring the Unix epoch and a raster config, runs both through `hive.build_manifest`, and asserts the two `temporal.epoch` strings are **identical**. This is the test that actually fails if someone reintroduces a literal on either branch.
  - Both were mutation-checked: with the literal restored **and** `iso_utc` switched to emit `Z`, both fail; on the shipped code both pass. A shared `_raster_windowed()` helper was added next to the existing `_windowed()`; no existing test was modified.

Not addressed here, and not this PR's to fix: `src/zagg/config.py` is ~2,981 lines, far over CLAUDE.md §4's ~1,200 ceiling. That is pre-existing and already covered by the planned `config.py` → `config/` split (issue #330 / PR #349), so this PR does not split it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWBdHhkKZh6cg93GpYBwku)_


