### PR TITLE
small fixes: staged sweep skip key carries the run ids; bench object model gains the column term

### DIFF
--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -51,10 +51,20 @@ on Lambda, so its artifacts may or may not have landed at measurement time;
 its column *placement* is dispatch cadence, which §4.6 declares
 "orchestration, never contract", so no fixed count could be right; and a
 partial or scoped sweep is a legal store state. The leaf column is on the
-other side of that line — one deterministic artifact per populated
-``(leaf, window)`` unit, written inside the same worker whose object count
-the issue #215 tripwire guards — so it is audited exactly, and a column that
-goes missing or arrives multiplied trips the per-shard assertion.
+other side of that line — one deterministic artifact per populated leaf,
+written inside the same worker whose object count the issue #215 tripwire
+guards — so it is audited exactly, and a column that goes missing or arrives
+multiplied trips the per-shard assertion.
+
+**The hive model assumes the UNWINDOWED leaf** (review finding), as the flat
+model assumes fullsphere HEALPix (:func:`_require_fullsphere`). One populated
+shard is one leaf and one column; a windowed store writes one of each per
+``(leaf, window)``, which this model does not count — and would not reach in
+any case, since the per-shard attribution builds its leaf prefixes from
+``hive.shard_leaf_path("", key)`` with no ``window=``, so a windowed leaf
+matches no prefix and surfaces as a loud ``other`` first. Widening the model
+to windows is its own change, with its own test surface; it is not smuggled
+in here.
 
 Determinism caveats (documented, not modeled): a populated shard is assumed to
 write every array — true when every field aggregates the same observations

--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -423,7 +423,11 @@ def store_object_counts(
 
     Returns ``{"objects_total", "objects_metadata", "objects_per_shard",
     "objects_rollups", "objects_overviews", "objects_telemetry",
-    "objects_other", "other_keys"}``. ``objects_per_shard`` keys are the
+    "objects_other", "other_keys"}``. ``objects_overviews`` is the
+    SECOND-PASS SWEEP bucket, of which overview zarrs are one family and
+    ancestor-node stage columns (issue #418) another — the name predates the
+    second family and is load-bearing for the record's readers, so it is
+    described here rather than renamed. ``objects_per_shard`` keys are the
     dispatched shards' external labels (``grid.shard_label``); a data object
     whose block resolves to an undispatched shard is keyed ``"block:<n>"`` so
     a stray write is visible rather than silently pooled. ``other_keys`` is a

--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -84,6 +84,8 @@ from __future__ import annotations
 
 import re
 
+from zagg.column import COLUMN_SUFFIX
+
 # Per-shard attribution on the flat layout assumes the 1-D fullsphere HEALPix
 # layout the benchmark manifests use (block index arithmetic on the cells
 # axis); the hive layout attributes by leaf prefix and is layout-agnostic.
@@ -94,13 +96,6 @@ import re
 #: 0/5-9 digits or letters and ``all`` is the reserved token — which is what
 #: lets the hive walk tell an overview zarr from a stray source leaf.
 _MORTON_ID_RE = re.compile(r"-?[1-6][1-4]*")
-
-
-def _column_suffix() -> str:
-    """``zagg.column.COLUMN_SUFFIX`` — the ONE definition of the name seam."""
-    from zagg.column import COLUMN_SUFFIX
-
-    return COLUMN_SUFFIX
 
 
 def _column_node(key: str) -> str | None:
@@ -119,7 +114,7 @@ def _column_node(key: str) -> str | None:
     parts = key.split("/")
     for i, part in enumerate(parts):
         if part.endswith(".zarr"):
-            return "/".join(parts[:i]) if part.endswith(_column_suffix()) else None
+            return "/".join(parts[:i]) if part.endswith(COLUMN_SUFFIX) else None
     return None
 
 
@@ -143,7 +138,7 @@ def _overview_node(key: str) -> str | None:
     for i, part in enumerate(parts):
         if not part.endswith(".zarr"):
             continue
-        if part.endswith(_column_suffix()):
+        if part.endswith(COLUMN_SUFFIX):
             return None
         stem = part.removesuffix(".zarr").split("_", 1)[0]
         return None if _MORTON_ID_RE.fullmatch(stem) else "/".join(parts[:i])

--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -29,6 +29,32 @@ so it cannot drift from what the template actually emits:
   default), making the sharded hive count EXACT like the flat sharded one; an
   unsharded K>1 leaf keeps the bounded 1..K dense estimate. (The commit stamp
   rewrites the leaf root ``zarr.json`` in place — no extra object.)
+- **hive leaf pyramid column** (issue #418): since the issue #384 ``/2``
+  default flip a default declaration also makes every leaf worker write its
+  own column artifact — ``{node}/{window}.pyramid.zarr``, a SIBLING of the
+  leaf (specification §4.6) — plus its D20 stats sidecar. It is modeled
+  exactly, per populated leaf, off the store's own ``pyramid`` declaration
+  (see :func:`_column_objects`): a column with no declared leaf levels costs
+  nothing, and a ``/1`` (or declared-off) store keeps the pre-#384 count.
+
+**Scope of the model: LEAF-ONLY — the fleet write path, never a swept
+ladder** (issue #418, the decision that issue asks to be made explicitly).
+What the model claims to predict exactly is what the *leaf workers* write:
+the leaf zarr, its sidecars, and — new — the leaf's own pyramid column.
+Everything the SWEEP writes stays outside the audited total, in the
+unbounded ``objects_rollups`` / ``objects_overviews`` buckets: the D9
+rollups (issue #300), the ladder overview zarrs above the shard node (issue
+#201/#384), and **stage columns** — the ``{window}.pyramid.zarr`` artifacts
+the staged sweep writes at ANCESTOR nodes (specification §4.6). Three
+reasons, all structural rather than convenient: the sweep is fire-and-forget
+on Lambda, so its artifacts may or may not have landed at measurement time;
+its column *placement* is dispatch cadence, which §4.6 declares
+"orchestration, never contract", so no fixed count could be right; and a
+partial or scoped sweep is a legal store state. The leaf column is on the
+other side of that line — one deterministic artifact per populated
+``(leaf, window)`` unit, written inside the same worker whose object count
+the issue #215 tripwire guards — so it is audited exactly, and a column that
+goes missing or arrives multiplied trips the per-shard assertion.
 
 Determinism caveats (documented, not modeled): a populated shard is assumed to
 write every array — true when every field aggregates the same observations
@@ -60,6 +86,33 @@ import re
 _MORTON_ID_RE = re.compile(r"-?[1-6][1-4]*")
 
 
+def _column_suffix() -> str:
+    """``zagg.column.COLUMN_SUFFIX`` — the ONE definition of the name seam."""
+    from zagg.column import COLUMN_SUFFIX
+
+    return COLUMN_SUFFIX
+
+
+def _column_node(key: str) -> str | None:
+    """The node dir holding ``key``'s pyramid COLUMN zarr, or ``None``.
+
+    A column artifact is ``{node}/{window}.pyramid.zarr`` (specification
+    §4.6): the leaf worker's own contribution at a leaf node, and the staged
+    sweep's relay at an ancestor node — the SAME basename grammar at both, so
+    the node the caller resolves it against is what tells them apart (a
+    dispatched leaf's node makes it write-path; anything else makes it a
+    sweep artifact). Keyed off ``COLUMN_SUFFIX`` rather than a second literal,
+    and checked on the FIRST ``.zarr`` segment for the same reason
+    :func:`_overview_node` is: an object nested under a real leaf's zarr is
+    that shard's, never a sibling artifact's.
+    """
+    parts = key.split("/")
+    for i, part in enumerate(parts):
+        if part.endswith(".zarr"):
+            return "/".join(parts[:i]) if part.endswith(_column_suffix()) else None
+    return None
+
+
 def _overview_node(key: str) -> str | None:
     """The node dir holding ``key``'s sweep overview zarr, or ``None``.
 
@@ -70,11 +123,18 @@ def _overview_node(key: str) -> str | None:
     (see :data:`_MORTON_ID_RE`). Taking the FIRST segment keeps the hive walk's
     leaf-membership-first ordering: anything nested under a real leaf's zarr is
     that shard's object, never an overview.
+
+    A COLUMN zarr is excluded (issue #418): its stem does not parse as a
+    morton id either, so it would otherwise read as an overview — but a
+    column is a different artifact family with a different audit posture
+    (:func:`_column_node`), and the two buckets must stay disjoint.
     """
     parts = key.split("/")
     for i, part in enumerate(parts):
         if not part.endswith(".zarr"):
             continue
+        if part.endswith(_column_suffix()):
+            return None
         stem = part.removesuffix(".zarr").split("_", 1)[0]
         return None if _MORTON_ID_RE.fullmatch(stem) else "/".join(parts[:i])
     return None
@@ -128,11 +188,48 @@ def _member_layouts(grid, *, leaf: bool = False) -> list[dict]:
     return members
 
 
+def _column_objects(pyramid, node_order: int) -> int:
+    """Objects ONE leaf's pyramid column costs, or 0 when none is declared.
+
+    The issue #384 ``/2`` default flip made this a term every default store
+    pays (issue #418). Derived from the store's own ``pyramid`` declaration
+    through the writer's own functions — :func:`zagg.column.column_resolutions`
+    for the groups and :func:`zagg.column.composable_fields` for the arrays —
+    so the model cannot drift from what ``write_column`` emits, the same
+    posture :func:`_member_layouts` takes toward the template spec.
+
+    Per :func:`zagg.column.write_column`'s D4 order, one column is: the root
+    ``zarr.json`` (the template, the attrs and the commit stamp all REWRITE
+    it — three PUTs, one object), then per resolution group a group
+    ``zarr.json`` plus, per array (``morton`` + one per composable field),
+    one ``zarr.json`` and one chunk object — the groups are one chunk each
+    (``chunks_per_shard == 1`` turns the inert sharding back off), so the
+    count is deterministic exactly as the #236 sharded leaf's is. The D20
+    stats sidecar written after the stamp is the ``+ 1``, counted like the
+    leaf's own ``stats.json`` sibling.
+
+    Zero for a ``/1`` (or declared-off) block, and zero when the declaration
+    carries no leaf-node entry — both are stores whose leaves write no column.
+    """
+    from zagg.column import column_resolutions, composable_fields
+    from zagg.pyramid import PYRAMID_SPEC_V2
+
+    if not isinstance(pyramid, dict) or pyramid.get("spec") != PYRAMID_SPEC_V2:
+        return 0
+    resolutions = column_resolutions(pyramid.get("overviews") or [], node_order)
+    if not resolutions:
+        return 0
+    fields = (pyramid.get("overview") or {}).get("fields") or {}
+    arrays = 1 + len(composable_fields(fields))
+    return 1 + len(resolutions) * (1 + 2 * arrays) + 1
+
+
 def expected_object_counts(
     grid,
     *,
     n_shards: int,
     store_layout: str = "flat",
+    pyramid: dict | None = None,
 ) -> dict:
     """Expected store object counts for ``n_shards`` populated shards.
 
@@ -141,6 +238,11 @@ def expected_object_counts(
     object count; ``exact`` is True when every per-shard count is
     deterministic (the flat sharded live matrix), in which case
     ``total_min == total_max`` is the asserted total.
+
+    ``pyramid`` is the store manifest's ``pyramid`` block (hive only) — the
+    declaration that decides whether each leaf also writes a column
+    (:func:`_column_objects`). :func:`measure_objects` reads it off the store
+    it is measuring; ``None`` models the pre-#384 shape, i.e. no column.
     """
     if store_layout == "flat":
         _require_fullsphere(grid)
@@ -205,8 +307,10 @@ def expected_object_counts(
         # may be legitimately absent for a unit whose submap event block was
         # dropped over the async payload cap, which then surfaces here as a
         # mismatch worth seeing rather than a modeled window).
+        # ... plus the leaf's own pyramid column and its sidecar (issue #418),
+        # exact per populated leaf and zero when none is declared.
         sidecar = 1 if grid.child_order > grid.parent_order else 0
-        lo = hi = 5 + len(members) + sidecar
+        lo = hi = 5 + len(members) + sidecar + _column_objects(pyramid, grid.parent_order)
         for m in members:
             blocks = m["blocks_per_shard"]
             hi += blocks
@@ -377,6 +481,14 @@ def store_object_counts(
         # at an UNDISPATCHED leaf's node stays a loud ``other``, which is the
         # "the model knows every object the run writes" contract.
         overview_nodes = {n for n in map(_overview_node, keys) if n is not None}
+        # ... and the nodes holding a SWEEP-written stage column (issue #418):
+        # its D20 sidecar sits beside it exactly as an overview's does, so it
+        # anchors the same branch. A dispatched leaf's node is excluded — its
+        # column sidecar is that shard's write-path object, caught by the
+        # sibling rule below, and the two branches must stay disjoint.
+        overview_nodes |= {
+            n for n in map(_column_node, keys) if n is not None and n + "/" not in stats_of
+        }
         for key in keys:
             if _is_root_telemetry(key):
                 telemetry += 1
@@ -407,6 +519,23 @@ def store_object_counts(
                 # attribution above and trips #215 instead of vanishing.
                 if key.endswith(".rollup.json"):
                     rollups += 1
+                    continue
+                # Pyramid columns (issue #418), before the overview branch —
+                # they share the "stem is not a morton id" shape but not the
+                # audit posture. A column under a DISPATCHED leaf's node is
+                # that shard's write-path object (the leaf worker wrote it
+                # while the shard's cells were resident), so it counts into
+                # ``per_shard`` and rides the exact #215 guard; a column at
+                # any other node is a STAGE column the sweep wrote, which
+                # joins the overviews bucket outside the audited total (the
+                # leaf-only scope stated in the module docstring).
+                column_node = _column_node(key)
+                if column_node is not None:
+                    label = stats_of.get(column_node + "/")
+                    if label is None:
+                        overviews += 1
+                    else:
+                        per_shard[label] = per_shard.get(label, 0) + 1
                     continue
                 # Sweep overview zarrs (issue #201): `{window}.zarr/...` at a
                 # digit node. The window-token basename can never parse as a
@@ -482,8 +611,22 @@ def measure_objects(
     and the mismatch description (null when clean). ``n_shards`` is the number
     of shards expected to have written (the dispatch count for the per-merge
     harness, the completed-with-data count for the full-AOI fan-out).
+
+    On hive the pyramid DECLARATION is read from the store's own manifest and
+    threaded into the model (issue #418), so the column term needs no new
+    argument at the harness call sites: the block is the run's declaration,
+    written by ``hive.build_manifest`` before any leaf runs, never a product
+    of the write path being audited. A hive store with no readable manifest
+    raises here rather than quietly modelling the pre-#384 shape.
     """
-    expected = expected_object_counts(grid, n_shards=n_shards, store_layout=store_layout)
+    pyramid = None
+    if store_layout == "hive":
+        from zagg.hive import read_manifest
+
+        pyramid = (read_manifest(store_path, **store_kwargs) or {}).get("pyramid")
+    expected = expected_object_counts(
+        grid, n_shards=n_shards, store_layout=store_layout, pyramid=pyramid
+    )
     measured = store_object_counts(
         store_path,
         grid=grid,

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -552,7 +552,13 @@ residual-race backstop).
 **Soft barriers.** Stage order is a scheduling preference, not
 correctness: a tuple run before its finer tuple landed under-covers loudly
 (`source_children`) and self-heals on the next pass — the skip gate keys on
-summed child generations, so a healed child forces the parent rewrite.
+summed child generations, so a healed child forces the parent rewrite. That
+key is a triple — leaf count, newest child stamp, and the set of `run_id`s
+those stamps carry ([issue #417](https://github.com/englacial/zagg/issues/417),
+[specification §4.5](specification.md)) — because stamps resolve to one
+second: without the run ids a child rewritten inside its own recorded second
+at an unchanged leaf count would read as current and the parent would keep
+the stale fold.
 
 **Aging.** Stage reruns refresh the ancestor artifacts they revisit (a
 rewrite is a fresh PUT), and the finisher's manifest RMW + root-MOC write

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -899,7 +899,8 @@ staged sweep's finisher.
   ```
 
   — the summed leaf count of the consumed children, the newest child stamp,
-  and the **sorted set of `run_id`s** those children's stamps carry
+  and the **sorted set of `run_id`s** those children's stamps carry, unioned
+  with the ids their own recorded blocks relay
   ([#417](https://github.com/englacial/zagg/issues/417)). A level is folded
   again exactly when this triple moves. The third term is load-bearing:
   stamps resolve to **one second**, so the first two alone read a child

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -656,7 +656,8 @@ relayed gen-1 partials — never 3 for an upfront level; gen 3 belongs only
 to the append-later cascade regime), and `source_children` (present in both
 stage regimes: a gather that under-covers says so exactly like a merge) —
 plus `run_id`, the sweep run that wrote the artifact, and a `generation`
-block summing the consumed children (the stage skip gate's ratchet key).
+block summing the consumed children (the stage skip gate's ratchet key —
+`{n_leaves, max_leaf_timestamp, run_ids}`, composition in §4.5).
 The commit stamp of a stage-written artifact carries the same `run_id` key
 (additive to the stamp grammar; fleet-written stamps never carry it, and a
 reader treats its absence as "not a stage artifact", never an error): it is
@@ -887,6 +888,32 @@ staged sweep's finisher.
   tolerate additional keys on a level entry, and `actuals` says nothing
   about artifacts still being present (overviews are regenerable caches,
   §4.1).
+- **The stage skip key** (`generation`, recorded per artifact in §4.4's
+  attrs, per stage column in §4.6, and in the sweep-internal envelope) is
+  the triple
+
+  ```json
+  "generation": {"n_leaves": 16,
+                 "max_leaf_timestamp": "2026-08-09T00:00:00+00:00",
+                 "run_ids": ["stage-20260809T000000Z-ab12cd"]}
+  ```
+
+  — the summed leaf count of the consumed children, the newest child stamp,
+  and the **sorted set of `run_id`s** those children's stamps carry
+  ([#417](https://github.com/englacial/zagg/issues/417)). A level is folded
+  again exactly when this triple moves. The third term is load-bearing:
+  stamps resolve to **one second**, so the first two alone read a child
+  rewritten inside its own recorded second at an unchanged leaf count as
+  *current*, and the `/1` content-hash backstop cannot apply without doing
+  the fold the skip exists to avoid. A run may not rewrite its own object
+  mid-run (single-writer law, §4.8), so a same-second rewrite is a foreign
+  run's and moves the set. `run_ids` is **additive**: absent, it MUST be
+  read as the empty set (a pre-#417 entry, or children that are all
+  fleet-written leaf columns — those stamps carry no `run_id`), never as a
+  wildcard that matches any set, so an upgraded store folds once more
+  rather than inheriting the blind spot. Fleet-written leaf columns
+  contribute no run id, so at the finest tuple the term is empty and the
+  gate rests on the pair alone.
 
 ### 4.6 Leaf column artifacts (`zagg-column/1`)
 
@@ -1041,8 +1068,8 @@ members at the same resolution — `groups` entries record `regime:
 **relay member** (the group at `shard_order`: the subtree's leaf node-order
 partials, the merge-source tier every coarser merge consumes — the espg
 merge-source ruling on the #384 thread). Stage-column attrs additionally
-carry `generation` (`{n_leaves, max_leaf_timestamp}` summed over the
-consumed children — the parent's skip-gate key), `source_children` (a
+carry `generation` (`{n_leaves, max_leaf_timestamp, run_ids}` summed over
+the consumed children — the parent's skip-gate key, §4.5), `source_children` (a
 gather that under-covered says so in the artifact), and `run_id`; the
 commit stamp carries `run_id` too. Cadence decides placement (columns sit
 at dispatch orders), so column EXISTENCE at a given ancestor order is
@@ -1097,7 +1124,10 @@ are unaffected: fleet ∥ fleet is governed by the leaf single-writer law and
 fleet ∥ sweep is allowed (the stage workers validate every column stamp
 before and after reading its groups and re-read on movement; stage stamps
 carry `run_id`, and a skip-if-current read that sees a foreign stamp
-written after the run started aborts loudly).
+written after the run started aborts loudly). The same `run_id` is a **term
+of the skip key** (§4.5): the abort covers a foreign stamp written *since
+this run started*, and the key covers the foreign rewrite that landed
+before it — inside the second the timestamp cannot resolve.
 
 ## 5. O11 content hashes
 

--- a/src/zagg/column.py
+++ b/src/zagg/column.py
@@ -80,6 +80,28 @@ def generation_key(block) -> tuple:
     )
 
 
+def stamped_generation_key(block, stamp) -> tuple:
+    """One child's contribution to its parent's skip key (issue #417).
+
+    :func:`generation_key` over the child's recorded ``generation`` block —
+    or, for a leaf column (which records none), the leaf identity: one leaf
+    at its stamp's timestamp — **unioned with the run id that stamped THIS
+    child**. That id is the term the issue turns on: the run that wrote the
+    child is what a same-second foreign rewrite changes, and reading the
+    relayed block alone would see only the ids of the child's own children
+    (empty all the way down a fleet-built store, so the gate would fall back
+    to the count/timestamp pair it is meant to strengthen). Fleet-written
+    stamps carry no ``run_id`` and contribute nothing.
+    """
+    stamp = stamp if isinstance(stamp, dict) else {}
+    if not isinstance(block, dict):
+        block = {"n_leaves": 1, "max_leaf_timestamp": stamp.get("written_at")}
+    runs = set(block.get("run_ids") or ())
+    if stamp.get("run_id"):
+        runs.add(stamp["run_id"])
+    return generation_key({**block, "run_ids": sorted(runs)})
+
+
 def column_resolutions(levels: list, node_order: int) -> list[int]:
     """The resolutions a leaf-node column carries, finest first (issue #383).
 

--- a/src/zagg/column.py
+++ b/src/zagg/column.py
@@ -55,6 +55,31 @@ COLUMN_ROLE = "column"
 LEAF_REGIME = "leaf-column"
 
 
+def generation_key(block) -> tuple:
+    """The staged sweep's skip-gate key over a summed ``generation`` block.
+
+    ``(n_leaves, max_leaf_timestamp, run ids)`` — the block the stage worker
+    records in these attrs and in the ladder entries it writes (§4.4/§4.6).
+    The run ids are the issue #417 term: stamps resolve to **one second**, so
+    the count/timestamp pair alone reads a same-second rewrite of a child at
+    an unchanged leaf count as *current* and serves stale content. Every
+    stage stamp carries its ``run_id`` (PR #416 phase 2), so a foreign
+    rewrite moves the id set, and the single-writer law forbids a run
+    rewriting its own object mid-run. A block without ``run_ids`` (pre-#417,
+    or children that are all fleet-written leaf columns — those stamps carry
+    no run id) keys on the empty tuple, never on a wildcard: an upgraded
+    store re-folds once rather than inheriting the blind spot. A non-block
+    keys on ``()``, which matches no generation.
+    """
+    if not isinstance(block, dict):
+        return ()
+    return (
+        int(block.get("n_leaves") or 0),
+        block.get("max_leaf_timestamp"),
+        tuple(block.get("run_ids") or ()),
+    )
+
+
 def column_resolutions(levels: list, node_order: int) -> list[int]:
     """The resolutions a leaf-node column carries, finest first (issue #383).
 

--- a/src/zagg/column.py
+++ b/src/zagg/column.py
@@ -70,13 +70,18 @@ def generation_key(block) -> tuple:
     no run id) keys on the empty tuple, never on a wildcard: an upgraded
     store re-folds once rather than inheriting the blind spot. A non-block
     keys on ``()``, which matches no generation.
+
+    ``run_ids`` is compared as a SET: the recorded list is read back off an
+    artifact this process did not write, so its order is not a property to
+    assume (review finding — an unsorted or duplicated list would otherwise
+    re-fold a whole ladder for nothing).
     """
     if not isinstance(block, dict):
         return ()
     return (
         int(block.get("n_leaves") or 0),
         block.get("max_leaf_timestamp"),
-        tuple(block.get("run_ids") or ()),
+        tuple(sorted(set(block.get("run_ids") or ()))),
     )
 
 

--- a/src/zagg/sweep_stage.py
+++ b/src/zagg/sweep_stage.py
@@ -301,21 +301,16 @@ class _ColumnReader:
     def generation(self) -> tuple:
         """This column's generation basis: its own, or the leaf identity.
 
-        :func:`zagg.column.generation_key`'s triple. Stage columns record a
-        ``generation`` block in their attrs (the summed ratchet); a leaf
-        column is one leaf — ``n_leaves: 1`` at its stamp timestamp, under
-        the run id that stamp carries (fleet-written ones carry none). The
-        parent's skip gate keys on the SUM of these.
+        :func:`zagg.column.stamped_generation_key`'s triple: a stage column's
+        recorded ``generation`` block (the summed ratchet) or a leaf column's
+        identity — one leaf at its stamp's timestamp — plus the run id THIS
+        column's own stamp carries (fleet-written ones carry none, review
+        finding). The parent's skip gate keys on the SUM of these.
         """
-        from zagg.column import COLUMN_ATTR, generation_key
+        from zagg.column import COLUMN_ATTR, stamped_generation_key
 
         block = (self.attrs.get(COLUMN_ATTR) or {}).get("generation")
-        if not isinstance(block, dict):
-            stamp = self.stamp or {}
-            block = {"n_leaves": 1, "max_leaf_timestamp": stamp.get("written_at")}
-            if stamp.get("run_id"):
-                block["run_ids"] = [stamp["run_id"]]
-        return generation_key(block)
+        return stamped_generation_key(block, self.stamp)
 
     def read(self, res: int, name: str) -> np.ndarray | None:
         """One group array, stamp-validated; ``None`` for an absent member.

--- a/src/zagg/sweep_stage.py
+++ b/src/zagg/sweep_stage.py
@@ -48,9 +48,10 @@ Fleets run concurrently with a live sweep: the worker validates each column's
 stamp before and after reading its groups and re-reads on movement, so a
 mid-read leaf rewrite never feeds a torn column into a merge; a mid-sweep
 append is ordinary under-coverage, recorded and healed by the next sweep.
-Stage-written stamps carry the run id; a skip-if-current read that sees a
-FOREIGN fresh stamp aborts loudly (:class:`ForeignSweepError`) — the backstop
-for residual races the lease cannot see (TTL clock skew, zombie workers).
+Stage-written stamps carry the run id: a skip-if-current read that sees a
+FOREIGN fresh stamp aborts loudly (:class:`ForeignSweepError` — the backstop
+for residual races the lease cannot see), and the run id is also a TERM of
+the skip key (issue #417), so a same-second rewrite cannot read as current.
 
 **Soft barriers.** Inter-stage barriers are scheduling preferences, not
 correctness (#381 point (6)): a stage run before its finer tuple landed
@@ -297,22 +298,24 @@ class _ColumnReader:
     def committed(self) -> bool:
         return self.stamp is not None
 
-    def generation(self) -> dict:
+    def generation(self) -> tuple:
         """This column's generation basis: its own, or the leaf identity.
 
-        Stage columns record a ``generation`` block in their attrs (the
-        summed ratchet); a leaf column is one leaf — ``n_leaves: 1`` at its
-        stamp timestamp. The parent's skip gate keys on the SUM of these.
+        :func:`zagg.column.generation_key`'s triple. Stage columns record a
+        ``generation`` block in their attrs (the summed ratchet); a leaf
+        column is one leaf — ``n_leaves: 1`` at its stamp timestamp, under
+        the run id that stamp carries (fleet-written ones carry none). The
+        parent's skip gate keys on the SUM of these.
         """
-        from zagg.column import COLUMN_ATTR
+        from zagg.column import COLUMN_ATTR, generation_key
 
         block = (self.attrs.get(COLUMN_ATTR) or {}).get("generation")
-        if isinstance(block, dict):
-            return {
-                "n_leaves": int(block.get("n_leaves") or 0),
-                "max_leaf_timestamp": block.get("max_leaf_timestamp"),
-            }
-        return {"n_leaves": 1, "max_leaf_timestamp": (self.stamp or {}).get("written_at")}
+        if not isinstance(block, dict):
+            stamp = self.stamp or {}
+            block = {"n_leaves": 1, "max_leaf_timestamp": stamp.get("written_at")}
+            if stamp.get("run_id"):
+                block["run_ids"] = [stamp["run_id"]]
+        return generation_key(block)
 
     def read(self, res: int, name: str) -> np.ndarray | None:
         """One group array, stamp-validated; ``None`` for an absent member.
@@ -386,16 +389,25 @@ def _readers_for(
 
 
 def _summed_generation(rows: list) -> dict:
-    """The ratchet key: child generations summed (skip-if-current basis)."""
-    n, stamps = 0, []
+    """The ratchet key: child generations summed (skip-if-current basis).
+
+    ``run_ids`` is the union over the contributing children — issue #417's
+    term; see :func:`zagg.column.generation_key`.
+    """
+    n, stamps, runs = 0, [], set()
     for row in rows:
         for reader in row:
             if _is_reader(reader):
-                gen = reader.generation()
-                n += gen["n_leaves"]
-                stamps.append(gen["max_leaf_timestamp"])
+                count, timestamp, run_ids = reader.generation()
+                n += count
+                stamps.append(timestamp)
+                runs.update(run_ids)
     stamps = [t for t in stamps if t is not None]
-    return {"n_leaves": int(n), "max_leaf_timestamp": max(stamps) if stamps else None}
+    return {
+        "n_leaves": int(n),
+        "max_leaf_timestamp": max(stamps) if stamps else None,
+        "run_ids": sorted(runs),
+    }
 
 
 def _gather_slabs(rows: list, fields: dict, *, res: int, span: int, n_out: int) -> tuple:
@@ -901,12 +913,13 @@ def stage_node(
     tuple order materializes every dirty artifact node beneath the dispatch
     node — skip-if-current keyed on SUMMED CHILD GENERATIONS (the ratchet:
     a healed or appended child moves the sum and forces the rewrite; a
-    content hash cannot be had without folding, so the generation pair is
-    the gate) — and finally its own stage column (relay + gatherables),
-    unless this is the root tuple (no parent consumes it) or the all-time
-    item (the per-window columns carry the gen-1 tier; an all-time column
-    would relay merged content, breaching the merge-source law).
+    content hash cannot be had without folding, so #417's count/timestamp/
+    run-id key is the gate) — and finally its own stage column (relay +
+    gatherables), unless this is the root tuple (no parent consumes it) or
+    the all-time item (per-window columns carry the gen-1 tier; an all-time
+    column would relay merged content, breaching the merge-source law).
     """
+    from zagg.column import generation_key
     from zagg.sweep_overview import ENVELOPE_NAME, _read_envelope
     from zagg.windows import union_time_range
 
@@ -939,7 +952,7 @@ def stage_node(
             entry = entries.get(key)
             if (
                 isinstance(entry, dict)
-                and entry.get("generation") == fresh_gen
+                and generation_key(entry.get("generation")) == generation_key(fresh_gen)
                 and entry.get("regime") == regime_plan
                 and _artifact_stamp(
                     store_root, target, entry.get("object"), run_id, run_started, store_kwargs
@@ -1100,7 +1113,7 @@ def _stage_column_current(
     """Whether the dispatch node's column is committed at the fresh generation."""
     import zarr
 
-    from zagg.column import COLUMN_ATTR, column_name
+    from zagg.column import COLUMN_ATTR, column_name, generation_key
     from zagg.hive import COMMIT_ATTR
     from zagg.store import open_store
 
@@ -1121,7 +1134,8 @@ def _stage_column_current(
             f"stage column {path} carries a fresh stamp from foreign sweep run "
             f"{stamp.get('run_id')!r}; two sweeps are live on this store — aborting"
         )
-    return (attrs.get(COLUMN_ATTR) or {}).get("generation") == fresh_gen
+    stored = (attrs.get(COLUMN_ATTR) or {}).get("generation")
+    return generation_key(stored) == generation_key(fresh_gen)
 
 
 def _sweep_spec() -> str:

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -425,6 +425,64 @@ def test_hive_overview_zarrs_count_into_their_own_bucket(monkeypatch):
     assert measured["other_keys"] == [f"{base}/-311.zarr/zarr.json"]
 
 
+def test_hive_columns_split_by_who_wrote_them(monkeypatch):
+    # Issue #418, the leaf-only scope: `{window}.pyramid.zarr` is one basename
+    # grammar with two writers. Under a DISPATCHED leaf's node it is the leaf
+    # worker's own write-path artifact (audited, per shard, so the #215 guard
+    # covers it); at an ancestor node it is a STAGE column the sweep wrote,
+    # which rides the overviews bucket outside the audited total — as does its
+    # D20 sidecar, while the leaf column's sidecar stays that shard's.
+    from zagg import hive
+
+    grid = from_config(_cfg())
+    word = int(morton_word(_KEY_A))
+    label = grid.shard_label(word)
+    leaf = hive.shard_leaf_path("", word).lstrip("/")
+    node = leaf.rsplit("/", 1)[0]
+    base = node.split("/", 1)[0]
+    keys = [
+        f"{leaf}/count/c/0",  # in-leaf data -> this shard
+        f"{node}/all.pyramid.zarr/zarr.json",  # the LEAF column -> this shard
+        f"{node}/all.pyramid.zarr/6/count/c/0",  # ... and its group object
+        f"{node}/all.pyramid.stats.json",  # ... and its D20 sidecar
+        f"{base}/all.pyramid.zarr/zarr.json",  # a STAGE column -> overviews
+        f"{base}/all.pyramid.stats.json",  # ... and its sidecar
+    ]
+    monkeypatch.setattr(bench_objects, "list_store_keys", lambda *a, **k: keys)
+    measured = bench_objects.store_object_counts(
+        "unused", grid=grid, shard_keys=[word], store_layout="hive"
+    )
+    assert measured["objects_per_shard"] == {label: 4}
+    assert measured["objects_overviews"] == 2
+    assert measured["objects_other"] == 0
+
+
+def test_column_term_is_zero_without_a_v2_declaration():
+    # The term keys off the store's own declaration: a `/1` block, a
+    # declared-off block and a `/2` block with no leaf-node entry all cost
+    # nothing, so a pre-#384 store keeps its pre-#384 count exactly.
+    from zagg.pyramid import PYRAMID_SPEC_V2
+
+    assert bench_objects._column_objects(None, 6) == 0
+    assert bench_objects._column_objects({"spec": "zagg-pyramid/1", "overview": {}}, 6) == 0
+    coarse = {
+        "spec": PYRAMID_SPEC_V2,
+        "overviews": [{"node": 5, "cells": [7]}],
+        "overview": {"fields": {"count": {"class": "exact"}}},
+    }
+    assert bench_objects._column_objects(coarse, 6) == 0
+    # One declared leaf resolution two orders down: groups 8, 7, 6 — one root
+    # zarr.json, per group a group zarr.json + (morton + one composable field)
+    # * (zarr.json + chunk), and the sidecar. A `none`-class field costs
+    # nothing: it exists at native resolution only and no column carries it.
+    block = {
+        "spec": PYRAMID_SPEC_V2,
+        "overviews": [{"node": 6, "cells": [8]}, {"node": 5, "cells": [7]}],
+        "overview": {"fields": {"count": {"class": "exact"}, "h": {"class": "none"}}},
+    }
+    assert bench_objects._column_objects(block, 6) == 1 + 3 * (1 + 2 * 2) + 1
+
+
 def test_hive_root_telemetry_accumulates_without_a_finding(monkeypatch):
     # Issue #362 (the red-main regression): a benchmark store reused across
     # runs accumulates one ``stats_{ts}_{run_id}.parquet`` (issue #297) and one
@@ -797,12 +855,19 @@ def test_expected_counts_sane_for_every_manifest_config():
         assert exp["total_max"] == exp["metadata"] + exp["per_shard_max"], rel
 
 
-def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
+@pytest.mark.parametrize("pyramid", [True, False], ids=["default", "pyramid-off"])
+def test_hive_sharded_store_matches_model(tmp_path, monkeypatch, pyramid):
     # Post issue #236: a sharded K>1 hive leaf writes ONE ShardingCodec object
     # per dense array (and one ragged object), so the hive model is EXACT.
     # End-to-end through the local runner (real process_and_write_hive +
     # write_leaf_to_zarr; only process_shard is faked, honoring the accumulate
     # contract), mirroring test_hive.test_local_hive_sharded_leaf_single_object.
+    #
+    # Both declaration shapes (issue #418): the DEFAULT, where the issue #384
+    # /2 flip makes every leaf worker write its own column artifact, and the
+    # `pyramid: false` opt-out that writes none. The audited posture is the
+    # default one — no escape hatch — and the opt-out is kept so the column
+    # term is pinned as a term (it must vanish, not merely be tolerated).
     import json
 
     import test_hive as th
@@ -815,11 +880,8 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     cfg = default_config("atl06")
     cfg.output["store_layout"] = "hive"
     cfg.output["grid"]["chunk_inner"] = 8  # K = 16; sharded defaults True (#236)
-    # The bench_objects model audits the BASE write path; since the issue #384
-    # /2 default flip a default declaration also writes the leaf column, which
-    # the model (a CI-owned script) has no term for yet — pin the audited
-    # posture explicitly. Flagged on the PR for the model's own column term.
-    cfg.output["pyramid"] = False
+    if not pyramid:
+        cfg.output["pyramid"] = False
     cfg.aggregation["variables"]["h"] = {
         "function": "np.sort",
         "source": "h_li",
@@ -851,7 +913,12 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     root = str(tmp_path / "out")
     agg(cfg, catalog=str(cat_path), store=root, backend="local")
 
-    expected = bench_objects.expected_object_counts(grid, n_shards=1, store_layout="hive")
+    from zagg.hive import read_manifest
+
+    block = read_manifest(root)["pyramid"]
+    expected = bench_objects.expected_object_counts(
+        grid, n_shards=1, store_layout="hive", pyramid=block
+    )
     measured = bench_objects.store_object_counts(
         root, grid=grid, shard_keys=[shard], store_layout="hive"
     )
@@ -861,9 +928,14 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch):
     # + MOC (the run parquet / sweep record are telemetry — issue #362).
     n_arrays = len(grid.shard_spec().members)
     assert expected["exact"] is True
+    # The leaf pyramid column (issue #418): one root zarr.json + per declared
+    # group a group zarr.json and a zarr.json + chunk object for `morton` and
+    # each composable field, + the D20 sidecar. Zero under the opt-out.
+    column = bench_objects._column_objects(block, grid.parent_order)
+    assert column == (1 + 3 * (1 + 2 * (1 + 3)) + 1 if pyramid else 0)
     # ... + the stats.json, granules.json and shardmap.json siblings
     # (issues #297/#388/#300).
-    assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 3
+    assert expected["per_shard_max"] == 2 + 2 * n_arrays + 1 + 3 + column
     assert expected["metadata"] == 3
     # Sweep rollups (issue #300), overview zarrs (issue #201 — with the D20
     # `{window}.stats.json` sidecar each overview leaf carries since issue

--- a/tests/test_sweep_stage.py
+++ b/tests/test_sweep_stage.py
@@ -18,6 +18,7 @@ Standing claims:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta
 
 import numpy as np
 import pytest
@@ -29,7 +30,7 @@ from zagg.grids.morton import morton_word
 from zagg.hive import MANIFEST_NAME, _utcnow, build_root_coverage, write_root_coverage
 from zagg.pyramid import PYRAMID_SPEC_V2, expand_overviews
 from zagg.store import open_store
-from zagg.sweep_overview import encode_digest
+from zagg.sweep_overview import ENVELOPE_NAME, encode_digest
 from zagg.sweep_stage import (
     STAGE_GATHER,
     STAGE_MERGE,
@@ -296,6 +297,15 @@ def _artifact(root, rel):
     return zarr.open_group(store, path="", mode="r", zarr_format=3)
 
 
+def _restamp(root, rel, **keys):
+    """Rewrite commit-stamp keys in place — the #380 spy pattern's injection arm."""
+    g = zarr.open_group(open_store(str(root / rel)), path="", mode="r+", zarr_format=3)
+    stamp = dict(g.attrs["morton_hive_commit"])
+    stamp.update(keys)
+    g.attrs["morton_hive_commit"] = stamp
+    return stamp
+
+
 def _ladder_arrays(root):
     """Every ladder artifact's arrays, keyed by store-relative path."""
     out = {}
@@ -365,11 +375,11 @@ class TestStagePass:
         m = _stage_store(tmp_path / "s")
         _sweep(tmp_path / "s", m)
         # Rewrite one leaf column with new content, stamped one hour later
-        # (stamps resolve to seconds; the ratchet keys on the generation pair).
-        real = hive_mod._utcnow
-        monkeypatch.setattr(
-            hive_mod, "_utcnow", lambda: real().replace("T0", "T1", 1) if "T0" in real() else real()
+        # (stamps resolve to seconds; the ratchet keys on the generation key).
+        later = (datetime.fromisoformat(_utcnow()) + timedelta(hours=1)).isoformat(
+            timespec="seconds"
         )
+        monkeypatch.setattr(hive_mod, "_utcnow", lambda: later)
         _write_leaf(tmp_path / "s", "1111", 9)
         monkeypatch.undo()
         (row,) = _sweep(tmp_path / "s", m, run_id="B")["stages"]
@@ -399,6 +409,44 @@ class TestStagePass:
         assert attrs["generation"]["n_leaves"] == 3
         counts = list(g["3"]["count"][:])
         assert counts[:2] == [136, 272] and counts[4] == 408
+
+
+class TestSameSecondSkipGate:
+    """Issue #417: the skip key carries the stamping RUN IDS, not the timestamp
+    alone. ``hive._utcnow`` resolves to one second, so a child rewritten inside
+    the same second at an unchanged leaf count moved neither term of the old
+    ``(n_leaves, max_leaf_timestamp)`` pair — the gate read it as current and
+    served the stale fold."""
+
+    def test_same_second_foreign_rewrite_is_refolded(self, tmp_path):
+        root = tmp_path / "s"
+        m = _stage_store(root)
+        _sweep(root, m)
+        leaf = "1/1/1/1/all.pyramid.zarr"
+        was = dict(_artifact(root, leaf).attrs)["morton_hive_commit"]["written_at"]
+        # A DIFFERENT run rewrites the column with new content and restamps it
+        # inside the recorded second: leaf count and timestamp both unmoved.
+        _write_leaf(root, "1111", 9)
+        _restamp(root, leaf, written_at=was, run_id="fleet-2")
+        assert dict(_artifact(root, leaf).attrs)["morton_hive_commit"]["written_at"] == was
+        (row,) = _sweep(root, m, run_id="B")["stages"]
+        assert row["written"] > 0
+        # The parent carries the REWRITE's partial (136 * 10), not the stale one.
+        assert list(_artifact(root, "1/1/1/all.zarr")["3"]["count"][:])[0] == 136 * 10
+
+    def test_entry_without_run_ids_stays_current(self, tmp_path):
+        """The upgrade path: a pre-#417 entry keys on the empty run-id set, and
+        fleet-written leaf columns carry no run id, so nothing re-folds."""
+        root = tmp_path / "s"
+        m = _stage_store(root)
+        _sweep(root, m)
+        for path in root.rglob(ENVELOPE_NAME):
+            envelope = json.loads(path.read_text())
+            for entry in envelope["windows"].values():
+                assert entry["generation"].pop("run_ids") == []
+            path.write_text(json.dumps(envelope, indent=1))
+        (row,) = _sweep(root, m, run_id="B")["stages"]
+        assert row["written"] == 0 and row["current"] == 7
 
 
 class TestMergeSourceLaw:

--- a/tests/test_sweep_stage.py
+++ b/tests/test_sweep_stage.py
@@ -303,7 +303,6 @@ def _restamp(root, rel, **keys):
     stamp = dict(g.attrs["morton_hive_commit"])
     stamp.update(keys)
     g.attrs["morton_hive_commit"] = stamp
-    return stamp
 
 
 def _ladder_arrays(root):
@@ -431,8 +430,34 @@ class TestSameSecondSkipGate:
         assert dict(_artifact(root, leaf).attrs)["morton_hive_commit"]["written_at"] == was
         (row,) = _sweep(root, m, run_id="B")["stages"]
         assert row["written"] > 0
-        # The parent carries the REWRITE's partial (136 * 10), not the stale one.
+        # The parent carries the REWRITE's partial (136 * 10), not the stale one,
+        # and so does every level above it (the gate is per artifact node, so a
+        # partial re-fold would satisfy the count alone — review finding).
         assert list(_artifact(root, "1/1/1/all.zarr")["3"]["count"][:])[0] == 136 * 10
+        assert list(_artifact(root, "1/1/all.zarr")["2"]["count"][:])[0] == 136 * 10 + 272
+        assert list(_artifact(root, "1/all.zarr")["1"]["count"][:])[0] == 136 * 10 + 272 + 408
+
+    def test_same_second_foreign_rewrite_of_a_stage_column_is_refolded(self, tmp_path):
+        """The arm the merge tiers rest on. At ``width=1`` the coarser tuples'
+        children are STAGE columns, whose stamps carry a real ``run_id``
+        (:func:`zagg.sweep_stage.write_stage_column` writes it) — so this arm
+        needs no injected grammar for the id, only the same-second restamp."""
+        root = tmp_path / "s"
+        m = _stage_store(root)
+        _sweep(root, m, width=1)
+        col = "1/1/1/all.pyramid.zarr"
+        was = dict(_artifact(root, col).attrs)["morton_hive_commit"]["written_at"]
+        before = list(_artifact(root, "1/1/all.zarr")["2"]["count"][:])
+        # A foreign run rewrites the order-2 column's RELAY member (the tier
+        # every coarser merge consumes) inside its own recorded second.
+        g = zarr.open_group(open_store(str(root / col)), path="", mode="r+", zarr_format=3)
+        g["3"]["count"][0] = 1000
+        _restamp(root, col, written_at=was, run_id="C")
+        _sweep(root, m, width=1, run_id="B")
+        after = list(_artifact(root, "1/1/all.zarr")["2"]["count"][:])
+        # The '111' output cell re-merges the tampered relay (1000) with its
+        # sibling '1112' partial (272), where it held 136 + 272 before.
+        assert before[0] == 136 + 272 and after[0] == 1000 + 272
 
     def test_entry_without_run_ids_stays_current(self, tmp_path):
         """The upgrade path: a pre-#417 entry keys on the empty run-id set, and


### PR DESCRIPTION
Closes #417. Closes #418.

Two `small-fix` issues bundled per CLAUDE.md §5, both fallout from merged PR #416 (its questions 6 and 7). They share no code: phase 1 is the staged sweep's skip gate, phase 2 is the CI object-count model.

## Phases

- [x] **Phase 1 — issue #417** (`4aa7107`, folds `1ebd3e1` / `68bbc13` / `9d5a1f7`): the staged sweep's skip key gains the `run_id` term, closing the same-second rewrite blind spot.
- [x] **Phase 2 — issue #418** (`0691bcd`, folds `ff685f6` / `a528a08` / `b0b51c6`): `.github/scripts/bench_objects.py` gains a leaf-pyramid-column term, its scope is documented in the script header, and `test_hive_sharded_store_matches_model` runs against the default (pyramid on) with the opt-out kept as a case.

## Phase 1 — issue #417: the skip key carries the run ids

**The blind spot.** `hive._utcnow()` resolves to **one second** (`datetime.now(timezone.utc).isoformat(timespec="seconds")`), so the ruled skip key — summed child `n_leaves` + max child stamp timestamp — cannot see a child column rewritten inside its own recorded second at an unchanged leaf count. The gate reads it as current and the parent keeps the stale fold. The `/1` content-hash backstop cannot apply here without doing the fold the skip exists to avoid.

**The fix.** The key becomes the triple `(n_leaves, max_leaf_timestamp, run_ids)`, where `run_ids` is the sorted set of `run_id`s carried by the consumed children's stamps (PR #416 phase 2 already puts one in every stage stamp — no extra I/O, the stamp is read anyway). A same-second rewrite by a *different* run moves the set; a same-second rewrite by the *same* run is excluded by the single-writer law.

Two pure helpers in `zagg/column.py` carry the grammar, next to `COLUMN_ATTR` (the `generation` block is part of that artifact's attrs, §4.6) — which also keeps `sweep_stage.py` under the §4 module cap, at **1,194** lines against 1,185 on `main`:

- `generation_key(block)` — the comparison key, `(n_leaves, max_leaf_timestamp, sorted set of run_ids)`;
- `stamped_generation_key(block, stamp)` — one child's contribution: its recorded block (or, for a leaf column, the leaf identity) **unioned with the run id on its own stamp**. That second helper is the load-bearing half, and it exists because of the self-review (below): reading the relayed block alone leaves the term empty in every store the sweep actually builds.

Both comparison sites key off it — the ladder-entry gate in `stage_node` and `_stage_column_current`.

Two deliberate choices:

1. **The run-id term is a SET over all contributing children, not the run id of the max-timestamp child.** A scalar "run id at the max timestamp" is maskable: with children at `(T, A)` and `(T, B)`, a rewrite of the first by a run sorting below `B` leaves the max pair at `(T, B)` and the blind spot open. The union over children moves under any child's foreign rewrite. It costs nothing in steady state — under the admission lease every stage column in a store is written by one run, so a re-sweep that rewrites nothing sees an unchanged set (no churn; pinned by `test_second_pass_is_current`).
2. **Absent `run_ids` reads as the empty set, never as a wildcard.** A pre-#417 envelope entry folds once more on upgrade rather than inheriting the blind spot. On a store whose children are fleet-written leaf columns (no `run_id` in the stamp) both sides are empty and nothing re-folds at all — pinned by `test_entry_without_run_ids_stays_current`.

**Spec (§4 obligation).** §4.5 gains the normative triple (including the additive rule — absent `run_ids` MUST read as the empty set, never as a wildcard); §4.8 records how the key and the foreign-fresh abort divide the concurrency space (the abort covers a foreign stamp written *since this run started*; the key covers the foreign rewrite that landed before it, inside the second the timestamp cannot resolve); §4.4/§4.6 spell the block as `{n_leaves, max_leaf_timestamp, run_ids}`. `docs/hive_layout.md`'s soft-barrier paragraph gets the narrative half.

**Conformance fixtures: unaffected, and here is why.** No fixture carries a `generation` block. `tests/data/spec/column/` is a **fleet-written leaf column** (`zagg_column` with `groups`/`cells_with_data_order`, no `generation` — that block is written only by `write_stage_column`), and `tests/data/spec/pyramid/` is a manifest whose stage content is the per-entry `actuals`, which this PR does not touch. `tools/generate_spec_fixtures.py` materializes no stage artifact (it calls `run_finisher` directly with synthetic per-level actuals). So the grammar change has no fixture surface to regenerate; `tests/test_spec_fixtures.py` passes untouched.

## Phase 2 — issue #418: the bench object-count model

**The gap.** A default store now writes a leaf column per populated leaf (`{node}/{window}.pyramid.zarr`, §4.6) plus its D20 sidecar, and the model had no term for it. Measured against a real default store, the 28 column-zarr objects were silently absorbed into `objects_overviews` (excluded from the audited total) while the 29th — the `all.pyramid.stats.json` sidecar — inflated the exact per-shard count. Hence the `pyramid: false` escape PR #416 had to pin, and hence "the object-count audit currently does not cover the default store shape at all".

**Scope, decided and documented** (the issue's second acceptance criterion). **LEAF-ONLY — the fleet write path, never a swept ladder.** The module header now states it and says why, in three structural reasons rather than convenience: the sweep is fire-and-forget on Lambda so its artifacts may not have landed at measurement time; stage-column *placement* is dispatch cadence, which §4.6 declares "orchestration, never contract", so no fixed count could be right; and a partial or scoped sweep is a legal store state. So D9 rollups, ladder overview zarrs **and ancestor-node stage columns** stay in the unbounded buckets, while the leaf column — one deterministic artifact written inside the same worker the issue #215 tripwire guards — is audited exactly.

**The term** (`_column_objects`), derived through the writer's own functions (`zagg.column.column_resolutions` for the groups, `composable_fields` for the arrays) so it cannot drift from `write_column`:

```python
    return 1 + len(resolutions) * (1 + 2 * arrays) + 1
```

one root `zarr.json` (template, attrs and stamp all rewrite it — three PUTs, one object), per declared group a group `zarr.json` plus `zarr.json` + chunk for `morton` and each composable field, and the sidecar. For the test geometry that is `1 + 3 * (1 + 2 * 4) + 1 = 29`, matching a real store's listing exactly. Zero for a `/1`, declared-off, or leaf-level-less declaration.

**No new argument at the harness call sites.** `measure_objects` reads the `pyramid` block from the store's own manifest and threads it into the model. That is deliberate under §1: `run_benchmark.py` and `run_full_aoi_benchmark.py` are `.github/` files issue #418 does **not** name, so they are untouched — and the manifest is the better source anyway, since `hive.build_manifest` writes it from the config before any leaf runs, making it the run's declaration rather than a product of the write path being audited. The audit therefore covers the default shape in CI now, not after a follow-up.

**Measured side.** `_column_node` classifies a column by the node it sits at: under a **dispatched leaf's** node it is that shard's write-path object (so it rides the exact per-shard #215 guard); anywhere else it is a stage column and joins the second-pass bucket, as does its sidecar. `_overview_node` now declines columns so the two buckets stay disjoint.

**The pinning test** is parametrized `[default, pyramid-off]`: the default arm has no escape hatch, and the opt-out arm asserts the term is exactly **zero**, so the column is pinned as a *term* rather than merely tolerated. Two unit tests join it — `test_hive_columns_split_by_who_wrote_them` (leaf column → per shard, stage column → second-pass bucket, both sidecars with them) and `test_column_term_is_zero_without_a_v2_declaration`.

**Blast radius:** `.github/scripts/bench_objects.py` and `tests/test_benchmark_objects.py` only. No other `.github/` file, nothing under `deployment/aws/`.

## Adversarial review (folded)

A fresh-context review ran after each phase and posted inline findings; all six are folded, with a reply and fix sha on every thread.

Phase 1 — the review caught a **real defect this PR would otherwise have shipped**: as first written, the run-id term was `[]` at every level of every store the sweep builds, because a stage column's contribution was read from its relayed `generation` block and never from its own stamp — the one place PR #416 put the run id. It passed only because the acceptance test injected a `run_id` into a *leaf* stamp, which no writer produces. Folded as `stamped_generation_key` (`1ebd3e1`), plus set-normalized comparison (`68bbc13`) and the missing stage-column test arm (`9d5a1f7`). That new arm fails against `4aa7107` (this PR's own phase-1 commit) and passes after — which is the evidence the fix is not inert.

Phase 2 — scope statement overstated the unit, `(leaf, window)` where the model counts per leaf, now fenced to the unwindowed leaf as `_require_fullsphere` fences the flat model (`ff685f6`); the `objects_overviews` key now describes itself as the second-pass sweep bucket holding two families, documented rather than renamed since its readers live in files this issue does not authorize (`a528a08`); and the column suffix resolves once at module scope instead of per key (`b0b51c6`).

**Process deviation, disclosed:** CLAUDE.md §2 asks for the review and fold to run as separate Opus-class subagents. No agent-spawning tool was available in this environment, so both passes were run by the same agent as separate, explicitly-scoped passes — review first (findings only, no edits), then fold (one commit per finding, staging only the files it touches, a reply on every thread). The independence the rule buys was approximated, not guaranteed; worth a skeptical eye on the phase-2 findings in particular, which are the weaker set.

## Disclosed drive-by: `test_ratchet_rewrites_on_child_change` was failing on `main`

That test — the "stamp moved → re-fold" half of #417's acceptance ("pinned by the existing suite") — is **red on a clean `main` checkout at most hours of the day**. Its clock patch only moves the stamp when the current UTC hour string happens to start with `0`:

```python
        monkeypatch.setattr(
            hive_mod, "_utcnow", lambda: real().replace("T0", "T1", 1) if "T0" in real() else real()
        )
```

At any hour ≥ 10 UTC the `else` branch returns the real clock, the rewrite lands in the same second, and — exactly the bug this PR fixes — the ratchet does not move, so `row["written"] > 0` fails. Verified on a stashed tree: `1 failed` on `main` at this session's clock. It is now a deterministic `+1 hour`:

```python
        later = (datetime.fromisoformat(_utcnow()) + timedelta(hours=1)).isoformat(
            timespec="seconds"
        )
        monkeypatch.setattr(hive_mod, "_utcnow", lambda: later)
```

Flagging rather than burying it, because CLAUDE.md §4 says to flag pre-existing failures rather than fix them: I judged this one in scope because it is the *acceptance pin* issue #417 names, in the file the issue's fix lands in, and it was failing for the very reason #417 exists. Say the word and it comes back out into its own issue.

## How it was tested

- `uv run pytest -q` (full suite, after `uv sync --extra test`) → **3768 passed, 38 skipped** in 7:46. Run again at the tip of the branch with the same result.
- `uv run ruff check src tests .github/scripts` → clean apart from the pre-existing `N818` below. `uv run ruff format --check` → clean apart from the pre-existing markdown fence below. The PR's ruff CI job is **green**.
- Phase 1's bite, verified by stashing `src/zagg/column.py` and `src/zagg/sweep_stage.py` back to `main`: `test_same_second_foreign_rewrite_is_refolded` fails on `assert row["written"] > 0` → `assert 0 > 0`, i.e. the gate skipped the node and served the stale fold. The stage-column arm fails the same way against the pre-fold commit.
- Phase 2's model checked against a real default store rather than only against itself: a listing of the end-to-end store shows exactly 28 `all.pyramid.zarr/...` objects plus one `all.pyramid.stats.json`, against the term's 29.

## Questions for review

1. **Fleet-written leaf columns still carry no run id, so the finest tuple's arm rests on the pair alone.** `column.write_column` stamps without a `run_id` (`hive.stamp_commit`'s is documented as stage-only: *"Fleet-written leaves and columns never carry it"*), so at the first dispatch tuple — whose children are leaf columns — the term is empty and a fleet rewrite of a leaf inside its recorded second is still invisible to the gate. Issue #417's ruled fix is what landed; the leaf arm is a separate decision:
   - **(1a)** leave it (recommended for a small-fix — the sweep-side blind spot #417 names is closed, and the leaf arm is a fleet-grammar change, not a sweep one);
   - **(1b)** thread the fleet run id into `write_column` → `stamp_commit(run_id=...)`, making the term non-empty everywhere at the cost of changing what a *fleet* stamp means (§4.6 says a reader treats `run_id`'s absence as "not a stage artifact");
   - **(1c)** add `granule_count` (already in the leaf column's stamp, already read — zero extra I/O) as a fourth key term, closing the leaf arm for the common append case without touching any writer.
2. **Set-valued third term vs. the issue's scalar `(timestamp, run_id)` phrasing.** Reasoning under phase 1's "deliberate choices" (1) — a scalar keyed to the max-timestamp child is maskable by a lexicographically smaller foreign run id at the same second. Confirm the set form, or say the word and it narrows to the scalar the issue text spells.
3. **`objects_overviews` now holds two artifact families and its name says one.** Documented, not renamed, because the key is read by `bench_metrics.py`, both `run_*_benchmark.py` and the rendered panel — `.github/` files issue #418 does not authorize. A rename to `objects_sweep` across those files is a clean follow-up if you want it; it needs its own issue to carry the CI-change authorization.
4. **Should the hive model grow a windowed arm?** The model (column term included, and the per-shard attribution it inherits) assumes the unwindowed leaf — now stated explicitly rather than implied. A windowed store's leaves would surface as loud `other` findings long before the column term mattered, so nothing is silently wrong today; widening it is a real change with its own test surface and I did not smuggle it in.

## Pre-existing findings (not fixed here)

- `uv run ruff check src tests` is red on `main` with `N818 Exception name UnknownCapability should be named with an Error suffix` (`src/zagg/registry.py:64`). The PR lint bot's ruleset (`--select=E,F,W,I`) does not see it.
- `uv run ruff format --check src tests` flags a python fence in `tests/data/benchmark/README.md:176`. Also pre-existing, also unseen by the bot's ruleset.

Both were flagged the same way on PR #379 (question (f)) and PR #416.