### PR TITLE
small fixes 2026-08-11: granule_count skip-key term; objects_overviews → objects_sweep rename

### DIFF
--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -676,6 +676,15 @@ def write_path_total(measured: dict) -> int:
     ``objects_expected`` is comparable to; ``objects_total`` stays gross
     because storage/cost questions want every object. Single-sourced so the
     reported figure and the asserted figure cannot drift apart.
+
+    Only ``objects_total`` is subscripted; the three subtrahends are read
+    tolerantly ON PURPOSE (review finding) — :func:`object_count_mismatch`
+    accepts a PARTIAL ``measured`` carrying just the terms an assertion
+    needs, so a caller that never swept omits the sweep buckets rather than
+    writing zeros. The cost of that tolerance is that a bucket RENAME would
+    under-subtract silently instead of raising; the key set the measured side
+    emits is pinned directly against this docstring so a half-done rename
+    fails there first.
     """
     return (
         measured["objects_total"]

--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -417,16 +417,15 @@ def store_object_counts(
     """LIST a run's output store and attribute its objects per shard.
 
     Returns ``{"objects_total", "objects_metadata", "objects_per_shard",
-    "objects_rollups", "objects_sweep", "objects_telemetry",
-    "objects_other", "other_keys"}``. ``objects_sweep`` is the SECOND-PASS
-    SWEEP bucket, of which overview zarrs are one family and ancestor-node
-    stage columns (issue #418) another — renamed from ``objects_overviews``
-    on issue #433, since the key held two families and its name said one.
-    ``objects_per_shard`` keys are the
-    dispatched shards' external labels (``grid.shard_label``); a data object
-    whose block resolves to an undispatched shard is keyed ``"block:<n>"`` so
-    a stray write is visible rather than silently pooled. ``other_keys`` is a
-    capped sample of unclassifiable keys.
+    "objects_rollups", "objects_sweep", "objects_telemetry", "objects_other",
+    "other_keys"}``. ``objects_sweep`` is the SECOND-PASS SWEEP bucket, of
+    which overview zarrs are one family and ancestor-node stage columns
+    (issue #418) another — named for the pass, not for one of its families
+    (issue #433). ``objects_per_shard`` keys are the dispatched shards'
+    external labels (``grid.shard_label``); a data object whose block resolves
+    to an undispatched shard is keyed ``"block:<n>"`` so a stray write is
+    visible rather than silently pooled. ``other_keys`` is a capped sample of
+    unclassifiable keys.
     """
     keys = [k for k in list_store_keys(store_path, **store_kwargs) if not _is_status_object(k)]
     per_shard: dict[str, int] = {}

--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -42,7 +42,7 @@ ladder** (issue #418, the decision that issue asks to be made explicitly).
 What the model claims to predict exactly is what the *leaf workers* write:
 the leaf zarr, its sidecars, and — new — the leaf's own pyramid column.
 Everything the SWEEP writes stays outside the audited total, in the
-unbounded ``objects_rollups`` / ``objects_overviews`` buckets: the D9
+unbounded ``objects_rollups`` / ``objects_sweep`` buckets: the D9
 rollups (issue #300), the ladder overview zarrs above the shard node (issue
 #201/#384), and **stage columns** — the ``{window}.pyramid.zarr`` artifacts
 the staged sweep writes at ANCESTOR nodes (specification §4.6). Three
@@ -417,12 +417,12 @@ def store_object_counts(
     """LIST a run's output store and attribute its objects per shard.
 
     Returns ``{"objects_total", "objects_metadata", "objects_per_shard",
-    "objects_rollups", "objects_overviews", "objects_telemetry",
-    "objects_other", "other_keys"}``. ``objects_overviews`` is the
-    SECOND-PASS SWEEP bucket, of which overview zarrs are one family and
-    ancestor-node stage columns (issue #418) another — the name predates the
-    second family and is load-bearing for the record's readers, so it is
-    described here rather than renamed. ``objects_per_shard`` keys are the
+    "objects_rollups", "objects_sweep", "objects_telemetry",
+    "objects_other", "other_keys"}``. ``objects_sweep`` is the SECOND-PASS
+    SWEEP bucket, of which overview zarrs are one family and ancestor-node
+    stage columns (issue #418) another — renamed from ``objects_overviews``
+    on issue #433, since the key held two families and its name said one.
+    ``objects_per_shard`` keys are the
     dispatched shards' external labels (``grid.shard_label``); a data object
     whose block resolves to an undispatched shard is keyed ``"block:<n>"`` so
     a stray write is visible rather than silently pooled. ``other_keys`` is a
@@ -433,7 +433,7 @@ def store_object_counts(
     other: list[str] = []
     metadata = 0
     rollups = 0
-    overviews = 0
+    sweep_objects = 0
     telemetry = 0
 
     if store_layout == "flat":
@@ -536,13 +536,13 @@ def store_object_counts(
                 # while the shard's cells were resident), so it counts into
                 # ``per_shard`` and rides the exact #215 guard; a column at
                 # any other node is a STAGE column the sweep wrote, which
-                # joins the overviews bucket outside the audited total (the
-                # leaf-only scope stated in the module docstring).
+                # joins the second-pass sweep bucket outside the audited total
+                # (the leaf-only scope stated in the module docstring).
                 column_node = _column_node(key)
                 if column_node is not None:
                     label = stats_of.get(column_node + "/")
                     if label is None:
-                        overviews += 1
+                        sweep_objects += 1
                     else:
                         per_shard[label] = per_shard.get(label, 0) + 1
                     continue
@@ -555,7 +555,7 @@ def store_object_counts(
                 # id-named `.zarr` outside the dispatched leaf set stays a
                 # loud ``other`` finding.
                 if _overview_node(key) is not None:
-                    overviews += 1
+                    sweep_objects += 1
                     continue
                 node, _, name = key.rpartition("/")
                 # Sidecar grammars, both naming generations
@@ -584,7 +584,7 @@ def store_object_counts(
                     # nor steal a real leaf sidecar's attribution; the
                     # ``overview_nodes`` anchor keeps every OTHER ``.stats.json``
                     # (store root, stray prefix, undispatched leaf) loud.
-                    overviews += 1
+                    sweep_objects += 1
                 else:
                     other.append(key)
     else:
@@ -595,7 +595,7 @@ def store_object_counts(
         "objects_metadata": metadata,
         "objects_per_shard": per_shard,
         "objects_rollups": rollups,
-        "objects_overviews": overviews,
+        "objects_sweep": sweep_objects,
         "objects_telemetry": telemetry,
         "objects_other": len(other),
         "other_keys": other[:20],
@@ -665,9 +665,10 @@ def write_path_total(measured: dict) -> int:
     ``objects_total`` is every object under the store prefix. Three buckets are
     not write-path objects and are subtracted here:
 
-    * sweep rollups (issue #300) and overview zarrs (issue #201) — second-pass
+    * ``objects_rollups`` (issue #300) and ``objects_sweep`` — the second-pass
       D9 caches the end-of-run sweep may or may not have landed by measurement
-      time (fire-and-forget on Lambda);
+      time (fire-and-forget on Lambda: overview zarrs, issue #201, and stage
+      columns, issue #418);
     * per-run root telemetry (issue #362) — additionally unbounded, since its
       names are per-run unique, so a reused store accumulates it and no fixed
       expectation could ever hold.
@@ -680,7 +681,7 @@ def write_path_total(measured: dict) -> int:
     return (
         measured["objects_total"]
         - measured.get("objects_rollups", 0)
-        - measured.get("objects_overviews", 0)
+        - measured.get("objects_sweep", 0)
         - measured.get("objects_telemetry", 0)
     )
 

--- a/.github/scripts/bench_objects.py
+++ b/.github/scripts/bench_objects.py
@@ -433,7 +433,7 @@ def store_object_counts(
     other: list[str] = []
     metadata = 0
     rollups = 0
-    sweep_objects = 0
+    sweep = 0
     telemetry = 0
 
     if store_layout == "flat":
@@ -542,7 +542,7 @@ def store_object_counts(
                 if column_node is not None:
                     label = stats_of.get(column_node + "/")
                     if label is None:
-                        sweep_objects += 1
+                        sweep += 1
                     else:
                         per_shard[label] = per_shard.get(label, 0) + 1
                     continue
@@ -555,7 +555,7 @@ def store_object_counts(
                 # id-named `.zarr` outside the dispatched leaf set stays a
                 # loud ``other`` finding.
                 if _overview_node(key) is not None:
-                    sweep_objects += 1
+                    sweep += 1
                     continue
                 node, _, name = key.rpartition("/")
                 # Sidecar grammars, both naming generations
@@ -584,7 +584,7 @@ def store_object_counts(
                     # nor steal a real leaf sidecar's attribution; the
                     # ``overview_nodes`` anchor keeps every OTHER ``.stats.json``
                     # (store root, stray prefix, undispatched leaf) loud.
-                    sweep_objects += 1
+                    sweep += 1
                 else:
                     other.append(key)
     else:
@@ -595,7 +595,7 @@ def store_object_counts(
         "objects_metadata": metadata,
         "objects_per_shard": per_shard,
         "objects_rollups": rollups,
-        "objects_sweep": sweep_objects,
+        "objects_sweep": sweep,
         "objects_telemetry": telemetry,
         "objects_other": len(other),
         "other_keys": other[:20],

--- a/docs/hive_layout.md
+++ b/docs/hive_layout.md
@@ -553,12 +553,17 @@ residual-race backstop).
 correctness: a tuple run before its finer tuple landed under-covers loudly
 (`source_children`) and self-heals on the next pass — the skip gate keys on
 summed child generations, so a healed child forces the parent rewrite. That
-key is a triple — leaf count, newest child stamp, and the set of `run_id`s
-those stamps carry ([issue #417](https://github.com/englacial/zagg/issues/417),
+key has four terms — leaf count, newest child stamp, the set of `run_id`s
+those stamps carry ([issue #417](https://github.com/englacial/zagg/issues/417))
+and their summed `granule_count`
+([issue #433](https://github.com/englacial/zagg/issues/433),
 [specification §4.5](specification.md)) — because stamps resolve to one
-second: without the run ids a child rewritten inside its own recorded second
-at an unchanged leaf count would read as current and the parent would keep
-the stale fold.
+second: without them a child rewritten inside its own recorded second at an
+unchanged leaf count would read as current and the parent would keep the
+stale fold. The last two divide the work by who wrote the child: a stage
+column carries the run id that wrote it, a fleet-written leaf column carries
+none — so at the finest tuple it is the granule count, which every writer
+stamps, that moves under a re-run over more granules.
 
 **Aging.** Stage reruns refresh the ancestor artifacts they revisit (a
 rewrite is a fresh PUT), and the finisher's manifest RMW + root-MOC write

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -657,7 +657,8 @@ to the append-later cascade regime), and `source_children` (present in both
 stage regimes: a gather that under-covers says so exactly like a merge) —
 plus `run_id`, the sweep run that wrote the artifact, and a `generation`
 block summing the consumed children (the stage skip gate's ratchet key —
-`{n_leaves, max_leaf_timestamp, run_ids}`, composition in §4.5).
+`{n_leaves, max_leaf_timestamp, run_ids, granule_count}`, composition in
+§4.5).
 The commit stamp of a stage-written artifact carries the same `run_id` key
 (additive to the stamp grammar; fleet-written stamps never carry it, and a
 reader treats its absence as "not a stage artifact", never an error): it is
@@ -895,26 +896,40 @@ staged sweep's finisher.
   ```json
   "generation": {"n_leaves": 16,
                  "max_leaf_timestamp": "2026-08-09T00:00:00+00:00",
-                 "run_ids": ["stage-20260809T000000Z-ab12cd"]}
+                 "run_ids": ["stage-20260809T000000Z-ab12cd"],
+                 "granule_count": 512}
   ```
 
   — the summed leaf count of the consumed children, the newest child stamp,
-  and the **sorted set of `run_id`s** those children's stamps carry, unioned
+  the **sorted set of `run_id`s** those children's stamps carry, unioned
   with the ids their own recorded blocks relay
-  ([#417](https://github.com/englacial/zagg/issues/417)). A level is folded
-  again exactly when this triple moves. The third term is load-bearing:
+  ([#417](https://github.com/englacial/zagg/issues/417)), and the summed
+  `granule_count` of those same stamps
+  ([#433](https://github.com/englacial/zagg/issues/433)). A level is folded
+  again exactly when these four terms move. The last two are load-bearing:
   stamps resolve to **one second**, so the first two alone read a child
   rewritten inside its own recorded second at an unchanged leaf count as
   *current*, and the `/1` content-hash backstop cannot apply without doing
   the fold the skip exists to avoid. A run may not rewrite its own object
   mid-run (single-writer law, §4.8), so a same-second rewrite is a foreign
-  run's and moves the set. `run_ids` is **additive**: absent, it MUST be
-  read as the empty set (a pre-#417 entry, or children that are all
-  fleet-written leaf columns — those stamps carry no `run_id`), never as a
-  wildcard that matches any set, so an upgraded store folds once more
-  rather than inheriting the blind spot. Fleet-written leaf columns
-  contribute no run id, so at the finest tuple the term is empty and the
-  gate rests on the pair alone.
+  run's and moves the id set — but only where the children are stage
+  artifacts: **fleet-written leaf columns carry no `run_id`** (§4.6:
+  absence means not-a-stage-artifact), so at the finest dispatch tuple that
+  term is empty and `granule_count` is what moves. Every stamp, fleet or
+  stage, records the granules it folded, so a leaf re-run over more
+  granules — the common append case — moves the fourth term at an unchanged
+  leaf count and second. A stage stamp's `granule_count` is already the sum
+  over its own children, so the term ratchets up the ladder exactly as
+  `n_leaves` does.
+
+  Both terms are **additive**: absent, `run_ids` MUST be read as the empty
+  set and `granule_count` as `0` — never as a wildcard that matches any
+  value — so an upgraded store (a pre-#417 or pre-#433 entry) folds once
+  more rather than inheriting the blind spot. A rewrite that changes neither
+  the leaf count, the second, the writing run nor the granule count is
+  invisible to the gate by construction; the fold it serves is the same
+  content in every case a writer produces, and the `/1` content hash remains
+  the divergence backstop.
 
 ### 4.6 Leaf column artifacts (`zagg-column/1`)
 
@@ -1069,7 +1084,8 @@ members at the same resolution — `groups` entries record `regime:
 **relay member** (the group at `shard_order`: the subtree's leaf node-order
 partials, the merge-source tier every coarser merge consumes — the espg
 merge-source ruling on the #384 thread). Stage-column attrs additionally
-carry `generation` (`{n_leaves, max_leaf_timestamp, run_ids}` summed over
+carry `generation` (`{n_leaves, max_leaf_timestamp, run_ids, granule_count}`
+summed over
 the consumed children — the parent's skip-gate key, §4.5), `source_children` (a
 gather that under-covered says so in the artifact), and `run_id`; the
 commit stamp carries `run_id` too. Cadence decides placement (columns sit
@@ -1128,7 +1144,9 @@ carry `run_id`, and a skip-if-current read that sees a foreign stamp
 written after the run started aborts loudly). The same `run_id` is a **term
 of the skip key** (§4.5): the abort covers a foreign stamp written *since
 this run started*, and the key covers the foreign rewrite that landed
-before it — inside the second the timestamp cannot resolve.
+before it — inside the second the timestamp cannot resolve. A *fleet*
+rewrite of a leaf column carries no `run_id` for either mechanism to see,
+which is why the key's fourth term is the leaf's `granule_count` (§4.5).
 
 ## 5. O11 content hashes
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -925,11 +925,15 @@ staged sweep's finisher.
   Both terms are **additive**: absent, `run_ids` MUST be read as the empty
   set and `granule_count` as `0` — never as a wildcard that matches any
   value — so an upgraded store (a pre-#417 or pre-#433 entry) folds once
-  more rather than inheriting the blind spot. A rewrite that changes neither
-  the leaf count, the second, the writing run nor the granule count is
-  invisible to the gate by construction; the fold it serves is the same
-  content in every case a writer produces, and the `/1` content hash remains
-  the divergence backstop.
+  more rather than inheriting the blind spot.
+
+  **Known boundary.** A rewrite that changes none of the four terms — same
+  leaf count, same recorded second, no `run_id`, same `granule_count` — is
+  invisible to the gate. A fleet leaf re-run over the *same* granule set
+  that nonetheless folds different bytes (a changed field declaration, a
+  repaired torn write) is the shape of it. The gate is a staleness ratchet,
+  not a content check: it deliberately decides without folding, and the `/1`
+  content hash is where content divergence is caught.
 
 ### 4.6 Leaf column artifacts (`zagg-column/1`)
 

--- a/src/zagg/column.py
+++ b/src/zagg/column.py
@@ -109,8 +109,16 @@ def stamped_generation_key(block, stamp) -> tuple:
     would fall back to the count/timestamp pair it is meant to strengthen).
     Fleet-written stamps carry no ``run_id`` and contribute none; they do
     carry ``granule_count``, which is the leaf arm's whole point (issue
-    #433). A stage stamp's ``granule_count`` is already the sum over its own
-    children, so the term ratchets up the ladder like ``n_leaves``.
+    #433).
+
+    The two are composed differently ON PURPOSE (review finding): the run id
+    is UNIONED with the block's, the granule count REPLACES it. A stage
+    column's stamp count and its recorded block's are the same sum over the
+    same children (:func:`zagg.sweep_stage._summed_generation` and the relay
+    column's stamp both reduce that run's readers), so replacing loses
+    nothing and upgrades a pre-#433 block — which carries no count — off the
+    stamp. Unioning or ADDING them would double-count every granule at every
+    level of the ladder.
     """
     stamp = stamp if isinstance(stamp, dict) else {}
     if not isinstance(block, dict):

--- a/src/zagg/column.py
+++ b/src/zagg/column.py
@@ -58,18 +58,27 @@ LEAF_REGIME = "leaf-column"
 def generation_key(block) -> tuple:
     """The staged sweep's skip-gate key over a summed ``generation`` block.
 
-    ``(n_leaves, max_leaf_timestamp, run ids)`` — the block the stage worker
-    records in these attrs and in the ladder entries it writes (§4.4/§4.6).
-    The run ids are the issue #417 term: stamps resolve to **one second**, so
-    the count/timestamp pair alone reads a same-second rewrite of a child at
-    an unchanged leaf count as *current* and serves stale content. Every
-    stage stamp carries its ``run_id`` (PR #416 phase 2), so a foreign
-    rewrite moves the id set, and the single-writer law forbids a run
-    rewriting its own object mid-run. A block without ``run_ids`` (pre-#417,
-    or children that are all fleet-written leaf columns — those stamps carry
-    no run id) keys on the empty tuple, never on a wildcard: an upgraded
-    store re-folds once rather than inheriting the blind spot. A non-block
-    keys on ``()``, which matches no generation.
+    ``(n_leaves, max_leaf_timestamp, run ids, granule_count)`` — the block
+    the stage worker records in these attrs and in the ladder entries it
+    writes (§4.4/§4.6). The last two terms exist because stamps resolve to
+    **one second**, so the count/timestamp pair alone reads a same-second
+    rewrite of a child at an unchanged leaf count as *current* and serves
+    stale content:
+
+    - ``run_ids`` (issue #417) — every STAGE stamp carries its ``run_id``
+      (PR #416 phase 2), so a foreign rewrite moves the id set, and the
+      single-writer law forbids a run rewriting its own object mid-run;
+    - ``granule_count`` (issue #433) — fleet-written leaf columns carry no
+      run id (§4.6: absence means not-a-stage-artifact), so at the finest
+      dispatch tuple the id term is empty and the run-id half cannot see a
+      same-second leaf rewrite at all. Every stamp, fleet or stage, records
+      the granules it folded, so the common case — a leaf re-run over more
+      granules — moves this term instead.
+
+    A block missing either term keys on that term's zero (empty tuple / 0),
+    never on a wildcard: an upgraded store re-folds once rather than
+    inheriting the blind spot. A non-block keys on ``()``, which matches no
+    generation.
 
     ``run_ids`` is compared as a SET: the recorded list is read back off an
     artifact this process did not write, so its order is not a property to
@@ -82,21 +91,26 @@ def generation_key(block) -> tuple:
         int(block.get("n_leaves") or 0),
         block.get("max_leaf_timestamp"),
         tuple(sorted(set(block.get("run_ids") or ()))),
+        int(block.get("granule_count") or 0),
     )
 
 
 def stamped_generation_key(block, stamp) -> tuple:
-    """One child's contribution to its parent's skip key (issue #417).
+    """One child's contribution to its parent's skip key (issues #417/#433).
 
     :func:`generation_key` over the child's recorded ``generation`` block —
     or, for a leaf column (which records none), the leaf identity: one leaf
     at its stamp's timestamp — **unioned with the run id that stamped THIS
-    child**. That id is the term the issue turns on: the run that wrote the
-    child is what a same-second foreign rewrite changes, and reading the
-    relayed block alone would see only the ids of the child's own children
-    (empty all the way down a fleet-built store, so the gate would fall back
-    to the count/timestamp pair it is meant to strengthen). Fleet-written
-    stamps carry no ``run_id`` and contribute nothing.
+    child, and carrying that stamp's own granule count**. Both come off the
+    child's stamp rather than its relayed block: the run that wrote the
+    child and the granules it folded are what a same-second foreign rewrite
+    changes, and reading the relayed block alone would see only its own
+    children's ids (empty all the way down a fleet-built store, so the gate
+    would fall back to the count/timestamp pair it is meant to strengthen).
+    Fleet-written stamps carry no ``run_id`` and contribute none; they do
+    carry ``granule_count``, which is the leaf arm's whole point (issue
+    #433). A stage stamp's ``granule_count`` is already the sum over its own
+    children, so the term ratchets up the ladder like ``n_leaves``.
     """
     stamp = stamp if isinstance(stamp, dict) else {}
     if not isinstance(block, dict):
@@ -104,7 +118,9 @@ def stamped_generation_key(block, stamp) -> tuple:
     runs = set(block.get("run_ids") or ())
     if stamp.get("run_id"):
         runs.add(stamp["run_id"])
-    return generation_key({**block, "run_ids": sorted(runs)})
+    return generation_key(
+        {**block, "run_ids": sorted(runs), "granule_count": stamp.get("granule_count")}
+    )
 
 
 def column_resolutions(levels: list, node_order: int) -> list[int]:

--- a/src/zagg/sweep_stage.py
+++ b/src/zagg/sweep_stage.py
@@ -51,9 +51,8 @@ append is ordinary under-coverage, recorded and healed by the next sweep.
 Stage-written stamps carry the run id: a skip-if-current read that sees a
 FOREIGN fresh stamp aborts loudly (:class:`ForeignSweepError` — the backstop
 for residual races the lease cannot see), and the run id is also a TERM of
-the skip key (issue #417) — alongside the granule count, the term that
-closes the finest tuple, whose fleet-written children carry no run id (issue
-#433) — so a same-second rewrite cannot read as current.
+the skip key, with the granule count for the fleet-written children that
+carry none (issues #417/#433), so a same-second rewrite cannot read as current.
 
 **Soft barriers.** Inter-stage barriers are scheduling preferences, not
 correctness (#381 point (6)): a stage run before its finer tuple landed
@@ -306,9 +305,8 @@ class _ColumnReader:
         :func:`zagg.column.stamped_generation_key`'s four terms: a stage
         column's recorded ``generation`` block (the summed ratchet) or a leaf
         column's identity — one leaf at its stamp's timestamp — plus the run
-        id THIS column's own stamp carries (fleet-written ones carry none,
-        review finding) and that stamp's granule count (every writer records
-        one — issue #433). The parent's skip gate keys on the SUM of these.
+        id and granule count THIS column's own stamp carries (fleet-written
+        ones carry no id, only a count). The parent's gate keys on the SUM.
         """
         from zagg.column import COLUMN_ATTR, stamped_generation_key
 
@@ -389,10 +387,8 @@ def _readers_for(
 def _summed_generation(rows: list) -> dict:
     """The ratchet key: child generations summed (skip-if-current basis).
 
-    ``run_ids`` is the union over the contributing children (issue #417's
-    term) and ``granule_count`` their sum (issue #433's, the arm that closes
-    the finest tuple, whose children carry no run id); see
-    :func:`zagg.column.generation_key`.
+    ``run_ids`` unions the contributing children's, ``granule_count`` sums
+    them (issues #417/#433); see :func:`zagg.column.generation_key`.
     """
     n, granules, stamps, runs = 0, 0, [], set()
     for row in rows:
@@ -918,9 +914,9 @@ def stage_node(
     content hash cannot be had without folding, so the #417/#433
     count/timestamp/run-id/granule key is the gate) — and finally its own
     stage column (relay + gatherables), unless this is the root tuple (no
-    parent consumes it) or
-    the all-time item (per-window columns carry the gen-1 tier; an all-time
-    column would relay merged content, breaching the merge-source law).
+    parent consumes it) or the all-time item (per-window columns carry the
+    gen-1 tier; an all-time column would relay merged content, breaching the
+    merge-source law).
     """
     from zagg.column import generation_key
     from zagg.sweep_overview import ENVELOPE_NAME, _read_envelope

--- a/src/zagg/sweep_stage.py
+++ b/src/zagg/sweep_stage.py
@@ -51,7 +51,9 @@ append is ordinary under-coverage, recorded and healed by the next sweep.
 Stage-written stamps carry the run id: a skip-if-current read that sees a
 FOREIGN fresh stamp aborts loudly (:class:`ForeignSweepError` — the backstop
 for residual races the lease cannot see), and the run id is also a TERM of
-the skip key (issue #417), so a same-second rewrite cannot read as current.
+the skip key (issue #417) — alongside the granule count, the term that
+closes the finest tuple, whose fleet-written children carry no run id (issue
+#433) — so a same-second rewrite cannot read as current.
 
 **Soft barriers.** Inter-stage barriers are scheduling preferences, not
 correctness (#381 point (6)): a stage run before its finer tuple landed
@@ -301,11 +303,12 @@ class _ColumnReader:
     def generation(self) -> tuple:
         """This column's generation basis: its own, or the leaf identity.
 
-        :func:`zagg.column.stamped_generation_key`'s triple: a stage column's
-        recorded ``generation`` block (the summed ratchet) or a leaf column's
-        identity — one leaf at its stamp's timestamp — plus the run id THIS
-        column's own stamp carries (fleet-written ones carry none, review
-        finding). The parent's skip gate keys on the SUM of these.
+        :func:`zagg.column.stamped_generation_key`'s four terms: a stage
+        column's recorded ``generation`` block (the summed ratchet) or a leaf
+        column's identity — one leaf at its stamp's timestamp — plus the run
+        id THIS column's own stamp carries (fleet-written ones carry none,
+        review finding) and that stamp's granule count (every writer records
+        one — issue #433). The parent's skip gate keys on the SUM of these.
         """
         from zagg.column import COLUMN_ATTR, stamped_generation_key
 
@@ -386,22 +389,26 @@ def _readers_for(
 def _summed_generation(rows: list) -> dict:
     """The ratchet key: child generations summed (skip-if-current basis).
 
-    ``run_ids`` is the union over the contributing children — issue #417's
-    term; see :func:`zagg.column.generation_key`.
+    ``run_ids`` is the union over the contributing children (issue #417's
+    term) and ``granule_count`` their sum (issue #433's, the arm that closes
+    the finest tuple, whose children carry no run id); see
+    :func:`zagg.column.generation_key`.
     """
-    n, stamps, runs = 0, [], set()
+    n, granules, stamps, runs = 0, 0, [], set()
     for row in rows:
         for reader in row:
             if _is_reader(reader):
-                count, timestamp, run_ids = reader.generation()
+                count, timestamp, run_ids, granule_count = reader.generation()
                 n += count
                 stamps.append(timestamp)
                 runs.update(run_ids)
+                granules += granule_count
     stamps = [t for t in stamps if t is not None]
     return {
         "n_leaves": int(n),
         "max_leaf_timestamp": max(stamps) if stamps else None,
         "run_ids": sorted(runs),
+        "granule_count": int(granules),
     }
 
 
@@ -908,9 +915,10 @@ def stage_node(
     tuple order materializes every dirty artifact node beneath the dispatch
     node — skip-if-current keyed on SUMMED CHILD GENERATIONS (the ratchet:
     a healed or appended child moves the sum and forces the rewrite; a
-    content hash cannot be had without folding, so #417's count/timestamp/
-    run-id key is the gate) — and finally its own stage column (relay +
-    gatherables), unless this is the root tuple (no parent consumes it) or
+    content hash cannot be had without folding, so the #417/#433
+    count/timestamp/run-id/granule key is the gate) — and finally its own
+    stage column (relay + gatherables), unless this is the root tuple (no
+    parent consumes it) or
     the all-time item (per-window columns carry the gen-1 tier; an all-time
     column would relay merged content, breaching the merge-source law).
     """

--- a/tests/test_benchmark_objects.py
+++ b/tests/test_benchmark_objects.py
@@ -349,12 +349,12 @@ def test_hive_store_matches_model(tmp_path, monkeypatch):
     # (issue #201, with their #342 sidecars) in their own buckets (second-pass
     # D9 caches); the write-path total excludes all three.
     assert measured["objects_rollups"] > 0
-    assert measured["objects_overviews"] > 0
+    assert measured["objects_sweep"] > 0
     assert any(k.endswith("/all.stats.json") for k in bench_objects.list_store_keys(root))
     write_path = (
         measured["objects_total"]
         - measured["objects_rollups"]
-        - measured["objects_overviews"]
+        - measured["objects_sweep"]
         - measured["objects_telemetry"]
     )
     assert write_path == expected["total_max"]
@@ -393,6 +393,29 @@ def test_hive_misplaced_rollup_counts_into_shard(monkeypatch):
     assert not any(k.endswith("stats.rollup.json") for k in measured["other_keys"])
 
 
+def test_measured_keys_are_the_documented_contract(monkeypatch):
+    # The bucket names are the record's grammar, and every reader of them
+    # (``write_path_total``) goes through ``.get(..., 0)`` — so a half-done
+    # rename reads as "zero objects in that bucket" instead of failing. Pin
+    # the key SET, which is what issue #433's ``objects_overviews`` ->
+    # ``objects_sweep`` rename moved.
+    grid = from_config(_cfg())
+    monkeypatch.setattr(bench_objects, "list_store_keys", lambda *a, **k: [])
+    measured = bench_objects.store_object_counts(
+        "unused", grid=grid, shard_keys=[int(morton_word(_KEY_A))], store_layout="hive"
+    )
+    assert set(measured) == {
+        "objects_total",
+        "objects_metadata",
+        "objects_per_shard",
+        "objects_rollups",
+        "objects_sweep",
+        "objects_telemetry",
+        "objects_other",
+        "other_keys",
+    }
+
+
 def test_hive_overview_zarrs_count_into_their_own_bucket(monkeypatch):
     # Sweep overview zarrs (issue #201) are `{window}.zarr` / `all.zarr` at a
     # digit node — window tokens can never parse as morton ids, so they get
@@ -418,7 +441,7 @@ def test_hive_overview_zarrs_count_into_their_own_bucket(monkeypatch):
     measured = bench_objects.store_object_counts(
         "unused", grid=grid, shard_keys=[word], store_layout="hive"
     )
-    assert measured["objects_overviews"] == 2
+    assert measured["objects_sweep"] == 2
     assert measured["objects_rollups"] == 1
     assert measured["objects_per_shard"] == {label: 1}
     assert measured["objects_other"] == 1
@@ -430,7 +453,7 @@ def test_hive_columns_split_by_who_wrote_them(monkeypatch):
     # grammar with two writers. Under a DISPATCHED leaf's node it is the leaf
     # worker's own write-path artifact (audited, per shard, so the #215 guard
     # covers it); at an ancestor node it is a STAGE column the sweep wrote,
-    # which rides the overviews bucket outside the audited total — as does its
+    # which rides the sweep bucket outside the audited total — as does its
     # D20 sidecar, while the leaf column's sidecar stays that shard's.
     from zagg import hive
 
@@ -445,7 +468,7 @@ def test_hive_columns_split_by_who_wrote_them(monkeypatch):
         f"{node}/all.pyramid.zarr/zarr.json",  # the LEAF column -> this shard
         f"{node}/all.pyramid.zarr/6/count/c/0",  # ... and its group object
         f"{node}/all.pyramid.stats.json",  # ... and its D20 sidecar
-        f"{base}/all.pyramid.zarr/zarr.json",  # a STAGE column -> overviews
+        f"{base}/all.pyramid.zarr/zarr.json",  # a STAGE column -> sweep
         f"{base}/all.pyramid.stats.json",  # ... and its sidecar
     ]
     monkeypatch.setattr(bench_objects, "list_store_keys", lambda *a, **k: keys)
@@ -453,7 +476,7 @@ def test_hive_columns_split_by_who_wrote_them(monkeypatch):
         "unused", grid=grid, shard_keys=[word], store_layout="hive"
     )
     assert measured["objects_per_shard"] == {label: 4}
-    assert measured["objects_overviews"] == 2
+    assert measured["objects_sweep"] == 2
     assert measured["objects_other"] == 0
 
 
@@ -548,7 +571,7 @@ def test_hive_node_stats_sidecars_classified(monkeypatch):
         f"{node}/2019.shardmap.json",  # D23-named leaf sub-map -> this shard
         f"{leaf}/2019.stats.json",  # MISPLACED in-leaf sidecar -> this shard
         f"{base}/all.zarr/zarr.json",  # the overview zarr itself
-        f"{base}/all.stats.json",  # its D23 sidecar -> overviews
+        f"{base}/all.stats.json",  # its D23 sidecar -> sweep
         f"{base}/2019.stats.json",  # a per-window overview sidecar
         "stats_20260731T000000Z_run0.parquet",
     ]
@@ -556,7 +579,7 @@ def test_hive_node_stats_sidecars_classified(monkeypatch):
     measured = bench_objects.store_object_counts(
         "unused", grid=grid, shard_keys=[word], store_layout="hive"
     )
-    assert measured["objects_overviews"] == 3  # the zarr + its two sidecars
+    assert measured["objects_sweep"] == 3  # the zarr + its two sidecars
     assert measured["objects_per_shard"] == {label: 6}
     assert measured["objects_metadata"] == 1
     assert measured["objects_telemetry"] == 1
@@ -587,7 +610,7 @@ def test_hive_stray_stats_json_stays_a_loud_other(monkeypatch):
         hive.MANIFEST_NAME,
         f"{leaf}/count/c/0",  # in-leaf data -> this shard
         f"{node}/2019.stats.json",  # dispatched leaf's D23 sidecar -> this shard
-        f"{base}/all.zarr/zarr.json",  # a real overview zarr -> overviews
+        f"{base}/all.zarr/zarr.json",  # a real overview zarr -> sweep
         f"{base}/all.stats.json",  # its sidecar, anchored to that node
         *strays,
     ]
@@ -595,7 +618,7 @@ def test_hive_stray_stats_json_stays_a_loud_other(monkeypatch):
     measured = bench_objects.store_object_counts(
         "unused", grid=grid, shard_keys=[word], store_layout="hive"
     )
-    assert measured["objects_overviews"] == 2  # the overview zarr + its sidecar
+    assert measured["objects_sweep"] == 2  # the overview zarr + its sidecar
     assert measured["objects_per_shard"] == {label: 2}
     assert measured["objects_metadata"] == 1
     assert measured["objects_other"] == 3
@@ -729,7 +752,7 @@ def test_measure_objects_reports_the_netted_count(tmp_path):
         "objects_metadata": 3,
         "objects_per_shard": {"1121121": 13},
         "objects_rollups": 5,
-        "objects_overviews": 3,
+        "objects_sweep": 3,
         "objects_telemetry": 24,
         "objects_other": 0,
         "other_keys": [],
@@ -944,7 +967,7 @@ def test_hive_sharded_store_matches_model(tmp_path, monkeypatch, pyramid):
     write_path = (
         measured["objects_total"]
         - measured["objects_rollups"]
-        - measured["objects_overviews"]
+        - measured["objects_sweep"]
         - measured["objects_telemetry"]
     )
     assert write_path == expected["total_max"]

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -15,7 +15,13 @@ import obstore
 import pytest
 import zarr
 
-from zagg.column import column_resolutions, fold_column, leaf_slabs
+from zagg.column import (
+    column_resolutions,
+    fold_column,
+    generation_key,
+    leaf_slabs,
+    stamped_generation_key,
+)
 from zagg.grids.morton import morton_word
 from zagg.hive import MANIFEST_NAME, shard_leaf_path, stamp_commit
 from zagg.stats.tdigest import build_tdigest, merge_tdigests_kway
@@ -92,6 +98,61 @@ def _make_leaf(root, decimal, cells):
         group[name][:] = slab
     stamp_commit(store, cells_with_data=len(cells), granule_count=1)
     return slabs
+
+
+class TestGenerationKey:
+    """The staged sweep's skip-gate key as a PURE function (issues #417/#433).
+    The sweep's own tests pin the gate's behavior; these pin the grammar
+    ``docs/specification.md`` §4.5 declares normative — term order, the
+    non-block sentinel, and the additive MUST ("absent reads as the zero,
+    never as a wildcard") per term and for both at once."""
+
+    BLOCK = {
+        "n_leaves": 2,
+        "max_leaf_timestamp": "2026-08-11T00:00:00+00:00",
+        "run_ids": ["stage-b", "stage-a"],
+        "granule_count": 7,
+    }
+
+    def test_term_order_and_normalization(self):
+        # The third term is a sorted SET: recorded order is not a property.
+        ts, ids = "2026-08-11T00:00:00+00:00", ("stage-a", "stage-b")
+        assert generation_key(self.BLOCK) == (2, ts, ids, 7)
+
+    def test_a_non_block_matches_no_generation(self):
+        for value in (None, [], "generation", 0):
+            assert generation_key(value) == ()
+
+    @pytest.mark.parametrize("absent", ["run_ids", "granule_count"])
+    def test_an_absent_term_reads_as_its_zero_not_a_wildcard(self, absent):
+        older = {k: v for k, v in self.BLOCK.items() if k != absent}
+        assert generation_key(older) != generation_key(self.BLOCK)
+        assert generation_key(older) == generation_key({**older, absent: None})
+
+    def test_a_pre_417_block_carries_neither_term(self):
+        older = {k: self.BLOCK[k] for k in ("n_leaves", "max_leaf_timestamp")}
+        assert generation_key(older) == (2, self.BLOCK["max_leaf_timestamp"], (), 0)
+
+    def test_the_leaf_arm_is_the_identity_plus_the_stamp_terms(self):
+        """Issue #433's arm — a fleet-written leaf column has no ``generation``
+        block and a stamp with a count but no ``run_id`` (§4.6), so the granule
+        count is the only term a same-second rewrite can move."""
+        stamp = {"written_at": "2026-08-11T00:00:00+00:00", "granule_count": 3}
+        assert stamped_generation_key(None, stamp) == (1, stamp["written_at"], (), 3)
+        appended = stamped_generation_key(None, {**stamp, "granule_count": 4})
+        assert appended != stamped_generation_key(None, stamp)
+
+    def test_the_stage_arm_unions_the_id_and_takes_the_stamp_count(self):
+        stamp = {"written_at": "…", "run_id": "stage-c", "granule_count": 7}
+        assert stamped_generation_key(self.BLOCK, stamp) == (
+            2,
+            self.BLOCK["max_leaf_timestamp"],
+            ("stage-a", "stage-b", "stage-c"),
+            7,
+        )
+        # A pre-#433 stage column reads the stamp's count, never falls back to 0.
+        older = {k: v for k, v in self.BLOCK.items() if k != "granule_count"}
+        assert stamped_generation_key(older, stamp)[3] == 7
 
 
 class TestColumnResolutions:

--- a/tests/test_sweep_stage.py
+++ b/tests/test_sweep_stage.py
@@ -411,11 +411,13 @@ class TestStagePass:
 
 
 class TestSameSecondSkipGate:
-    """Issue #417: the skip key carries the stamping RUN IDS, not the timestamp
-    alone. ``hive._utcnow`` resolves to one second, so a child rewritten inside
-    the same second at an unchanged leaf count moved neither term of the old
-    ``(n_leaves, max_leaf_timestamp)`` pair — the gate read it as current and
-    served the stale fold."""
+    """Issues #417/#433: the skip key carries the stamping RUN IDS and the
+    summed GRANULE COUNT, not the timestamp alone. ``hive._utcnow`` resolves to
+    one second, so a child rewritten inside the same second at an unchanged leaf
+    count moved neither term of the old ``(n_leaves, max_leaf_timestamp)`` pair
+    — the gate read it as current and served the stale fold. The two added
+    terms split by who wrote the child: a stage column carries a ``run_id``, a
+    fleet-written leaf column carries only its granule count."""
 
     def test_same_second_foreign_rewrite_is_refolded(self, tmp_path):
         root = tmp_path / "s"
@@ -459,6 +461,32 @@ class TestSameSecondSkipGate:
         # sibling '1112' partial (272), where it held 136 + 272 before.
         assert before[0] == 136 + 272 and after[0] == 1000 + 272
 
+    def test_same_second_fleet_rewrite_of_a_leaf_is_refolded(self, tmp_path):
+        """Issue #433's arm: the FINEST tuple, whose children are fleet-written
+        leaf columns. Their stamps carry no ``run_id`` at all (specification
+        §4.6 — absence means not-a-stage-artifact), so #417's third term is
+        empty here and the fourth is what moves: a leaf re-run over MORE
+        GRANULES, restamped inside its own recorded second at an unchanged leaf
+        count. No injected stamp grammar — ``write_column`` writes exactly the
+        stamp this asserts on."""
+        root = tmp_path / "s"
+        m = _stage_store(root)
+        _sweep(root, m)
+        leaf = "1/1/1/1/all.pyramid.zarr"
+        stamp = dict(_artifact(root, leaf).attrs)["morton_hive_commit"]
+        was, granules = stamp["written_at"], stamp["granule_count"]
+        _write_leaf(root, "1111", 9, granules=granules + 1)
+        _restamp(root, leaf, written_at=was)
+        stamp = dict(_artifact(root, leaf).attrs)["morton_hive_commit"]
+        assert stamp["written_at"] == was and "run_id" not in stamp
+        (row,) = _sweep(root, m, run_id="B")["stages"]
+        assert row["written"] > 0
+        # The parent carries the REWRITE's partial (136 * 10), not the stale
+        # one, and so does every level above it.
+        assert list(_artifact(root, "1/1/1/all.zarr")["3"]["count"][:])[0] == 136 * 10
+        assert list(_artifact(root, "1/1/all.zarr")["2"]["count"][:])[0] == 136 * 10 + 272
+        assert list(_artifact(root, "1/all.zarr")["1"]["count"][:])[0] == 136 * 10 + 272 + 408
+
     def test_entry_without_run_ids_stays_current(self, tmp_path):
         """The upgrade path: a pre-#417 entry keys on the empty run-id set, and
         fleet-written leaf columns carry no run id, so nothing re-folds."""
@@ -472,6 +500,21 @@ class TestSameSecondSkipGate:
             path.write_text(json.dumps(envelope, indent=1))
         (row,) = _sweep(root, m, run_id="B")["stages"]
         assert row["written"] == 0 and row["current"] == 7
+
+    def test_entry_without_a_granule_count_refolds_once(self, tmp_path):
+        """The other half of the upgrade path: a pre-#433 entry keys on ``0``,
+        never on a wildcard, so a store swept before the term existed folds once
+        more rather than inheriting the blind spot (specification §4.5)."""
+        root = tmp_path / "s"
+        m = _stage_store(root)
+        _sweep(root, m)
+        for path in root.rglob(ENVELOPE_NAME):
+            envelope = json.loads(path.read_text())
+            for entry in envelope["windows"].values():
+                assert entry["generation"].pop("granule_count") > 0
+            path.write_text(json.dumps(envelope, indent=1))
+        (row,) = _sweep(root, m, run_id="B")["stages"]
+        assert row["written"] == 7 and row["current"] == 0
 
 
 class TestMergeSourceLaw:


### PR DESCRIPTION
Closes #433.

Two ruled follow-ups from PR #421's review questions, bundled per CLAUDE.md §5. They share no code: phase 1 is the staged sweep's skip gate, phase 2 is the CI object-count model's bucket name.

## Phases

- [x] **Phase 1 — the skip key's leaf arm** (`896a183`, folds `ef36dcf` / `74c4629` / `63bffa2` / `45532c0`): `granule_count` becomes the key's fourth term, closing the finest dispatch tuple whose children carry no `run_id`.
- [x] **Phase 2 — `objects_overviews` → `objects_sweep`** (`9d52ed2`, folds `a1af00d` / `cae7a18` / `427e632`): mechanical rename + grep-clean in `.github/scripts/bench_objects.py` and its test.

## Phase 1 — `granule_count` as the fourth key term (issue #433 (1), PR #421 Q1 option 1c)

**The residual blind spot.** PR #421 closed the same-second rewrite hole for *stage* children by adding `run_ids` to the skip key. It could not close the **finest dispatch tuple**, whose children are fleet-written leaf columns: `column.write_column` stamps through `hive.stamp_commit` without a `run_id`, and specification §4.6 makes that absence load-bearing (*"Fleet-written leaves and columns never carry it; readers treat absence as 'not a stage artifact'"*). So at that tuple the id term is empty on both sides, and a leaf rewritten inside its own recorded second at an unchanged `n_leaves` + max stamp timestamp is invisible to the gate.

**The fix — option 1c, no writer touched.** Every commit stamp, fleet or stage, already records `granule_count` (`hive.stamp_commit` writes it unconditionally), and the stage worker already reads the child's whole stamp. It becomes the key's fourth term:

```python
    return (
        int(block.get("n_leaves") or 0),
        block.get("max_leaf_timestamp"),
        tuple(sorted(set(block.get("run_ids") or ()))),
        int(block.get("granule_count") or 0),
    )
```

`stamped_generation_key` takes it off **the child's own stamp**, exactly as it already takes the run id — the same reasoning as PR #421's phase-1 fold (`1d7d80a`): the relayed block describes the child's *children*, while the stamp describes the child. `_summed_generation` sums it into the recorded block, so the term ratchets up the ladder like `n_leaves` does.

The two stamp-sourced terms are composed differently on purpose: the run id is **unioned** with the block's, the granule count **replaces** it. For a stage column the two agree by construction — `_summed_generation` and the relay column's own stamp both reduce the same `readers.values()` — so replacing loses nothing, and it is what lets a pre-#433 stage column (block with no count, stamp with one) upgrade off the stamp. Unioning or adding would double-count every granule at every level. That is now stated at the override and asserted in `TestGenerationKey`.

Zero extra I/O, zero writer change, no change to fleet stamp semantics.

**Additive, never a wildcard.** An absent `granule_count` reads as `0`, matching #417's rule for `run_ids`: a store swept before the term existed folds once more rather than inheriting the blind spot. Pinned by `test_entry_without_a_granule_count_refolds_once` (7 written, 0 current) alongside the existing `test_entry_without_run_ids_stays_current` (0 written, 7 current), so the two upgrade paths are pinned in opposite directions.

**Spec (§4 obligation).** §4.5's normative block gains the fourth term, the additive rule for it, the statement of *which* arm each of the last two terms covers (stage children → `run_ids`; fleet-written leaf children → `granule_count`), and a **Known boundary** paragraph for what the key still cannot see (question (1) below). §4.4 and §4.6 spell the block as `{n_leaves, max_leaf_timestamp, run_ids, granule_count}`. §4.8's concurrency split records that a fleet rewrite carries no `run_id` for *either* mechanism to see, which is why the fourth term exists. `docs/hive_layout.md`'s soft-barrier paragraph gets the narrative half.

**Conformance fixtures: unaffected, re-verified.** No fixture under `tests/data/spec/` carries a `generation` block at all (`grep -rl generation tests/data/spec/` is empty) — `tests/data/spec/column/` is a fleet-written leaf column, whose `zagg_column` payload has no `generation` (that block is written only by `write_stage_column`), and `tests/data/spec/pyramid/` is a manifest whose stage content is the per-entry `actuals`, untouched here. `tools/generate_spec_fixtures.py` materializes no stage artifact. So there is no fixture surface to regenerate; `tests/test_spec_fixtures.py` passes untouched. Same finding as PR #421, re-checked rather than assumed.

**Tests.** The issue asks for the #417 fixture's leaf-arm variant: `test_same_second_fleet_rewrite_of_a_leaf_is_refolded` re-runs leaf `1111` over one more granule and restamps it to its own recorded second **without injecting a run id** — it asserts `"run_id" not in stamp`, so the arm rides the stamp `write_column` actually produces rather than injected grammar (the weakness PR #421's self-review caught in its first draft). It then asserts the rewrite's partial (`136 * 10`) reaches every level above, not just the immediate parent. `TestGenerationKey` in `tests/test_column.py` adds the unit-level complement the review asked for: term order, the `()` sentinel, the additive rule per term and for a block missing both, and both arms of `stamped_generation_key`.

Both new sweep tests were verified to **fail against the base commit**: with `src/zagg/column.py` and `src/zagg/sweep_stage.py` stashed back to `671834c`, `test_same_second_fleet_rewrite_of_a_leaf_is_refolded` and `test_entry_without_a_granule_count_refolds_once` both fail; they pass at `896a183`.

**Module cap (§4).** Phase 1 as first written took `src/zagg/sweep_stage.py` to **1,202** lines, over the cap; the self-review caught it and `ef36dcf` brought it back to **1,198** by tightening the prose the phase had added on top of `zagg.column.generation_key`'s own documentation — no code moved out of the module. `tests/test_column.py` hit the same wall when the unit class landed (1,204) and was trimmed to **1,199** in the same commit that added it.

## Phase 2 — `objects_overviews` → `objects_sweep` (issue #433 (2), PR #421 Q3)

The key holds two artifact families — sweep overview zarrs (issue #201) and ancestor-node stage columns (issue #418) — and its name said one. PR #421 documented the mismatch rather than renaming, because the rename needed CI-change authorization; issue #433 grants it.

**Blast radius is two files:** `.github/scripts/bench_objects.py` (named by the issue) and `tests/test_benchmark_objects.py`. A repo-wide grep for `objects_overviews` across `src`, `tests`, `docs`, `.github`, `tools` and `deployment` is now empty. **No `.github/workflows/*.yml` was touched** — none mentions the key, so §1 never came into play. See question (2) for why the rename is narrower than the issue anticipated.

The local accumulator moved with the key (`overviews` → `sweep`), matching its three neighbours `metadata` / `rollups` / `telemetry`: it counted both families under a one-family name, which is the same defect the key had, and leaving it would have made the emit line read `"objects_sweep": overviews`. The genuinely overview-specific names — `_overview_node`, `overview_nodes`, and the comments about overview *zarrs* — are deliberately untouched: they name a family, not the bucket.

**Test.** The rename rides the existing assertions, plus one new guard: `test_measured_keys_are_the_documented_contract` pins the returned key SET against the docstring. That matters because `write_path_total` reads the sweep-side buckets through `.get(..., 0)`, so a half-done rename would under-subtract *silently* rather than raise. That tolerance is load-bearing and now documented at the function — `object_count_mismatch` is called with a **partial** `measured` (`test_hive_metadata_ceiling_covers_sweep_written_root_moc` passes a five-key dict with no sweep buckets at all), so subscripting would turn those callers into `KeyError`s.

## Adversarial review (folded)

A fresh-context review ran after each phase and posted inline findings; all seven are folded, with a reply and a fix sha on every thread.

**Phase 1** — the module-cap breach above (`ef36dcf`); the spec asserting a guarantee the code does not provide, now a stated **Known boundary** (`74c4629`); `generation_key` changing arity with no direct test, now `TestGenerationKey` (`63bffa2`); and the union-vs-replace asymmetry of the two stamp-sourced terms, now stated at the override (`45532c0`).

**Phase 2** — the accumulator's name breaking its neighbours' pattern (`a1af00d`); a ragged reflow and a changelog clause in the return-contract docstring (`cae7a18`); and the `.get(..., 0)` question, answered by investigation and documented rather than changed (`427e632`).

**Process deviation, disclosed:** CLAUDE.md §2 asks for the review and the fold to run as separate Opus-class subagents. No agent-spawning tool was reachable in this environment, so both passes were run by the same agent as separate, explicitly-scoped passes — review first (findings only, no edits), then fold (one commit per finding, staging only the files that finding touches, a reply on every thread). The independence the rule buys was approximated, not guaranteed. The same deviation was recorded on PR #421.

## How it was tested

- `uv run pytest -q` (full suite, after `uv sync --extra test`) → **3807 passed, 38 skipped** at the phase-1 tip; re-run at the branch tip with the same result.
- `uv run ruff check src tests .github/scripts` → clean apart from the pre-existing `N818` below. `uv run ruff format --check src tests` → clean apart from the pre-existing markdown fence below. The PR's `ruff` CI job is **green**.
- Phase 1's bite verified by stashing `src/zagg/column.py` and `src/zagg/sweep_stage.py` back to `671834c` (above).
- Phase 2 verified by `uv run pytest tests/test_benchmark_objects.py -q` (30 passed) plus the repo-wide grep.

## Questions for review

1. **The residual the fourth term does not cover, stated plainly.** A same-second rewrite of a leaf column that changes neither the leaf count, the second, the writing run *nor the granule count* remains invisible to the gate. The common append case — a leaf re-run over more granules — moves the term, which is what issue #433 asks for; a re-run over the *same* granules that folds different bytes (a changed field declaration, a repaired torn write) does not. Written into §4.5 as a **Known boundary** rather than left implicit, with the `/1` content hash named as the divergence backstop. Flagging it because closing it would need a per-artifact content term the skip gate exists to avoid computing — no action wanted unless you disagree with recording it as a boundary.
2. **Issue #433 (2) names more files than the rename actually touches.** The issue authorizes `.github/scripts/bench_metrics.py`, `run_cold_benchmark.py` / `run_warm_benchmark.py` and "the rendered panel template" alongside `bench_objects.py`. A repo-wide grep for `objects_overviews` returns **only** `.github/scripts/bench_objects.py` and `tests/test_benchmark_objects.py`: `bench_metrics.py` never copies the key into a record (it threads `objects_total` / `objects_write_path` / `objects_expected` / `objects_per_shard` / `objects_telemetry` / `objects_mismatch` and stops), so no panel and no `run_*_benchmark.py` reads it, and there is no `run_cold_benchmark.py` / `run_warm_benchmark.py` in the tree (the entrypoints are `run_benchmark.py`, `run_full_aoi_benchmark.py`, `run_raster_benchmark.py`). No persisted metrics row has ever carried the key under either name. **Say the word if the key was meant to be *added* to the recorded set** as part of this — that is a real gap (the second-pass bucket is invisible in metrics history today), but it is a model change rather than a rename and I did not smuggle it in.
3. **Renaming the local accumulator is slightly wider than the issue's letter.** Issue #433 authorizes the *key*; `overviews` → `sweep` is the variable that emits it, carrying the same one-name-two-families defect. Kept, for the reason above; trivially reverted if you want the diff to be literally the key.

## Pre-existing findings (not fixed here)

- `uv run ruff check src tests` is red on the base commit with `N818 Exception name UnknownCapability should be named with an Error suffix` (`src/zagg/registry.py:64`). The PR lint bot's ruleset (`--select=E,F,W,I`) does not see it.
- `uv run ruff format --check src tests` flags a python fence in `tests/data/benchmark/README.md`. Also pre-existing, also unseen by the bot's ruleset.

Both were flagged the same way on PR #379, PR #416 and PR #421.