### PR TITLE
state satisfied mortie minimums in arrival voice, guard the rest

### DIFF
--- a/docs/morton_arrow.md
+++ b/docs/morton_arrow.md
@@ -8,7 +8,7 @@ across every surface it crosses (issue
 | Surface | Carrier | Form |
 | --- | --- | --- |
 | pandas carrier (worker) | `pandas.DataFrame` | `mortie.MortonIndexArray` extension array (#71) |
-| arro3 carrier (worker) | `arro3.core.Table` | `morton_index` Arrow **extension type** over the PyCapsule C Data Interface (mortie ≥ 0.8.4) |
+| arro3 carrier (worker) | `arro3.core.Table` | `morton_index` Arrow **extension type** over the PyCapsule C Data Interface (added in mortie 0.8.4) |
 | catalog / shardmap parquet | `pyarrow.Table` | `morton_index` pyarrow extension type (registered by mortie on import) |
 | Zarr store (on disk) | Zarr v3 array | plain `uint64` — the packed words, byte-for-byte |
 

--- a/docs/ragged_layout.md
+++ b/docs/ragged_layout.md
@@ -141,7 +141,7 @@ a row-major reshape of the 1-D axis scrambles the 2-D block spatially beyond
 2-cell runs. The readers instead place each cell at the **bit deinterleave**
 of its chunk-local nested rank
 ([issue #336](https://github.com/englacial/zagg/issues/336)):
-`mortie.rank_to_xy` / `xy_to_rank` (mortie ≥ 0.9.3), whose contract is
+`mortie.rank_to_xy` / `xy_to_rank` (added in mortie 0.9.3), whose contract is
 normative in mortie's `docs/specification.md` **§8** and frozen for mortie 1.x
 — `x` gathers the rank's even bits, `y` its odd bits, origin `(0, 0)` at the
 subtree's south corner, equal to healpy's face-local `pix2xyf` (nest)

--- a/src/zagg/grids/morton.py
+++ b/src/zagg/grids/morton.py
@@ -4,11 +4,11 @@ The ``morton`` output coordinate is carried in memory as a mortie
 :class:`~mortie.morton_index.MortonIndexArray` (a pandas ExtensionArray over the
 packed ``uint64`` Morton words), and crosses the Arrow carrier boundary as
 mortie's ``morton_index`` Arrow **extension type** over the PyCapsule C Data
-Interface (:func:`morton_to_arrow` / :func:`morton_from_arrow`; mortie >= 0.8.4,
-issue #135) — typed on both the pandas and arro3 surfaces, no pyarrow on the
-worker path. On disk it is stored as plain ``uint64`` — Zarr stores numpy
-dtypes, and the extension metadata lives at the interchange layer only — and
-reconstructed as a ``MortonIndexArray`` on read.
+Interface (:func:`morton_to_arrow` / :func:`morton_from_arrow`; added in
+mortie 0.8.4, issue #135) — typed on both the pandas and arro3 surfaces, no
+pyarrow on the worker path. On disk it is stored as plain ``uint64`` — Zarr
+stores numpy dtypes, and the extension metadata lives at the interchange layer
+only — and reconstructed as a ``MortonIndexArray`` on read.
 
 This is the contained #71 migration: only the ``morton`` coordinate adopts the
 type — and since the D16 flip (issue #304) it is the only stored cell
@@ -199,7 +199,7 @@ def morton_to_arrow(values):
     The Arrow leg of the boundary: the returned array carries mortie's
     ``morton_index`` extension type in its field metadata
     (:data:`MORTON_EXTENSION_NAME`), pulled zero-copy over the PyCapsule C Data
-    Interface (``MortonIndexArray.__arrow_c_array__``; mortie >= 0.8.4) — no
+    Interface (``MortonIndexArray.__arrow_c_array__``; added in mortie 0.8.4) — no
     pyarrow on the path. Accepts a ``MortonIndexArray`` or any
     ``uint64``-coercible array-like of packed words; the all-zero empty sentinel
     is exported as an Arrow null.

--- a/tests/test_mortie_versions.py
+++ b/tests/test_mortie_versions.py
@@ -17,12 +17,19 @@ an API the dependency floor does not guarantee, which reaches a user as an
 ``AttributeError`` where the docs said otherwise. So every mortie version
 quoted under ``docs/`` or ``src/`` must be at or below the floor, and the
 ``aoi_mask`` family — the sites that document (3) and therefore cannot be
-de-versioned — must quote the enforced constant exactly.
+de-versioned — must quote the enforced constant exactly wherever they state it
+as a *requirement* (``mortie >= 0.8.3``). Arrival voice in those same files
+("shipped in 0.8.2") is history, not a restatement of the gate, so it is held
+to the floor like any other citation and not to the constant.
 
-Scope note: a citation is recognized only where the release number is
-lexically attached to the word ``mortie``. A bare "shipped in 0.8.2" further
-along the same sentence (``src/zagg/grids/aoi.py``) is not matched, because no
-regex separates it from the other version numbers prose carries.
+Scope note — two blind spots, both deliberate and both needing a human eye on a
+``MIN_MORTIE_VERSION`` bump. A citation is recognized only where the release
+number is lexically attached to the word ``mortie``: bare literals further along
+a sentence ("espg/mortie#59 + #70, shipped in 0.8.2", ``src/zagg/grids/aoi.py``)
+are invisible here, because no regex separates them from the other version
+numbers prose carries. And whether a wrapped citation is seen depends on the
+words between ``mortie`` and the number, so reflowing a paragraph can move one
+in or out of scope.
 """
 
 import re
@@ -61,20 +68,26 @@ AOI_MASK_FILES = ("docs/aoi_mask.md", "src/zagg/grids/aoi.py")
 # version — ``#`` is outside the separator class), "frozen for mortie 1.x" (no
 # second numeric component), and upper bounds like ``mortie < 1.0``, which
 # promise no API and so are not citations this guard is about.
+#
+# Group 1 is the comparison operator, present only in **requirement** voice
+# ("zagg needs at least this"); arrival voice ("added in mortie 0.8.4") leaves
+# it ``None``. That distinction is what scopes the ``aoi_mask`` equality rule.
 _CITATION = re.compile(
-    r"mortie[\s(:,_-]*(?:version|release)?\s*(?:>=|==|~=|>|≥)?\s*v?(\d+\.\d+(?:\.\d+)*)",
+    r"mortie[\s(:,_-]*(?:version|release)?\s*(>=|==|~=|>|≥)?\s*v?(\d+\.\d+(?:\.\d+)*)",
     re.IGNORECASE,
 )
 
 
-def _cited_versions(text):
+def _cited_versions(text, requirement_voice_only=False):
     """Every mortie release ``text`` names, as ``(Version, line number)``."""
     return [
-        (Version(m.group(1)), text.count("\n", 0, m.start(1)) + 1) for m in _CITATION.finditer(text)
+        (Version(m.group(2)), text.count("\n", 0, m.start(2)) + 1)
+        for m in _CITATION.finditer(text)
+        if m.group(1) or not requirement_voice_only
     ]
 
 
-def _scan():
+def _scan(requirement_voice_only=False):
     """Every mortie citation under the scan roots, as ``(path, line, Version)``."""
     sites = []
     for root in SCAN_ROOTS:
@@ -82,7 +95,8 @@ def _scan():
             if path.suffix not in SCAN_SUFFIXES or not path.is_file():
                 continue
             rel = path.relative_to(REPO_ROOT).as_posix()
-            for version, line in _cited_versions(path.read_text(encoding="utf-8")):
+            text = path.read_text(encoding="utf-8")
+            for version, line in _cited_versions(text, requirement_voice_only):
                 sites.append((rel, line, version))
     return sites
 
@@ -148,7 +162,10 @@ class TestQuotedVersionsAgainstFloor:
     def test_aoi_mask_prose_matches_the_runtime_gate(self):
         # These six sites document a gate that raises (``aoi.py`` lines 66-80),
         # so they keep requirement voice — and must quote the constant itself.
-        family = [s for s in _scan() if s[0] in AOI_MASK_FILES]
+        # Requirement voice only: the same two files also carry arrival-voice
+        # history ("shipped in 0.8.2"), which is factually correct at a version
+        # *below* the gate and must not be dragged into an equality rule.
+        family = [s for s in _scan(requirement_voice_only=True) if s[0] in AOI_MASK_FILES]
         assert len(family) >= 6, f"aoi_mask citations vanished from the scan: {family}"
         wrong = [s for s in family if s[2] != Version(MIN_MORTIE_VERSION)]
         assert not wrong, (
@@ -217,6 +234,13 @@ class TestGuardFires:
             "tagged mortie v0.10.0",
         ):
             assert [str(v) for v, _ in _cited_versions(spelling)] == ["0.10.0"], spelling
+
+    def test_requirement_voice_is_told_from_arrival_voice(self):
+        # The split the ``aoi_mask`` equality rule rides on: only a citation
+        # carrying a comparison operator states an obligation.
+        text = "aoi_mask needs mortie >= 0.8.3; the MOC cap shipped in mortie 0.8.2"
+        assert [str(v) for v, _ in _cited_versions(text)] == ["0.8.3", "0.8.2"]
+        assert [str(v) for v, _ in _cited_versions(text, requirement_voice_only=True)] == ["0.8.3"]
 
     def test_the_floor_line_is_not_scanned_as_a_citation(self):
         # The regex would happily match ``mortie>=0.9.3`` in pyproject.toml, so

--- a/tests/test_mortie_versions.py
+++ b/tests/test_mortie_versions.py
@@ -1,0 +1,179 @@
+"""Drift guard: no mortie version zagg's prose quotes may outrun the floor.
+
+zagg names mortie release numbers in three different voices, and only one of
+them is a live obligation:
+
+1. the **package floor** — ``mortie>=…`` in ``[project.dependencies]``, the
+   single source (``deployment/aws/build_layer.sh`` derives ``MORTIE_SPEC``
+   from it, issue #322);
+2. **arrival notes** in narrative docs and docstrings ("added in mortie
+   0.8.4") — historically true, permanently satisfied because the floor
+   already exceeds them, and enforced by nothing at runtime;
+3. the one **runtime gate**, :data:`zagg.grids.aoi.MIN_MORTIE_VERSION`, which
+   ``_assert_mortie_version`` turns into a ``RuntimeError``.
+
+The failure mode worth guarding is (2) drifting *above* (1): prose promising
+an API the dependency floor does not guarantee, which reaches a user as an
+``AttributeError`` where the docs said otherwise. So every mortie version
+quoted under ``docs/`` or ``src/`` must be at or below the floor, and the
+``aoi_mask`` family — the sites that document (3) and therefore cannot be
+de-versioned — must quote the enforced constant exactly.
+
+Scope note: a citation is recognized only where the release number is
+lexically attached to the word ``mortie``. A bare "shipped in 0.8.2" further
+along the same sentence (``src/zagg/grids/aoi.py``) is not matched, because no
+regex separates it from the other version numbers prose carries.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from zagg.grids.aoi import MIN_MORTIE_VERSION
+
+REPO_ROOT = Path(__file__).parent.parent
+
+# Prose scanned for citations: narrative docs plus the shipped package
+# (docstrings, comments, bundled config YAML). ``pyproject.toml`` is
+# deliberately outside both roots — it is the floor these citations are
+# measured against, not one of them.
+SCAN_ROOTS = (REPO_ROOT / "docs", REPO_ROOT / "src")
+SCAN_SUFFIXES = {".md", ".py", ".yaml", ".yml"}
+
+# The ``aoi_mask`` family: the six sites documenting the runtime gate.
+AOI_MASK_FILES = ("docs/aoi_mask.md", "src/zagg/grids/aoi.py")
+
+# ``mortie`` followed by a release number, in every voice the tree uses:
+# ``mortie >= 0.8.3``, ``mortie ≥ 0.8.4``, ``mortie>=0.8.3``, bare
+# ``mortie 0.8.1``, and the backticked variants (the backticks fall outside
+# the match). Whitespace spans newlines so a wrapped citation is not a blind
+# spot. ``espg/mortie#89`` does not match: an issue reference is not a
+# version, and neither is "frozen for mortie 1.x".
+_CITATION = re.compile(r"mortie\s*(?:>=|≥)?\s*v?(\d+\.\d+(?:\.\d+)*)")
+
+
+def _cited_versions(text):
+    """Every mortie release ``text`` names, as ``(Version, line number)``."""
+    return [
+        (Version(m.group(1)), text.count("\n", 0, m.start()) + 1) for m in _CITATION.finditer(text)
+    ]
+
+
+def _scan():
+    """Every mortie citation under the scan roots, as ``(path, line, Version)``."""
+    sites = []
+    for root in SCAN_ROOTS:
+        for path in sorted(root.rglob("*")):
+            if path.suffix not in SCAN_SUFFIXES or not path.is_file():
+                continue
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            for version, line in _cited_versions(path.read_text(encoding="utf-8")):
+                sites.append((rel, line, version))
+    return sites
+
+
+def _above(sites, floor):
+    """The comparison the guard makes — PEP 440 ordering, never string compare."""
+    return [s for s in sites if s[2] > floor]
+
+
+def _mortie_floor():
+    """The ``>=`` floor from ``[project.dependencies]``."""
+    deps = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    reqs = [Requirement(d) for d in deps["project"]["dependencies"]]
+    spec = next(r.specifier for r in reqs if r.name == "mortie")
+    lower = [Version(s.version) for s in spec if s.operator in (">=", "==", "~=")]
+    assert len(lower) == 1, f"expected one mortie lower bound in pyproject, got {lower}"
+    return lower[0]
+
+
+class TestQuotedVersionsAgainstFloor:
+    """Nothing zagg's prose promises may exceed what the floor guarantees."""
+
+    def test_scan_finds_the_versioned_sites(self):
+        # A regex that silently matched nothing would let every other test in
+        # this module pass forever, so pin that the scan has real work to do.
+        sites = _scan()
+        assert len(sites) >= 12, f"mortie citation scan went blind: {sites}"
+        files = {path for path, _, _ in sites}
+        for expected in (
+            "docs/aoi_mask.md",
+            "docs/morton_arrow.md",
+            "docs/ragged_layout.md",
+            "src/zagg/grids/aoi.py",
+            "src/zagg/grids/morton.py",
+            "src/zagg/grids/healpix.py",
+        ):
+            assert expected in files, f"{expected} no longer reached by the scan"
+
+    def test_no_citation_outruns_the_floor(self):
+        floor = _mortie_floor()
+        over = _above(_scan(), floor)
+        assert not over, (
+            f"prose quotes a mortie version above the pyproject floor {floor}: {over}. "
+            "Either raise the floor in [project.dependencies] (an espg-authorized "
+            "dependency change) or restate the prose against a shipped release."
+        )
+
+    def test_runtime_gate_is_at_or_below_the_floor(self):
+        floor = _mortie_floor()
+        assert Version(MIN_MORTIE_VERSION) <= floor, (
+            f"zagg.grids.aoi.MIN_MORTIE_VERSION ({MIN_MORTIE_VERSION}) is above the "
+            f"pyproject floor ({floor}) — aoi_mask would raise on a conforming install"
+        )
+
+    def test_aoi_mask_prose_matches_the_runtime_gate(self):
+        # These six sites document a gate that raises (``aoi.py`` lines 66-80),
+        # so they keep requirement voice — and must quote the constant itself.
+        family = [s for s in _scan() if s[0] in AOI_MASK_FILES]
+        assert len(family) >= 6, f"aoi_mask citations vanished from the scan: {family}"
+        wrong = [s for s in family if s[2] != Version(MIN_MORTIE_VERSION)]
+        assert not wrong, (
+            f"aoi_mask prose disagrees with MIN_MORTIE_VERSION ({MIN_MORTIE_VERSION}): {wrong}"
+        )
+
+
+class TestGuardFires:
+    """A guard that cannot fail is worse than no guard — prove each part bites."""
+
+    def test_a_citation_above_the_floor_is_caught(self):
+        floor = _mortie_floor()
+        text = "the ragged reader rides `mortie >= 99.0.0`, whose contract is normative"
+        sites = [("docs/synthetic.md", line, v) for v, line in _cited_versions(text)]
+        assert [str(s[2]) for s in sites] == ["99.0.0"]
+        assert _above(sites, floor) == sites
+
+    def test_ordering_is_pep440_not_lexicographic(self):
+        # The case a string compare gets backwards: "0.10.0" < "0.9.5" as text.
+        assert "0.10.0" < "0.9.5"
+        assert Version("0.10.0") > Version("0.9.5")
+        sites = [("docs/synthetic.md", 1, Version("0.10.0"))]
+        assert _above(sites, Version("0.9.5")) == sites
+        assert _above(sites, Version("0.10.0")) == []
+
+    def test_issue_references_are_not_versions(self):
+        assert _cited_versions("(espg/mortie#89, espg/mortie#100) and mortie 1.x") == []
+
+    def test_every_citation_spelling_is_recognized(self):
+        text = (
+            "`mortie >= 0.8.3` and mortie ≥ 0.8.4 and `mortie>=0.9.3` and "
+            "mortie 0.8.1 and added in mortie\n0.9.0"  # wrapped by a line break
+        )
+        assert [str(v) for v, _ in _cited_versions(text)] == [
+            "0.8.3",
+            "0.8.4",
+            "0.9.3",
+            "0.8.1",
+            "0.9.0",
+        ]
+
+    def test_the_floor_line_is_not_scanned_as_a_citation(self):
+        # The regex would happily match ``mortie>=0.9.3`` in pyproject.toml, so
+        # the exclusion has to come from the scan roots — not from luck.
+        floor = _mortie_floor()
+        assert [v for v, _ in _cited_versions(f'    "mortie>={floor}",')] == [floor]
+        scanned = {path for path, _, _ in _scan()}
+        assert not any(path.endswith("pyproject.toml") for path in scanned)

--- a/tests/test_mortie_versions.py
+++ b/tests/test_mortie_versions.py
@@ -120,18 +120,14 @@ class TestQuotedVersionsAgainstFloor:
     def test_scan_finds_the_versioned_sites(self):
         # A regex that silently matched nothing would let every other test in
         # this module pass forever, so pin that the scan has real work to do.
+        # Only the count, deliberately: naming the files would ratchet them in
+        # place, and *deleting* an unenforced per-feature minimum is the very
+        # edit this PR argues for. The actual is 16, across docs/aoi_mask.md,
+        # docs/design/sparse_coverage.md, docs/morton_arrow.md,
+        # docs/ragged_layout.md, src/zagg/configs/atl03_tdigest_healpix.yaml,
+        # and src/zagg/{grids/aoi,grids/healpix,grids/morton,readers/_layout}.py.
         sites = _scan()
         assert len(sites) >= 12, f"mortie citation scan went blind: {sites}"
-        files = {path for path, _, _ in sites}
-        for expected in (
-            "docs/aoi_mask.md",
-            "docs/morton_arrow.md",
-            "docs/ragged_layout.md",
-            "src/zagg/grids/aoi.py",
-            "src/zagg/grids/morton.py",
-            "src/zagg/grids/healpix.py",
-        ):
-            assert expected in files, f"{expected} no longer reached by the scan"
 
     def test_no_citation_outruns_the_floor(self):
         floor = _mortie_floor()

--- a/tests/test_mortie_versions.py
+++ b/tests/test_mortie_versions.py
@@ -46,13 +46,24 @@ SCAN_SUFFIXES = {".md", ".py", ".yaml", ".yml"}
 # The ``aoi_mask`` family: the six sites documenting the runtime gate.
 AOI_MASK_FILES = ("docs/aoi_mask.md", "src/zagg/grids/aoi.py")
 
-# ``mortie`` followed by a release number, in every voice the tree uses:
-# ``mortie >= 0.8.3``, ``mortie ≥ 0.8.4``, ``mortie>=0.8.3``, bare
-# ``mortie 0.8.1``, and the backticked variants (the backticks fall outside
-# the match). Whitespace spans newlines so a wrapped citation is not a blind
-# spot. ``espg/mortie#89`` does not match: an issue reference is not a
-# version, and neither is "frozen for mortie 1.x".
-_CITATION = re.compile(r"mortie\s*(?:>=|≥)?\s*v?(\d+\.\d+(?:\.\d+)*)")
+# ``mortie`` followed by a release number. A missed spelling is a *silent*
+# pass, the one failure mode a drift guard cannot afford, so the separator and
+# operator sets are deliberately loose: ``mortie >= 0.8.3``, ``mortie ≥ 0.8.4``,
+# ``mortie>=0.8.3``, ``mortie==0.9.3`` (how a pin gets written up — the
+# ``lambda`` extra is nothing but ``==`` pins), ``mortie ~= 0.9``, bare
+# ``mortie 0.8.1``, ``mortie (0.9.0)`` / ``mortie: 0.9.0`` / ``mortie-0.9.0``,
+# ``mortie version 0.9.0``, sentence-initial ``Mortie 0.9.0``, and the
+# backticked variants (the backticks fall outside the match). Whitespace spans
+# newlines so a wrapped citation is not a blind spot.
+#
+# Deliberately *not* matched: ``espg/mortie#89`` (an issue reference is not a
+# version — ``#`` is outside the separator class), "frozen for mortie 1.x" (no
+# second numeric component), and upper bounds like ``mortie < 1.0``, which
+# promise no API and so are not citations this guard is about.
+_CITATION = re.compile(
+    r"mortie[\s(:,_-]*(?:version|release)?\s*(?:>=|==|~=|>|≥)?\s*v?(\d+\.\d+(?:\.\d+)*)",
+    re.IGNORECASE,
+)
 
 
 def _cited_versions(text):
@@ -162,6 +173,10 @@ class TestGuardFires:
 
     def test_issue_references_are_not_versions(self):
         assert _cited_versions("(espg/mortie#89, espg/mortie#100) and mortie 1.x") == []
+        # Widening the operator set must not drag these in: an issue number is
+        # not a release, and an upper bound is not a promise about an API.
+        assert _cited_versions("gated on mortie#116, and frozen for mortie 1.x") == []
+        assert _cited_versions("pinned mortie < 1.0 while the API settles") == []
 
     def test_every_citation_spelling_is_recognized(self):
         text = (
@@ -175,6 +190,24 @@ class TestGuardFires:
             "0.8.1",
             "0.9.0",
         ]
+
+    def test_the_spellings_that_used_to_pass_silently_are_caught(self):
+        # Each of these read as no citation at all before the pattern was
+        # widened — a doc could promise an unshipped API and stay green.
+        for spelling in (
+            "Mortie 0.10.0 adds the flat export",  # sentence-initial
+            "the layer pins mortie==0.10.0",  # how a pin gets written up
+            "mortie ~= 0.10.0",
+            "mortie > 0.10.0",
+            "the cover entry points (mortie (0.10.0))",
+            "see mortie: 0.10.0",
+            "shipped in mortie, 0.10.0",
+            "the mortie-0.10.0 wheel",
+            "needs mortie version 0.10.0",
+            "requires at least mortie release 0.10.0",
+            "tagged mortie v0.10.0",
+        ):
+            assert [str(v) for v, _ in _cited_versions(spelling)] == ["0.10.0"], spelling
 
     def test_the_floor_line_is_not_scanned_as_a_citation(self):
         # The regex would happily match ``mortie>=0.9.3`` in pyproject.toml, so

--- a/tests/test_mortie_versions.py
+++ b/tests/test_mortie_versions.py
@@ -243,9 +243,12 @@ class TestGuardFires:
         assert [str(v) for v, _ in _cited_versions(text, requirement_voice_only=True)] == ["0.8.3"]
 
     def test_the_floor_line_is_not_scanned_as_a_citation(self):
-        # The regex would happily match ``mortie>=0.9.3`` in pyproject.toml, so
-        # the exclusion has to come from the scan roots — not from luck.
+        # The regex would happily match ``mortie>={floor}`` in pyproject.toml —
+        # reading the floor back as a citation would make the comparison
+        # self-satisfying — so assert the two mechanisms that actually exclude
+        # it, rather than a path check no scanned suffix could ever satisfy.
         floor = _mortie_floor()
         assert [v for v, _ in _cited_versions(f'    "mortie>={floor}",')] == [floor]
-        scanned = {path for path, _, _ in _scan()}
-        assert not any(path.endswith("pyproject.toml") for path in scanned)
+        assert ".toml" not in SCAN_SUFFIXES
+        pyproject = REPO_ROOT / "pyproject.toml"
+        assert not any(pyproject.is_relative_to(root) for root in SCAN_ROOTS)

--- a/tests/test_mortie_versions.py
+++ b/tests/test_mortie_versions.py
@@ -30,6 +30,7 @@ import tomllib
 from pathlib import Path
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from zagg.grids.aoi import MIN_MORTIE_VERSION
@@ -93,11 +94,23 @@ def _above(sites, floor):
 
 def _mortie_floor():
     """The ``>=`` floor from ``[project.dependencies]``."""
-    deps = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    reqs = [Requirement(d) for d in deps["project"]["dependencies"]]
-    spec = next(r.specifier for r in reqs if r.name == "mortie")
-    lower = [Version(s.version) for s in spec if s.operator in (">=", "==", "~=")]
-    assert len(lower) == 1, f"expected one mortie lower bound in pyproject, got {lower}"
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    reqs = [Requirement(d) for d in pyproject["project"]["dependencies"]]
+    # Every mortie requirement, not the first: a marker-split pair would leave
+    # half the matrix measured against the other half's floor. Names are
+    # normalized so a legal ``Mortie>=…`` is found rather than raising blank.
+    mortie = [r for r in reqs if canonicalize_name(r.name) == "mortie"]
+    assert len(mortie) == 1, f"expected exactly one mortie requirement in pyproject, got {mortie}"
+    # ``"*" not in`` keeps a wildcard pin (``mortie==0.9.*``) out of
+    # ``Version`` — it reaches the assertion below instead of ``InvalidVersion``.
+    lower = [
+        Version(s.version)
+        for s in mortie[0].specifier
+        if s.operator in (">=", "==", "~=") and "*" not in s.version
+    ]
+    assert len(lower) == 1, (
+        f"expected one concrete mortie lower bound in pyproject, got {lower} from {mortie[0]}"
+    )
     return lower[0]
 
 

--- a/tests/test_mortie_versions.py
+++ b/tests/test_mortie_versions.py
@@ -58,7 +58,7 @@ _CITATION = re.compile(r"mortie\s*(?:>=|≥)?\s*v?(\d+\.\d+(?:\.\d+)*)")
 def _cited_versions(text):
     """Every mortie release ``text`` names, as ``(Version, line number)``."""
     return [
-        (Version(m.group(1)), text.count("\n", 0, m.start()) + 1) for m in _CITATION.finditer(text)
+        (Version(m.group(1)), text.count("\n", 0, m.start(1)) + 1) for m in _CITATION.finditer(text)
     ]
 
 
@@ -153,6 +153,12 @@ class TestGuardFires:
         sites = [("docs/synthetic.md", 1, Version("0.10.0"))]
         assert _above(sites, Version("0.9.5")) == sites
         assert _above(sites, Version("0.10.0")) == []
+
+    def test_a_wrapped_citation_reports_the_version_line(self):
+        # The word and the number can land on different lines (``_layout.py``,
+        # ``morton.py``). The site printed has to be where the *number* is, or
+        # a failure sends the reader to a line that carries no version at all.
+        assert _cited_versions("added in mortie\n0.9.0") == [(Version("0.9.0"), 2)]
 
     def test_issue_references_are_not_versions(self):
         assert _cited_versions("(espg/mortie#89, espg/mortie#100) and mortie 1.x") == []


### PR DESCRIPTION
No originating issue — directed by espg in conversation on 2026-08-08, so the rationale lives here.

## Why

zagg's prose cites mortie release numbers in ~16 places, in three distinct voices. Only one of them is a live obligation, and conflating them makes the docs read as if the package carried more unenforced version contracts than it does:

1. **The package floor** — `mortie>=0.9.3` in `[project.dependencies]`. Single source: `deployment/aws/build_layer.sh` derives `MORTIE_SPEC` from it via `tomllib` (issue #322), and it was removed from `CLAUDE.md` §7 in 6988e9e6 for the same reason. Not touched here.
2. **Per-feature minimums with no runtime enforcement** — historically true, permanently satisfied because the floor already exceeds them. Written in requirement voice (`mortie >= 0.8.4`) they read as live obligations a reader might have to satisfy; they are not. **These get the voice fix.**
3. **Genuine provenance** — "resolved in mortie 0.9.0", "mortie 0.8.5, espg/mortie#100". Immutable statements about when something landed, correct as written. Left alone.

## Phases

- [x] Phase 1 — restate the four unenforced per-feature minimums in arrival voice (prose only, no behavior change)
- [x] Phase 2 — drift guard so the prose can never promise more than the floor guarantees
- [x] Phase 3 — adversarial self-review folded (6 of 7 findings; the 7th is declined and stands for review)

## Phase 1 — the four sites

Requirement voice → arrival voice, matching each site's surrounding prose rather than one template:

**`docs/morton_arrow.md:11`** (table cell — terse, so the parenthetical stays terse):

```diff
-| arro3 carrier (worker) | `arro3.core.Table` | `morton_index` Arrow **extension type** over the PyCapsule C Data Interface (mortie ≥ 0.8.4) |
+| arro3 carrier (worker) | `arro3.core.Table` | `morton_index` Arrow **extension type** over the PyCapsule C Data Interface (added in mortie 0.8.4) |
```

**`docs/ragged_layout.md:144`** (mid-sentence, beside the "frozen for mortie 1.x" provenance that follows it):

```diff
-`mortie.rank_to_xy` / `xy_to_rank` (mortie ≥ 0.9.3), whose contract is
+`mortie.rank_to_xy` / `xy_to_rank` (added in mortie 0.9.3), whose contract is
```

**`src/zagg/grids/morton.py:7`** (module docstring; rewrapped so `mortie 0.8.4` stays on one line):

```diff
-Interface (:func:`morton_to_arrow` / :func:`morton_from_arrow`; mortie >= 0.8.4,
-issue #135) — typed on both the pandas and arro3 surfaces, no pyarrow on the
-worker path. On disk it is stored as plain ``uint64`` — Zarr stores numpy
-dtypes, and the extension metadata lives at the interchange layer only — and
-reconstructed as a ``MortonIndexArray`` on read.
+Interface (:func:`morton_to_arrow` / :func:`morton_from_arrow`; added in
+mortie 0.8.4, issue #135) — typed on both the pandas and arro3 surfaces, no
+pyarrow on the worker path. On disk it is stored as plain ``uint64`` — Zarr
+stores numpy dtypes, and the extension metadata lives at the interchange layer
+only — and reconstructed as a ``MortonIndexArray`` on read.
```

**`src/zagg/grids/morton.py:202`** (`morton_to_arrow` docstring):

```diff
-    Interface (``MortonIndexArray.__arrow_c_array__``; mortie >= 0.8.4) — no
+    Interface (``MortonIndexArray.__arrow_c_array__``; added in mortie 0.8.4) — no
```

No code changed anywhere in phase 1 — the only non-citation edit is the rewrap of the three lines following the `morton.py` module-docstring citation, which keeps the paragraph at its existing ~78-column width.

### Deliberately not touched: the `aoi_mask` six

Six further sites cite `mortie >= 0.8.3` — `docs/aoi_mask.md:82,102,197,204` and `src/zagg/grids/aoi.py:26,88`. Requirement voice is *correct* there, because that one is a **real, enforced runtime gate**. `src/zagg/grids/aoi.py:42` defines the constant and `_assert_mortie_version` raises on a stale environment (`src/zagg/grids/aoi.py:66-80`):

```python
MIN_MORTIE_VERSION = "0.8.3"
...
    if resolved < Version(MIN_MORTIE_VERSION):
        raise RuntimeError(
            f"aoi_mask requires mortie >= {MIN_MORTIE_VERSION} (the order-29 MOC "
            f"coverage cap, espg/mortie#59 + #70, plus the public WKB/WKT cover "
            f"entry points, espg/mortie#89); resolved {raw}. Upgrade mortie "
            "or disable output.aoi_mask."
        )
```

Rewriting those six to arrival voice would make the docs *less* accurate — a user really can hit that `RuntimeError`. They stay, and phase 2 pins them to the constant instead.

Also untouched, as category (3): `src/zagg/grids/healpix.py:37,355`, `src/zagg/grids/morton.py:122`, `src/zagg/readers/_layout.py:7`, `docs/design/sparse_coverage.md:932`, and the `child_order 19` config-YAML comments — all already arrival/provenance voice.

## Phase 2 — the drift guard

`tests/test_mortie_versions.py`, following the `pyproject.toml`-reading convention already in `tests/test_lambda_build.py::TestLayerExtraParity` (`tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())`) and the floor-vs-runtime check in `tests/test_rectilinear.py::TestTransformerThreadSafety`.

**Two invariants:**

1. Every mortie version quoted under `docs/` or `src/` is **≤ the `pyproject.toml` floor**. This catches the one failure mode that matters: prose promising a feature the dependency does not guarantee, so a user hits `AttributeError` where the docs said they wouldn't. The floor is parsed from `[project.dependencies]` with `packaging.requirements.Requirement`, and every comparison goes through `packaging.version.Version` — never a string compare.
2. `MIN_MORTIE_VERSION` is **≤ the floor**, and every **requirement-voice** version quoted in the `aoi_mask` family (`docs/aoi_mask.md`, `src/zagg/grids/aoi.py`) **equals** it. That constant is the source of truth for the enforced gate, and those six sites are exactly the ones that cannot be de-versioned — so they are where a guard earns its keep. Arrival voice in those same two files ("the MOC cap shipped in mortie 0.8.2") is history rather than a restatement of the gate, so it is held to the floor like any other citation, not to the constant.

**The regex** — `mortie[\s(:,_-]*(?:version|release)?\s*(>=|==|~=|>|≥)?\s*v?(\d+\.\d+(?:\.\d+)*)`, case-insensitive — handles `>=`, `≥`, `==`/`~=`/`>`, bare `mortie 0.8.1`, `mortie (0.9.0)` / `mortie: 0.9.0` / `mortie-0.9.0`, `mortie version 0.9.0`, sentence-initial `Mortie 0.9.0`, and backticked/unbackticked variants (backticks fall outside the match). Whitespace spans newlines so a citation wrapped across a line break is not a blind spot. It does **not** match `espg/mortie#89` (`#` is outside the separator class), `frozen for mortie 1.x` (no second numeric component), or upper bounds like `mortie < 1.0` (an upper bound promises no API). Group 1 — the comparison operator, present only in requirement voice — is what scopes invariant (2).

The floor line in `pyproject.toml` is never read back as a citation because `.toml` is not in `SCAN_SUFFIXES` *and* the file sits outside both `SCAN_ROOTS`; the guard asserts both mechanisms rather than a path check that no scanned suffix could satisfy anyway.

**What it finds — 16 sites, floor `0.9.3`, of which 6 are requirement voice:**

```
docs/aoi_mask.md:82                            0.8.3  requirement
docs/aoi_mask.md:102                           0.8.3  requirement
docs/aoi_mask.md:197                           0.8.3  requirement
docs/aoi_mask.md:204                           0.8.3  requirement
docs/design/sparse_coverage.md:932             0.9.0  arrival
docs/morton_arrow.md:11                        0.8.4  arrival
docs/ragged_layout.md:144                      0.9.3  arrival
src/zagg/configs/atl03_tdigest_healpix.yaml:13 0.8.1  arrival
src/zagg/grids/aoi.py:26                       0.8.3  requirement
src/zagg/grids/aoi.py:88                       0.8.3  requirement
src/zagg/grids/healpix.py:37                   0.8.1  arrival
src/zagg/grids/healpix.py:355                  0.8.5  arrival
src/zagg/grids/morton.py:8                     0.8.4  arrival
src/zagg/grids/morton.py:122                   0.9.1  arrival
src/zagg/grids/morton.py:202                   0.8.4  arrival
src/zagg/readers/_layout.py:7                  0.9.3  arrival
```

The 6 requirement-voice sites are exactly the `aoi_mask` family, all `0.8.3` == `MIN_MORTIE_VERSION`; the other ten are all ≤ `0.9.3`. Two of them (`morton.py:122`, `readers/_layout.py:7`) sit inside sentences where the word `mortie` and the number land on different lines, so a line-scoped grep misses them — the newline-tolerant whitespace is what surfaces them.

### Proving the guard fires

A guard that passes vacuously is worse than none, so non-vacuity is asserted rather than assumed:

- `test_scan_finds_the_versioned_sites` asserts the scan returns ≥ 12 sites — a regex that silently matched nothing would otherwise let every other test in the module pass forever. Deliberately a count and not a per-file list: naming the files would ratchet them in place, and *deleting* an unenforced per-feature minimum is the very edit phase 1 argues for.
- `test_a_citation_above_the_floor_is_caught` feeds a synthetic `mortie >= 99.0.0` through the *same* `_cited_versions` / `_above` helpers the tree scan uses and asserts it is flagged.
- `test_ordering_is_pep440_not_lexicographic` pins the exact case a string compare gets backwards: `"0.10.0" < "0.9.5"` as text, `Version("0.10.0") > Version("0.9.5")` as versions, and `_above` agreeing with the latter.
- `test_issue_references_are_not_versions`, `test_every_citation_spelling_is_recognized`, and `test_the_spellings_that_used_to_pass_silently_are_caught` pin the regex's negative and positive cases — including `mortie==0.10.0`, sentence-initial `Mortie`, and the wrapped-across-a-newline spelling.
- `test_a_wrapped_citation_reports_the_version_line` pins that a site is reported at the line carrying the *number*, not the line carrying the word `mortie`, so a failure never sends the reader to a line with no version on it.
- `test_requirement_voice_is_told_from_arrival_voice` pins the operator split that invariant (2) rides on.
- `test_the_floor_line_is_not_scanned_as_a_citation` shows the regex *would* match `"mortie>=0.9.3"` in `pyproject.toml`, then asserts the two mechanisms that actually exclude it (`.toml` absent from `SCAN_SUFFIXES`, and the file outside `SCAN_ROOTS`).

Beyond the unit tests, both invariants were mutation-tested against the real tree, twice — once as first written and once after the fold:

```
# docs/ragged_layout.md:144 → mortie 9.9.9
AssertionError: prose quotes a mortie version above the pyproject floor 0.9.3:
[('docs/ragged_layout.md', 144, <Version('9.9.9')>)]. Either raise the floor in
[project.dependencies] (an espg-authorized dependency change) or restate the prose
against a shipped release.

# src/zagg/grids/aoi.py:26 → mortie >= 0.8.9
AssertionError: aoi_mask prose disagrees with MIN_MORTIE_VERSION (0.8.3):
[('src/zagg/grids/aoi.py', 26, <Version('0.8.9')>)]
```

Both mutations were reverted; `git status` is clean of them.

## Phase 3 — adversarial self-review, folded

A fresh-context review agent posted 7 inline findings (§2). Six were folded, one commit each; one is declined and stands for review:

| Finding | Disposition |
| --- | --- |
| Line numbers off by one for citations stitched across a newline | Fixed — report the version group's own line (`0f9d8798`) |
| Regex false negatives: no `re.IGNORECASE`, only `>=`/`≥`, so `mortie==0.10.0` passed silently | Fixed — widened operator + separator sets, with regression cases both ways (`ac5d864f`) |
| Floor parse: first-match `next()`, uncanonicalized name compare, wildcard pin raising `InvalidVersion` | Fixed — collect every mortie requirement and assert exactly one, `canonicalize_name`, wildcard kept out of `Version` (`01ca19f1`) |
| The per-file presence list ratchets citations in place, against phase 1's own thesis | Fixed — count-based anti-vacuity assertion kept, file list demoted to a comment (`6f989ed9`) |
| `aoi.py:35,37,54` state versions in detached voice, invisible to the scan, so a `MIN_MORTIE_VERSION` bump leaves them stale — and file-scoped equality *penalized* fixing them | Fixed — equality scoped to requirement voice, claim narrowed, residual blind spot named in the module docstring (`4cf0c51c`) |
| `test_the_floor_line_is_not_scanned_as_a_citation` was a tautology, and misattributed the mechanism to `SCAN_ROOTS` | Fixed — asserts `SCAN_SUFFIXES` and a roots check that can actually fail (`01bb10b2`) |
| Regex false *positives*: `mortie 1.0` or "gated on mortie 0.10.0" would redden correct prose | **Declined, standing for review.** A sentence naming a release above the floor is the signal this guard exists to raise, and both proposed remedies (an opt-out marker, or excluding `docs/design/`) narrow the directive rather than the false-positive set. Worth overriding if the design docs' forward-looking voice turns out to trip it in practice. |

## How it was tested

`uv run ruff check src tests`, `uv run ruff format --check src tests`, `uv run pytest -q` in a worktree synced with the catalog/analysis/viz/benchmark/test extras + dev group (mortie 0.9.5).

Phase 1 is prose-only, so the existing suite is its regression check. Baseline with the new file excluded: **3699 passed, 10 skipped, 1 failed**. With it: **3711 passed, 10 skipped, 1 failed** — exactly the 12 tests this PR adds. The one failure is `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`, pre-existing, local-only, and green on CI.

## Questions for review

- **Scan scope — the known blind spot.** A version is recognized only where the release number is lexically attached to the word `mortie`. Three bare literals inside `src/zagg/grids/aoi.py` (`:35` "shipped in 0.8.2", `:37` "ship in 0.8.3", `:54` "the same 0.8.3 release" — the last inside `_assert_mortie_version`'s own docstring) are therefore invisible to the guard, so a `MIN_MORTIE_VERSION` bump still needs a human eye on that block. Widening to catch them means matching every bare `x.y.z` in prose that also carries `zarr>=3.1.5`, `pyproj 3.7`, `numpy 2.2.6`, and Python 3.12 — I judged the false-positive cost worse than the gap, and wrote it into the module docstring as a scope note rather than hiding it. Say the word if you'd rather have the noisier version.
- **False positives are possible, by design.** `mortie 1.0` matches and would fail the guard; so would a forward-looking "gated on mortie 0.10.0" of the kind `docs/design/sparse_coverage.md:392,905` currently writes without a number. This is the declined review finding above. My reasoning is that such a sentence is exactly what should get a human's attention, but the counter-argument (design docs are narrative, not promises) is real — excluding `docs/design/` from `SCAN_ROOTS` is a one-line change if you prefer it.
- **`tests/` is not scanned.** `tests/test_grids.py:158,165` and `tests/test_morton_arrow.py:3` cite mortie versions too. They document test intent rather than a user-facing promise, so they are out of scope here — say the word if they should be in.

Pre-existing and not fixed here (unrelated to this change): `N818` at `src/zagg/registry.py:64`, and the `ruff format --check` diff on `tests/data/benchmark/README.md`.
