### PR TITLE
small fixes 2026-08-08: use mortie's flat exports instead of the tools submodule (issue #406)

### DIFF
--- a/data/build_aoi_shardmap.py
+++ b/data/build_aoi_shardmap.py
@@ -126,7 +126,7 @@ def _leak_check(grid, shard_keys, boxes, margin_deg: float = 1.0) -> dict:
     scattered multipart AOI the global box spans everything between the parts,
     where a fill leak would go undetected.
     """
-    from mortie.tools import mort2polygon
+    from mortie import mort2polygon
 
     lats, lons = [], []
     for k in shard_keys:

--- a/data/conus/build_conus_shardmap.py
+++ b/data/conus/build_conus_shardmap.py
@@ -107,7 +107,7 @@ def _leak_check(grid, shard_keys, bbox, margin_deg: float = 1.0) -> dict:
     Guards against a mortie #103-style base-cell fill regression. Returns the
     covered-cell lat/lon extent for the record.
     """
-    from mortie.tools import mort2polygon
+    from mortie import mort2polygon
 
     lon0, lat0, lon1, lat1 = bbox
     lats, lons = [], []

--- a/demo/05_california_read.ipynb
+++ b/demo/05_california_read.ipynb
@@ -193,7 +193,7 @@
     "print(f\"order-{overview_order} overview: {ov.sizes['cells']} cells; \"\n",
     "      f\"count sum {int(ov['count'].sum()):,} (leaves: exactness check vs the run total)\")\n",
     "\n",
-    "from mortie.tools import mort2polygon\n",
+    "from mortie import mort2polygon\n",
     "\n",
     "words = [int(w) for w in ov[\"morton\"].values]\n",
     "lat = np.array([np.mean([p[0] for p in mort2polygon(w, step=4)]) for w in words])\n",

--- a/notebooks/aoi_mask.ipynb
+++ b/notebooks/aoi_mask.ipynb
@@ -66,7 +66,7 @@
     "# 3) Visualize the in-AOI cells by their HEALPix center (decode only for the\n",
     "#    picture — the mask itself never decodes centers).\n",
     "import matplotlib.pyplot as plt\n",
-    "from mortie.tools import mort2geo\n",
+    "from mortie import mort2geo\n",
     "\n",
     "clat, clon = mort2geo(np.asarray(children))\n",
     "fig, ax = plt.subplots(figsize=(5, 5))\n",

--- a/src/zagg/grids/healpix.py
+++ b/src/zagg/grids/healpix.py
@@ -249,7 +249,7 @@ class HealpixGrid:
         crossing the antimeridian or enclosing a pole, where a lon/lat box is
         the wrong shape entirely.
         """
-        from mortie.tools import mort2polygon
+        from mortie import mort2polygon
 
         lats: list[float] = []
         lons: list[float] = []
@@ -433,7 +433,7 @@ class HealpixGrid:
 
     def shard_footprint(self, shard_key):
         """Parent-cell polygon in WGS84 (lon, lat)."""
-        from mortie.tools import mort2polygon
+        from mortie import mort2polygon
         from shapely.geometry import Polygon
 
         verts = mort2polygon(int(shard_key), step=32)


### PR DESCRIPTION
Closes #406.

Mechanical import swap, zero behaviour change: every remaining consumer of the
`mortie.tools` submodule path moves to mortie's flat export.

```diff
-from mortie.tools import mort2polygon
+from mortie import mort2polygon
```

## Why this PR exists rather than PR #398

#406 was already implemented as `ae408ea` on PR #398's branch
(`claude/small-fixes-2026-08-05`), but that PR cannot carry the fix to merge, for
two independent reasons:

1. **PR #398 is entangled with an unsettled design.** It closes #390 (refuse a
   sub-second windowing epoch), whose design is now bound up with #410
   (temporal/timespan representation). That will not be settled soon. #406 is an
   unrelated mechanical import fix and should not sit behind a temporal-design
   decision.
2. **PR #398 structurally cannot reach two of the six sites.** Its branch forked
   at `196867b`, *before* PR #395 ("land the AOI/CONUS shardmap builders",
   issue #372) merged on 2026-08-07 and added `data/` to the repo. Those files
   were never in its tree, so `git ls-files data` on that branch is genuinely
   empty — which is exactly how the first correction comment on #406 came to
   report the `data/` scripts as untracked.

This PR is cut from a `main` (`4edbf0ee`) that contains #395, so it can see all
six. It carries `ae408ea` forward by cherry-pick (authorship preserved) and adds
the two `data/` sites on top.

## Why it matters

`mortie.tools` is not an advertised submodule — only `arrow` and `morton_index`
are. espg/mortie#159 (PR espg/mortie#169) moves `mort2polygon` and `mort2geo`
into `mortie/convert.py`, and **that PR cannot merge until all six sites here are
clear**. The PR #169 review independently surfaced the same six
([r3740911256](https://github.com/espg/mortie/pull/169#discussion_r3740911256)).

Both names are flat exports on every mortie version that has the function, so
there is no floor bump here — `mortie>=0.7.2` in `pyproject.toml` is unchanged.

## Sites

| File | Line | Name | Commit |
| --- | --- | --- | --- |
| `src/zagg/grids/healpix.py` | 252 (`shards_bbox`) | `mort2polygon` | `e31070c` (cherry-pick) |
| `src/zagg/grids/healpix.py` | 436 (`shard_footprint`) | `mort2polygon` | `e31070c` (cherry-pick) |
| `demo/05_california_read.ipynb` | 196 | `mort2polygon` | `e31070c` (cherry-pick) |
| `notebooks/aoi_mask.ipynb` | 69 | **`mort2geo`** | `e31070c` (cherry-pick) |
| `data/build_aoi_shardmap.py` | 129 (`_leak_check`) | `mort2polygon` | `a49832c` |
| `data/conus/build_conus_shardmap.py` | 110 (`_leak_check`) | `mort2polygon` | `a49832c` |

Note the notebook site is `mort2geo`, not `mort2polygon` — #159 moves the two
names independently, so both had to be swept.

`data/conus/plot_conus_shardmap.py` appears in this issue's original site list
but is **not tracked on `main`** (it exists only as an untracked local file), so
it is out of scope here.

## Phases

- [x] Cherry-pick `ae408ea` — the four sites PR #398 can see (`e31070c`)
- [x] The two `data/` sites PR #398's fork point put out of reach (`a49832c`)

## How it was tested

**Acceptance** — `git grep -n "mortie\.tools\|from mortie import tools"` over the
whole worktree returns nothing.

**Both names are object-identical across the two paths**, which is what makes
this a no-op (mortie 0.9.4):

```
mort2polygon  callable True  in __all__ True  identical True
mort2geo      callable True  in __all__ True  identical True
```

**Test coverage is uneven, and worth stating plainly:**

- The two `src/zagg/grids/healpix.py` sites *are* covered — `shards_bbox` and
  `shard_footprint` are both exercised by `tests/`, so `pytest` genuinely
  executes that half of the change.
- The two `data/` scripts and the two notebooks are **not** covered by the test
  suite at all. That is precisely why nothing in zagg's CI would have caught the
  espg/mortie#159 break.

So rather than imply the suite exercises the `data/` change, both scripts were
imported by path and their `_leak_check` — the one function carrying the changed
import — was called on real order-9 morton keys over CONUS. On the happy path
`_leak_check` never touches `grid`, so this runs standalone:

```
morton keys: [3856734946517319689, 3841143871635456009, 3823498909032906761]
build_aoi_shardmap._leak_check   -> {'passed': True, ..., 'cell_lat_min': 35.2328, 'cell_lat_max': 40.5278}
build_conus_shardmap._leak_check -> {'passed': True, ..., 'cell_lat_min': 35.2328, 'cell_lat_max': 40.5278}
```

Cell centres land on the input points, so the swapped import resolves and
`mort2polygon` returns correct geometry through it.

**Gates** (`uv run`):

| Gate | Result |
| --- | --- |
| `ruff check src tests` | 1 error — pre-existing `N818` at `src/zagg/registry.py:64` |
| `ruff format --check src tests` | 1 file would be reformatted — pre-existing, `tests/data/benchmark/README.md` |
| `pytest -q` | **1 failed, 3671 passed, 38 skipped** — the failure is pre-existing `test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` |

All three failures are pre-existing on `4edbf0ee` and unrelated to this diff;
flagged, not fixed, per CLAUDE.md §4. The flaky `test_client_transport.py` poller
test passed on both runs.

## Questions for review

- **PR #398 is left untouched** — no revert, no push, no label change; re-scoping
  it is not this run's call. Once this merges, `ae408ea` there becomes a no-op
  and PR #398's diff for those four files should drop out on rebase. A note to
  that effect is on its thread.
- The branch is `claude/small-fixes-2026-08-08` (the date this ran); the earlier
  small-fix bundle is `claude/small-fixes-2026-08-05`.
