### PR TITLE
leaf_column rename, granule-id sibling objects, refusal manifest (issue #388 follow-up trio)

### DIFF
--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -197,14 +197,16 @@ def expected_object_counts(
         # Leaf fixed objects: leaf root zarr.json + group zarr.json + one
         # zarr.json per array, plus the in-leaf coverage.moc sidecar (written
         # for any populated leaf when the leaf has depth, i.e. child_order >
-        # parent_order), plus TWO node-dir siblings per successful shard: the
-        # stats.json sidecar (issue #297) and the shardmap.json leaf sub-map
-        # (issue #300 — same success gate; on the Lambda path it may be
-        # legitimately absent for a unit whose submap event block was dropped
-        # over the async payload cap, which then surfaces here as a mismatch
-        # worth seeing rather than a modeled window).
+        # parent_order), plus THREE node-dir siblings per successful shard:
+        # the stats.json sidecar (issue #297), its granules.json recorded
+        # id list (issue #388 — written by the leaf seam right after the
+        # commit stamp, so it lands on both backends) and the shardmap.json
+        # leaf sub-map (issue #300 — same success gate; on the Lambda path it
+        # may be legitimately absent for a unit whose submap event block was
+        # dropped over the async payload cap, which then surfaces here as a
+        # mismatch worth seeing rather than a modeled window).
         sidecar = 1 if grid.child_order > grid.parent_order else 0
-        lo = hi = 4 + len(members) + sidecar
+        lo = hi = 5 + len(members) + sidecar
         for m in members:
             blocks = m["blocks_per_shard"]
             hi += blocks
@@ -357,9 +359,10 @@ def store_object_counts(
             hive.shard_leaf_path("", int(k)).lstrip("/") + "/": grid.shard_label(int(k))
             for k in shard_keys
         }
-        # The per-shard stats sidecar (issue #297) and the leaf sub-map
-        # (issue #300) are SIBLINGS of the leaf .zarr — ``{node}/stats.json``
-        # and ``{node}/shardmap.json`` (``_{window}`` suffixed when windowed)
+        # The per-shard stats sidecar (issue #297), its recorded granule-id
+        # list (issue #388) and the leaf sub-map (issue #300) are SIBLINGS of
+        # the leaf .zarr — ``{node}/stats.json``, ``{node}/granules.json`` and
+        # ``{node}/shardmap.json`` (``_{window}`` suffixed when windowed)
         # — so attribute them to the node's shard rather than pooling them in
         # ``other``.
         stats_of = {
@@ -427,7 +430,7 @@ def store_object_counts(
                     name == f"{stem}.json"
                     or (name.startswith(f"{stem}_") and name.endswith(".json"))
                     or name.endswith(f".{stem}.json")
-                    for stem in ("stats", "shardmap")
+                    for stem in ("stats", "granules", "shardmap")
                 )
                 if is_sibling and node + "/" in stats_of:
                     per_shard[stats_of[node + "/"]] = per_shard.get(stats_of[node + "/"], 0) + 1

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -663,11 +663,30 @@ enablement:
   default — reports `cells_current: 0` indefinitely until question (1)'s
   key-list fix lands.
 
+The *catalog* half needs no enablement in either family: the granule-id
+sibling is written by the **seam**, not by the dispatcher that writes the
+sidecar, so every leaf a fleet worker commits from this release on records
+its input set — which is what the contraction guard, running in whatever
+process re-dispatches that unit later, diffs against.
+
+**Where the recorded id list lives.** Not in the stats sidecar: in a
+**sibling object beside it** — `granules.json` (`granules_{window}.json`
+windowed), on the sidecar's own spec-keyed naming grammar — written by the
+leaf seam right after the commit stamp, carrying the ids *and* the
+`granules_sha256` they hash to. Identity equality never reads it: that is the
+sidecar's hash compare, which is what keeps a fan-out dedup check
+(`dedup.shard_status` per shard, one GET) and the worker-side run-record
+assembly small. The list is fetched exactly once, only when the hashes
+disagree, and only to **name** which granules a contraction dropped — a pole
+shard's ~4,600 ids are ≈550 KB, and they would otherwise ride every one of
+those GETs. A sibling whose `granules_sha256` does not match the sidecar's
+(a torn rewrite: one of the two writes lost) is rejected as unrecorded rather
+than trusted.
+
 **The contraction guard cannot protect leaves written before this
-release.** The recorded granule-id *list* (`granule_ids` in the stats
-sidecar) arrives with issue #388. A sidecar written before it records only
-the hash — there is no recorded set to diff — so any mismatch over such a
-leaf classifies `unrecorded-ids` and performs the **silent wholesale
+release.** That sibling arrives with issue #388. A leaf written before it has
+only the recorded hash — there is no recorded set to diff — so any mismatch
+over such a leaf classifies `unrecorded-ids` and performs the **silent wholesale
 rewrite the guard exists to prevent**, contraction or not. The guard only
 protects a leaf after that leaf has been rewritten at least once under this
 release. These rewrites are counted apart (`cells_unrecorded` in the run
@@ -688,8 +707,9 @@ object layout while both identity halves hold): changing those still needs
 
 A skipped unit still resets the purge clock: every object in its footprint
 gets a fresh `LastModified` (lifecycle rules act per object) — the leaf
-`.zarr` tree (stamp, arrays, in-leaf `coverage.moc`), the stats sidecar and
-sub-map siblings, and the declared column tree plus its own sidecar.
+`.zarr` tree (stamp, arrays, in-leaf `coverage.moc`), the stats sidecar, its
+granule-id sibling and the sub-map sibling, and the declared column tree plus
+its own sidecar.
 Local stores use `os.utime`; S3 uses a server-side self-copy (`CopyObject`
 onto itself, `MetadataDirective: REPLACE`) that preserves content, the ETag
 of non-multipart objects, and the object's storage class. A local run's

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -685,9 +685,12 @@ than trusted.
 
 **The contraction guard cannot protect leaves written before this
 release.** That sibling arrives with issue #388. A leaf written before it has
-only the recorded hash — there is no recorded set to diff — so any mismatch
-over such a leaf classifies `unrecorded-ids` and performs the **silent wholesale
-rewrite the guard exists to prevent**, contraction or not. The guard only
+only the recorded hash — there is no recorded set to diff — so any
+*granule-hash* mismatch over such a leaf classifies `unrecorded-ids` and
+performs the **silent wholesale rewrite the guard exists to prevent**,
+contraction or not. (A config-only rerun — same inputs, changed semantic core
+— is not one of these: the hashes agree, so it reads `semantic-mismatch`
+without any sibling read, and never inflates `cells_unrecorded`.) The guard only
 protects a leaf after that leaf has been rewritten at least once under this
 release. These rewrites are counted apart (`cells_unrecorded` in the run
 summary; the CLI prints them as "rewritten with the guard inert") so an

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -636,7 +636,7 @@ Three verdicts:
 | verdict | when | what happens |
 |---|---|---|
 | **current** | both halves match, leaf stamped, column agrees with the declaration | fold no-ops; the unit writes **nothing** (no arrays, no stamp, no sidecar, no sub-map, no column — zero sweep dirtiness); the lifecycle touch below runs; counted as `cells_current` |
-| **refused** | the planned set drops recorded ids: `recorded ∖ planned ≠ ∅` — deliberately *not* strict-subset, so a shardmap that grew while silently dropping old granules (an upstream purge behind a fresh catalog query) still trips it | the unit refuses, logs the **first five** missing ids and their total count (the full list rides only the in-process `missing_granules` metadata, and a refused unit writes no run-record row — PR #397 question (9) — so plan triage around the count, not around recovering the set from durable artifacts), writes nothing, and counts as `cells_refused` — never as an error. `--allow-contraction` (`agg(allow_contraction=True)`; on Lambda an `allow_contraction` event field) turns it into a normal rewrite |
+| **refused** | the planned set drops recorded ids: `recorded ∖ planned ≠ ∅` — deliberately *not* strict-subset, so a shardmap that grew while silently dropping old granules (an upstream purge behind a fresh catalog query) still trips it | the unit refuses, writes nothing, and counts as `cells_refused` — never as an error. The log names the **first five** missing ids and their total; the **full per-unit diff is the refusal manifest** at the store root ([below](#the-refusal-manifest)). `--allow-contraction` (`agg(allow_contraction=True)`; on Lambda an `allow_contraction` event field) turns it into a normal rewrite |
 | **rewrite** | everything else — expansion (new cycles), a semantic change, no/unreadable sidecar, an unstamped leaf, column drift, or a pre-#388 sidecar (below) | today's wholesale D4 rewrite, column included |
 
 The gate is **on by default for the local backend**; `--overwrite` disables
@@ -703,6 +703,36 @@ beyond the column artifact (e.g. flipping `sharded` changes the leaf's
 object layout while both identity halves hold): changing those still needs
 `--overwrite` (PR #397 question (8)).
 
+### The refusal manifest
+
+A refused unit writes **nothing** — no leaf, no sidecar, no run-parquet row —
+so a run that refuses leaves the store byte-identical and the only in-band
+trace is a worker log line truncated to five missing ids. Since issue #388 a
+run that ends with `cells_refused > 0` also writes one small JSON object at
+the store root:
+
+```
+refusals_{YYYYmmddTHHMMSSZ}_{run_id}.json
+```
+
+Timestamp-first like the `stats_*.parquet` run records (and outside their
+glob, so run-record discovery never mistakes one for the other). It carries
+the run context needed to act on it — `run_id`, write timestamp, the run's
+`semantic_hash`, the zagg version — and one entry per refused unit: its
+`shard_key` and `window`, the classification (`contraction` or `mixed`), and
+the **complete** `missing_granules` list, which is exactly what the guard read
+from that leaf's granule-id sibling in order to name the drop. Triage the
+diff from this object, not from the logs.
+
+Two deliberate limits. A **pure-skip** run (nothing refused) writes nothing
+here and stays row-less — the counters and the leaf sidecars are the record of
+a no-op run, and an empty manifest per rerun would be litter. And the manifest
+is written by the **local backend only**: D8 keeps the Lambda dispatcher from
+writing to the store, and no once-per-run worker-side seam exists yet to carry
+it — the same gap, with the same resolution, as the store-root touch below
+(PR #397 question (10)). A fleet run's refusals are visible in its summary
+counters and worker logs, not in a durable object.
+
 ### The lifecycle touch
 
 A skipped unit still resets the purge clock: every object in its footprint
@@ -744,8 +774,10 @@ re-running the sweep does **not** refresh them: a second sweep over an
 unchanged tree recomputes but PUTs nothing, so the obvious "just sweep
 periodically to keep them alive" workaround silently no-ops. The store-root
 trio, separately, is touched by the
-**local backend only** (D8 keeps the Lambda dispatcher from writing to the
-store, and the handler has no root-touch mode yet — PR #397 question (10)).
+**local backend only** — as is the refusal manifest above, for the same reason
+(D8 keeps the Lambda dispatcher from writing to the store, and the handler has
+no once-per-run root-write mode yet; both wait on the same resolution — PR #397
+question (10)).
 
 **There is no lifecycle rule that separates leaves from the ancestor
 artifacts above them.** An S3 lifecycle filter keys on prefix, object tags,

--- a/src/zagg/__main__.py
+++ b/src/zagg/__main__.py
@@ -190,6 +190,10 @@ examples:
                 "Rerun with --allow-contraction to rewrite them; --overwrite "
                 "disables the guard instead of acknowledging it."
             )
+            # The log names only the first five missing ids per unit; the
+            # manifest is the durable full diff (issue #388).
+            if results.get("refusal_manifest_path"):
+                print(f"  Which granules, per unit: {results['refusal_manifest_path']}")
         # The lifecycle touch is fail-open, so a total failure (a read-scoped
         # role, an SCP, an ACL edge — s3:PutObject denied fails EVERY object
         # of EVERY unit) otherwise renders as an unqualified "N current" and

--- a/src/zagg/dedup.py
+++ b/src/zagg/dedup.py
@@ -183,9 +183,30 @@ def leaf_recorded_ids(leaf_path, recorded, *, spec=None, store_kwargs=None):
     torn rewrite (one of the two PUTs lost, or a stale sibling beside a fresh
     sidecar) reads as no recorded set rather than as ids that could name the
     wrong granules as dropped — or, worse, hide real ones. Fail-open on every
-    other fault (absent, unreadable, malformed): ``None``, which the caller
-    classifies ``unrecorded-ids`` and rewrites.
+    other fault (absent, unreadable, malformed): the RECORD's own
+    ``granule_ids`` if it carries one (the back-compat window below), else
+    ``None``, which the caller classifies ``unrecorded-ids`` and rewrites.
+
+    The sibling is also read leniently on its ``spec`` marker — an absent or
+    unknown one is not a rejection. Only the hash pairing decides, so a future
+    ``zagg-granule-ids/N`` that keeps these two keys stays readable, and an
+    unrecognized one degrades to the ruled ``unrecorded-ids`` fallback rather
+    than to an error.
     """
+    ids = _sibling_ids(leaf_path, recorded, spec, store_kwargs)
+    if ids is not None:
+        return ids
+    # Back-compat (issue #388): leaves written in the window between PR #397's
+    # merge (``3f13af2``) and the commit that moved the list out carry it ON
+    # the record with no sibling at all. Without this they classify
+    # ``unrecorded-ids`` forever; with it those stores self-heal, and the list
+    # pairs by construction (``build_record`` hashed the very ids it embedded).
+    legacy = (recorded or {}).get("granule_ids")
+    return legacy if isinstance(legacy, list) else None
+
+
+def _sibling_ids(leaf_path, recorded, spec, store_kwargs):
+    """The paired granule-id sibling's list, or ``None``; see above."""
     from zagg.telemetry import read_granule_ids
 
     try:

--- a/src/zagg/dedup.py
+++ b/src/zagg/dedup.py
@@ -25,7 +25,10 @@ silently ships wrong data; a wrong "recompute" costs one shard's work.
 :func:`classify_leaf_identity` (issue #388) is the worker-side flavor of the
 same comparison: pure (the caller supplies the recorded sidecar), with the
 id-set reading — equal / expansion / contraction / mixed — that the leaf
-skip-if-current and contraction-guard decisions key on.
+skip-if-current and contraction-guard decisions key on. The recorded id LIST
+it diffs against is NOT in the sidecar: it sits in a sibling object read
+lazily, on hash mismatch only, through :func:`leaf_recorded_ids` — so both
+comparisons above keep their one small GET per shard.
 """
 
 from __future__ import annotations
@@ -166,13 +169,53 @@ def has_run(
 IDENTITY_ACTIONS = ("skip", "rewrite", "refuse")
 
 
-def classify_leaf_identity(recorded, *, semantic_hash, planned_ids) -> dict:
+def leaf_recorded_ids(leaf_path, recorded, *, spec=None, store_kwargs=None):
+    """The leaf's recorded granule-id list, or ``None`` (issue #388).
+
+    Reads the sidecar's ``granules.json`` SIBLING
+    (:func:`zagg.telemetry.read_granule_ids`) — the object the id list moved
+    to so identity EQUALITY stays a ``granules_sha256`` compare against the
+    small sidecar. Call it only on a hash mismatch: this is the one read the
+    split exists to avoid paying per shard.
+
+    ``recorded`` is the sidecar record it must PAIR with: the sibling is
+    accepted only when its own ``granules_sha256`` equals the sidecar's, so a
+    torn rewrite (one of the two PUTs lost, or a stale sibling beside a fresh
+    sidecar) reads as no recorded set rather than as ids that could name the
+    wrong granules as dropped — or, worse, hide real ones. Fail-open on every
+    other fault (absent, unreadable, malformed): ``None``, which the caller
+    classifies ``unrecorded-ids`` and rewrites.
+    """
+    from zagg.telemetry import read_granule_ids
+
+    try:
+        sibling = read_granule_ids(str(leaf_path), spec, **(store_kwargs or {}))
+    except Exception as e:
+        logger.warning(f"granule-id sibling read failed (degrading to rewrite, issue #388): {e}")
+        return None
+    if not isinstance(sibling, dict):
+        return None
+    ids = sibling.get("granule_ids")
+    if not isinstance(ids, list):
+        return None
+    if sibling.get("granules_sha256") != (recorded or {}).get("granules_sha256"):
+        logger.warning(
+            f"granule-id sibling at {leaf_path} does not pair with the stats sidecar "
+            f"(hash mismatch) — treating the recorded id set as unrecorded (issue #388)"
+        )
+        return None
+    return ids
+
+
+def classify_leaf_identity(recorded, *, semantic_hash, planned_ids, load_recorded_ids=None) -> dict:
     """Classify one planned unit against its leaf's recorded identity (#388).
 
     Identity is the ruled PAIR: the run's ``semantic_hash`` (what/how, D19)
     x the unit's planned granule-id set (over what). The recorded side is
-    the leaf's D20 stats sidecar (``semantic_hash``, ``granules_sha256``,
-    and — from issue #388 on — ``granule_ids``).
+    the leaf's D20 stats sidecar (``semantic_hash``, ``granules_sha256``) —
+    and, only when those disagree, the recorded id LIST, which lives in the
+    sidecar's own sibling object and is fetched through
+    ``load_recorded_ids`` (:func:`leaf_recorded_ids`).
 
     Fast path: ``granules_sha256`` equality (one compare — the common rerun
     case). The id-set difference runs ONLY on a mismatch, classifying:
@@ -205,7 +248,8 @@ def classify_leaf_identity(recorded, *, semantic_hash, planned_ids) -> dict:
     ``no-sidecar``/``expansion``: callers must count and surface it apart
     from the ordinary rewrites (the phase-2 run stats, the phase-4 operator
     docs), because the guard cannot protect any leaf written before this
-    release — no fleet sidecar predating issue #388 records ``granule_ids``.
+    release — no leaf written before issue #388 has the granule-id sibling
+    that records its input set.
 
     Parameters
     ----------
@@ -222,6 +266,12 @@ def classify_leaf_identity(recorded, *, semantic_hash, planned_ids) -> dict:
         planned set is UNKNOWN and never refuses (``unknown-planned``); the
         empty list means the unit genuinely plans no inputs, which against a
         non-empty recorded set is a full contraction and does refuse.
+    load_recorded_ids : callable, optional
+        Zero-argument loader for the leaf's RECORDED id list, called at most
+        once and ONLY after the ``granules_sha256`` fast path failed — the
+        laziness is the whole point of keeping the list out of the record
+        (issue #388's ruling). ``None`` (or a loader returning ``None``)
+        means no recorded set is available: ``unrecorded-ids``.
 
     Returns
     -------
@@ -242,13 +292,17 @@ def classify_leaf_identity(recorded, *, semantic_hash, planned_ids) -> dict:
     semantic_match = semantic_hash is not None and recorded.get("semantic_hash") == semantic_hash
     if rec_hash is not None and rec_hash == granules_sha256(planned) and semantic_match:
         return {"action": "skip", "classification": "equal", "missing": []}
-    rec_ids = recorded.get("granule_ids")
+    # The ONE read the fast path exists to avoid: the recorded id list lives
+    # beside the sidecar, not in it (issue #388's ruling on question (6)), and
+    # is fetched only now that the hashes disagree.
+    rec_ids = load_recorded_ids() if load_recorded_ids is not None else None
     if rec_ids is None:
-        # Pre-#388 sidecar (or a cross-leaf rollup, where the field collapses
-        # to None): something mismatched, but there is no recorded set to
-        # diff — undecidable, so today's rewrite. NOT a benign ambiguity: on
-        # a contracted rerun this is the wholesale rewrite the guard exists to
-        # stop, and every leaf written before this release lands here. Its own
+        # No recorded set to diff — a pre-#388 leaf, a lost sibling PUT, or a
+        # sibling that does not pair with the sidecar. Something mismatched,
+        # but the direction is undecidable, so today's rewrite. NOT a benign
+        # ambiguity: on a contracted rerun this is the wholesale rewrite the
+        # guard exists to stop, and every leaf written before this release
+        # lands here. Its own
         # classification for exactly that reason — count it apart from the
         # ordinary rewrites and say so in the operator docs (see the class
         # docstring's one-sided-conservatism note).
@@ -271,4 +325,11 @@ def classify_leaf_identity(recorded, *, semantic_hash, planned_ids) -> dict:
     return {"action": "rewrite", "classification": "expansion", "missing": []}
 
 
-__all__ = ["IDENTITY_ACTIONS", "STATUSES", "classify_leaf_identity", "has_run", "shard_status"]
+__all__ = [
+    "IDENTITY_ACTIONS",
+    "STATUSES",
+    "classify_leaf_identity",
+    "has_run",
+    "leaf_recorded_ids",
+    "shard_status",
+]

--- a/src/zagg/dedup.py
+++ b/src/zagg/dedup.py
@@ -268,7 +268,9 @@ def classify_leaf_identity(recorded, *, semantic_hash, planned_ids, load_recorde
         non-empty recorded set is a full contraction and does refuse.
     load_recorded_ids : callable, optional
         Zero-argument loader for the leaf's RECORDED id list, called at most
-        once and ONLY after the ``granules_sha256`` fast path failed — the
+        once and ONLY when the recorded and planned ``granules_sha256``
+        DISAGREE — never on the skip path, and never on the equal-hash /
+        changed-semantic quadrant, whose verdict the hashes alone decide. The
         laziness is the whole point of keeping the list out of the record
         (issue #388's ruling). ``None`` (or a loader returning ``None``)
         means no recorded set is available: ``unrecorded-ids``.
@@ -290,8 +292,20 @@ def classify_leaf_identity(recorded, *, semantic_hash, planned_ids, load_recorde
     planned = [str(g) for g in planned_ids]
     rec_hash = recorded.get("granules_sha256")
     semantic_match = semantic_hash is not None and recorded.get("semantic_hash") == semantic_hash
-    if rec_hash is not None and rec_hash == granules_sha256(planned) and semantic_match:
+    hashes_match = rec_hash is not None and rec_hash == granules_sha256(planned)
+    if hashes_match and semantic_match:
         return {"action": "skip", "classification": "equal", "missing": []}
+    if hashes_match:
+        # Equal hashes mean an identical sorted id multiset, so the diff is
+        # provably empty and the ONLY reachable verdict is semantic-mismatch:
+        # decide it here rather than paying the sibling GET for a read that
+        # cannot change the answer. This is the ordinary config-only rerun
+        # (same inputs, changed semantic core) — at CA o9 that would be 2,721
+        # needless GETs of up to ~550 KB each, which is exactly the per-shard
+        # cost the id list was split out of the sidecar to avoid. It also
+        # keeps this quadrant OFF ``unrecorded-ids`` when the sibling is
+        # absent: the guard is not inert here, it has proved no contraction.
+        return {"action": "rewrite", "classification": "semantic-mismatch", "missing": []}
     # The ONE read the fast path exists to avoid: the recorded id list lives
     # beside the sidecar, not in it (issue #388's ruling on question (6)), and
     # is fetched only now that the hashes disagree.

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -1231,7 +1231,7 @@ def leaf_identity_gate(
     way, and a contraction over debris is still a contraction the operator
     should be told about.
     """
-    from zagg.dedup import classify_leaf_identity
+    from zagg.dedup import classify_leaf_identity, leaf_recorded_ids
     from zagg.telemetry import read_sidecar
 
     t0 = time.time()
@@ -1254,7 +1254,15 @@ def leaf_identity_gate(
         )
         recorded = None
     identity = classify_leaf_identity(
-        recorded, semantic_hash=semantic_hash, planned_ids=planned_ids
+        recorded,
+        semantic_hash=semantic_hash,
+        planned_ids=planned_ids,
+        # LAZY by construction (issue #388's ruling on question (6)): the
+        # recorded id list is a sibling object, GET only when the
+        # granules_sha256 fast path failed and the diff has to be named.
+        load_recorded_ids=lambda: leaf_recorded_ids(
+            leaf_path, recorded, spec=sidecar_spec, store_kwargs=store_kwargs
+        ),
     )
     if identity["action"] == "skip":
         drift = None
@@ -1367,8 +1375,11 @@ def process_and_write_hive(
     sidecar returns a ``{"current": True}`` metadata dict and writes nothing;
     a contraction (``recorded ∖ planned ≠ ∅``, the ruled predicate) returns
     ``{"refused": True, "missing_granules": [...]}`` unless
-    ``allow_contraction`` rides the call. Default ``False`` keeps this seam
-    byte-identical for callers that have not opted in (the Lambda handler).
+    ``allow_contraction`` rides the call. Default ``False`` keeps the GATE
+    inert for callers that have not opted in (the Lambda handler); the
+    granule-id sibling below is written either way, because it is what a
+    LATER run's guard diffs against — a leaf must record its input set
+    whether or not the run that wrote it had the gate armed.
     ``semantic_hash`` is the RUN config's D19 digest when the caller holds it
     (the local runner); ``None`` falls back to hashing this worker's own
     ``config`` — the same digest except under the per-cell
@@ -1380,7 +1391,11 @@ def process_and_write_hive(
     ``telemetry.build_record``'s validated metadata fallback.
     ``sidecar_spec`` is the manifest spec in effect, keying the sidecar name
     (``telemetry.sidecar_key``); the gate reads with it and degrades to
-    rewrite when the sidecar is absent under that name.
+    rewrite when the sidecar is absent under that name. It also keys the
+    granule-id SIBLING this seam writes after the commit stamp
+    (``telemetry.write_granule_ids``, issue #388) — the recorded id set the
+    contraction guard later diffs, kept out of the sidecar and the response
+    envelope so an identity check stays one small GET.
     """
     from zagg.processing import (
         process_shard,
@@ -1640,6 +1655,15 @@ def process_and_write_hive(
             time_range=time_range,
         )
         _write_elapsed += time.time() - _t0
+        # The recorded granule-id list, as this leaf's own sibling object
+        # (issue #388): AFTER the stamp, so it never certifies a leaf that
+        # did not land, and written here rather than at the caller's sidecar
+        # PUT because ``granule_urls`` is the very list the identity gate
+        # compares — one source for the recorded id space, on both backends.
+        # Fail-open inside (telemetry class, D9).
+        from zagg.telemetry import write_granule_ids
+
+        write_granule_ids(leaf_path, granule_urls, spec=sidecar_spec, **store_kwargs)
     # Write-phase split (issue #249): read/index/aggregate come from
     # ``process_shard``; ``write`` is the leaf write-out above (template +
     # dense chunks + ragged + coverage sidecar + stamp). Same gate as the flat

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -1629,7 +1629,8 @@ def process_and_write_hive(
     # sidecar is PUT just before it (issue #200 phase 2), and both inherit
     # its debris semantics: a torn worker's coverage never becomes visible.
     # The leaf write order is pinned: dense (streamed, or one object each when
-    # sharded) -> ragged (one object, issue #209) -> coverage sidecar -> stamp.
+    # sharded) -> ragged (one object, issue #209) -> coverage sidecar -> stamp
+    # -> granule-id sibling (issue #388; after the stamp, inside the bracket).
     if "store" in box and not metadata.get("error"):
         _t0 = time.time()
         if not sharded:
@@ -1660,16 +1661,18 @@ def process_and_write_hive(
             window=window["label"] if window else None,
             time_range=time_range,
         )
-        _write_elapsed += time.time() - _t0
         # The recorded granule-id list, as this leaf's own sibling object
         # (issue #388): AFTER the stamp, so it never certifies a leaf that
         # did not land, and written here rather than at the caller's sidecar
         # PUT because ``granule_urls`` is the very list the identity gate
         # compares — one source for the recorded id space, on both backends.
-        # Fail-open inside (telemetry class, D9).
+        # Fail-open inside (telemetry class, D9). Inside the write bracket:
+        # it is a write this seam performs, so ``phase_timings["write"]``
+        # must account for it.
         from zagg.telemetry import write_granule_ids
 
         write_granule_ids(leaf_path, granule_urls, spec=sidecar_spec, **store_kwargs)
+        _write_elapsed += time.time() - _t0
     # Write-phase split (issue #249): read/index/aggregate come from
     # ``process_shard``; ``write`` is the leaf write-out above (template +
     # dense chunks + ragged + coverage sidecar + stamp). Same gate as the flat

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -1184,6 +1184,7 @@ def leaf_identity_gate(
     sidecar_spec,
     store_kwargs,
     shard_key,
+    window=None,
     column_path=None,
     column_declared=None,
 ):
@@ -1280,6 +1281,10 @@ def leaf_identity_gate(
             identity = {"action": "rewrite", "classification": drift, "missing": []}
     base = {
         "shard_key": int(shard_key),
+        # The unit is (shard, WINDOW): a refusal manifest that named only the
+        # shard would be ambiguous on a windowed store, where the same shard
+        # holds one leaf per window (issue #388's ruling on question (9)).
+        "window": window,
         "identity": identity["classification"],
         "semantic_hash": semantic_hash,
         "cells_with_data": 0,
@@ -1446,6 +1451,7 @@ def process_and_write_hive(
             sidecar_spec=sidecar_spec,
             store_kwargs=store_kwargs,
             shard_key=shard_key,
+            window=window["label"] if window else None,
             column_path=column_path,
             column_declared=column_declared,
         )

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -1725,7 +1725,7 @@ def process_and_write_hive(
             metadata["column_error"] = str(e)
         else:
             if column is not None:
-                metadata["column"] = column
+                metadata["leaf_column"] = column
                 if "phase_timings" in metadata:
                     metadata["phase_timings"]["column"] = time.time() - _t0
     return metadata

--- a/src/zagg/lifecycle.py
+++ b/src/zagg/lifecycle.py
@@ -8,8 +8,9 @@ across the unit's WHOLE footprint (lifecycle rules act per object):
 
 - the leaf ``.zarr`` tree — commit stamp, arrays, and the in-leaf
   ``coverage.moc`` sidecar included (they are objects under the prefix);
-- the D20 stats sidecar and D22 sub-map SIBLINGS of the leaf
-  (:func:`zagg.telemetry.sidecar_key` / :func:`zagg.sweep.submap_key`, the
+- the D20 stats sidecar, its issue #388 granule-id list, and the D22 sub-map
+  SIBLINGS of the leaf (:func:`zagg.telemetry.sidecar_key` /
+  :func:`zagg.telemetry.granule_ids_key` / :func:`zagg.sweep.submap_key`, the
   spec-keyed naming seams);
 - the issue #383 leaf column tree plus its own stats sidecar, when the run
   declares one — the identity gate has already verified declaration and
@@ -114,12 +115,16 @@ def touch_current_unit(
     try:
         from zagg.column import _sidecar_name as column_sidecar_name
         from zagg.sweep import submap_key
-        from zagg.telemetry import sidecar_path
+        from zagg.telemetry import granule_ids_path, sidecar_path
 
         prefix, _, name = str(leaf_path).rstrip("/").rpartition("/")
         trees = [str(leaf_path)]
         objects = [
             sidecar_path(str(leaf_path), sidecar_spec),
+            # The recorded id list (issue #388) ages with the sidecar it
+            # pairs with: losing it to a lifecycle rule would silently
+            # disarm the contraction guard on a leaf that is otherwise fresh.
+            granule_ids_path(str(leaf_path), sidecar_spec),
             f"{prefix}/{submap_key(name, sidecar_spec)}",
         ]
         if column_path:

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -1240,7 +1240,11 @@ def process_and_write_raster_hive(
     raster id space (:func:`zagg.telemetry.raster_granule_ids`) as the
     planned set. A skipped/refused unit returns early with ``timesteps: 0``
     and ``leaf_written: False``, having written nothing. Default off keeps
-    this seam byte-identical for callers that have not opted in.
+    this seam byte-identical for callers that have not opted in — except for
+    the granule-id SIBLING written after the stamp
+    (:func:`zagg.telemetry.write_granule_ids`), which is unconditional: it is
+    what a LATER run's contraction guard diffs against, so a leaf must record
+    it whether or not the run that wrote the leaf had the gate armed.
     """
     from zagg.hive import (
         COVERAGE_SIDECAR,
@@ -1432,6 +1436,15 @@ def process_and_write_raster_hive(
             time_range=time_range,
         )
         write_s += time.time() - _t0
+        # The recorded granule-id list as this leaf's sibling object (issue
+        # #388), after the stamp and in the raster id space the gate plans
+        # against — the vector seam's posture, same rationale (one source for
+        # the recorded id space; fail-open inside).
+        from zagg.telemetry import write_granule_ids
+
+        write_granule_ids(
+            leaf_path, raster_granule_ids(granules), spec=sidecar_spec, **store_kwargs
+        )
     # Phase split (issues #100/#249; always-on collection since issue #297 —
     # the stats sidecar needs complete timings by default): only a unit that
     # actually wrote carries it, so a no-data unit stays write-less and

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -1215,11 +1215,12 @@ def process_and_write_raster_hive(
 
     The stamp is the leaf's FINAL write: dense slabs (streamed) -> coverage
     sidecar (edge shards only; interior shards stamp ``"full"`` with no
-    sidecar PUT) -> stamp. ``cells_with_data`` counts the occupied-cell
+    sidecar PUT) -> stamp -> granule-id sibling (issue #388).
+    ``cells_with_data`` counts the occupied-cell
     union; ``granule_count`` the unit's acquisitions (asset-carrying
     entries). Phase timings are always collected (issue #297):
     ``metadata["phase_timings"] = {"sample", "write", "hash"}`` with the leaf
-    write-out (template + slabs + sidecar + stamp) as ``write``; the
+    write-out (template + slabs + sidecar + stamp + sibling) as ``write``; the
     per-stage ``stages`` block (issue #249) stays gated on ``profile`` /
     a passed ``stage_stats`` (the local dispatcher's debug-logging flavor).
 
@@ -1396,7 +1397,8 @@ def process_and_write_raster_hive(
         meta["identity"] = identity["classification"]
     # Stamp ONLY a leaf that wrote slabs: a unit that streamed nothing has no
     # prefix, and a worker error raised out above, leaving debris (D4). Write
-    # order is pinned: dense slabs -> coverage sidecar -> stamp.
+    # order is pinned: dense slabs -> coverage sidecar -> stamp -> granule-id
+    # sibling (issue #388; after the stamp, inside the write bracket).
     meta["cells_with_data"] = 0
     # Accurate leaf-written signal for the stats-sidecar gate (issue #297): set
     # iff a slab streamed (``"store" in box``), so both dispatchers gate the
@@ -1436,16 +1438,17 @@ def process_and_write_raster_hive(
             window=label,
             time_range=time_range,
         )
-        write_s += time.time() - _t0
         # The recorded granule-id list as this leaf's sibling object (issue
         # #388), after the stamp and in the raster id space the gate plans
         # against — the vector seam's posture, same rationale (one source for
-        # the recorded id space; fail-open inside).
+        # the recorded id space; fail-open inside; inside the write bracket,
+        # because the write phase must account for every PUT the seam makes).
         from zagg.telemetry import write_granule_ids
 
         write_granule_ids(
             leaf_path, raster_granule_ids(granules), spec=sidecar_spec, **store_kwargs
         )
+        write_s += time.time() - _t0
     # Phase split (issues #100/#249; always-on collection since issue #297 —
     # the stats sidecar needs complete timings by default): only a unit that
     # actually wrote carries it, so a no-data unit stays write-less and

--- a/src/zagg/processing/raster.py
+++ b/src/zagg/processing/raster.py
@@ -1285,6 +1285,7 @@ def process_and_write_raster_hive(
             sidecar_spec=sidecar_spec,
             store_kwargs=store_kwargs,
             shard_key=shard_key,
+            window=label,
         )
         if unit_meta is not None:
             out = {**unit_meta, "timesteps": 0, "skipped": 0, "leaf_written": False}

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -1144,6 +1144,10 @@ class RasterStrategy:
                 root_touch = touch_store_root(store_path, store_kwargs=store_kwargs)
                 identity["objects_touched"] += root_touch["touched"]
                 identity["touch_failures"] += root_touch["failed"]
+        # Store-root refusal manifest (issue #388) — see _write_refusals.
+        refusal_manifest_path = _write_refusals(
+            store_path, ok_metas, identity, run_id, run_semantic_hash, store_kwargs
+        )
         # Run-level stats parquet (issue #297 phase 3), BEFORE the all-failed
         # raise below so the failure evidence persists at the store root.
         from zagg.telemetry import failure_record, flatten_record
@@ -1184,6 +1188,7 @@ class RasterStrategy:
             "cells_error": errors,
             # Skip-if-current run stats (issue #388) — see _identity_counts.
             **identity,
+            "refusal_manifest_path": refusal_manifest_path,
             # Shared summary key across strategies. For the raster path this is
             # the count of shard×timestep slabs written, not a per-cell obs tally
             # (see RasterStrategy docstring); ``timesteps`` is the datatake count.
@@ -2823,6 +2828,36 @@ def _identity_counts(metas) -> dict:
     }
 
 
+def _write_refusals(store_path, metas, identity, run_id, semantic_hash, store_kwargs) -> str | None:
+    """The run's store-root refusal manifest, or ``None`` (issue #388).
+
+    A refused unit writes nothing at all, so without this the missing-granule
+    diff lives only in a worker log line truncated to five ids. Ruled
+    (question (9)(c)): ONE small root object per run that refused, and — ruled
+    (9)(a) — nothing whatsoever for a pure-skip run, which stays row-less.
+
+    Rides the LOCAL wrap-up seam for the same reason the root ``coverage.moc``
+    union and the phase-3 ``touch_store_root`` do: this process is also the
+    worker and already PUTs every leaf with these credentials, so the D8
+    orchestrator-no-write rule (which sends the Lambda paths through a worker
+    invoke) does not constrain it. The FLEET has no once-per-run worker-side
+    seam to carry it, exactly as the store-root touch does not — the two share
+    a resolution (the PR #397 question (10) fork). Fail-open inside
+    ``write_refusal_manifest`` (D9).
+    """
+    if not identity["cells_refused"]:
+        return None
+    from zagg.telemetry import write_refusal_manifest
+
+    return write_refusal_manifest(
+        store_path,
+        [m for m in metas if isinstance(m, dict) and m.get("refused")],
+        run_id=run_id,
+        semantic_hash=semantic_hash,
+        store_kwargs=store_kwargs,
+    )
+
+
 def _run_local(
     config,
     catalog_data,
@@ -3174,6 +3209,9 @@ def _run_local(
         root_touch = touch_store_root(store_path, store_kwargs=store_kwargs)
         identity["objects_touched"] += root_touch["touched"]
         identity["touch_failures"] += root_touch["failed"]
+    refusal_manifest_path = _write_refusals(
+        store_path, report.results, identity, run_id, run_semantic_hash, store_kwargs
+    )
 
     summary = {
         "total_cells": len(cells),
@@ -3181,6 +3219,9 @@ def _run_local(
         "cells_error": report.cells_error,
         # Skip-if-current run stats (issue #388) — see _identity_counts.
         **identity,
+        # Store-root refusal manifest (issue #388), local-only like the root
+        # touch above; None when nothing refused — see _write_refusals.
+        "refusal_manifest_path": refusal_manifest_path,
         "total_obs": report.total_obs,
         "wall_time_s": wall_time,
         "store_path": store_path,

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -14,6 +14,13 @@ summation order. Identity-like fields (``shard_key``, ``granules_sha256``,
 ``invoked_by``, ...) merge as equal-or-``None``: a mismatch collapses to
 ``None`` (absorbing), which keeps the fold associative.
 
+The sidecar has one SIBLING of its own (issue #388): ``granules.json``, the
+recorded granule-id list behind the record's ``granules_sha256``, on the same
+spec-keyed naming grammar (:func:`granule_ids_key`). It is deliberately not a
+record key — identity equality is the hash compare every fan-out reader
+already makes, and the list is fetched only to name what a contraction
+dropped.
+
 ``build_record``/``merge`` are pure (no I/O); the sidecar/parquet helpers below
 them do object-store I/O and import their backends lazily.
 """
@@ -40,6 +47,17 @@ SCHEMA_VERSION = 1
 #: — mirroring the ``{full_id}_{window}.zarr`` leaf naming so two windows of one
 #: shard cannot clobber each other's sidecar.
 SIDECAR_NAME = "stats.json"
+
+#: Recorded granule-id list object (issue #388) — a SIBLING of the stats
+#: sidecar, on the same naming grammar (:func:`granule_ids_key`), holding the
+#: id list behind the sidecar's ``granules_sha256``. Split out of the record
+#: on the espg ruling (question (6)(c)): identity EQUALITY is the small
+#: sidecar's hash compare, which every fan-out reader already pays
+#: (``dedup.shard_status`` per shard, ``rows_from_status`` per envelope), so
+#: the list — ~4,600 ids ≈ 550 KB on a pole shard — must never ride the
+#: record, the response envelope, or those GETs. It is read exactly once, and
+#: only when the hash MISMATCHES: to NAME the granules a contraction dropped.
+GRANULE_IDS_NAME = "granules.json"
 
 #: ``platform.machine()`` spellings -> the #298 price-table arch keys, so the
 #: worker-side record prices with the same table the dispatcher's cost block
@@ -80,11 +98,6 @@ _EQ_OR_NONE_KEYS = (
     # collapses it to None (absence = unverifiable, §5.3) while merge([r])
     # stays r.
     "content_hashes",
-    # The recorded granule-id LIST (issue #388) — the id-set half of the
-    # skip-if-current identity pair, kept next to its hash so a contraction
-    # refusal can name the dropped ids. Per-leaf like content_hashes: a
-    # cross-leaf rollup collapses it to None.
-    "granule_ids",
     # Leaf pyramid column basename (issue #383's deferred run-record key,
     # landed with #388): D22 discovery is run-record-driven, so column
     # existence must be discoverable without a tree listing. Named
@@ -227,13 +240,11 @@ def build_record(
         "zagg_version": _zagg_version(),
         "n_shards": 1,
         "n_granules": int(n_granules),
+        # The catalog identity half, and the ONLY id-derived value the record
+        # carries: the id LIST behind it lives in its own sibling object
+        # (:data:`GRANULE_IDS_NAME`, issue #388) so it never rides this record,
+        # the response envelope, or any fan-out identity GET.
         "granules_sha256": granules_sha256(granule_ids),
-        # The recorded id LIST behind that hash (issue #388), in the hash's
-        # own canonical order (sorted, duplicates kept) — the set a later
-        # rerun's contraction guard diffs against to NAME dropped ids.
-        # Envelope-borne and sidecar-recorded, never a run-parquet column
-        # (the join key there is granules_sha256).
-        "granule_ids": sorted(str(g) for g in granule_ids) if granule_ids else None,
         # O11 content hashes (issue #342, spec §5.3): the verification half of
         # the D19 identity split, computed by the hive leaf writer from the
         # staged arrays and ridden here off ``metadata``. None wherever no
@@ -325,12 +336,9 @@ def merge(records: Iterable[dict]) -> dict:
             # #297). One level deeper than a plain ``dict()``: flat values
             # (``lambda``/``invoked_by``) are unaffected, but
             # ``content_hashes`` nests an ``arrays`` map (issue #342) that a
-            # shallow copy would still alias. Lists (``granule_ids``, issue
-            # #388) copy shallow — their elements are strings.
+            # shallow copy would still alias.
             if isinstance(first, dict):
                 out[key] = {k: dict(v) if isinstance(v, dict) else v for k, v in first.items()}
-            elif isinstance(first, list):
-                out[key] = list(first)
             else:
                 out[key] = first
         else:
@@ -419,8 +427,9 @@ _ROW_SCALARS = (
     # reads right on the pyramid column's own row ("the column this LEAF
     # carries"). Renamed pre-release under the issue #388 ruling; nothing
     # published this schema under the old spelling.
-    # ``granule_ids`` (a list) stays out — the parquet join key for catalog
-    # identity is granules_sha256.
+    # The granule-id LIST has no column here and never had: the parquet join
+    # key for catalog identity is granules_sha256, and since issue #388 the
+    # list is not even on the record (:data:`GRANULE_IDS_NAME`).
     "leaf_column",
     "max_memory_mb",
     "container_hwm_mb",
@@ -656,6 +665,28 @@ def sidecar_key(leaf_name: str, spec: str | None = None) -> str:
     a writer/reader spec mismatch would key the wrong sidecar name and read as
     absent instead of failing.
     """
+    return _sibling_key(leaf_name, SIDECAR_NAME, spec)
+
+
+def granule_ids_key(leaf_name: str, spec: str | None = None) -> str:
+    """Object name of a leaf's recorded granule-id list (issue #388).
+
+    The stats sidecar's grammar with :data:`GRANULE_IDS_NAME` as the base
+    name, so the two siblings are named by ONE rule and cannot drift:
+    ``granules.json`` / ``granules_{window}.json`` on the legacy specs,
+    ``{stem}.granules.json`` under :data:`SPEC_V3`. Unrecognized specs raise,
+    exactly as in :func:`sidecar_key`.
+    """
+    return _sibling_key(leaf_name, GRANULE_IDS_NAME, spec)
+
+
+def _sibling_key(leaf_name: str, base: str, spec: str | None) -> str:
+    """The spec-keyed name of a leaf SIBLING object; see :func:`sidecar_key`.
+
+    One grammar for the whole D20 sibling family — the sidecar and the issue
+    #388 granule-id list differ only in ``base``. Kept private so the family
+    stays closed: every sibling name has a named ``*_key`` owner above it.
+    """
     if spec == SPEC_V3:
         from zagg.windows import validate_label
 
@@ -667,7 +698,7 @@ def sidecar_key(leaf_name: str, spec: str | None = None) -> str:
         # malformed key. The ``all`` schedule-none token satisfies the explicit
         # grammar, so it keeps passing.
         validate_label(stem)
-        return f"{stem}.stats.json"
+        return f"{stem}.{base}"
     if spec not in _LEGACY_SPECS:
         raise ValueError(
             f"unknown store spec {spec!r} (one of {_LEGACY_SPECS} for legacy names "
@@ -677,8 +708,8 @@ def sidecar_key(leaf_name: str, spec: str | None = None) -> str:
 
     _full_id, window = split_leaf_name(leaf_name)
     if window is None:
-        return SIDECAR_NAME
-    stem, ext = SIDECAR_NAME.rsplit(".", 1)
+        return base
+    stem, ext = base.rsplit(".", 1)
     return f"{stem}_{window}.{ext}"
 
 
@@ -700,6 +731,82 @@ def write_sidecar(leaf_path: str, record: dict, spec: str | None = None, **store
         sidecar_key(name, spec),
         json.dumps(record).encode(),
     )
+
+
+def granule_ids_path(leaf_path: str, spec: str | None = None) -> str:
+    """Absolute path of a leaf's granule-id list object (issue #388)."""
+    prefix, _, name = leaf_path.rstrip("/").rpartition("/")
+    return f"{prefix}/{granule_ids_key(name, spec)}"
+
+
+def write_granule_ids(leaf_path: str, granule_ids, spec: str | None = None, **store_kwargs) -> bool:
+    """PUT the leaf's recorded granule-id list beside its sidecar (issue #388).
+
+    Written by the leaf SEAMS (``hive.process_and_write_hive`` /
+    ``processing.raster.process_and_write_raster_hive``) right after the D4
+    commit stamp, not by the dispatcher that writes the sidecar: the seam
+    holds the very list the identity gate compares as ``planned_ids``, so the
+    recorded and planned id SPACES have one source, and a worker-side write
+    is the D8-sanctioned one — which is also what carries this to the fleet
+    with no Lambda-handler change (the sidecar's own ``semantic_hash``
+    precedent).
+
+    The object is self-describing and self-pairing: it carries the
+    ``granules_sha256`` of the list it holds, and a reader must accept it
+    only when that matches the sidecar's (:func:`zagg.dedup.leaf_recorded_ids`).
+    A torn rewrite — new sidecar, lost sibling PUT, or the reverse — then
+    reads as "no recorded set" rather than as a stale set that could refuse
+    or excuse the wrong granules.
+
+    Fail-open INSIDE (the ``zagg.column`` sidecar precedent, D9 telemetry
+    class): the leaf is already committed when this runs, so a failed PUT
+    must never fail the unit. Returns whether the object landed; the cost of
+    it not landing is one wholesale rewrite (``unrecorded-ids``) on a later
+    mismatching rerun, never a wrong skip.
+    """
+    import logging
+
+    try:
+        import obstore
+
+        from zagg.store import open_object_store
+
+        prefix, _, name = leaf_path.rstrip("/").rpartition("/")
+        ids = sorted(str(g) for g in granule_ids) if granule_ids else []
+        obstore.put(
+            open_object_store(prefix, **store_kwargs),
+            granule_ids_key(name, spec),
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "granules_sha256": granules_sha256(ids),
+                    "granule_ids": ids,
+                }
+            ).encode(),
+        )
+        return True
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            f"granule-id sibling write failed (fail-open, issue #388): {e}"
+        )
+        return False
+
+
+def read_granule_ids(leaf_path: str, spec: str | None = None, **store_kwargs) -> dict | None:
+    """The leaf's granule-id list object, or ``None`` when absent (issue #388)."""
+    import obstore
+    from obstore.exceptions import NotFoundError
+
+    from zagg.store import open_object_store
+
+    prefix, _, name = leaf_path.rstrip("/").rpartition("/")
+    try:
+        data = obstore.get(
+            open_object_store(prefix, **store_kwargs), granule_ids_key(name, spec)
+        ).bytes()
+    except (FileNotFoundError, NotFoundError):
+        return None
+    return json.loads(bytes(data))
 
 
 def read_sidecar(leaf_path: str, spec: str | None = None, **store_kwargs) -> dict | None:

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -561,43 +561,49 @@ def write_refusal_manifest(
     and object-less at the root (ruled (9)(a)).
 
     Fail-open (D9 telemetry class, the sweep run record's posture): a failed
-    PUT logs and returns ``None`` — the run's exit status and its
-    ``cells_refused`` count are unaffected. Callers must be store-writers in
-    their own right (D8): the local dispatcher is also the worker, which is
-    why this rides the same wrap-up seam as the root ``coverage.moc``.
+    write logs and returns ``None`` — the run's exit status and its
+    ``cells_refused`` count are unaffected. The COMPOSITION is inside the
+    same guard as the PUT (``write_granule_ids``'s posture), because this runs
+    before the summary and the run-stats parquet: a ``MemoryError`` on an
+    unbounded refusal set, or a malformed ``missing_granules``, must cost the
+    manifest, never the run record of a run that already did all its work.
+    Callers must be store-writers in their own right (D8): the local
+    dispatcher is also the worker, which is why this rides the same wrap-up
+    seam as the root ``coverage.moc``.
     """
     import logging
 
-    units = []
-    for meta in refusals:
-        if not isinstance(meta, dict):
-            continue
-        missing = [str(g) for g in (meta.get("missing_granules") or [])]
-        units.append(
-            {
-                "shard_key": meta.get("shard_key"),
-                "window": meta.get("window"),
-                "identity": meta.get("identity"),
-                "n_missing": len(missing),
-                "missing_granules": missing,
-            }
-        )
-    if not units:
-        return None
-    units.sort(key=lambda u: (str(u["shard_key"]), str(u["window"])))
-    body = {
-        "spec": REFUSAL_SPEC,
-        "schema_version": SCHEMA_VERSION,
-        "run_id": run_id,
-        # The run context needed to act on it: WHEN, and WHICH product
-        # (the D19 semantic core the refused units were dispatched under).
-        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "semantic_hash": semantic_hash,
-        "zagg_version": _zagg_version(),
-        "cells_refused": len(units),
-        "units": units,
-    }
     try:
+        units = []
+        for meta in refusals:
+            if not isinstance(meta, dict):
+                continue
+            missing = [str(g) for g in (meta.get("missing_granules") or [])]
+            units.append(
+                {
+                    "shard_key": meta.get("shard_key"),
+                    "window": meta.get("window"),
+                    "identity": meta.get("identity"),
+                    "n_missing": len(missing),
+                    "missing_granules": missing,
+                }
+            )
+        if not units:
+            return None
+        units.sort(key=lambda u: (str(u["shard_key"]), str(u["window"])))
+        body = {
+            "spec": REFUSAL_SPEC,
+            "schema_version": SCHEMA_VERSION,
+            "run_id": run_id,
+            # The run context needed to act on it: WHEN, and WHICH product
+            # (the D19 semantic core the refused units were dispatched under).
+            "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "semantic_hash": semantic_hash,
+            "zagg_version": _zagg_version(),
+            "cells_refused": len(units),
+            "units": units,
+        }
+
         import obstore
 
         from zagg.store import open_object_store

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -87,9 +87,9 @@ _EQ_OR_NONE_KEYS = (
     "granule_ids",
     # Leaf pyramid column basename (issue #383's deferred run-record key,
     # landed with #388): D22 discovery is run-record-driven, so column
-    # existence must be discoverable without a tree listing. The name is
-    # SQL-reserved where this reaches parquet — see _ROW_SCALARS below.
-    "column",
+    # existence must be discoverable without a tree listing. Named
+    # ``leaf_column``, not ``column`` — see _ROW_SCALARS below.
+    "leaf_column",
     "zagg_version",
     "lambda",
     "invoked_by",
@@ -271,17 +271,23 @@ def build_record(
         # so run-record-driven discovery (D22) sees columns without a tree
         # listing. The column's resolution set lives in the artifact's own
         # ``zagg_column`` attrs — read the column, not this row, for it.
-        # READ IT AS: "the column basename this UNIT wrote alongside its
-        # leaf" — NOT "the column this record describes". ``None`` means no
-        # column was recorded by this unit; it is never a denial that the
-        # described artifact is one. The pyramid column's OWN stats sidecar
-        # records ``None`` here (``zagg.column`` builds it from a hand-made
-        # metadata dict with no ``column`` key — only the leaf record carries
-        # the basename, via ``hive.py``), and so does any cross-leaf rollup,
-        # where the equal-or-None merge collapses it. So a sidecar scan for
-        # column-bearing units must key on the LEAF records, not on the
-        # column artifacts' own.
-        "column": metadata.get("column"),
+        #
+        # Named ``leaf_column`` (espg ruling on issue #388, question (5)(c);
+        # renamed before the schema released) for two reasons. (1) ``column``
+        # is SQL-reserved in both engines this record's parquet targets
+        # (DuckDB, Trino/Athena): the unquoted ``WHERE column IS NOT NULL``
+        # is a parse error, so every filter would have to quote it. (2) It
+        # reads correctly on the pyramid column's OWN record: "the column
+        # this LEAF carries" — NOT "the column this record describes".
+        # ``None`` means no column was recorded by this unit; it is never a
+        # denial that the described artifact is one. The pyramid column's own
+        # stats sidecar records ``None`` here (``zagg.column`` builds it from
+        # a hand-made metadata dict with no ``leaf_column`` key — only the
+        # leaf record carries the basename, via ``hive.py``), and so does any
+        # cross-leaf rollup, where the equal-or-None merge collapses it. So a
+        # sidecar scan for column-bearing units must key on the LEAF records,
+        # not on the column artifacts' own.
+        "leaf_column": metadata.get("leaf_column"),
         "gb_seconds": gb_seconds,
         "est_cost_usd": est_cost,
         "max_memory_mb": _opt_float(metadata.get("max_memory_mb")),
@@ -403,18 +409,19 @@ _ROW_SCALARS = (
     "raster_bytes_read",
     "raster_px_decoded",
     "raster_px_sampled",
-    # Column basename (issue #383's deferred run-record key): a scalar
+    # Leaf column basename (issue #383's deferred run-record key): a scalar
     # string, so D22 run-record discovery can find column-bearing leaves
-    # from the run parquet alone, without a tree listing. Mind the spelling
-    # at the query: ``column`` is SQL-reserved and reserved in both engines
-    # this parquet targets (DuckDB, Trino/Athena), so a filter on it must
-    # quote the identifier — ``WHERE "column" IS NOT NULL``, not
-    # ``WHERE column IS NOT NULL``, which is a parse error. Renaming the key
-    # (``column_name`` / ``leaf_column``) is open for review while the
-    # schema is unreleased — see the PR's Questions for review.
+    # from the run parquet alone, without a tree listing. The name is
+    # ``leaf_column`` and not the bare ``column`` precisely because this is
+    # the form the query engines see: ``column`` is SQL-reserved in DuckDB
+    # and Trino/Athena, where ``WHERE column IS NOT NULL`` is a parse error
+    # and every filter would need ``WHERE "column" IS NOT NULL``. It also
+    # reads right on the pyramid column's own row ("the column this LEAF
+    # carries"). Renamed pre-release under the issue #388 ruling; nothing
+    # published this schema under the old spelling.
     # ``granule_ids`` (a list) stays out — the parquet join key for catalog
     # identity is granules_sha256.
-    "column",
+    "leaf_column",
     "max_memory_mb",
     "container_hwm_mb",
     "timestamp",

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -59,6 +59,16 @@ SIDECAR_NAME = "stats.json"
 #: only when the hash MISMATCHES: to NAME the granules a contraction dropped.
 GRANULE_IDS_NAME = "granules.json"
 
+#: The granule-id sibling's OWN version marker (issue #388), on the refusal
+#: manifest's precedent. Deliberately not :data:`SCHEMA_VERSION`: that number
+#: versions the D20 run RECORD, which this object exists to not be — welding
+#: them would bump the sibling on every record rev and make a sibling format
+#: change unversionable without revving the record. Readers must treat it
+#: leniently (:func:`zagg.dedup.leaf_recorded_ids`): the hash pairing is what
+#: decides, and an unknown marker degrades to ``unrecorded-ids``, never to an
+#: error.
+GRANULE_IDS_SPEC = "zagg-granule-ids/1"
+
 #: ``platform.machine()`` spellings -> the #298 price-table arch keys, so the
 #: worker-side record prices with the same table the dispatcher's cost block
 #: uses. An unmapped/absent arch falls back to the flat default rate.
@@ -871,9 +881,11 @@ def write_granule_ids(leaf_path: str, granule_ids, spec: str | None = None, **st
     with no Lambda-handler change (the sidecar's own ``semantic_hash``
     precedent).
 
-    The object is self-describing and self-pairing: it carries the
-    ``granules_sha256`` of the list it holds, and a reader must accept it
-    only when that matches the sidecar's (:func:`zagg.dedup.leaf_recorded_ids`).
+    The object is self-describing and self-pairing: it carries its own
+    :data:`GRANULE_IDS_SPEC` marker (not the D20 record's ``schema_version``
+    — this is deliberately not that schema) and the ``granules_sha256`` of the
+    list it holds, and a reader must accept it only when that hash matches the
+    sidecar's (:func:`zagg.dedup.leaf_recorded_ids`).
     A torn rewrite — new sidecar, lost sibling PUT, or the reverse — then
     reads as "no recorded set" rather than as a stale set that could refuse
     or excuse the wrong granules.
@@ -898,7 +910,7 @@ def write_granule_ids(leaf_path: str, granule_ids, spec: str | None = None, **st
             granule_ids_key(name, spec),
             json.dumps(
                 {
-                    "schema_version": SCHEMA_VERSION,
+                    "spec": GRANULE_IDS_SPEC,
                     "granules_sha256": granules_sha256(ids),
                     "granule_ids": ids,
                 }

--- a/src/zagg/telemetry.py
+++ b/src/zagg/telemetry.py
@@ -490,16 +490,130 @@ def run_parquet_key(run_id: str, timestamp: str | None = None) -> str:
     ``validate_label``, a malformed value RAISES rather than composing a
     traversing key.
     """
+    return _run_scoped_key("stats", "parquet", run_id, timestamp, what="run parquet")
+
+
+#: Refusal manifest object name (issue #388, ruled question (9)(c)): the
+#: store-ROOT record of a run's contraction refusals. Timestamp-first like the
+#: run parquet and the sweep's own record, and deliberately outside the
+#: ``stats_*.parquet`` glob the sweep's run-record discovery scans.
+REFUSAL_SPEC = "zagg-refusals/1"
+
+
+def refusal_manifest_key(run_id: str, timestamp: str | None = None) -> str:
+    """Store-root object name of a run's refusal manifest (issue #388).
+
+    ``refusals_{ts}_{run_id}.json`` — the run parquet's grammar with its own
+    stem, so a listing of a store root sorts a run's artifacts together and
+    neither name can be mistaken for the other's.
+    """
+    return _run_scoped_key("refusals", "json", run_id, timestamp, what="refusal manifest")
+
+
+def _run_scoped_key(stem: str, ext: str, run_id: str, timestamp: str | None, *, what: str) -> str:
+    """``{stem}_{ts}_{run_id}.{ext}`` with both components validated.
+
+    Both flow into the object KEY, so both are checked against their frozen
+    grammar first — the D8 worker-invoke transport (issue #313) makes
+    ``timestamp`` a caller-supplied input, and an embedded ``/`` or ``..``
+    would escape the store root. Like :func:`sidecar_key`'s ``validate_label``,
+    a malformed value RAISES rather than composing a traversing key.
+    """
     ts = timestamp or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     if not _RUN_TS_RE.match(ts):
         raise ValueError(
-            f"run parquet timestamp {ts!r} does not match the D20 grammar ({_RUN_TS_RE.pattern})"
+            f"{what} timestamp {ts!r} does not match the D20 grammar ({_RUN_TS_RE.pattern})"
         )
     if not isinstance(run_id, str) or not _RUN_ID_RE.match(run_id):
         raise ValueError(
             f"run_id {run_id!r} does not match the opaque key charset ({_RUN_ID_RE.pattern})"
         )
-    return f"stats_{ts}_{run_id}.parquet"
+    return f"{stem}_{ts}_{run_id}.{ext}"
+
+
+def write_refusal_manifest(
+    store_root: str,
+    refusals,
+    *,
+    run_id: str,
+    timestamp: str | None = None,
+    semantic_hash: str | None = None,
+    store_kwargs: dict | None = None,
+) -> str | None:
+    """PUT the run's refusal manifest at the store root; its path or ``None``.
+
+    A refused unit (the issue #388 contraction guard) writes NOTHING — no
+    leaf, no sidecar, no run-parquet row — so before this the only trace of
+    which granules a rerun would have dropped was a worker log line truncated
+    to five ids. This is the durable full list, ruled (question (9)(c)) as
+    ONE small root object per refusing run rather than a synthesized D20 row:
+    a refusal has no ``n_obs``, no ``content_hashes`` and no committed leaf to
+    describe, so a run-record row for it would change what a row IS.
+
+    ``refusals`` is the run's refused unit metadata dicts (the seams'
+    ``{"refused": True, "missing_granules": [...]}`` early returns). Each
+    contributes its unit identity, its classification (``contraction`` /
+    ``mixed``) and the FULL missing-id diff — which is exactly the id list the
+    guard read from the leaf's granule-id sibling to name the drop, composed
+    here into one place an operator can act from. Units sort by (shard,
+    window) so two runs over the same refusal set produce comparable objects.
+    Nothing is written when nothing refused: a pure-skip run stays row-less
+    and object-less at the root (ruled (9)(a)).
+
+    Fail-open (D9 telemetry class, the sweep run record's posture): a failed
+    PUT logs and returns ``None`` — the run's exit status and its
+    ``cells_refused`` count are unaffected. Callers must be store-writers in
+    their own right (D8): the local dispatcher is also the worker, which is
+    why this rides the same wrap-up seam as the root ``coverage.moc``.
+    """
+    import logging
+
+    units = []
+    for meta in refusals:
+        if not isinstance(meta, dict):
+            continue
+        missing = [str(g) for g in (meta.get("missing_granules") or [])]
+        units.append(
+            {
+                "shard_key": meta.get("shard_key"),
+                "window": meta.get("window"),
+                "identity": meta.get("identity"),
+                "n_missing": len(missing),
+                "missing_granules": missing,
+            }
+        )
+    if not units:
+        return None
+    units.sort(key=lambda u: (str(u["shard_key"]), str(u["window"])))
+    body = {
+        "spec": REFUSAL_SPEC,
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        # The run context needed to act on it: WHEN, and WHICH product
+        # (the D19 semantic core the refused units were dispatched under).
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "semantic_hash": semantic_hash,
+        "zagg_version": _zagg_version(),
+        "cells_refused": len(units),
+        "units": units,
+    }
+    try:
+        import obstore
+
+        from zagg.store import open_object_store
+
+        key = refusal_manifest_key(run_id, timestamp)
+        obstore.put(
+            open_object_store(store_root, **(store_kwargs or {})),
+            key,
+            json.dumps(body, indent=1).encode(),
+        )
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            f"refusal manifest write failed (fail-open, issue #388): {e}"
+        )
+        return None
+    return f"{store_root.rstrip('/')}/{key}"
 
 
 def write_run_parquet(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2418,12 +2418,12 @@ def test_run_target_threads_store_layout():
 
 
 def test_hive_config_expected_counts_root_moc_optional():
-    # The committed hive arm's model: per-shard DATA is exact (11 objects/leaf,
+    # The committed hive arm's model: per-shard DATA is exact (12 objects/leaf,
     # the sharded-write-bypass tripwire), but the store-root coverage.moc is a
     # fail-open, regenerable D9 cache (runner.write_root_coverage) that may be
     # present OR absent -- so store-root metadata is a [1, 3] window (the
     # morton_hive.json manifest always; +coverage.moc and aggregation.yaml when
-    # they land) and the total is [12, 14]. Per-run root telemetry (the run
+    # they land) and the total is [13, 15]. Per-run root telemetry (the run
     # stats parquet, the sweep run record) is NOT in the window since issue
     # #362 -- per-run-unique names accumulate in a reused store, so they ride
     # the unbounded objects_telemetry bucket instead. A real bypass still fails
@@ -2439,17 +2439,17 @@ def test_hive_config_expected_counts_root_moc_optional():
     exp = bench_objects.expected_object_counts(grid, n_shards=1, store_layout="hive")
     # 3 arrays (morton/count/h_tdigest — no legacy cell_ids since the D16
     # flip, issue #304): leaf root+group zarr.json (2) + 3 array zarr.json +
-    # 3 sharded data objects + coverage sidecar + stats.json AND
-    # shardmap.json siblings (issues #297/#300) = 11.
+    # 3 sharded data objects + coverage sidecar + the stats.json,
+    # granules.json and shardmap.json siblings (issues #297/#388/#300) = 12.
     # Store root: morton_hive.json (always) + coverage.moc (optional) +
     # aggregation.yaml (optional, issue #299) -> [1, 3].
     assert exp == {
         "metadata": 3,
         "metadata_min": 1,
-        "per_shard_min": 11,
-        "per_shard_max": 11,
-        "total_min": 12,
-        "total_max": 14,
+        "per_shard_min": 12,
+        "per_shard_max": 12,
+        "total_min": 13,
+        "total_max": 15,
         "exact": True,
     }
 

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -856,8 +856,9 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     # + MOC (the run parquet / sweep record are telemetry — issue #362).
     n_arrays = len(grid.shard_spec().members)
     assert expected["exact"] is True
-    # ... + the stats.json AND shardmap.json siblings (issues #297/#300).
-    assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 2
+    # ... + the stats.json, granules.json and shardmap.json siblings
+    # (issues #297/#388/#300).
+    assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 3
     assert expected["metadata"] == 3
     # Sweep rollups (issue #300), overview zarrs (issue #201 — with the D20
     # `{window}.stats.json` sidecar each overview leaf carries since issue

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -834,7 +834,7 @@ class TestWorkerIntegration:
 
         meta, leaf = _run_unit(tmp_path, monkeypatch, pyramid=self.PYRAMID)
         assert meta.get("error") is None
-        assert meta["column"] == "all.pyramid.zarr"
+        assert meta["leaf_column"] == "all.pyramid.zarr"
         assert "column" in meta["phase_timings"]
         assert read_commit(open_store(str(leaf))) is not None
         column = leaf.parent / "all.pyramid.zarr"
@@ -854,18 +854,18 @@ class TestWorkerIntegration:
 
     def test_no_column_without_the_overviews_knob(self, tmp_path, monkeypatch):
         meta, leaf = _run_unit(tmp_path, monkeypatch, pyramid=None)
-        assert meta.get("error") is None and "column" not in meta
+        assert meta.get("error") is None and "leaf_column" not in meta
         assert not list(leaf.parent.glob("*.pyramid.zarr"))
 
     def test_dropping_the_knob_clears_the_previous_column(self, tmp_path, monkeypatch):
         meta, leaf = _run_unit(tmp_path, monkeypatch, pyramid=self.PYRAMID)
-        assert meta["column"] == "all.pyramid.zarr"
+        assert meta["leaf_column"] == "all.pyramid.zarr"
         assert (leaf.parent / "all.pyramid.zarr").exists()
         assert (leaf.parent / "all.pyramid.stats.json").exists()
         # Same leaf, declaration removed: the fresh leaf must not keep a
         # STAMPED column folded from the superseded run's cells.
         meta, leaf = _run_unit(tmp_path, monkeypatch, pyramid=None)
-        assert meta.get("error") is None and "column" not in meta
+        assert meta.get("error") is None and "leaf_column" not in meta
         assert not (leaf.parent / "all.pyramid.zarr").exists()
         assert not (leaf.parent / "all.pyramid.stats.json").exists()
         assert (leaf / "zarr.json").exists()
@@ -882,7 +882,7 @@ class TestWorkerIntegration:
             time_range=[31536000.0, 31536060.0],
         )
         assert meta.get("error") is None
-        assert meta["column"] == "2019.pyramid.zarr"
+        assert meta["leaf_column"] == "2019.pyramid.zarr"
         stamp = read_commit(open_store(str(leaf.parent / "2019.pyramid.zarr")))
         assert stamp is not None and stamp["window"] == "2019"
         # The D15 truth half: the worker's observed extent, converted to the
@@ -903,10 +903,10 @@ class TestWorkerIntegration:
             )
 
         meta, leaf = run("2019", 0.0, 1.0)
-        assert meta["column"] == "2019.pyramid.zarr"
+        assert meta["leaf_column"] == "2019.pyramid.zarr"
         first = _column_bytes(leaf.parent / "2019.pyramid.zarr")
         meta = run("2020", 1.0, 2.0)[0]
-        assert meta["column"] == "2020.pyramid.zarr"
+        assert meta["leaf_column"] == "2020.pyramid.zarr"
         # The D13 case: the second window's WHOLESALE clear is scoped to its
         # own basename, so the first window's column and sidecar are untouched.
         assert _column_bytes(leaf.parent / "2019.pyramid.zarr") == first
@@ -936,7 +936,7 @@ class TestWorkerIntegration:
         meta, stream_leaf = _run_unit(
             tmp_path / "stream", monkeypatch, pyramid=self.PYRAMID, sharded=False
         )
-        assert meta.get("error") is None and meta["column"] == "all.pyramid.zarr"
+        assert meta.get("error") is None and meta["leaf_column"] == "all.pyramid.zarr"
         assert _column_bytes(stream_leaf.parent / "all.pyramid.zarr") == _column_bytes(
             leaf.parent / "all.pyramid.zarr"
         )
@@ -953,7 +953,7 @@ class TestWorkerIntegration:
         # build its failure record from, and the unit still reports FAILED.
         assert meta["error"] == "leaf column: column write exploded"
         assert meta["column_error"] == "column write exploded"
-        assert "column" not in meta
+        assert "leaf_column" not in meta
         # The state the retry has to repair (§4.6 failure identity): the leaf
         # is COMMITTED and stamped, and no column stands beside it.
         assert read_commit(open_store(str(leaf))) is not None
@@ -977,7 +977,7 @@ class TestWorkerIntegration:
     def test_errored_shard_writes_neither_leaf_nor_column(self, tmp_path, monkeypatch):
         meta, leaf = _run_unit(tmp_path, monkeypatch, pyramid=self.PYRAMID, fail=True)
         assert meta.get("error") == "synthetic failure"
-        assert "column" not in meta
+        assert "leaf_column" not in meta
         assert not leaf.exists()
         assert not list(leaf.parent.glob("*.pyramid.zarr"))
 
@@ -1046,7 +1046,7 @@ class TestColumnDefeatsTheSkipGate:
         # Same inputs, same D19 hash; only the declaration changed.
         redo, _leaf = _run_unit(tmp_path, monkeypatch, pyramid=self.PYRAMID, skip_if_current=True)
         assert redo["identity"] == "column-drift" and "current" not in redo
-        assert redo["column"] == "all.pyramid.zarr"
+        assert redo["leaf_column"] == "all.pyramid.zarr"
         assert (leaf.parent / "all.pyramid.zarr").exists()
 
     def test_dropping_the_column_defeats_the_skip(self, tmp_path, monkeypatch):
@@ -1095,7 +1095,7 @@ class TestColumnDefeatsTheSkipGate:
             time_range=[31536000.0, 31536060.0],
             skip_if_current=True,
         )
-        assert redo["identity"] == "column-drift" and redo["column"] == "2019.pyramid.zarr"
+        assert redo["identity"] == "column-drift" and redo["leaf_column"] == "2019.pyramid.zarr"
         assert (leaf.parent / "2019.pyramid.zarr").exists()
 
     def test_a_skip_touches_the_column_family_too(self, tmp_path, monkeypatch):

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -388,6 +388,24 @@ class TestLeafRecordedIds:
             path.write_text(body)
             assert leaf_recorded_ids(leaf, self._sidecar(self.IDS)) is None
 
+    def test_record_borne_ids_are_read_when_no_sibling_exists(self, tmp_path):
+        # The 3f13af2..this-PR window: PR #397 put the id list ON the record
+        # and there is no sibling beside those leaves. Falling back to it
+        # keeps the guard armed over them instead of classifying every one
+        # unrecorded-ids forever.
+        recorded = dict(self._sidecar(self.IDS), granule_ids=sorted(self.IDS))
+        assert leaf_recorded_ids(self._leaf(tmp_path), recorded) == sorted(self.IDS)
+        # A malformed record-borne value is still no recorded set.
+        assert leaf_recorded_ids(self._leaf(tmp_path), {"granule_ids": "nope"}) is None
+
+    def test_the_sibling_wins_over_a_record_borne_list(self, tmp_path):
+        # A store rewritten under this release has both for one run; the
+        # sibling is the current writer, so it is what the diff must use.
+        leaf = self._leaf(tmp_path)
+        write_granule_ids(leaf, self.IDS)
+        recorded = dict(self._sidecar(self.IDS), granule_ids=["s3://b/stale.h5"])
+        assert leaf_recorded_ids(leaf, recorded) == sorted(self.IDS)
+
     def test_windowed_sibling_is_per_window(self, tmp_path):
         # Same grammar as the sidecar: two windows of one shard cannot
         # clobber each other's recorded set.

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -388,6 +388,22 @@ class TestLeafRecordedIds:
             path.write_text(body)
             assert leaf_recorded_ids(leaf, self._sidecar(self.IDS)) is None
 
+    def test_the_spec_marker_is_read_leniently(self, tmp_path):
+        # The hash pairing decides, not the marker: a sibling with an unknown
+        # or absent spec must still read (a future zagg-granule-ids/N that
+        # keeps these keys), and never raise — the ruled fallback posture is
+        # unrecorded-ids, not an error.
+        import json
+
+        leaf = self._leaf(tmp_path)
+        write_granule_ids(leaf, self.IDS)
+        path = pathlib.Path(granule_ids_path(leaf))
+        body = json.loads(path.read_text())
+        for spec in ("zagg-granule-ids/99", None):
+            body["spec"] = spec
+            path.write_text(json.dumps(body))
+            assert leaf_recorded_ids(leaf, self._sidecar(self.IDS)) == sorted(self.IDS)
+
     def test_record_borne_ids_are_read_when_no_sibling_exists(self, tmp_path):
         # The 3f13af2..this-PR window: PR #397 put the id list ON the record
         # and there is no sibling beside those leaves. Falling back to it

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -298,6 +298,19 @@ class TestClassifyLeafIdentity:
     def test_semantic_mismatch_with_equal_sets_rewrites_not_refuses(self):
         got = self._classify(self.IDS, semantic="b" * 64)
         assert got == {"action": "rewrite", "classification": "semantic-mismatch", "missing": []}
+        # And it costs NO sibling read: equal hashes mean an identical id
+        # multiset, so the diff cannot change the verdict. This is the routine
+        # config-only rerun — one needless ~550 KB GET per shard otherwise.
+        assert self.loads == 0
+
+    def test_semantic_mismatch_without_a_sibling_is_not_unrecorded(self):
+        # Same quadrant over a pre-#388 leaf: the guard is NOT inert here (the
+        # hashes prove no contraction), so it must not report as unrecorded —
+        # a config-only rerun over a pre-#388 store would otherwise come back
+        # 100% cells_unrecorded.
+        got = self._classify(self.IDS, semantic="b" * 64, sibling=False)
+        assert got == {"action": "rewrite", "classification": "semantic-mismatch", "missing": []}
+        assert self.loads == 0
 
     def test_null_recorded_semantic_never_skips(self):
         # Fleet-written pre-#388 vector sidecars record semantic_hash null

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -6,18 +6,27 @@ absent leaves are plain misses.
 """
 
 import copy
+import pathlib
 
 import numpy as np
 import zarr
 
 from zagg import hive
 from zagg.config import default_config
-from zagg.dedup import classify_leaf_identity, has_run, shard_status
+from zagg.dedup import classify_leaf_identity, has_run, leaf_recorded_ids, shard_status
 from zagg.grids import HealpixGrid
 from zagg.grids.morton import morton_word
 from zagg.semantics import semantic_hash
 from zagg.store import open_store
-from zagg.telemetry import build_record, granules_sha256, sidecar_key, write_sidecar
+from zagg.telemetry import (
+    build_record,
+    granule_ids_key,
+    granule_ids_path,
+    granules_sha256,
+    sidecar_key,
+    write_granule_ids,
+    write_sidecar,
+)
 
 WORD = morton_word("1121121")  # order-6 shard key
 GRANULES = ["s3://b/g1.h5", "s3://b/g2.h5"]
@@ -188,42 +197,75 @@ class TestHasRun:
 
 class TestClassifyLeafIdentity:
     """Worker-side identity readings (issue #388): equal / expansion /
-    contraction / mixed, with every ambiguity degrading to rewrite."""
+    contraction / mixed, with every ambiguity degrading to rewrite.
+
+    The recorded id LIST is not in the sidecar (the ruling on question (6)):
+    it comes from a sibling object through a lazy loader, so these fix the
+    sidecar's hash and hand the classifier a loader whose call count is
+    itself asserted."""
 
     SEM = "a" * 64
     IDS = ["s3://b/g1.h5", "s3://b/g2.h5", "s3://b/g3.h5"]
 
-    def _recorded(self, ids=None, semantic=SEM, with_ids=True):
-        ids = self.IDS if ids is None else ids
-        rec = {"semantic_hash": semantic, "granules_sha256": granules_sha256(ids)}
-        if with_ids:
-            rec["granule_ids"] = sorted(ids)
-        return rec
+    def _classify(self, planned_ids, *, ids=None, semantic=SEM, want=SEM, sibling=True):
+        """Classify ``planned_ids`` against a leaf recording ``ids``.
+
+        ``sibling=False`` models a leaf with no recorded id list at all — a
+        pre-#388 leaf, a lost PUT, or a sibling that failed to pair. The
+        loader's call count lands on ``self.loads``."""
+        recorded_ids = self.IDS if ids is None else ids
+        recorded = {
+            "semantic_hash": semantic,
+            "granules_sha256": granules_sha256(recorded_ids),
+        }
+        self.loads = 0
+
+        def _load():
+            self.loads += 1
+            return sorted(recorded_ids) if sibling else None
+
+        return classify_leaf_identity(
+            recorded,
+            semantic_hash=want,
+            planned_ids=planned_ids,
+            load_recorded_ids=_load,
+        )
 
     def test_equal_skips_on_the_hash_fast_path(self):
-        # Order must not matter: the hash is over the sorted ids.
-        got = classify_leaf_identity(
-            self._recorded(), semantic_hash=self.SEM, planned_ids=self.IDS[::-1]
-        )
+        # Order must not matter: the hash is over the sorted ids. And the
+        # sibling is NEVER read on this path — the whole point of the split.
+        got = self._classify(self.IDS[::-1])
         assert got == {"action": "skip", "classification": "equal", "missing": []}
+        assert self.loads == 0
 
-    def test_equal_without_recorded_ids_still_skips(self):
-        # The fast path never needs the id list, so pre-#388 sidecars skip too.
-        got = classify_leaf_identity(
-            self._recorded(with_ids=False), semantic_hash=self.SEM, planned_ids=self.IDS
-        )
+    def test_equal_without_a_recorded_sibling_still_skips(self):
+        # The fast path never needs the id list, so a leaf whose sibling is
+        # absent (pre-#388, or a lost PUT) still skips when the hash matches.
+        got = self._classify(self.IDS, sibling=False)
         assert got["action"] == "skip"
+        assert self.loads == 0
+
+    def test_the_sibling_is_read_once_on_mismatch(self):
+        # The one read the split pays for, and only once per classification.
+        self._classify(self.IDS[:2])
+        assert self.loads == 1
+
+    def test_missing_loader_reads_as_unrecorded(self):
+        # A caller that supplies none (or a pure caller with no store in
+        # scope) has no recorded set to diff: today's rewrite, counted apart.
+        got = classify_leaf_identity(
+            {"semantic_hash": self.SEM, "granules_sha256": granules_sha256(self.IDS)},
+            semantic_hash=self.SEM,
+            planned_ids=self.IDS[:2],
+        )
+        assert got == {"action": "rewrite", "classification": "unrecorded-ids", "missing": []}
 
     def test_expansion_rewrites(self):
-        got = classify_leaf_identity(
-            self._recorded(), semantic_hash=self.SEM, planned_ids=self.IDS + ["s3://b/g4.h5"]
-        )
+        got = self._classify(self.IDS + ["s3://b/g4.h5"])
         assert got == {"action": "rewrite", "classification": "expansion", "missing": []}
 
     def test_pure_contraction_refuses_and_names_ids(self):
-        got = classify_leaf_identity(
-            self._recorded(), semantic_hash=self.SEM, planned_ids=self.IDS[:2]
-        )
+        got = self._classify(self.IDS[:2])
         assert got["action"] == "refuse"
         assert got["classification"] == "contraction"
         assert got["missing"] == ["s3://b/g3.h5"]
@@ -232,8 +274,7 @@ class TestClassifyLeafIdentity:
         # The ruled predicate is recorded - planned != {} — NOT strict subset:
         # the planned set can even be LARGER while data drops (the upstream
         # purge behind a fresh catalog query, the espg contraction ruling).
-        planned = self.IDS[:2] + ["s3://b/new1.h5", "s3://b/new2.h5"]
-        got = classify_leaf_identity(self._recorded(), semantic_hash=self.SEM, planned_ids=planned)
+        got = self._classify(self.IDS[:2] + ["s3://b/new1.h5", "s3://b/new2.h5"])
         assert got["action"] == "refuse"
         assert got["classification"] == "mixed"
         assert got["missing"] == ["s3://b/g3.h5"]
@@ -241,9 +282,7 @@ class TestClassifyLeafIdentity:
     def test_contraction_beats_semantic_mismatch(self):
         # Dropping inputs refuses even when the semantic hash also changed —
         # the guard is about data loss, not intent drift.
-        got = classify_leaf_identity(
-            self._recorded(semantic="b" * 64), semantic_hash=self.SEM, planned_ids=self.IDS[:1]
-        )
+        got = self._classify(self.IDS[:1], semantic="b" * 64)
         assert got["action"] == "refuse"
         assert got["missing"] == sorted(self.IDS[1:])
 
@@ -251,33 +290,27 @@ class TestClassifyLeafIdentity:
         got = classify_leaf_identity(None, semantic_hash=self.SEM, planned_ids=self.IDS)
         assert got == {"action": "rewrite", "classification": "no-sidecar", "missing": []}
 
-    def test_pre388_sidecar_on_mismatch_rewrites(self):
+    def test_absent_sibling_on_mismatch_rewrites(self):
         # Hash mismatch + no recorded id list: undecidable, today's rewrite.
-        got = classify_leaf_identity(
-            self._recorded(with_ids=False), semantic_hash=self.SEM, planned_ids=self.IDS[:2]
-        )
+        got = self._classify(self.IDS[:2], sibling=False)
         assert got == {"action": "rewrite", "classification": "unrecorded-ids", "missing": []}
 
     def test_semantic_mismatch_with_equal_sets_rewrites_not_refuses(self):
-        got = classify_leaf_identity(
-            self._recorded(semantic="b" * 64), semantic_hash=self.SEM, planned_ids=self.IDS
-        )
+        got = self._classify(self.IDS, semantic="b" * 64)
         assert got == {"action": "rewrite", "classification": "semantic-mismatch", "missing": []}
 
     def test_null_recorded_semantic_never_skips(self):
         # Fleet-written pre-#388 vector sidecars record semantic_hash null
         # (the Lambda handler passes none): never provably current.
-        got = classify_leaf_identity(
-            self._recorded(semantic=None), semantic_hash=self.SEM, planned_ids=self.IDS
-        )
+        got = self._classify(self.IDS, semantic=None)
         assert got["action"] == "rewrite"
 
     def test_caller_without_semantic_hash_never_skips(self):
-        got = classify_leaf_identity(self._recorded(), semantic_hash=None, planned_ids=self.IDS)
+        got = self._classify(self.IDS, want=None)
         assert got["action"] == "rewrite"
 
     def test_empty_planned_set_is_pure_contraction(self):
-        got = classify_leaf_identity(self._recorded(), semantic_hash=self.SEM, planned_ids=[])
+        got = self._classify([])
         assert got["action"] == "refuse"
         assert got["classification"] == "contraction"
         assert got["missing"] == sorted(self.IDS)
@@ -286,23 +319,65 @@ class TestClassifyLeafIdentity:
         # None is UNKNOWN, not empty: it must not diff to "every recorded id
         # was dropped" and refuse — the maximally ambiguous input takes the
         # conservative rewrite, the same direction as every other ambiguity.
-        got = classify_leaf_identity(self._recorded(), semantic_hash=self.SEM, planned_ids=None)
+        got = self._classify(None)
         assert got == {"action": "rewrite", "classification": "unknown-planned", "missing": []}
+        assert self.loads == 0
 
     def test_planned_ids_are_iterated_not_truth_tested(self):
         # A numpy id array raises ValueError on a bare truthiness test; the
         # planned set is iterated instead, so array-shaped callers work.
-        planned = np.array(self.IDS)
-        got = classify_leaf_identity(self._recorded(), semantic_hash=self.SEM, planned_ids=planned)
-        assert got["action"] == "skip"
-        empty = classify_leaf_identity(
-            self._recorded(), semantic_hash=self.SEM, planned_ids=np.array([], dtype=object)
-        )
+        assert self._classify(np.array(self.IDS))["action"] == "skip"
+        empty = self._classify(np.array([], dtype=object))
         assert empty["action"] == "refuse"  # an empty ARRAY is still empty, not unknown
 
     def test_duplicate_drift_with_equal_sets_rewrites(self):
         # granules_sha256 keeps duplicates; the set diff dedups. Same set,
         # different multiset -> not current, not a contraction.
-        rec = self._recorded(ids=self.IDS + [self.IDS[0]])
-        got = classify_leaf_identity(rec, semantic_hash=self.SEM, planned_ids=self.IDS)
+        got = self._classify(self.IDS, ids=self.IDS + [self.IDS[0]])
         assert got == {"action": "rewrite", "classification": "id-multiset-drift", "missing": []}
+
+
+class TestLeafRecordedIds:
+    """The sibling read (issue #388): pairs with its sidecar or reads absent."""
+
+    IDS = ["s3://b/g2.h5", "s3://b/g1.h5"]
+
+    def _leaf(self, tmp_path):
+        leaf = hive.shard_leaf_path(str(tmp_path), WORD)
+        (pathlib.Path(leaf).parent).mkdir(parents=True, exist_ok=True)
+        return leaf
+
+    def _sidecar(self, ids):
+        return {"granules_sha256": granules_sha256(ids)}
+
+    def test_round_trips_the_recorded_set_sorted(self, tmp_path):
+        leaf = self._leaf(tmp_path)
+        assert write_granule_ids(leaf, self.IDS) is True
+        got = leaf_recorded_ids(leaf, self._sidecar(self.IDS))
+        assert got == sorted(self.IDS)
+
+    def test_absent_sibling_reads_none(self, tmp_path):
+        assert leaf_recorded_ids(self._leaf(tmp_path), self._sidecar(self.IDS)) is None
+
+    def test_unpaired_sibling_is_rejected(self, tmp_path):
+        # A torn rewrite (sibling from one run, sidecar from another) must
+        # read as unrecorded — a stale set would name the wrong granules as
+        # dropped, or hide real ones.
+        leaf = self._leaf(tmp_path)
+        write_granule_ids(leaf, self.IDS)
+        assert leaf_recorded_ids(leaf, self._sidecar(self.IDS + ["s3://b/g3.h5"])) is None
+
+    def test_malformed_sibling_reads_none(self, tmp_path):
+        leaf = self._leaf(tmp_path)
+        write_granule_ids(leaf, self.IDS)
+        path = pathlib.Path(granule_ids_path(leaf))
+        for body in ("[]", '"nope"', '{"granule_ids": "not-a-list"}', "{oh no"):
+            path.write_text(body)
+            assert leaf_recorded_ids(leaf, self._sidecar(self.IDS)) is None
+
+    def test_windowed_sibling_is_per_window(self, tmp_path):
+        # Same grammar as the sidecar: two windows of one shard cannot
+        # clobber each other's recorded set.
+        assert granule_ids_key("1121121.zarr") == "granules.json"
+        assert granule_ids_key("1121121_2025.zarr") == "granules_2025.json"
+        assert granule_ids_key("2025.zarr", "morton-hive/3") == "2025.granules.json"

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -2198,11 +2198,21 @@ class TestRunnerWiring:
         # leaf, sidecar and recorded id list all untouched by the refusal
         assert read_sidecar(leaf) == sidecar
         assert read_granule_ids(leaf) == recorded_ids
+        # ...and the refusal's ONLY durable trace: the store-root manifest,
+        # carrying the full diff a truncated log line cannot (issue #388).
+        manifest = json.loads(open(s2["refusal_manifest_path"]).read())
+        assert manifest["cells_refused"] == 1
+        unit = manifest["units"][0]
+        assert unit["shard_key"] == int(shard) and unit["identity"] == "contraction"
+        assert unit["missing_granules"] == [_rec(2)["s3"]]
+        assert os.path.basename(s2["refusal_manifest_path"]).startswith("refusals_")
 
         s3 = agg(cfg, catalog=contracted, store=root, backend="local", allow_contraction=True)
         assert len(calls) == 2  # the flag proceeds as a normal D4 rewrite
         assert s3["cells_refused"] == 0 and s3["cells_with_data"] == 1
         assert read_granule_ids(leaf)["granule_ids"] == [_rec(1)["s3"]]
+        # Ruled (9)(a): a run with nothing refused writes no manifest.
+        assert s3["refusal_manifest_path"] is None
 
     def test_lambda_hive_fires_async_setup_after_ping(self, monkeypatch, cfg, tmp_path):
         # Issue #252 hybrid: a hive lambda run dispatches NO synchronous

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -981,9 +981,13 @@ class TestProcessAndWriteHive:
                 continue
             if dirpath.endswith(".zarr") or ".zarr" + os.sep in dirpath:
                 continue  # inside a leaf: vanilla zarr v3, its own business
-            # An intermediate digit node: no objects (zarr.json or otherwise),
-            # only digit children and leaf dirs.
-            assert filenames == [], f"object above the leaf at {dirpath}: {filenames}"
+            # An intermediate digit node: no ZARR metadata, only digit
+            # children, leaf dirs, and the leaf's own JSON siblings (the D20
+            # stats sidecar, its issue #388 granule-id list, the D22 sub-map).
+            assert all(f.endswith(".json") for f in filenames), (
+                f"non-JSON object above the leaf at {dirpath}: {filenames}"
+            )
+            assert "zarr.json" not in filenames, f"zarr metadata above the leaf at {dirpath}"
             for d in dirnames:
                 assert d.endswith(".zarr") or (len(d) == 1 and d in "1234"), (
                     f"non-hive child {d!r} at {dirpath}"
@@ -1248,13 +1252,14 @@ class TestLeafSkipIfCurrent:
         assert meta["semantic_hash"] == "f" * 64
 
     def test_unrecorded_ids_rewrites_with_its_own_classification(self, monkeypatch, cfg, tmp_path):
-        # A pre-#388 sidecar records no granule_ids: any mismatch classifies
-        # ``unrecorded-ids`` and rewrites — the guard is INERT there, and the
-        # classification is what the run stats count apart (cells_unrecorded).
-        from zagg.telemetry import write_sidecar
+        # A leaf written before issue #388 has no granule-id sibling beside
+        # its sidecar, so any mismatch classifies ``unrecorded-ids`` and
+        # rewrites — the guard is INERT there, and the classification is what
+        # the run stats count apart (cells_unrecorded).
+        from zagg.telemetry import granule_ids_path
 
         grid, shard, root, record = self._write_leaf(monkeypatch, cfg, tmp_path)
-        write_sidecar(hive.shard_leaf_path(root, shard), {**record, "granule_ids": None})
+        os.remove(granule_ids_path(hive.shard_leaf_path(root, shard)))
         calls = self._counting_fake(monkeypatch, grid)
         meta = hive.process_and_write_hive(
             shard, [self.URLS[0]], grid, {}, root, cfg, store_kwargs={}, skip_if_current=True
@@ -2066,7 +2071,7 @@ class TestRunnerWiring:
         from zagg import runner
         from zagg.grids import from_config
         from zagg.runner import agg
-        from zagg.telemetry import read_sidecar
+        from zagg.telemetry import read_granule_ids, read_sidecar
 
         cfg.output["store_layout"] = "hive"
         catalog_path, shard = self._catalog(tmp_path)
@@ -2087,7 +2092,9 @@ class TestRunnerWiring:
         assert (s1["objects_touched"], s1["touch_failures"]) == (0, 0)
         leaf = hive.shard_leaf_path(root, shard)
         sidecar = read_sidecar(leaf)
-        assert sidecar["granule_ids"] == [_rec(1)["s3"]]
+        # The id LIST is the sidecar's sibling, never a record key (issue #388).
+        assert "granule_ids" not in sidecar
+        assert read_granule_ids(leaf)["granule_ids"] == [_rec(1)["s3"]]
 
         # Age the store-ROOT objects: ensure_manifest early-returns on a
         # frozen-key match, so without the phase-3 root touch they would keep
@@ -2144,7 +2151,7 @@ class TestRunnerWiring:
         from zagg import runner
         from zagg.grids import from_config
         from zagg.runner import agg
-        from zagg.telemetry import read_sidecar
+        from zagg.telemetry import read_granule_ids, read_sidecar
 
         cfg.output["store_layout"] = "hive"
         shard = _shard_word()
@@ -2182,17 +2189,20 @@ class TestRunnerWiring:
         agg(cfg, catalog=full, store=root, backend="local")
         leaf = hive.shard_leaf_path(root, shard)
         sidecar = read_sidecar(leaf)
-        assert len(calls) == 1 and len(sidecar["granule_ids"]) == 2
+        recorded_ids = read_granule_ids(leaf)
+        assert len(calls) == 1 and len(recorded_ids["granule_ids"]) == 2
 
         s2 = agg(cfg, catalog=contracted, store=root, backend="local")
         assert len(calls) == 1  # refused: the fold never ran
         assert s2["cells_refused"] == 1 and s2["cells_error"] == 0
-        assert read_sidecar(leaf) == sidecar  # leaf + sidecar untouched
+        # leaf, sidecar and recorded id list all untouched by the refusal
+        assert read_sidecar(leaf) == sidecar
+        assert read_granule_ids(leaf) == recorded_ids
 
         s3 = agg(cfg, catalog=contracted, store=root, backend="local", allow_contraction=True)
         assert len(calls) == 2  # the flag proceeds as a normal D4 rewrite
         assert s3["cells_refused"] == 0 and s3["cells_with_data"] == 1
-        assert read_sidecar(leaf)["granule_ids"] == [_rec(1)["s3"]]
+        assert read_granule_ids(leaf)["granule_ids"] == [_rec(1)["s3"]]
 
     def test_lambda_hive_fires_async_setup_after_ping(self, monkeypatch, cfg, tmp_path):
         # Issue #252 hybrid: a hive lambda run dispatches NO synchronous

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -7,6 +7,7 @@ retry semantics (D4), and the local runner's hive write path.
 
 import json
 import os
+import time
 from dataclasses import asdict
 
 import numpy as np
@@ -1790,6 +1791,23 @@ class TestHiveProfileWritePhase:
 
         leaf = hive.shard_leaf_path(root, shard)
         assert hive.read_commit(open_store(leaf))["complete"] is True
+
+    def test_write_phase_covers_the_granule_id_sibling(self, monkeypatch, cfg, tmp_path):
+        # The bracket must account for EVERY PUT the seam makes (issue #388):
+        # phase_timings["write"] flattens to phase_write on the D20 record and
+        # into every run parquet, so a PUT outside it silently under-reports.
+        import zagg.telemetry as telemetry
+
+        real = telemetry.write_granule_ids
+
+        def slow(*a, **k):
+            time.sleep(0.05)
+            return real(*a, **k)
+
+        monkeypatch.setattr(telemetry, "write_granule_ids", slow)
+        fake = self._profiled_fake(self._grid(cfg), ragged={"h": ([np.array([1.0, 2.0])], [0])})
+        _grid, _shard, _root, meta = self._run(monkeypatch, cfg, tmp_path, fake)
+        assert meta["phase_timings"]["write"] >= 0.05
 
     def test_sharded_default_path_stamps_write_when_timed(self, monkeypatch, cfg, tmp_path):
         # Sharded edition: the post-stream write_leaf_to_zarr bracket lands in

--- a/tests/test_hive_windows.py
+++ b/tests/test_hive_windows.py
@@ -1651,6 +1651,9 @@ class TestProcessAndWriteHiveWindowed:
             skip_if_current=True,
         )
         assert skipped["current"] is True and skipped["identity"] == "equal"
+        # The gate's verdict names the (shard, WINDOW) unit, not just the
+        # shard — what the refusal manifest keys its entries on (issue #388).
+        assert skipped["window"] == "2019"
         # ...and the touch moved exactly the 2019 unit's footprint.
         assert skipped["touched_objects"] > 0 and skipped["touch_failed"] == 0
         inside = [os.path.join(d, n) for d, _s, files in os.walk(leaf) for n in files] + [

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -25,7 +25,7 @@ def _fresh_client_cache(monkeypatch):
     monkeypatch.setattr(lifecycle, "_CLIENTS", {})
 
 
-def _make_unit(tmp_path, *, submap=True, column=False):
+def _make_unit(tmp_path, *, submap=True, column=False, granule_ids=True):
     """A committed-looking local unit: leaf tree + sidecar siblings."""
     node = tmp_path / "store" / "-5" / "1"
     leaf = node / LEAF
@@ -34,6 +34,8 @@ def _make_unit(tmp_path, *, submap=True, column=False):
     (leaf / "m" / "c" / "0").write_bytes(b"\x00\x01")
     (leaf / "coverage.moc").write_bytes(b"moc")
     (node / "stats.json").write_bytes(b"{}")
+    if granule_ids:
+        (node / "granules.json").write_bytes(b"{}")
     if submap:
         (node / "shardmap.json").write_bytes(b"{}")
     column_path = None
@@ -68,8 +70,9 @@ class TestTouchLocal:
         aged = _age(node)
         counts = lifecycle.touch_current_unit(str(leaf))
         after = _mtimes(node)
-        # Leaf tree (coverage.moc included) + stats.json + shardmap.json.
-        assert counts == {"touched": 5, "failed": 0}
+        # Leaf tree (coverage.moc included) + stats.json + granules.json +
+        # shardmap.json.
+        assert counts == {"touched": 6, "failed": 0}
         assert all(mtime > aged for mtime in after.values())
 
     def test_column_tree_and_sidecar_ride_the_footprint(self, tmp_path):
@@ -78,7 +81,7 @@ class TestTouchLocal:
         counts = lifecycle.touch_current_unit(str(leaf), column_path=str(column))
         after = _mtimes(node)
         # + the column's two objects and its own stats sidecar.
-        assert counts == {"touched": 8, "failed": 0}
+        assert counts == {"touched": 9, "failed": 0}
         assert all(mtime > aged for mtime in after.values())
 
     def test_absent_column_is_left_out(self, tmp_path):
@@ -86,13 +89,20 @@ class TestTouchLocal:
         # of the footprint — nothing to touch, nothing to fail.
         node, leaf, _column = _make_unit(tmp_path)
         counts = lifecycle.touch_current_unit(str(leaf), column_path=None)
-        assert counts["failed"] == 0 and counts["touched"] == 5
+        assert counts["failed"] == 0 and counts["touched"] == 6
 
     def test_missing_submap_is_neither_touched_nor_failed(self, tmp_path):
         # A unit legitimately has no sub-map (non-HEALPix, id-less entries).
         _node, leaf, _column = _make_unit(tmp_path, submap=False)
         counts = lifecycle.touch_current_unit(str(leaf))
-        assert counts == {"touched": 4, "failed": 0}
+        assert counts == {"touched": 5, "failed": 0}
+
+    def test_missing_granule_ids_sibling_is_neither_touched_nor_failed(self, tmp_path):
+        # A leaf written before issue #388 (or one whose fail-open sibling PUT
+        # was lost) has no granules.json: absent, not a failure.
+        _node, leaf, _column = _make_unit(tmp_path, granule_ids=False)
+        counts = lifecycle.touch_current_unit(str(leaf))
+        assert counts == {"touched": 5, "failed": 0}
 
     def test_a_failing_utime_counts_and_never_raises(self, tmp_path, monkeypatch):
         node, leaf, _column = _make_unit(tmp_path)
@@ -106,7 +116,7 @@ class TestTouchLocal:
 
         monkeypatch.setattr(lifecycle.os, "utime", flaky)
         counts = lifecycle.touch_current_unit(str(leaf))
-        assert counts == {"touched": 4, "failed": 1}
+        assert counts == {"touched": 5, "failed": 1}
 
     def test_footprint_assembly_failure_is_fail_open(self):
         # A leaf name the spec-keyed naming seam refuses (not a .zarr name)
@@ -128,6 +138,7 @@ class TestTouchLocal:
         outsiders = [
             node / "123_2020.zarr" / "zarr.json",  # the sibling window's leaf
             node / "stats_2020.json",  # ...and its sidecar
+            node / "granules_2020.json",  # ...and its recorded id list
             node / "shardmap_2020.json",  # ...and its sub-map
             # A key that is a STRING prefix extension of the leaf's: matched
             # by a prefix-less LIST, excluded by the trailing slash.
@@ -233,6 +244,7 @@ class TestTouchS3:
         calls = client.copy_object.call_args_list
         assert {c.kwargs["Key"] for c in calls} == set(self.TREE_KEYS) | {
             "store/-5/1/stats.json",
+            "store/-5/1/granules.json",
             "store/-5/1/shardmap.json",
         }
         for c in calls:
@@ -242,7 +254,7 @@ class TestTouchS3:
             # LIST/HEAD omit the class for STANDARD; the copy must still name
             # one, or REPLACE resets whatever the object had.
             assert c.kwargs["StorageClass"] == "STANDARD"
-        assert counts == {"touched": 5, "failed": 0}
+        assert counts == {"touched": 6, "failed": 0}
 
     def test_the_storage_class_is_preserved_not_reset_to_standard(self, monkeypatch):
         # MetadataDirective=REPLACE covers SYSTEM metadata, so a copy with no
@@ -266,10 +278,11 @@ class TestTouchS3:
             self.TREE_KEYS[1]: "STANDARD_IA",
             # The siblings have no LIST entry: one HEAD each buys the class.
             "store/-5/1/stats.json": "STANDARD_IA",
+            "store/-5/1/granules.json": "STANDARD_IA",
             "store/-5/1/shardmap.json": "STANDARD_IA",
         }
-        assert client.head_object.call_count == 2  # named objects only
-        assert counts == {"touched": 4, "failed": 0}
+        assert client.head_object.call_count == 3  # named objects only
+        assert counts == {"touched": 5, "failed": 0}
 
     def test_absent_sibling_is_neither_touched_nor_failed(self, monkeypatch):
         # copy of a missing key (e.g. no sub-map was ever written) NoSuchKey-s;
@@ -283,7 +296,7 @@ class TestTouchS3:
         err = ClientError({"Error": {"Code": "AccessDenied"}}, "CopyObject")
         self._client(monkeypatch, copy_error=err)
         counts = lifecycle.touch_current_unit(f"s3://{self.BUCKET}/store/-5/1/{LEAF}")
-        assert counts == {"touched": 0, "failed": 5}
+        assert counts == {"touched": 0, "failed": 6}
 
     def test_a_list_fault_aborts_fail_open(self, monkeypatch):
         client = self._client(monkeypatch)

--- a/tests/test_raster_pipeline.py
+++ b/tests/test_raster_pipeline.py
@@ -1420,13 +1420,15 @@ class TestRasterHiveWorker:
         assert len(calls) == 1 and meta["identity"] == "no-sidecar"
 
     def test_unrecorded_ids_rewrites_with_its_own_classification(self, tmp_path, monkeypatch):
-        # A pre-#388 sidecar records no granule_ids: the guard is INERT, and
-        # the classification is what the run stats count apart.
+        # A leaf written before issue #388 has no granule-id sibling: the
+        # guard is INERT, and the classification is what run stats count apart.
+        import os
+
         from zagg.processing.raster import process_and_write_raster_hive
-        from zagg.telemetry import read_sidecar, write_sidecar
+        from zagg.telemetry import granule_ids_path
 
         cfg, grid, shard, granules, root, leaf = self._committed_leaf_with_sidecar(tmp_path)
-        write_sidecar(leaf, {**read_sidecar(leaf), "granule_ids": None})
+        os.remove(granule_ids_path(leaf))
         calls = self._counting(monkeypatch)
         meta = process_and_write_raster_hive(
             shard, granules[:1], grid, root, cfg, store_kwargs={}, skip_if_current=True

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -1996,12 +1996,18 @@ class TestRasterLocalRerun:
         s2 = agg(cfg, catalog=contracted, backend="local", max_workers=2)
         assert s2["cells_refused"] == 1 and s2["cells_error"] == 0
         assert s2["cells_with_data"] == 0
+        # The raster refusal is durable at the store root too (issue #388):
+        # same manifest, raster id space (STAC item ids, not granule urls).
+        manifest = json.loads(open(s2["refusal_manifest_path"]).read())
+        assert manifest["cells_refused"] == 1
+        assert manifest["units"][0]["missing_granules"] == ["g1"]
         # The committed leaf is protected: still the two-timestep axis.
         red = open_array(leaf + f"/{grid.group_path}/red", zarr_format=3, consolidated=False)
         assert red.shape[0] == 2
 
         s3 = agg(cfg, catalog=contracted, backend="local", max_workers=2, allow_contraction=True)
         assert s3["cells_refused"] == 0 and s3["cells_with_data"] == 1
+        assert s3["refusal_manifest_path"] is None
         red = open_array(leaf + f"/{grid.group_path}/red", zarr_format=3, consolidated=False)
         assert red.shape[0] == 1
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1569,6 +1569,10 @@ class TestSummaryKeysByteIdentical:
         "backend",
         "results",
         "run_stats_path",  # run-level stats parquet (issue #297 phase 3)
+        # Store-root refusal manifest (issue #388): always present, None
+        # unless a unit refused. LOCAL-only — the fleet has no once-per-run
+        # worker-side write seam (D8), so _LAMBDA_KEYS below does not carry it.
+        "refusal_manifest_path",
     } | _IDENTITY_KEYS
     _LAMBDA_KEYS = {
         "total_cells",
@@ -4779,6 +4783,20 @@ class TestCliContractionGuardSurface:
         assert "Done: 0 cells with data" in out
         assert "3 refused" in out
         assert "--allow-contraction" in out
+
+    def test_refusals_point_at_the_durable_manifest(self, monkeypatch, capsys):
+        # The log truncates to five missing ids per unit; the manifest is the
+        # full diff, so the CLI must say where it is (issue #388, ruled (9)).
+        summary = {
+            **self.SUMMARY,
+            "cells_current": 0,
+            "cells_refused": 3,
+            "cells_unrecorded": 0,
+            "refusal_manifest_path": "/store/refusals_20260807T101112Z_cafe01.json",
+        }
+        self._run(monkeypatch, [], summary)
+        out = capsys.readouterr().out
+        assert "refusals_20260807T101112Z_cafe01.json" in out
 
     def test_skip_only_run_reports_current(self, monkeypatch, capsys):
         summary = {**self.SUMMARY, "cells_current": 7, "cells_refused": 0, "cells_unrecorded": 2}

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -8,12 +8,16 @@ from zagg.telemetry import (
     build_record,
     failure_record,
     flatten_record,
+    granule_ids_key,
+    granule_ids_path,
     granules_sha256,
     merge,
+    read_granule_ids,
     read_sidecar,
     run_parquet_key,
     sidecar_key,
     sidecar_path,
+    write_granule_ids,
     write_run_parquet,
     write_sidecar,
 )
@@ -477,6 +481,59 @@ class TestSidecarIO:
         assert read_sidecar(str(tmp_path / "-4" / "-4.zarr")) is None
 
 
+class TestGranuleIdsSibling:
+    """The recorded id list is its own sibling (issue #388, ruled (6)(c)):
+    same spec-keyed grammar as the sidecar, self-pairing, fail-open."""
+
+    IDS = ["s3://b/g2.h5", "s3://b/g1.h5"]
+
+    def test_key_shares_the_sidecar_grammar(self):
+        from zagg.windows import leaf_name_v3
+
+        assert granule_ids_key("-4211322.zarr") == "granules.json"
+        assert granule_ids_key("-4211322_20260713.zarr") == "granules_20260713.json"
+        assert granule_ids_key(leaf_name_v3("2019"), SPEC_V3) == "2019.granules.json"
+        # And the same strictness: an unknown spec cannot silently fall back.
+        with pytest.raises(ValueError, match="unknown store spec"):
+            granule_ids_key("-4211322.zarr", "morton-hive/4")
+
+    def test_path_is_a_sibling_beside_the_sidecar(self):
+        leaf = "/root/-4/2/1/1/3/2/2/-4211322.zarr"
+        assert granule_ids_path(leaf) == "/root/-4/2/1/1/3/2/2/granules.json"
+
+    def test_write_read_roundtrip_sorted_and_self_hashing(self, tmp_path):
+        leaf = str(tmp_path / "-4" / "2" / "-42.zarr")
+        assert write_granule_ids(leaf, self.IDS) is True
+        got = read_granule_ids(leaf)
+        assert got["granule_ids"] == sorted(self.IDS)
+        # Self-pairing: the object carries the hash of the list it holds, so a
+        # reader can reject a sibling that does not belong to the sidecar.
+        assert got["granules_sha256"] == granules_sha256(self.IDS)
+        assert (tmp_path / "-4" / "2" / "granules.json").exists()
+
+    def test_empty_id_set_records_an_empty_list(self, tmp_path):
+        leaf = str(tmp_path / "-4" / "2" / "-42.zarr")
+        write_granule_ids(leaf, [])
+        got = read_granule_ids(leaf)
+        assert got["granule_ids"] == [] and got["granules_sha256"] is None
+
+    def test_write_is_fail_open(self, tmp_path, monkeypatch):
+        # Called from the seam with the leaf already COMMITTED: a failed PUT
+        # must count as "no recorded set" on a later run, never fail the unit.
+        import obstore
+
+        def boom(*a, **k):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(obstore, "put", boom)
+        leaf = str(tmp_path / "-4" / "2" / "-42.zarr")
+        assert write_granule_ids(leaf, self.IDS) is False
+
+    def test_read_absent_returns_none(self, tmp_path):
+        (tmp_path / "-4").mkdir()
+        assert read_granule_ids(str(tmp_path / "-4" / "-4.zarr")) is None
+
+
 class TestRunParquet:
     """Run-level parquet rows (issue #297 phase 3): flattened records plus
     dispatcher-built failure rows, round-trippable by fastparquet and pyarrow."""
@@ -690,23 +747,27 @@ class TestRunParquetShardKeyExactness:
 
 
 class TestRecordedIdentity:
-    """Issue #388 record keys: the granule-id list behind granules_sha256,
-    the #383 column basename, and the metadata semantic-hash fallback."""
+    """Issue #388 record keys: the catalog hash (the id LIST is a sibling
+    object, not a record key), the #383 column basename, and the metadata
+    semantic-hash fallback."""
 
-    def test_granule_ids_recorded_sorted_with_duplicates(self):
-        # The hash's own canonical form: sorted, duplicates kept — so the
-        # recorded list regenerates the recorded hash exactly.
+    def test_the_id_list_is_never_a_record_key(self):
+        # Ruled (question (6)(c)): the record carries the HASH only, so the
+        # per-shard identity GETs and the response envelope stay small.
         rec = build_record(
             shard_key=1,
             metadata={"duration_s": 1.0},
             granule_ids=["s3://b/g2.h5", "s3://b/g1.h5", "s3://b/g1.h5"],
         )
-        assert rec["granule_ids"] == ["s3://b/g1.h5", "s3://b/g1.h5", "s3://b/g2.h5"]
-        assert rec["granules_sha256"] == granules_sha256(rec["granule_ids"])
+        assert "granule_ids" not in rec
+        # Duplicates are kept: the hash is over the sorted multiset.
+        assert rec["granules_sha256"] == granules_sha256(
+            ["s3://b/g1.h5", "s3://b/g1.h5", "s3://b/g2.h5"]
+        )
+        assert rec["n_granules"] == 3
 
-    def test_granule_ids_absent_reads_none(self):
+    def test_granules_sha256_absent_reads_none(self):
         rec = build_record(shard_key=1, metadata={"duration_s": 1.0})
-        assert rec["granule_ids"] is None
         assert rec["granules_sha256"] is None
 
     def test_leaf_column_rides_metadata(self):
@@ -747,10 +808,10 @@ class TestRecordedIdentity:
         b = _record()
         b["timestamp"] = a["timestamp"]
         folded = merge([a, b])
-        assert folded["granule_ids"] == a["granule_ids"]
+        assert folded["granules_sha256"] == a["granules_sha256"]
         assert folded["leaf_column"] is None  # absent in both -> stays None
         mismatched = _record(granules=("s3://b/other.h5",))
-        assert merge([a, mismatched])["granule_ids"] is None
+        assert merge([a, mismatched])["granules_sha256"] is None
 
     def test_merge_folds_leaf_column_equal_or_none(self):
         # The reading that matters for a windowed node: two windows of one
@@ -769,14 +830,14 @@ class TestRecordedIdentity:
         # with one that wrote none reads as "no common column").
         assert merge([with_column("all.pyramid.zarr"), _record()])["leaf_column"] is None
 
-    def test_merge_single_record_does_not_alias_the_id_list(self):
+    def test_merge_single_record_does_not_alias_nested_dicts(self):
         a = _record()
+        a["content_hashes"] = {"arrays": {"h_li": "ab"}, "combined": "cd"}
         folded = merge([a])
-        assert folded["granule_ids"] == a["granule_ids"]
-        folded["granule_ids"].append("mutated")
-        assert a["granule_ids"][-1] != "mutated"
+        folded["content_hashes"]["arrays"]["h_li"] = "mutated"
+        assert a["content_hashes"]["arrays"]["h_li"] == "ab"
 
-    def test_flatten_carries_leaf_column_not_granule_ids(self):
+    def test_flatten_carries_leaf_column_not_the_id_list(self):
         rec = build_record(
             shard_key=1, metadata={"duration_s": 1.0, "leaf_column": "all.pyramid.zarr"}
         )

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,5 +1,7 @@
 """Tests for the per-shard stats schema + merge fold (issue #297 phase 1)."""
 
+import pathlib
+
 import pytest
 
 from zagg.telemetry import (
@@ -14,10 +16,12 @@ from zagg.telemetry import (
     merge,
     read_granule_ids,
     read_sidecar,
+    refusal_manifest_key,
     run_parquet_key,
     sidecar_key,
     sidecar_path,
     write_granule_ids,
+    write_refusal_manifest,
     write_run_parquet,
     write_sidecar,
 )
@@ -479,6 +483,71 @@ class TestSidecarIO:
     def test_read_absent_returns_none(self, tmp_path):
         (tmp_path / "-4").mkdir()
         assert read_sidecar(str(tmp_path / "-4" / "-4.zarr")) is None
+
+
+class TestRefusalManifest:
+    """The store-root refusal record (issue #388, ruled (9)(c)+(a))."""
+
+    def _refused(self, shard, missing, *, window=None, identity="contraction"):
+        return {
+            "shard_key": shard,
+            "window": window,
+            "identity": identity,
+            "refused": True,
+            "missing_granules": missing,
+        }
+
+    def test_key_shape_and_traversal_guard(self):
+        key = refusal_manifest_key("abc123", timestamp="20260718T010203Z")
+        assert key == "refusals_20260718T010203Z_abc123.json"
+        # Outside the run-record glob: a refusal object must never read as a
+        # shard run record to the sweep's discovery scan.
+        assert not key.startswith("stats_") and not key.endswith(".parquet")
+        for run_id, ts in (("../../etc/passwd", "20260718T010203Z"), ("abc123", "../evil")):
+            with pytest.raises(ValueError):
+                refusal_manifest_key(run_id, timestamp=ts)
+
+    def test_writes_the_full_diff_per_unit(self, tmp_path):
+        import json
+
+        root = str(tmp_path / "store")
+        path = write_refusal_manifest(
+            root,
+            [
+                self._refused(7, ["s3://b/g9.h5", "s3://b/g8.h5"]),
+                self._refused(3, ["s3://b/g1.h5"], window="2019", identity="mixed"),
+            ],
+            run_id="cafe01",
+            timestamp="20260718T010203Z",
+            semantic_hash="a" * 64,
+        )
+        assert path.endswith("/refusals_20260718T010203Z_cafe01.json")
+        body = json.loads(pathlib.Path(path).read_bytes())
+        assert body["spec"] == "zagg-refusals/1"
+        assert body["run_id"] == "cafe01" and body["semantic_hash"] == "a" * 64
+        assert body["cells_refused"] == 2 and isinstance(body["zagg_version"], str)
+        # Sorted by (shard, window) so two runs over one refusal set compare.
+        assert [(u["shard_key"], u["window"]) for u in body["units"]] == [(3, "2019"), (7, None)]
+        mixed, contraction = body["units"]
+        assert mixed["identity"] == "mixed" and mixed["n_missing"] == 1
+        # The FULL list, not the log's first five — that is the whole point.
+        assert contraction["missing_granules"] == ["s3://b/g9.h5", "s3://b/g8.h5"]
+        assert contraction["n_missing"] == 2
+
+    def test_nothing_refused_writes_nothing(self, tmp_path):
+        # Ruled (9)(a): a pure-skip run stays row-less AND object-less.
+        root = tmp_path / "store"
+        assert write_refusal_manifest(str(root), [], run_id="cafe01") is None
+        assert not root.exists()
+
+    def test_write_is_fail_open(self, tmp_path, monkeypatch):
+        import obstore
+
+        monkeypatch.setattr(obstore, "put", lambda *a, **k: (_ for _ in ()).throw(RuntimeError()))
+        got = write_refusal_manifest(
+            str(tmp_path / "store"), [self._refused(1, ["s3://b/g1.h5"])], run_id="cafe01"
+        )
+        assert got is None
 
 
 class TestGranuleIdsSibling:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -549,6 +549,22 @@ class TestRefusalManifest:
         )
         assert got is None
 
+    def test_composition_is_fail_open_too(self, tmp_path):
+        # It runs BEFORE the summary and the run-stats parquet, so a raise
+        # while building the units would destroy the run record of a run that
+        # already did all its work. A malformed missing_granules (the shape
+        # the isinstance check one line up already anticipates) and the
+        # unbounded-size raiser must both cost only the manifest.
+        root = str(tmp_path / "store")
+        assert write_refusal_manifest(root, [self._refused(1, 7)], run_id="cafe01") is None
+
+        class Boom(list):
+            def __iter__(self):
+                raise MemoryError("units too big")
+
+        big = self._refused(1, Boom(["s3://b/g1.h5"]))
+        assert write_refusal_manifest(root, [big], run_id="cafe01") is None
+
 
 class TestGranuleIdsSibling:
     """The recorded id list is its own sibling (issue #388, ruled (6)(c)):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -581,7 +581,7 @@ class TestRunParquet:
         assert table.num_rows == 3
         assert "invoked_by" in table.column_names
 
-    def test_column_round_trips_all_null_and_mixed(self, tmp_path):
+    def test_leaf_column_round_trips_all_null_and_mixed(self, tmp_path):
         """Issue #383's deferred key is the first ``_ROW_SCALARS`` string that
         is all-null in the overwhelming majority of runs; ``object_encoding=
         "utf8"`` is what keeps fastparquet from choking on that column (the
@@ -591,7 +591,7 @@ class TestRunParquet:
         def with_column(key, name=None):
             meta = {"duration_s": 1.0}
             if name is not None:
-                meta["column"] = name
+                meta["leaf_column"] = name
             return flatten_record(build_record(shard_key=key, metadata=meta))
 
         # All-null: the ordinary run, where no unit wrote a column.
@@ -599,7 +599,7 @@ class TestRunParquet:
             str(tmp_path / "none"), [with_column(1), with_column(2)], run_id="bb01"
         )
         df = pd.read_parquet(allnull, engine="fastparquet")
-        assert "column" in df.columns and df["column"].isna().all()
+        assert "leaf_column" in df.columns and df["leaf_column"].isna().all()
 
         # Mixed: one column-bearing leaf among plain ones, the shape D22
         # discovery actually queries.
@@ -609,12 +609,12 @@ class TestRunParquet:
             run_id="bb02",
         )
         df = pd.read_parquet(mixed, engine="fastparquet").set_index("shard_key")
-        assert df.loc[2, "column"] == "all.pyramid.zarr"
-        assert pd.isna(df.loc[1, "column"]) and pd.isna(df.loc[3, "column"])
+        assert df.loc[2, "leaf_column"] == "all.pyramid.zarr"
+        assert pd.isna(df.loc[1, "leaf_column"]) and pd.isna(df.loc[3, "leaf_column"])
         # pyarrow (the duckdb/Athena reader family) sees it as a string column.
         pa_parquet = pytest.importorskip("pyarrow.parquet")
         table = pa_parquet.read_table(mixed)
-        assert "column" in table.column_names
+        assert "leaf_column" in table.column_names
 
     def test_empty_rows_raise(self, tmp_path):
         with pytest.raises(ValueError, match="at least one"):
@@ -709,12 +709,14 @@ class TestRecordedIdentity:
         assert rec["granule_ids"] is None
         assert rec["granules_sha256"] is None
 
-    def test_column_rides_metadata(self):
+    def test_leaf_column_rides_metadata(self):
         # The #383 deferred run-record key: the worker stamps
-        # metadata["column"] iff the unit wrote a column artifact.
-        assert _record()["column"] is None
-        rec = build_record(shard_key=1, metadata={"duration_s": 1.0, "column": "all.pyramid.zarr"})
-        assert rec["column"] == "all.pyramid.zarr"
+        # metadata["leaf_column"] iff the unit wrote a column artifact.
+        assert _record()["leaf_column"] is None
+        rec = build_record(
+            shard_key=1, metadata={"duration_s": 1.0, "leaf_column": "all.pyramid.zarr"}
+        )
+        assert rec["leaf_column"] == "all.pyramid.zarr"
 
     def test_semantic_hash_falls_back_to_metadata(self):
         # Issue #388: the shared seams stamp metadata["semantic_hash"], so a
@@ -746,26 +748,26 @@ class TestRecordedIdentity:
         b["timestamp"] = a["timestamp"]
         folded = merge([a, b])
         assert folded["granule_ids"] == a["granule_ids"]
-        assert folded["column"] is None  # absent in both -> stays None
+        assert folded["leaf_column"] is None  # absent in both -> stays None
         mismatched = _record(granules=("s3://b/other.h5",))
         assert merge([a, mismatched])["granule_ids"] is None
 
-    def test_merge_folds_column_equal_or_none(self):
+    def test_merge_folds_leaf_column_equal_or_none(self):
         # The reading that matters for a windowed node: two windows of one
         # shard, each having written a column, roll up. Equal survives the
         # fold; a mismatch collapses, like every other identity field.
         def with_column(name):
             return build_record(
-                shard_key=1, metadata={"duration_s": 1.0, "column": name}, window="2019"
+                shard_key=1, metadata={"duration_s": 1.0, "leaf_column": name}, window="2019"
             )
 
         same = [with_column("all.pyramid.zarr"), with_column("all.pyramid.zarr")]
-        assert merge(same)["column"] == "all.pyramid.zarr"
+        assert merge(same)["leaf_column"] == "all.pyramid.zarr"
         mixed = [with_column("all.pyramid.zarr"), with_column("h_li.pyramid.zarr")]
-        assert merge(mixed)["column"] is None
+        assert merge(mixed)["leaf_column"] is None
         # None is absorbing on this key too (a column-writing unit rolled up
         # with one that wrote none reads as "no common column").
-        assert merge([with_column("all.pyramid.zarr"), _record()])["column"] is None
+        assert merge([with_column("all.pyramid.zarr"), _record()])["leaf_column"] is None
 
     def test_merge_single_record_does_not_alias_the_id_list(self):
         a = _record()
@@ -774,8 +776,10 @@ class TestRecordedIdentity:
         folded["granule_ids"].append("mutated")
         assert a["granule_ids"][-1] != "mutated"
 
-    def test_flatten_carries_column_not_granule_ids(self):
-        rec = build_record(shard_key=1, metadata={"duration_s": 1.0, "column": "all.pyramid.zarr"})
+    def test_flatten_carries_leaf_column_not_granule_ids(self):
+        rec = build_record(
+            shard_key=1, metadata={"duration_s": 1.0, "leaf_column": "all.pyramid.zarr"}
+        )
         row = flatten_record(rec)
-        assert row["column"] == "all.pyramid.zarr"
+        assert row["leaf_column"] == "all.pyramid.zarr"
         assert "granule_ids" not in row

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -591,6 +591,10 @@ class TestGranuleIdsSibling:
         assert write_granule_ids(leaf, self.IDS) is True
         got = read_granule_ids(leaf)
         assert got["granule_ids"] == sorted(self.IDS)
+        # Its OWN version marker, not the D20 record's schema_version: a
+        # record rev must not bump this object, nor this object the record.
+        assert got["spec"] == "zagg-granule-ids/1"
+        assert "schema_version" not in got
         # Self-pairing: the object carries the hash of the list it holds, so a
         # reader can reject a sibling that does not belong to the sidecar.
         assert got["granules_sha256"] == granules_sha256(self.IDS)

--- a/tools/generate_spec_fixtures.py
+++ b/tools/generate_spec_fixtures.py
@@ -424,10 +424,13 @@ def build(out: Path, kitchen_sink: bool, pyramid: dict | None = None) -> None:
         # wrote the leaf's column; record the raw knob, the decoded groups,
         # and the column's own O11 hashes so a spec-text decoder can be
         # asserted against committed bytes.
-        assert meta.get("column"), meta
+        # ``meta["leaf_column"]`` is the seam's own key (issue #388 renamed it
+        # from the SQL-reserved ``column``); the fixture's ``column`` block
+        # below is the fixture schema's name and stays as published.
+        assert meta.get("leaf_column"), meta
         expected["declared"] = pyramid
         expected["column"] = _column_expected(
-            out / leaf_rel.rsplit("/", 1)[0] / meta["column"], meta["column"]
+            out / leaf_rel.rsplit("/", 1)[0] / meta["leaf_column"], meta["leaf_column"]
         )
     expected_path = out.parent / f"{out.name}.expected.json"
     expected_path.write_text(json.dumps(expected, indent=1) + "\n")


### PR DESCRIPTION
Refs #388. Refs #402 (items (5)/(6)/(9)). Follows PR #397 (merged as `3f13af2`).

The three schema/artifact changes espg **ruled pre-merge** on the PR #397 thread ([the ratification comment](https://github.com/englacial/zagg/pull/397#issuecomment-5223154774)). PR #397 merged first, so they land here instead — unchanged in content. **Timing still matters**: these were ruled cheap *because the schema is unreleased*, and it still is. The D20 `column` key and the record-borne `granule_ids` exist on `main` only between `3f13af2` and this PR; landing before the next `*.*.*` tag preserves the "nothing published this spelling" premise the rulings rest on.

## Rulings landed

- [x] **(5)(c) — the D20 record/parquet key `column` renames to `leaf_column`** (`e00d7f4`). Every site: the seam metadata stamp (`hive.py`), `telemetry.build_record`'s key set, `_EQ_OR_NONE_KEYS` (both merge arms), `_ROW_SCALARS`/`flatten_record`, the parquet round-trip test, and `tools/generate_spec_fixtures.py`'s read of the seam's metadata. Two reasons, both recorded at the key: `column` is **SQL-reserved** in DuckDB and Trino/Athena — the unquoted `WHERE column IS NOT NULL` is a parse error, so every filter on the run parquet would need `WHERE "column" IS NOT NULL` — and `leaf_column` reads correctly on the pyramid column's own record ("the column this LEAF carries", not "the column this record is"). The spec-fixture *file* key `column` in `tests/data/spec/column.expected.json` is the fixture schema's own name and is deliberately untouched (published; not the D20 record).

- [x] **(6)(c) — `granule_ids` moves off the record/envelope into a sibling object** (`c980446`). The record now carries the catalog **hash** only; the id LIST lives in `granules.json` beside the stats sidecar, on the sidecar's own spec-keyed grammar (`granules_{window}.json`; `{stem}.granules.json` under `morton-hive/3`), derived through one private `_sibling_key` owner so the two names cannot drift.
  - **Identity equality never reads it.** `classify_leaf_identity` takes a `load_recorded_ids` callable and invokes it **only when the recorded and planned `granules_sha256` DISAGREE** — pinned by tests asserting the loader's call count is 0 on the skip path, 0 on the equal-hash/changed-semantic quadrant, and exactly 1 on a hash mismatch. The list exists to *name* the diff a refusal reports. (The narrower gate is review fold `c320eea`; as first written the loader fired whenever the fast path failed, which made a routine config-only rerun pay one sibling GET per shard for a verdict the hashes alone decide.)
  - **The interaction check the ruling asked for holds**: `dedup.shard_status` (one GET per shard across a whole shardmap in `has_run`) and `telemetry.rows_from_status` (one GET per mirrored envelope inside a 900 s worker) read the sidecar/envelope only — neither needs the sibling, and both got *smaller*: the ~4,600-id / ≈550 KB pole payload is off every one of those GETs and off the response envelope entirely.
  - **Self-pairing**: the sibling records the `granules_sha256` of the list it holds, and `dedup.leaf_recorded_ids` accepts it only when that equals the sidecar's. A torn rewrite (either PUT lost, or a stale sibling beside a fresh sidecar) reads as *unrecorded*, not as ids that could name the wrong granules as dropped. Absent sibling on a mismatch → the pre-#388 `unrecorded-ids` path, exactly as ruled for question (4)(a).
  - **Back-compat over the `3f13af2`..this-PR window** (review fold `9d7f65d`): leaves written after PR #397 merged but before this PR carry the id list ON the record with no sibling. `leaf_recorded_ids` falls back to `recorded["granule_ids"]` when the sibling is absent or unusable, so those leaves stay guarded and self-heal on their next rewrite instead of classifying `unrecorded-ids` forever. The sibling wins whenever both exist; the fallback pairs by construction (`build_record` hashed the very ids it embedded).
  - **Written by the leaf SEAMS, not by the dispatchers that write the sidecar** — see "Questions for review" (1) below; this is the one place I did not take the obvious reading of "write sites". The adversarial review confirmed the implementation, the justification and the cost; the numbers are in that question now.
  - Lifecycle: `touch_current_unit`'s footprint gains the sibling (a lifecycle rule reaping it would silently disarm the guard on an otherwise-fresh leaf), with the over-touch pin extended to `granules_2020.json`; the docs' footprint list and the `.github/scripts/bench_objects.py` object model both gain it (see the note under Testing).

- [x] **(9)(c)+(a) — a store-root refusal manifest** (`b462ef2`). A run that ends with `cells_refused > 0` writes ONE small JSON at the store root, `refusals_{ts}_{run_id}.json` — timestamp-first like `stats_*.parquet` and `sweep_stats_*.json`, and outside the `stats_*.parquet` glob the sweep's run-record discovery scans. It carries the run context needed to act (`run_id`, timestamp, the run's `semantic_hash`, zagg version) and one entry per refused unit: `shard_key`, `window`, the classification (`contraction`/`mixed`), `n_missing`, and the **complete** `missing_granules` list — the composition of (6)'s sibling reads. Units sort by (shard, window) so two runs over one refusal set produce comparable objects. **No D20 schema change and no synthesized unit rows** — that was the point of (c) over (b). **Ruled (9)(a)**: a pure-skip run writes nothing here and stays row-less.
  - **D8**: the write rides the same local wrap-up seam as the root `coverage.moc` union and `touch_store_root` — `runner._write_refusals`, with `c71198f`'s rationale mirrored ("the LOCAL dispatcher runs it in-process; this process is also the worker"). The fleet has no once-per-run worker-side seam, so the manifest is **local-backend-only**, exactly like the store-root touch; the docs now say both wait on question (10)'s resolution.
  - The gate's verdict now names the `(shard, window)` unit (`leaf_identity_gate(window=...)`), because on a windowed store the shard alone is ambiguous.
  - Operator surface: the summary gains `refusal_manifest_path` (local summaries only, `None` when nothing refused), the CLI prints it under the refusal remedy line, and the phase-4 docs gain a **The refusal manifest** section. The truncated-log caveat (phase-4 finding 4) now points at the manifest as the durable full list instead of telling operators to triage on the count.
  - Sort caveat, for anyone diffing two manifests: units sort by `str(shard_key)`, i.e. **lexicographically** — `10` precedes `9`. Deterministic and comparable across runs, which is all the ordering is for, but it is not numeric order.

## Review fold

Five findings from the adversarial self-review, one commit each:

- `c320eea` — **the sibling read was not gated on the hash mismatch it is documented to be gated on.** It also fired on the "hashes equal, semantic hash differs" quadrant, whose verdict is provably `semantic-mismatch` regardless of the id list — a routine config-only rerun therefore fanned out one sibling GET per shard (2,721 at CA o9, ~550 KB each on a pole unit). `semantic-mismatch` now short-circuits before any load, pinned at `loads == 0`. Second-order fix: with the sibling absent that quadrant used to degrade to `unrecorded-ids`, so a config-only rerun over a pre-#388 store reported 100% `cells_unrecorded` — the counter that means "the guard was inert" — when the hashes had in fact *proved* no contraction.
- `9d7f65d` — **back-compat read of the record-borne `granule_ids`** for the `3f13af2`..this-PR window (see the (6)(c) bullet above).
- `5a7e3eb` — **`write_refusal_manifest`'s fail-open now covers the unit composition**, not just the PUT. It runs at `_run_local:3212`, *before* the summary and the run-stats parquet, so a `MemoryError` on question (3)'s unbounded case or a `TypeError` on malformed `missing_granules` used to destroy the run record of a run that had already done all its work. `write_granule_ids` already had the whole body inside its guard; these now match.
- `45bb7eb` — **the sibling PUT moved inside the write-phase bracket** on both leaf families. It sat one line after `_write_elapsed +=` (and after `write_s +=` on the raster seam), so `phase_timings["write"]` → `phase_write` under-reported by one PUT per leaf in every run parquet and benchmark record. Pinned by a test that wraps the PUT in a 50 ms sleep and asserts the bracket sees it.
- `7b04101` — **the granule-id sibling got its own `spec: "zagg-granule-ids/1"` marker** instead of borrowing the D20 record's `SCHEMA_VERSION` (see Spec assessment). The PR-body sentence that claimed both new objects already carried their own marker is corrected in the same pass — it was true only of the refusal manifest.

`docs/hive_layout.md` follows the first of these: the "fetched exactly once, only when the hashes disagree" invariant is now true as written, and the pre-#388 paragraph says *granule-hash* mismatch, with an explicit note that a config-only rerun is not one of these and never inflates `cells_unrecorded`.

## Testing

- `uv run pytest -q` on this branch (three ruling commits + five review folds): **3,671 passed / 38 skipped / 1 failed** — the failure is the pre-existing, environment-dependent `test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`, flagged not fixed. The other known-flaky one, `test_client_transport.py::TestStatusPoller::test_invoke_fault_burns_an_attempt_and_retries`, failed on one earlier run of the same tree and passed here; it also fails on clean `main`.
- `uv run ruff check src tests`: clean on the diff; the pre-existing `N818` at `src/zagg/registry.py:64` is flagged, not fixed. `uv run ruff format --check src tests`: clean on the diff; the pre-existing `tests/data/benchmark/README.md` reformat is flagged, not fixed.
- New/changed tests, by ruling:
  - **(5)** the parquet round-trip (all-null + mixed, fastparquet *and* pyarrow), the metadata-rides-the-key pin, both merge arms, and the seam's stamp — all renamed in place; `test_column.py`'s 12 seam assertions follow. `metadata["phase_timings"]["column"]` is a phase name, not the record key, and is deliberately unchanged.
  - **(6)** `TestGranuleIdsSibling` (key grammar across all three specs + unknown-spec raise, sibling path, sorted self-hashing round-trip, empty-set case, fail-open write, absent read); `TestLeafRecordedIds` (round-trip, absent, **unpaired-hash rejection**, four malformed bodies, per-window naming); `TestClassifyLeafIdentity` rebuilt around a counting loader (0 calls on the fast path, exactly 1 on mismatch, `None` loader → `unrecorded-ids`); the "pre-#388 leaf" models on both seams now *delete the sibling* rather than nulling a record key, which is what a pre-#388 leaf actually looks like; the lifecycle footprint counts and the S3 exact-key sets gain it; the end-to-end vector rerun asserts the sidecar has no `granule_ids` and the sibling has them.
  - **review fold** `TestClassifyLeafIdentity::test_semantic_mismatch_with_equal_sets_rewrites_not_refuses` (now `loads == 0`) and `::test_semantic_mismatch_without_a_sibling_is_not_unrecorded`; `TestLeafRecordedIds::test_record_borne_ids_are_read_when_no_sibling_exists`, `::test_the_sibling_wins_over_a_record_borne_list`, `::test_the_spec_marker_is_read_leniently`; `TestRefusalManifest::test_composition_is_fail_open_too` (malformed `missing_granules` + a `MemoryError` raiser); `test_hive.py::test_write_phase_covers_the_granule_id_sibling`.
  - **(9)** `TestRefusalManifest` (key shape + traversal guard + not-a-run-record, full per-unit diff with sort order, nothing-refused-writes-nothing, fail-open); end-to-end refusal→manifest on **both** leaf families (`test_hive.py` vector with the exact dropped id, `test_raster_runner.py` raster in the STAC-item id space), the `refusal_manifest_path is None` pin on the `--allow-contraction` rerun, the CLI pointer test, the summary key-set pin, and the windowed unit-identity pin.
- **One file outside `src`/`tests` changed**: `.github/scripts/bench_objects.py`, the benchmark object-count model. The per-leaf model had "TWO node-dir siblings"; with the granule-id list it is three, and without the update the in-tree tests fail (`objects_other == 1`, `total_max` off by one). Flagging it explicitly per CLAUDE.md §1, and **correcting an earlier claim in this body that it is "test-support"** — it is not. Besides `tests/test_benchmark_objects.py`, it is imported by `.github/scripts/run_benchmark.py` and `run_full_aoi_benchmark.py`, executed by `lambda-benchmark.yml` and `lambda-benchmark-fullaoi.yml`, and base-pinned from `main` by `lambda-benchmark-command.yml`. The deploy coupling was checked and is **safe**: the command workflow never redeploys, and the push-to-`main` path rebuilds the layer from the merged tree in the same run, so the object model and the fleet code it models land together. No workflow file is touched.

## Spec assessment

No byte-contract change, consistent with PR #397's own assessment. `docs/specification.md`, `tools/generate_spec_fixtures.py`'s *fixture schema*, and `tests/data/spec/` are unchanged (the fixtures tool's one edit reads the seam's renamed metadata key; the emitted fixture JSON is byte-identical). `SCHEMA_VERSION` stays 1: the D20 record's keys are pre-release and rev in place per the constant's own rule, and this is a rename plus a key removal, both before publication. The two new object families are **operational**, where §4.7's informative scope-out already places the stats/sub-map families: `granules.json` is a sibling of a sidecar the spec does not normatively describe beyond its naming grammar, and the refusal manifest is per-run root telemetry like `stats_*.parquet`/`sweep_stats_*.json`. Both carry a version marker of their own so a future reader has a versioning handle: the manifest `spec: "zagg-refusals/1"` **plus** `schema_version` (it is run-record-class), and the sibling `spec: "zagg-granule-ids/1"` alone (review fold `7b04101` — as first written it borrowed the D20 record's `SCHEMA_VERSION`, welding a schema it deliberately is not). Readers must treat the sibling's marker leniently: the sidecar hash pairing is what decides, and an unknown marker degrades to the ruled `unrecorded-ids` fallback rather than raising.

## Questions for review

1. **The granule-id sibling is written by the leaf SEAMS, not at the dispatcher-side sidecar write sites** — the one place I read the ruling's "write sites" against its most literal sense, deliberately, and the one thing to overrule if you disagree. Reasons: (a) **D8** — a store write belongs worker-side, and the seams already PUT the whole leaf; (b) **fleet coverage with no `deployment/aws/` edit** — PR #397 banked "fleet vector sidecars record the identity half with zero handler changes" via the seam's `semantic_hash` stamp; putting the sibling at the dispatcher sites would have *un*-banked the catalog half, leaving every fleet-written leaf `unrecorded-ids` (guard permanently inert on the fleet) until question (1)'s handler change lands. Via the seam, both leaf families record their input set from this release's deploy onward; (c) **one source for the id space** — the seam writes the very list the gate compares as `planned_ids`, instead of the dispatcher recomputing `_resolve_urls(records, driver)` in lockstep. The cost, stated plainly: the sibling PUT is **unconditional** on a committed leaf, so a caller that never opted into the gate (today's Lambda handler) is no longer byte-identical — it writes one extra small object per leaf. Both seam docstrings say so at the opt-in kwarg.

    **The adversarial review measured this and the placement stands unless you overrule it.** What it confirmed: the PUT is gated on a **committed** leaf (`hive.py:1656` / `processing/raster.py:1412`), so it is one object per **(node, window)**, never per shard-attempt. Object-count delta on `atl03_tdigest_healpix_o9_hive.yaml`: **+9.1% objects/shard** (11 → 12), **+7.7%** on `_located`, **+5.3%** on `_strata`. Request/cost delta at CA o9: **+2,721 PUTs ≈ $0.0136 against $65.30 of compute — 0.02%**. Size: ~110 B/id ⇒ ~22 KB on a typical shard, ~500 KB on a pole shard. Also worth recording: **no test ever pinned the fleet's exact object set**, so PR #397's "byte-identical when unarmed" property was unpinned to begin with — this changes a real behavior, not a guarded one. If you would still rather the fleet stay byte-identical until the handler opts in, this moves to the two `runner.py` sidecar sites in one commit.

    Two facts for the handler recipe (which PR #401 owns), both **pre-existing and out of scope here** under §1 — `deployment/aws/` and the handler are not named by this PR: (a) `lambda_handler.py:1687`/`:1860` pass neither `sidecar_spec` nor `write_sidecar(spec=)`, so the fleet writes **both** the sidecar and the sibling with `spec=None` — on a `morton-hive/3` store both land under the legacy name; (b) on the skip path, an absent sibling costs one extra S3 `head_object` per skipped unit in `touch_current_unit` (**+2,721 HEADs** on an all-skip CA o9 rerun over a pre-#388 store). Neither is fixable in this PR; recording them so the handler change lands with both in hand.
2. **`refusal_manifest_path` is on the two LOCAL summaries only** (always present, `None` when nothing refused), not on the Lambda ones, because there is no fleet writer at all — unlike `run_stats_path`, which both backends produce. That is an asymmetric summary key set; the alternative (always-`None` on the fleet) reads as "no refusals" rather than "not recorded". Left as-is; say the word if you want the key mirrored.
3. **The manifest is unbounded in size by design.** A run where many pole shards refuse could write a large object (~550 KB of ids per refused pole unit). Truncating would defeat the entire reason (9)(c) exists — the docs now tell operators to triage from this object rather than from the truncated log — so it carries the full diff. Worth a size guard, or is "proportional to the refusal set" fine? (Review fold `5a7e3eb` at least made the worst case *degrade*: the unit composition is now inside the same fail-open guard as the PUT, so a `MemoryError` here costs the manifest, not the run record.)
4. **A narrow pre-existing hole in the skip guard, inherited from PR #397 — neither widened nor narrowed by this PR, and deliberately NOT fixed here.** The sidecar PUT happens after the commit stamp, so if a rewrite dies **after the stamp but before the sidecar PUT**, the leaf holds run-2 data under run-1's sidecar. A later run planning run-1's id set then matches both `granules_sha256` and `semantic_hash`, passes `_leaf_is_committed`, and **skips a leaf whose contents do not match what the sidecar says**. Three ways out, all yours to pick: (a) reorder — sidecar before stamp (costs the "sidecar only ever describes a committed leaf" property, and a torn pair the other way then reads as a stale record on a leaf that never landed); (b) carry an id-set digest in the stamp itself, so the commit and the identity claim land in one object and cannot tear apart; (c) accept it as narrow — it needs a crash inside a one-PUT window, and the failure mode is a stale leaf, not corrupt data. My read is (c) is defensible and (b) is the real fix, but this is a D4 change and belongs on its own issue rather than in a follow-up trio.

