### PR TITLE
Unindexed builds: cover from WKB and intersect before materializing records (issue #445)

### DIFF
--- a/docs/api/catalog.md
+++ b/docs/api/catalog.md
@@ -89,6 +89,21 @@ so for a multi-part granule the column is a superset and the index can place it
 in shards the geometry path misses. No CMR ATL03/06 footprint is multi-part
 today; antimeridian-split STAC footprints are the natural producer.
 
+### What indexing buys, after #445
+
+An **unindexed** mortie `swath` build on a HEALPix grid now covers the geometry
+column itself — the same `from_wkbs` cover, at the grid's `parent_order`, thrown
+away when the build ends — and runs the same intersection
+([issue #445](https://github.com/englacial/zagg/issues/445)). The column no
+longer buys a *different* code path; it buys **skipping the cover**, which is
+most of a first build. Index when many builds share one catalog; skip it for a
+one-shot build and pay the cover once, in memory. The MultiPolygon superset
+above and the null-geometry refusal are properties of that shared cover, so the
+unindexed path has them too. `footprint="beams"`, the spherely backend,
+rectilinear grids and paired builds still cover from decoded records, and the
+`footprint_cells` metadata verdict still means "the stored column answered this
+build" — an unindexed build that covered its own is not that.
+
 ### Choosing the order
 
 **Index at the grid's `parent_order`.** A MOC answers any shard order coarser

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -424,7 +424,9 @@ def _regroup_hits(hit_shards, hit_owners) -> Dict[int, List[int]]:
     return out
 
 
-def _intersect_footprint_cells(rows, values, offsets, grid, all_shards) -> Dict[int, List[int]]:
+def _intersect_footprint_cells(
+    rows, values, offsets, grid, all_shards, *, stored: bool = True
+) -> Dict[int, List[int]]:
     """Shard assignment from row-aligned footprint MOCs -- no geometry (issue #396).
 
     The phase-3 fast path, and since issue #445 the *only* mortie ``swath``
@@ -442,6 +444,14 @@ def _intersect_footprint_cells(rows, values, offsets, grid, all_shards) -> Dict[
     record ``i`` came from); it is not the identity, because
     ``granule_records`` drops rows whose geometry is empty or not polygonal
     while the cover has one entry per row.
+
+    ``stored`` says which of those two covers arrived, and is used for one
+    thing: the cell-budget refusal's remediation clause. Re-indexing or dropping
+    the ``footprint_cells`` column is only actionable when there *is* one
+    (``plan is not None`` in :meth:`ShardMap.build`); an ephemeral cover has
+    neither, so it gets the remedies that do apply to it. Nothing else branches
+    on it -- the assignment is identical either way, which is the point of the
+    shared intersection.
 
     mortie 0.9.6's batch twins (espg/mortie#173) remove the per-granule Python
     loop: one ``mocs_and(aoi_moc, ...)`` per block of records (empty results
@@ -485,8 +495,14 @@ def _intersect_footprint_cells(rows, values, offsets, grid, all_shards) -> Dict[
     # of quietly losing one granule. This is a real divergence from the
     # geometry path, which still swallows the same refusal per ring
     # (``_intersect_mortie``, below): the same catalog + grid can now raise
-    # where it built, depending on whether the column is present. Deliberate,
-    # and narrow -- refusal is not unreachable, but it is remote. ``aoi_moc``
+    # where it built. Since issue #445 the presence of the column is no longer
+    # what decides which side you are on -- every mortie HEALPix ``swath`` build
+    # reaches this raise, stored column or ephemeral cover alike, and only
+    # ``footprint="beams"``, spherely, rectilinear and paired builds still
+    # swallow it on the geometry path. (That is why the raise below takes
+    # ``stored``: the remedy differs even though the refusal does not.)
+    # Deliberate, and narrow -- refusal is not unreachable, but it is remote.
+    # ``aoi_moc``
     # is compressed, so the intersection can keep cells *coarser* than
     # ``parent_order`` and ``mocs_to_orders`` can genuinely expand; the bound
     # is the AOI-clipped footprint densified at ``parent_order``, so tripping
@@ -545,13 +561,31 @@ def _intersect_footprint_cells(rows, values, offsets, grid, all_shards) -> Dict[
             # un-rebased "MOC 400" out of a 512-record block is a plausible
             # record index, so it would send the operator to the wrong granule
             # rather than obviously failing. Re-raise, never swallow.
+            # The remedy depends on where the cover came from (issue #445).
+            # Telling the operator of an *unindexed* build to re-index or drop a
+            # column names two things that do not exist, and re-indexing would
+            # not move this anyway: the flattening target is ``parent_order``
+            # whatever ``mortie_order`` was. So name what is actually actionable
+            # on each path.
+            remedy = (
+                "Re-index the catalog at a coarser order, or drop the "
+                "footprint_cells column to build from geometry."
+                if stored
+                else (
+                    f"This build covered the catalog itself -- there is no "
+                    f"footprint_cells column to re-cut or drop, and the cover is "
+                    f"flattened to the grid's parent_order {parent_order} whatever "
+                    f"order it ran at. The bound is one granule's AOI-clipped "
+                    f"footprint densified at parent_order {parent_order}: build "
+                    f"against a grid with a coarser parent_order, or narrow or "
+                    f"split the region so that footprint clips smaller."
+                )
+            )
             raise ValueError(
-                f"footprint_cells batch failed within records "
-                f"{own[0]}-{own[-1]} (the MOC index in the message counts this "
-                f"block's {own.size} prefilter survivors inside that range, "
-                f"which are generally not contiguous records): {exc}. "
-                f"Re-index the catalog at a coarser order, or drop the "
-                f"footprint_cells column to build from geometry."
+                f"{'footprint_cells' if stored else 'footprint cover'} batch failed "
+                f"within records {own[0]}-{own[-1]} (the MOC index in the message "
+                f"counts this block's {own.size} prefilter survivors inside that "
+                f"range, which are generally not contiguous records): {exc}. {remedy}"
             ) from exc
         # Every slot in this block is non-empty by the predicate's contract,
         # so ``flat`` is never empty here and each owner repeats >= 1 time.
@@ -1413,7 +1447,12 @@ class ShardMap:
         t0 = time.perf_counter()
         if cells is not None:
             values, offsets, mortie_order, rows, _ = cells
-            shard_to_idx = _intersect_footprint_cells(rows, values, offsets, grid, all_shards)
+            # ``stored`` only steers the cell-budget refusal's remedy: the
+            # stored column can be re-cut or dropped, an ephemeral cover cannot
+            # (issue #445).
+            shard_to_idx = _intersect_footprint_cells(
+                rows, values, offsets, grid, all_shards, stored=plan is not None
+            )
         elif chosen == "mortie":
             mortie_order = _resolve_mortie_order(mortie_order, grid)
             shard_to_idx = _intersect_mortie(

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -696,6 +696,22 @@ def _live_cells_plan(catalog, grid, chosen, footprint, mortie_order):
     cover this path would otherwise need is not materializable). espg's ruling,
     2026-08-16.
 
+    That default is **flat by measurement and superset-safe by construction**,
+    not an identity. mortie's coverage is conservative per order, so
+    ``cover(parent_order)`` is a superset of
+    ``moc_to_order(cover(chunk_order), parent_order)``: refining a fine cover
+    down does not reproduce a coarse one, and a boundary cell the fine cover
+    misses can survive at the coarse one. The direction never inverts -- a true
+    granule/shard pair is never dropped, only extra ones admitted -- and at the
+    orders production runs there is no difference at all: a 200-polygon
+    randomized sweep measured 0/200 rows differing at parent/chunk 9/13, 11/13,
+    8/12 and 9/11, against 1-2 rows and up to 0.71% extra cells at the coarse
+    pairs 6/10, 5/9 and 3/7. So the clone-scale digest match at
+    ``parent_order=9`` is real, and a coarse-grid build inherits the same
+    conservative posture the stored index already ships (the MultiPolygon
+    superset below, the AOI overhang of #101). Pinned by
+    ``TestLiveCover::test_coarse_shard_order_covers_a_superset``.
+
     An explicit ``mortie_order`` is still **honored literally**: it is a request
     for a cover at that order, so the cover runs there whatever it costs, and is
     validated against ``parent_order`` exactly as the geometry path validates it.
@@ -804,6 +820,11 @@ def _resolve_mortie_order(mortie_order, grid) -> int:
     HEALPix ``swath`` path covers from WKB instead and defaults to
     ``parent_order`` on the same sweep evidence quoted above, calling this only
     to honor (and validate) an explicit pin -- see :func:`_live_cells_plan`.
+    The sweep makes those two defaults *measurably* equal at production orders,
+    not equal by construction: a cover at ``parent_order`` is a superset of the
+    same footprint covered here and refined down, never a subset, and the gap is
+    reachable at coarse shard orders. :func:`_live_cells_plan` carries the
+    numbers.
     """
     is_healpix = hasattr(grid, "parent_order") and hasattr(grid, "child_order")
     if mortie_order is not None:
@@ -1257,7 +1278,13 @@ class ShardMap:
         real-catalog sweep in :func:`_resolve_mortie_order` measures granules per
         shard flat -- so an unpinned unindexed build records
         ``mortie_order = parent_order`` where it used to record the chunk order.
-        Same assignment, less cover. A caller-pinned ``mortie_order`` is still
+        Same assignment at the orders production runs (byte-identical over the
+        555,867-granule clone, and 0/200 rows differing in a randomized sweep at
+        parent/chunk 9/13, 11/13, 8/12 and 9/11), and **superset-safe** in
+        general: mortie's coverage is conservative per order, so the coarser
+        cover can admit a boundary shard that the finer cover refined down
+        misses -- up to 0.71% extra cells at 3/7 -- and never drops one. See
+        :func:`_live_cells_plan`. A caller-pinned ``mortie_order`` is still
         honored literally. Unchanged paths: ``footprint="beams"`` (the cover is
         the swath, not the corridors), the spherely backend, rectilinear grids,
         and paired builds (issue #425).

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -625,7 +625,10 @@ def _footprint_cells_plan(catalog, grid, chosen, footprint, mortie_order):
     - ``footprint="swath"`` -- the column covers the CMR footprint, not the
       per-beam corridors ``footprint="beams"`` decomposes it into (issue #65);
     - ``mortie_order`` was not pinned by the caller -- an explicit order asks for
-      a cover at *that* order, which the column cannot restate;
+      a cover at *that* order, which the column cannot restate. Since issue #445
+      declining here does **not** mean falling back to geometry: an indexed
+      catalog with a pinned order lands on :func:`_live_cells_plan`'s ephemeral
+      cover and inherits its deltas (see :meth:`ShardMap.build`'s Notes);
     - the grid is HEALPix and the catalog carries the column.
 
     Takes no records and materializes none (issue #439): the plan is what lets
@@ -750,7 +753,13 @@ def _live_cells_plan(catalog, grid, chosen, footprint, mortie_order):
     for a cover at that order, so the cover runs there whatever it costs, and is
     validated against ``parent_order`` exactly as the geometry path validates it.
     (The stored plan cannot honor a pin at all -- a persisted column cannot
-    restate its order -- which is why it refuses instead.)
+    restate its order -- which is why it declines instead.) Note what that
+    means for an *indexed* catalog: a pinned build there declines the stored
+    plan and lands **here**, not on the geometry path it took pre-#445, so it
+    covers from WKB and inherits this path's deltas. Pinned by
+    ``TestLiveCover::test_a_pinned_indexed_build_covers_live_too``, and raised
+    for espg's ruling on PR #447 (the alternative is gating indexed catalogs out
+    of this plan to keep the records-path assignment for pinned builds).
 
     Engages on the same shape :func:`_footprint_cells_plan` does, minus the
     column: the backend resolves to ``mortie`` (a spherely build stays exact-S2),
@@ -1334,6 +1343,18 @@ class ShardMap:
         raised ``AttributeError`` on the same row: both refuse, one legibly.
         Memory is the index's documented posture, screen peak included (~1 GB
         over the parquet read at clone scale, issue #429).
+
+        **A pinned ``mortie_order`` covers live whether or not the catalog is
+        indexed.** A persisted column cannot restate an arbitrary order, so the
+        stored plan declines a pin (:func:`_footprint_cells_plan`) -- and since
+        issue #445 what catches it is the ephemeral cover, not the geometry
+        path. So an *indexed* catalog built with an explicit ``mortie_order``
+        is a third population whose assignment can move: it inherits the same
+        two deltas above (measured on a two-part MultiPolygon: 8 shards on the
+        records path, 13 on the cover). The pin is honored either way, and
+        ``metadata["footprint_cells"]`` still records ``False`` there -- it
+        means "the stored column did not answer this build", which stays the
+        thing the operator can act on. Flagged for review on PR #447.
         """
         if footprint not in ("swath", "beams"):
             raise ValueError(f"footprint must be 'swath' or 'beams' (got {footprint!r})")

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -425,11 +425,14 @@ def _regroup_hits(hit_shards, hit_owners) -> Dict[int, List[int]]:
 
 
 def _intersect_footprint_cells(rows, values, offsets, grid, all_shards) -> Dict[int, List[int]]:
-    """Shard assignment from the catalog's stored MOCs -- no geometry (issue #396).
+    """Shard assignment from row-aligned footprint MOCs -- no geometry (issue #396).
 
-    The phase-3 fast path. Where ``_intersect_mortie`` covers every footprint
-    from its vertices on every build, this reads the cover the catalog already
-    carries (``Catalog.index_footprints``) and does set algebra only: the AOI's
+    The phase-3 fast path, and since issue #445 the *only* mortie ``swath``
+    intersection: the cover it consumes is either the one the catalog carries
+    (``Catalog.index_footprints``) or the one this build just made
+    (``_live_cells_plan``), which is the whole remaining difference between an
+    indexed build and an unindexed one. Where ``_intersect_mortie`` covers every
+    footprint from its vertices, this does set algebra only: the AOI's
     shard keys are themselves a MOC at ``parent_order``, so a granule's shards
     are ``moc_to_order(moc_and(granule_moc, aoi_moc), parent_order)`` -- no
     ``searchsorted`` filter either, since intersecting with the AOI first is
@@ -438,7 +441,7 @@ def _intersect_footprint_cells(rows, values, offsets, grid, all_shards) -> Dict[
     ``rows`` maps record index -> catalog table row (``rows[i]`` is the row
     record ``i`` came from); it is not the identity, because
     ``granule_records`` drops rows whose geometry is empty or not polygonal
-    while the column has one entry per row.
+    while the cover has one entry per row.
 
     mortie 0.9.6's batch twins (espg/mortie#173) remove the per-granule Python
     loop: one ``mocs_and(aoi_moc, ...)`` per block of records (empty results
@@ -668,6 +671,66 @@ def _footprint_cells_plan(catalog, grid, chosen, footprint, mortie_order):
     return values, offsets, order, rows, int(rows.size)
 
 
+def _live_cells_plan(catalog, grid, chosen, footprint, mortie_order):
+    """The same inputs as :func:`_footprint_cells_plan`, covered now (issue #445).
+
+    An *unindexed* catalog is one whose cover was never persisted -- not one that
+    needs a different intersection. So the live mortie build becomes
+    build-an-ephemeral-index-and-query-it: cover the WKB column with
+    :meth:`~zagg.catalog.Catalog.cover_footprints` (no records, no column), then
+    hand :func:`_intersect_footprint_cells` exactly what the stored path hands
+    it. Records follow for the hit rows only, via the shared :func:`_hit_records`.
+    On the 555,867-granule ATL03 clone against California that is 86.9 s -> ~33 s,
+    and the record decode that dominated it stops running over rows the AOI
+    discards (99.6% of them).
+
+    **The cover runs at the grid's ``parent_order``**, not at
+    :func:`_resolve_mortie_order`'s chunk-order default. A shard map records one
+    thing -- which ``parent_order`` cells a footprint touches -- and that is
+    exactly what an order-``parent_order`` cover answers; the real-catalog order
+    sweep quoted in :func:`_resolve_mortie_order` (``bench/neon_order_sweep.py``)
+    measures granules/shard flat for every order >= ``parent_order``, so a finer
+    MOC buys precision the shard cells cannot see while coverage words per
+    granule roughly double per order (``index_footprints`` prices the clone at
+    ~270-420 MB at order 9 against ~9-13 GB at order 13 -- the whole-catalog o13
+    cover this path would otherwise need is not materializable). espg's ruling,
+    2026-08-16.
+
+    An explicit ``mortie_order`` is still **honored literally**: it is a request
+    for a cover at that order, so the cover runs there whatever it costs, and is
+    validated against ``parent_order`` exactly as the geometry path validates it.
+    (The stored plan cannot honor a pin at all -- a persisted column cannot
+    restate its order -- which is why it refuses instead.)
+
+    Engages on the same shape :func:`_footprint_cells_plan` does, minus the
+    column: the backend resolves to ``mortie`` (a spherely build stays exact-S2),
+    ``footprint="swath"`` (the cover is the CMR footprint, not the per-beam
+    corridors of #65 -- those keep :func:`_intersect_mortie`), and the grid is
+    HEALPix. Paired builds (issue #425) never reach here -- ``build`` gates them
+    out, as it does for the stored plan.
+
+    Returns
+    -------
+    tuple or None
+        ``(values, offsets, order, rows, considered)`` -- the same contract
+        :func:`_footprint_cells_plan` returns, so both feed the same
+        intersection: ``offsets`` are table-row-aligned, ``rows`` maps record
+        index -> table row, and ``considered`` is the screen popcount, the
+        ``total_granules`` the eager path reported as ``len(records)``.
+    """
+    if chosen != "mortie" or footprint != "swath":
+        return None
+    parent_order = getattr(grid, "parent_order", None)
+    cover = getattr(catalog, "cover_footprints", None)
+    if parent_order is None or not callable(cover):
+        return None
+    # An explicit pin is resolved (and validated -- coarser than the shards still
+    # raises) before the cover, so a refusal costs nothing, as on the stored path.
+    order = parent_order if mortie_order is None else _resolve_mortie_order(mortie_order, grid)
+    values, offsets, rows = cover(order)
+    return values, offsets, order, rows, int(rows.size)
+
+
 def _hit_records(catalog, rows, shard_to_idx):
     """Decode granule records for the assigned rows only (issue #439).
 
@@ -735,6 +798,12 @@ def _resolve_mortie_order(mortie_order, grid) -> int:
     explicit ``mortie_order`` is honored but still validated against
     ``parent_order``. Non-HEALPix grids (no ``parent_order`` / ``child_order``)
     keep the legacy default of 8.
+
+    This resolves the order for the paths that cover from decoded rings --
+    ``footprint="beams"``, non-HEALPix grids, :meth:`ShardMap.reproject`. The
+    HEALPix ``swath`` path covers from WKB instead and defaults to
+    ``parent_order`` on the same sweep evidence quoted above, calling this only
+    to honor (and validate) an explicit pin -- see :func:`_live_cells_plan`.
     """
     is_healpix = hasattr(grid, "parent_order") and hasattr(grid, "child_order")
     if mortie_order is not None:
@@ -1175,6 +1244,35 @@ class ShardMap:
         ``total_granules`` still counts the records *considered* (the whole
         post-screen catalog), which :meth:`~zagg.catalog.Catalog.granule_row_mask`
         supplies without decoding any.
+
+        **An unindexed mortie build covers first too** (issue #445). "Indexed"
+        now means only that the cover was persisted: a mortie ``swath`` build on
+        a HEALPix grid with no usable column covers the WKB column itself
+        (:meth:`~zagg.catalog.Catalog.cover_footprints`) and runs the *same*
+        intersection, instead of decoding every record to cover from its rings.
+        On the clone/California case that is 86.9 s -> ~33 s. Records still
+        follow the intersection, and ``total_granules`` is still the screen
+        popcount. The cover runs at the grid's ``parent_order`` -- the order the
+        map's shard membership is stated in, and the order beyond which the
+        real-catalog sweep in :func:`_resolve_mortie_order` measures granules per
+        shard flat -- so an unpinned unindexed build records
+        ``mortie_order = parent_order`` where it used to record the chunk order.
+        Same assignment, less cover. A caller-pinned ``mortie_order`` is still
+        honored literally. Unchanged paths: ``footprint="beams"`` (the cover is
+        the swath, not the corridors), the spherely backend, rectilinear grids,
+        and paired builds (issue #425).
+
+        Two deltas ride on it, both inherited from the cover this path now shares
+        with the index. **MultiPolygon** footprints get the same superset as
+        above -- the cover takes every part where
+        :meth:`~zagg.catalog.Catalog.granule_records` reads only the largest
+        part's exterior ring -- so a multi-part granule may assign to more shards
+        than it did pre-#445; every CMR ATL03/06 granule is single-part, so no
+        production build moves. And a **null** geometry is refused by name
+        (:meth:`~zagg.catalog.Catalog.granule_row_mask`) where the record loop
+        raised ``AttributeError`` on the same row: both refuse, one legibly.
+        Memory is the index's documented posture, screen peak included (~1 GB
+        over the parquet read at clone scale, issue #429).
         """
         if footprint not in ("swath", "beams"):
             raise ValueError(f"footprint must be 'swath' or 'beams' (got {footprint!r})")
@@ -1249,7 +1347,10 @@ class ShardMap:
         # the intersection would make this branch's number incomparable with the
         # ``build_wall_s`` already recorded in existing manifests. Two segments
         # rather than one span because the geometry path's ``granule_records``
-        # sits between them and has always been outside (issue #439).
+        # sits between them and has always been outside (issue #439). The
+        # ephemeral cover (issue #445) sits in the first segment for the same
+        # reason the geometry path's cover sits in the second: covering is
+        # intersection work, and ``build_wall_s`` has always counted it.
         t0 = time.perf_counter()
         # A paired build never plans: pairing filtered the records, and the
         # plan's positional table alignment cannot represent that (issue #425).
@@ -1258,6 +1359,16 @@ class ShardMap:
             if paired_records is not None
             else _footprint_cells_plan(catalog, grid, chosen, footprint, mortie_order)
         )
+        # No stored column: cover one now and query it, rather than decoding
+        # every record to cover from its rings (issue #445). Same intersection,
+        # same records step -- the only difference from ``plan`` is that nothing
+        # was persisted, which is why the metadata below keys off ``plan`` alone.
+        live = (
+            _live_cells_plan(catalog, grid, chosen, footprint, mortie_order)
+            if plan is None and paired_records is None
+            else None
+        )
+        cells = plan if plan is not None else live
         plan_wall = time.perf_counter() - t0
         # Records are the fast path's whole remaining cost -- shapely-parsing
         # every row's WKB and ``to_pylist``-ing the nested assets column ran ~25 s
@@ -1266,15 +1377,15 @@ class ShardMap:
         # there, for its hit rows only; every other path needs them all up front.
         if paired_records is not None:
             records = paired_records
-        elif plan is not None:
+        elif cells is not None:
             records = None
         else:
             records = catalog.granule_records()
-        considered = plan[4] if plan is not None else len(records)
+        considered = cells[4] if cells is not None else len(records)
 
         t0 = time.perf_counter()
-        if plan is not None:
-            values, offsets, mortie_order, rows, _ = plan
+        if cells is not None:
+            values, offsets, mortie_order, rows, _ = cells
             shard_to_idx = _intersect_footprint_cells(rows, values, offsets, grid, all_shards)
         elif chosen == "mortie":
             mortie_order = _resolve_mortie_order(mortie_order, grid)
@@ -1295,9 +1406,10 @@ class ShardMap:
                 product=product,
             )
         wall = plan_wall + (time.perf_counter() - t0)
-        if plan is not None:
-            # Outside the timer on purpose: ``build_wall_s`` covers the plan and
-            # the intersection, and record decode has never been part of it.
+        if cells is not None:
+            # Outside the timer on purpose: ``build_wall_s`` covers the plan (the
+            # ephemeral cover included) and the intersection, and record decode
+            # has never been part of it.
             records, shard_to_idx = _hit_records(catalog, rows, shard_to_idx)
 
         from zagg.catalog.sources import FOOTPRINT_CELLS_ORDER

--- a/src/zagg/catalog/sources.py
+++ b/src/zagg/catalog/sources.py
@@ -567,6 +567,74 @@ class Catalog:
             )
         return ~shapely.is_empty(geoms) & np.isin(type_ids, (3, 6))
 
+    def cover_footprints(self, order: int) -> tuple:
+        """Cover every footprint at ``order`` and return the MOCs -- persisting nothing.
+
+        The shared core of :meth:`index_footprints` and of ``ShardMap.build``'s
+        **unindexed** mortie path (issue #445): one ``mortie.arrow.from_wkbs``
+        call over the geometry column, screened by :meth:`granule_row_mask`, in
+        the same row-aligned ragged layout :meth:`footprint_cells` returns. The
+        only difference between the two callers is what they do with it --
+        ``index_footprints`` writes it into a column, ``build`` intersects it and
+        drops it -- so they cannot drift on the cover itself. "Indexed" is
+        therefore a statement about persistence, not about how a build assigns.
+
+        Parameters
+        ----------
+        order : int
+            HEALPix order to cover at. Unvalidated here: callers own the bound
+            (``index_footprints`` refuses above ``MORTIE_MOC_ORDER_CAP``,
+            ``build`` covers at the grid's ``parent_order``).
+
+        Returns
+        -------
+        tuple
+            ``(values, offsets, rows)``. ``values`` is every covered row's
+            morton words concatenated (``uint64``); ``offsets`` are arrow list
+            offsets **over the whole table** (``int64``, length
+            ``table.num_rows + 1``), so row ``i``'s MOC is
+            ``values[offsets[i]:offsets[i + 1]]`` and a screened-out row carries
+            a zero-length run; ``rows`` is the covered table rows (``int64``,
+            ascending) -- ``np.flatnonzero`` of the screen, which is exactly the
+            order :meth:`granule_records` emits.
+
+        Notes
+        -----
+        Row-aligned rather than compact so both callers index it by table row:
+        the column ``index_footprints`` writes is one entry per row by contract,
+        and ``build``'s intersection is positional against the same table. The
+        empty runs cost 8 bytes each.
+
+        Memory is :meth:`index_footprints`' documented posture, because it is
+        this method: ``from_wkbs`` bounds its own peak at roughly the result
+        size, and the screen's WKB copy plus live shapely objects is the term it
+        does not bound (~1 GB over the parquet read on the 555,867-row ATL03
+        clone -- a peak, not a leak, issue #429).
+        """
+        from mortie.arrow import from_wkbs
+
+        column = self.table.column("geometry")
+        # The shapely objects the screen decodes die with the call, so its peak
+        # does not stack with the cover below (see ``granule_row_mask``).
+        keep = self.granule_row_mask()
+        if keep.all():
+            # The case that actually occurs (every catalog in the tree); taking
+            # the column whole avoids a second WKB copy.
+            values, kept_offsets = from_wkbs(column, order=int(order))
+        elif keep.any():
+            values, kept_offsets = from_wkbs(column.filter(pa.array(keep)), order=int(order))
+        else:
+            values, kept_offsets = np.empty(0, dtype=np.uint64), np.zeros(1, dtype=np.int64)
+        # Scatter the kept rows' MOC lengths back over every row: screened rows
+        # get a zero-length run, so ``values[offsets[i]:offsets[i + 1]]`` stays
+        # keyed by table row.
+        counts = np.zeros(len(keep), dtype=np.int64)
+        counts[keep] = np.diff(kept_offsets)
+        offsets = np.zeros(len(keep) + 1, dtype=np.int64)
+        np.cumsum(counts, out=offsets[1:])
+        rows = np.flatnonzero(keep).astype(np.int64, copy=False)
+        return np.asarray(values, dtype=np.uint64), offsets, rows
+
     def index_footprints(self, order: int) -> "Catalog":
         """Precompute the ``footprint_cells`` morton MOC column (issue #396).
 
@@ -635,14 +703,14 @@ class Catalog:
         MB after ``to_numpy`` (a full WKB copy) -> 1,794 MB with the shapely
         objects live. They die with ``granule_row_mask``'s frame, so that stays
         a peak rather than stacking with the cover, but a whole-clone index
-        wants headroom for it. The ``keep.all()`` short-circuit below avoids a
-        second ~334 MB WKB copy in the case that actually occurs (nothing screened out --
-        every catalog in the tree). Reading the geometry-type word straight out
+        wants headroom for it. :meth:`cover_footprints`' ``keep.all()``
+        short-circuit avoids a second ~334 MB WKB copy in the case that actually
+        occurs (nothing screened out -- every catalog in the tree). Reading the geometry-type word straight out
         of the WKB, or chunking the ``from_wkb`` call, would drop the screen's
         peak entirely; not done here because it trades the shared shapely
         predicate for a hand-rolled one.
         """
-        from mortie.arrow import from_morton_index, from_wkbs
+        from mortie.arrow import from_morton_index
 
         from zagg.catalog.shardmap import MORTIE_MOC_ORDER_CAP
 
@@ -653,23 +721,11 @@ class Catalog:
                 f"finer column could not be the cover any build asks for. Index at "
                 f"order <= {MORTIE_MOC_ORDER_CAP} (the grid's parent_order is the right choice)."
             )
-        column = self.table.column("geometry")
-        # The shapely objects the screen decodes die with the call, so its peak
-        # does not stack with the cover below (see ``granule_row_mask``).
-        keep = self.granule_row_mask()
-        if keep.all():
-            values, kept_offsets = from_wkbs(column, order=int(order))
-        elif keep.any():
-            values, kept_offsets = from_wkbs(column.filter(pa.array(keep)), order=int(order))
-        else:
-            values, kept_offsets = np.empty(0, dtype=np.uint64), np.zeros(1, dtype=np.int64)
-        # Scatter the kept rows' MOC lengths back over every row: screened rows
-        # get a zero-length run, so ``values[offsets[i]:offsets[i + 1]]`` stays
-        # keyed by table row.
-        counts = np.zeros(len(keep), dtype=np.int64)
-        counts[keep] = np.diff(kept_offsets)
-        offsets = np.zeros(len(keep) + 1, dtype=np.int64)
-        np.cumsum(counts, out=offsets[1:])
+        # The cover, the screen and the row-aligned scatter all live in
+        # :meth:`cover_footprints` -- shared with ``ShardMap.build``'s unindexed
+        # path (issue #445), which runs the identical cover and simply keeps it
+        # in memory. This method is that cover plus the column write.
+        values, offsets, _ = self.cover_footprints(int(order))
         cells = pa.LargeListArray.from_arrays(
             pa.array(offsets, pa.int64()), from_morton_index(values)
         )

--- a/src/zagg/catalog/sources.py
+++ b/src/zagg/catalog/sources.py
@@ -705,10 +705,10 @@ class Catalog:
         a peak rather than stacking with the cover, but a whole-clone index
         wants headroom for it. :meth:`cover_footprints`' ``keep.all()``
         short-circuit avoids a second ~334 MB WKB copy in the case that actually
-        occurs (nothing screened out -- every catalog in the tree). Reading the geometry-type word straight out
-        of the WKB, or chunking the ``from_wkb`` call, would drop the screen's
-        peak entirely; not done here because it trades the shared shapely
-        predicate for a hand-rolled one.
+        occurs (nothing screened out -- every catalog in the tree). Reading the
+        geometry-type word straight out of the WKB, or chunking the
+        ``from_wkb`` call, would drop the screen's peak entirely; not done here
+        because it trades the shared shapely predicate for a hand-rolled one.
         """
         from mortie.arrow import from_morton_index
 

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -1520,6 +1520,17 @@ class TestLiveCover:
         sm = ShardMap.build(_overlapping_catalog(n=4), hp_grid, backend="mortie")
         assert 0.05 <= sm.metadata["build_wall_s"] < 0.2
 
+    def test_empty_catalog_builds_an_empty_map(self, hp_grid):
+        # ``filter_bbox`` can cut a catalog to nothing, and the records path
+        # handled that by returning ``{}`` out of ``_flatten_rings``. The cover
+        # has to land in the same place: no blob for ``from_wkbs`` to parse, and
+        # an offsets array that is still one entry per (zero) row.
+        cat = _overlapping_catalog(n=2)
+        empty = Catalog(cat.table.slice(0, 0), dict(cat.metadata))
+        sm = ShardMap.build(empty, hp_grid, backend="mortie")
+        assert sm.shard_keys == []
+        assert sm.metadata["total_granules"] == 0
+
     @pytest.mark.parametrize(
         "kwargs",
         [

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -11,6 +11,7 @@ import json
 import pathlib
 import sys
 import tempfile
+import time
 import types
 
 import numpy as np
@@ -125,6 +126,20 @@ def fake_spherely(monkeypatch):
     mod.intersects = _fake_intersects
     monkeypatch.setitem(sys.modules, "spherely", mod)
     return mod
+
+
+@pytest.fixture
+def pre_445_path(monkeypatch):
+    """Force ``build`` back onto the pre-#445 records-first path -- the oracle.
+
+    Before issue #445 an unindexed mortie build decoded every record and covered
+    each footprint from its rings (``_intersect_mortie``). Returning ``None``
+    from the ephemeral plan restores exactly that branch, so the two-stage cover
+    can be pinned against the path it replaced without a build kwarg that would
+    exist only for tests. The stored-column plan is untouched, so an indexed
+    build under this fixture still takes its own fast path.
+    """
+    monkeypatch.setattr(shardmap, "_live_cells_plan", lambda *a, **k: None)
 
 
 class TestBuildSpherelyBrute:
@@ -303,11 +318,18 @@ class TestMortieOrder:
 
     def test_default_keys_to_chunk_order(self, catalog):
         # chunk_inner=13 (the shipped ATL03 config) -> MOC order 13, the inner
-        # chunk the worker dispatches at.
+        # chunk the worker dispatches at. That is the resolver's contract, and
+        # it still governs every path that covers from decoded rings (beams,
+        # non-HEALPix, reproject). A HEALPix swath build covers from WKB instead
+        # and defaults to parent_order (issue #445), so it records 11 -- pinned
+        # beside the resolver so the two defaults can't drift unnoticed.
+        from zagg.catalog.shardmap import _resolve_mortie_order
+
         g = HealpixGrid(11, 19, layout="fullsphere", chunk_inner=13)
         assert g.chunk_order == 13
+        assert _resolve_mortie_order(None, g) == 13
         sm = ShardMap.build(catalog, g, backend="mortie")
-        assert sm.metadata["mortie_order"] == 13
+        assert sm.metadata["mortie_order"] == 11
 
     def test_default_falls_back_to_parent_order(self, catalog, hp_grid):
         # chunk_inner unset -> chunk_order == parent_order, so the MOC order is the
@@ -316,8 +338,11 @@ class TestMortieOrder:
         sm = ShardMap.build(catalog, hp_grid, backend="mortie")
         assert sm.metadata["mortie_order"] == 11
 
-    def test_default_under_mortie_cap_at_leaf_order_19(self, catalog):
-        # The shipped production grid (chunk_inner 13) -> 13, under the order-18 cap.
+    def test_default_under_mortie_cap_at_leaf_order_19(self, catalog, pre_445_path):
+        # The shipped production grid (chunk_inner 13) -> 13, under the order-18
+        # cap. Read on the records path, which is where the derived order is
+        # still what a build runs at (issue #445 moved the WKB path to
+        # parent_order); the leaf order 19 must not leak into either.
         g = HealpixGrid(11, 19, layout="fullsphere", chunk_inner=13)
         sm = ShardMap.build(catalog, g, backend="mortie")
         assert sm.metadata["mortie_order"] == 13
@@ -731,13 +756,16 @@ class TestFootprintCells:
         fast = ShardMap.build(cat.index_footprints(11), hp_grid, backend="mortie")
         assert _shard_ids(fast) == _shard_ids(geometry)
 
-    def test_multipolygon_is_a_superset_not_an_identity(self, hp_grid):
+    def test_multipolygon_is_a_superset_not_an_identity(self, hp_grid, pre_445_path):
         # The one place the fast path is deliberately NOT the geometry path.
         # ``index_footprints`` covers the union of the rings in each blob;
         # ``granule_records`` reads the largest part's exterior ring only. So a
         # two-part footprint gets the second part's shards from the index and
         # not from geometry -- a superset, and the intended answer. Alignment is
         # unaffected: every geometry shard is still present, with the same ids.
+        # The oracle is the pre-#445 records path (``pre_445_path``): the live
+        # path now shares this cover, so it shares the superset too -- pinned in
+        # ``TestLiveCover`` rather than smuggled in here as an equality.
         multi = _item("MULTI", -76.62, -76.60)
 
         def _ring(lon0, lon1):
@@ -1222,7 +1250,7 @@ class TestDeferredRecords:
         assert assigned == {"G0", "G1"}
         assert sm.metadata["total_granules"] == 2
 
-    def test_null_geometry_refuses_on_both_paths(self, hp_grid):
+    def test_null_geometry_refuses_on_both_paths(self, hp_grid, fake_spherely):
         # Predicate parity, the one input where the vectorised screen and the
         # row-wise loop see different things: ``shapely.from_wkb`` maps a null
         # WKB to ``None``, whose ``get_type_id`` is -1 (screened) while
@@ -1235,8 +1263,14 @@ class TestDeferredRecords:
         indexed = _with_null_geometry(_catalog(items).index_footprints(11), 0)
         with pytest.raises(ValueError, match="null geometry .*first at row 0"):
             ShardMap.build(indexed, hp_grid, backend="mortie")
-        with pytest.raises(AttributeError):
+        # The unindexed mortie build now runs the same screen (issue #445), so
+        # it refuses by name where it used to die on ``None.is_empty``. Still a
+        # refusal, and the record-decoding backends still give the old one --
+        # what must never happen is one path dropping the granule in silence.
+        with pytest.raises(ValueError, match="null geometry .*first at row 0"):
             ShardMap.build(_with_null_geometry(_catalog(items), 0), hp_grid, backend="mortie")
+        with pytest.raises(AttributeError):
+            ShardMap.build(_with_null_geometry(_catalog(items), 0), hp_grid, backend="spherely")
 
     def test_duplicate_ids_outside_the_aoi_still_refuse(self, hp_grid):
         # The duplicate-id refusal is a statement about the catalog, not about
@@ -1277,11 +1311,13 @@ class TestDeferredRecords:
         with pytest.raises(ValueError, match="order 9, coarser than.*parent_order 11"):
             ShardMap.build(cat, hp_grid, backend="mortie")
 
-    def test_multipolygon_superset_survives_the_inversion(self, hp_grid):
+    def test_multipolygon_superset_survives_the_inversion(self, hp_grid, pre_445_path):
         # The disclosed divergence (the column covers every part, the record
         # reads the largest part's ring) is a property of the COLUMN, so
         # intersecting first must not narrow it -- the second part's shards
-        # still appear, still carrying the granule's own record.
+        # still appear, still carrying the granule's own record. Oracle is the
+        # pre-#445 records path, since the live one now shares the column's
+        # cover (issue #445) and so shares its superset.
         def _ring(lon0, lon1):
             return [[lon0, 38.85], [lon1, 38.85], [lon1, 38.93], [lon0, 38.93], [lon0, 38.85]]
 
@@ -1298,6 +1334,211 @@ class TestDeferredRecords:
         by_shard = dict(zip(fast.shard_keys, fast.granules, strict=True))
         assert all([g["id"] for g in by_shard[k]] == ["MULTI"] for k in extra)
         assert all(g["s3"] == "s3://b/MULTI.h5" for k in extra for g in by_shard[k])
+
+
+class TestLiveCover:
+    """An UNINDEXED mortie build covers from WKB too (issue #445).
+
+    Same inversion as #439, applied to the path that had kept the old order:
+    cover the geometry column, intersect, then decode records for the hits. The
+    oracle is the path it replaces -- ``pre_445_path`` restores the record-first
+    ``_intersect_mortie`` build -- and the pin is the serialized manifest, so
+    "faster" cannot quietly become "different". The two intended divergences
+    (the MultiPolygon superset, inherited with the cover; the cover order, now
+    ``parent_order``) are pinned as divergences, each on its own.
+    """
+
+    @pytest.fixture
+    def hp_grid(self):
+        # chunk_inner=13 with parent_order=11 -- the shipped ATL03 shape, and
+        # the one that separates the two defaults: the records path covers at
+        # the chunk order 13, this one at the shard order 11.
+        return HealpixGrid(11, 19, layout="fullsphere", chunk_inner=13)
+
+    @staticmethod
+    def _payload(sm, tmp_path, name, *, drop=("build_wall_s",)):
+        """The serialized manifest, minus the keys that are not the assignment."""
+        path = str(tmp_path / name)
+        sm.to_json(path)
+        payload = json.loads(pathlib.Path(path).read_text())
+        for key in drop:
+            payload["metadata"].pop(key, None)
+        return payload
+
+    def _region(self):
+        return [
+            (
+                np.array([38.85, 38.85, 38.93, 38.93, 38.85]),
+                np.array([-76.62, -76.55, -76.55, -76.62, -76.62]),
+            )
+        ]
+
+    def test_serializes_identically_to_the_pre_445_path(self, hp_grid, tmp_path, monkeypatch):
+        # The invariant the issue rests on: same catalog, same grid, same AOI ->
+        # the same JSON, key for key, on the single-part footprints every CMR
+        # ATL03/06 granule has. Includes a screened (non-polygonal) row and an
+        # AOI narrower than the catalog, so the ``rows`` map is not the identity
+        # and most records go unassigned.
+        #
+        # It doubles as an in-suite check of the order-sweep invariant quoted in
+        # ``_resolve_mortie_order``: the oracle covers at the chunk order 13 and
+        # this path at the shard order 11, and the assignment is the same,
+        # because a shard map states order-11 membership and nothing finer.
+        items = [_item(f"G{i:02d}", -76.62 + 0.008 * i, -76.60 + 0.008 * i) for i in range(24)]
+        pt = _item("PT", -76.60, -76.58)
+        pt["geometry"] = {"type": "Point", "coordinates": [-76.59, 38.89]}
+        cat = _catalog(items[:11] + [pt] + items[11:])
+        live = ShardMap.build(cat, hp_grid, region=self._region(), backend="mortie")
+        monkeypatch.setattr(shardmap, "_live_cells_plan", lambda *a, **k: None)
+        oracle = ShardMap.build(cat, hp_grid, region=self._region(), backend="mortie")
+        assert 0 < live.metadata["granules_assigned"] < live.metadata["total_granules"], (
+            "the AOI must discard records, or the inversion is untested here"
+        )
+        assert live.metadata["mortie_order"] == 11
+        assert oracle.metadata["mortie_order"] == 13
+        drop = ("build_wall_s", "mortie_order")
+        assert self._payload(live, tmp_path, "live.json", drop=drop) == self._payload(
+            oracle, tmp_path, "oracle.json", drop=drop
+        )
+
+    def test_default_order_is_the_shard_order(self, hp_grid, monkeypatch):
+        # espg's ruling (2026-08-16): the map records order-11 shard membership,
+        # and the sweep in ``_resolve_mortie_order`` measures granules/shard flat
+        # for every order >= parent_order, so covering at the chunk order buys
+        # nothing and costs ~2x the MOC words per order. One cover, at 11.
+        orders = []
+        real = Catalog.cover_footprints
+        monkeypatch.setattr(
+            Catalog,
+            "cover_footprints",
+            lambda self, order: (orders.append(order), real(self, order))[1],
+        )
+        sm = ShardMap.build(_overlapping_catalog(), hp_grid, backend="mortie")
+        assert orders == [11]
+        assert sm.metadata["mortie_order"] == 11
+        assert "footprint_cells" not in sm.metadata, "nothing was persisted"
+
+    def test_pinned_order_is_honored_and_matches_the_oracle(self, hp_grid, tmp_path, monkeypatch):
+        # An explicit order is a request for a cover at that order -- nothing is
+        # persisted here, so unlike the stored plan (which refuses a pin it
+        # cannot restate) this path simply covers there, and must land the
+        # oracle's assignment at the same pin.
+        cat = _overlapping_catalog()
+        live = ShardMap.build(
+            cat, hp_grid, region=self._region(), backend="mortie", mortie_order=13
+        )
+        assert live.metadata["mortie_order"] == 13
+        monkeypatch.setattr(shardmap, "_live_cells_plan", lambda *a, **k: None)
+        oracle = ShardMap.build(
+            cat, hp_grid, region=self._region(), backend="mortie", mortie_order=13
+        )
+        assert self._payload(live, tmp_path, "p.json") == self._payload(oracle, tmp_path, "o.json")
+
+    def test_pinned_order_coarser_than_the_shards_still_refuses(self, hp_grid):
+        # The pin is validated exactly as the records path validates it (#92),
+        # and before any cover runs.
+        with pytest.raises(ValueError, match="coarser than the grid's parent_order"):
+            ShardMap.build(_overlapping_catalog(), hp_grid, backend="mortie", mortie_order=8)
+
+    def test_total_granules_counts_the_screen(self, hp_grid, monkeypatch):
+        # ``total_granules`` is the records CONSIDERED. The live path never
+        # builds that list, so it counts the row screen -- and must land on the
+        # number the records path reports from ``len(records)``, screened row
+        # and all.
+        good = [_item(f"G{i:02d}", -76.62 + 0.008 * i, -76.60 + 0.008 * i) for i in range(6)]
+        pt = _item("PT", -76.62, -76.60)
+        pt["geometry"] = {"type": "Point", "coordinates": [-76.61, 38.89]}
+        cat = _catalog(good[:3] + [pt] + good[3:])
+        assert len(cat.granule_records()) == 6, "the fixture must screen exactly one row"
+        live = ShardMap.build(cat, hp_grid, backend="mortie")
+        monkeypatch.setattr(shardmap, "_live_cells_plan", lambda *a, **k: None)
+        oracle = ShardMap.build(cat, hp_grid, backend="mortie")
+        assert live.metadata["total_granules"] == oracle.metadata["total_granules"] == 6
+        assert live.metadata["granules_assigned"] == oracle.metadata["granules_assigned"]
+
+    def test_records_are_decoded_for_the_hits_only(self, hp_grid, monkeypatch):
+        # The point of the inversion: an AOI that keeps a handful of granules
+        # must not pay to decode the rest (~25 s of a 29.5 s clone-scale build).
+        cat = _overlapping_catalog(n=24)
+        decoded: list = []
+        real = Catalog.granule_records
+        monkeypatch.setattr(
+            Catalog,
+            "granule_records",
+            lambda self: (decoded.append(self.table.num_rows), real(self))[1],
+        )
+        narrow = [
+            (
+                np.array([38.85, 38.85, 38.93, 38.93, 38.85]),
+                np.array([-76.62, -76.60, -76.60, -76.62, -76.62]),
+            )
+        ]
+        sm = ShardMap.build(cat, hp_grid, region=narrow, backend="mortie")
+        assigned = sm.metadata["granules_assigned"]
+        assert 0 < assigned < 24, "the AOI must discard granules, or nothing is being pinned"
+        assert decoded == [assigned], f"decoded {decoded} rows for {assigned} assigned granules"
+
+    def test_multipolygon_is_a_superset_of_the_records_path(self, hp_grid, monkeypatch):
+        # The disclosed divergence, now inherited by the live path: ``from_wkbs``
+        # covers the union of the parts inside each blob, where
+        # ``granule_records`` reads the largest part's exterior ring only. So a
+        # multi-part footprint assigns to shards the pre-#445 build never saw --
+        # a superset, never a swap, and never for a CMR ATL03/06 granule (all
+        # single-part).
+        def _ring(lon0, lon1):
+            return [[lon0, 38.85], [lon1, 38.85], [lon1, 38.93], [lon0, 38.93], [lon0, 38.85]]
+
+        multi = _item("MULTI", -76.62, -76.60)
+        multi["geometry"] = {
+            "type": "MultiPolygon",
+            "coordinates": [[_ring(-76.62, -76.60)], [_ring(-76.53, -76.52)]],
+        }
+        cat = _catalog([_item("G00", -76.56, -76.54), multi])
+        live = ShardMap.build(cat, hp_grid, backend="mortie")
+        monkeypatch.setattr(shardmap, "_live_cells_plan", lambda *a, **k: None)
+        oracle = ShardMap.build(cat, hp_grid, backend="mortie")
+        extra = set(live.shard_keys) - set(oracle.shard_keys)
+        assert extra, "the second part must contribute shards the records path never sees"
+        assert set(oracle.shard_keys) <= set(live.shard_keys)
+        by_shard = dict(zip(live.shard_keys, live.granules, strict=True))
+        assert all([g["id"] for g in by_shard[k]] == ["MULTI"] for k in extra)
+
+    def test_build_wall_spans_the_cover_but_not_the_records(self, hp_grid, monkeypatch):
+        # ``build_wall_s`` has always covered the plan and the intersection and
+        # never the record decode (issue #439); the ephemeral cover is
+        # intersection work, so it lands inside. Pinned with a sleep on each
+        # side rather than by reading the code.
+        real_cover, real_records = Catalog.cover_footprints, Catalog.granule_records
+        monkeypatch.setattr(
+            Catalog,
+            "cover_footprints",
+            lambda self, order: (time.sleep(0.05), real_cover(self, order))[1],
+        )
+        monkeypatch.setattr(
+            Catalog, "granule_records", lambda self: (time.sleep(0.2), real_records(self))[1]
+        )
+        sm = ShardMap.build(_overlapping_catalog(n=4), hp_grid, backend="mortie")
+        assert 0.05 <= sm.metadata["build_wall_s"] < 0.2
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"chosen": "spherely"}, id="spherely-backend"),
+            pytest.param({"footprint": "beams"}, id="beams-footprint"),
+        ],
+    )
+    def test_gated_off_for_the_paths_that_need_records(self, hp_grid, grid, kwargs):
+        # Each exclusion is a path whose geometry the cover does not describe:
+        # spherely is exact S2 (a MOC swap would change semantics behind the
+        # caller, espg/mortie#32), ``beams`` covers per-beam corridors rather
+        # than the CMR swath (#65), and a rectilinear grid has no shard order
+        # for the cover to key to. Each must fall through to the records path.
+        args = {"chosen": "mortie", "footprint": "swath", **kwargs}
+        cat = _overlapping_catalog(n=2)
+        gated = shardmap._live_cells_plan(cat, hp_grid, args["chosen"], args["footprint"], None)
+        assert gated is None
+        assert shardmap._live_cells_plan(cat, grid, "mortie", "swath", None) is None
+        assert shardmap._live_cells_plan(cat, hp_grid, "mortie", "swath", None) is not None
 
 
 class TestIO:
@@ -2124,6 +2365,23 @@ class TestPairedAssetBuild:
         for gid in assigned:  # only paired primaries; the pairless third never appears
             assert not gid.startswith("GEDI01_B_2019120")
         assert {p["id"][:10] for p in sm.metadata["pairless"]} == {"GEDI01_B_2", "GEDI02_A_2"}
+
+    def test_paired_build_skips_the_ephemeral_cover_too(self, monkeypatch):
+        """Pairing filters records, so neither cover-first path may engage.
+
+        The ephemeral cover (issue #445) aligns positionally to the raw catalog
+        table exactly as the stored column does, so a paired build has to stay
+        on the records path for the same reason -- and unlike the stored plan,
+        this one engages on an *unindexed* catalog, which is every paired build.
+        """
+        l1b, l2a = self._catalogs()
+        monkeypatch.setattr(
+            shardmap,
+            "_live_cells_plan",
+            lambda *a, **k: pytest.fail("a paired build must not cover-and-intersect"),
+        )
+        sm = ShardMap.build(l1b, HealpixGrid(11, 17, layout="fullsphere"), sibling_catalog=l2a)
+        assert {rec["id"] for shard in sm.granules for rec in shard}
 
     def test_pairless_excluded_and_reported(self, grid, fake_spherely):
         l1b, l2a = self._catalogs()

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -1467,6 +1467,48 @@ class TestLiveCover:
         )
         assert self._payload(live, tmp_path, "p.json") == self._payload(oracle, tmp_path, "o.json")
 
+    def test_a_pinned_indexed_build_covers_live_too(self, hp_grid, tmp_path, monkeypatch):
+        # The third population whose assignment moves. ``_footprint_cells_plan``
+        # declines a pinned order (a persisted column cannot restate one), and
+        # since #445 what catches that is THIS plan, not the geometry path -- so
+        # an indexed catalog built with ``mortie_order=`` covers from WKB and
+        # inherits the MultiPolygon superset, exactly as the unindexed build
+        # does. Pinned three ways: same assignment as the unindexed pinned
+        # build, a strict superset of the pre-#445 records path, and the
+        # ``footprint_cells: False`` metadata unchanged (the stored column
+        # really did go unused).
+        def _ring(lon0, lon1):
+            return [[lon0, 38.85], [lon1, 38.85], [lon1, 38.93], [lon0, 38.93], [lon0, 38.85]]
+
+        def _cat():
+            multi = _item("MULTI", -76.62, -76.60)
+            multi["geometry"] = {
+                "type": "MultiPolygon",
+                "coordinates": [[_ring(-76.62, -76.60)], [_ring(-76.53, -76.52)]],
+            }
+            return _catalog([_item("G00", -76.56, -76.54), multi])
+
+        indexed = ShardMap.build(_cat().index_footprints(11), hp_grid, mortie_order=13)
+        unindexed = ShardMap.build(_cat(), hp_grid, backend="mortie", mortie_order=13)
+        monkeypatch.setattr(shardmap, "_live_cells_plan", lambda *a, **k: None)
+        records = ShardMap.build(_cat().index_footprints(11), hp_grid, mortie_order=13)
+        assert indexed.metadata["footprint_cells"] is False
+        assert records.metadata["footprint_cells"] is False
+        assert indexed.metadata["mortie_order"] == 13
+        # ``footprint_cells_order`` is the CATALOG's own metadata, carried
+        # through by the indexed build and legitimately absent from the
+        # unindexed one; everything else must match key for key.
+        drop = ("build_wall_s", "footprint_cells", "footprint_cells_order")
+        assert self._payload(indexed, tmp_path, "i.json", drop=drop) == self._payload(
+            unindexed, tmp_path, "u.json", drop=drop
+        )
+        assert set(records.shard_keys) < set(indexed.shard_keys), (
+            "the pinned indexed build must inherit the cover's MultiPolygon superset"
+        )
+        by_shard = dict(zip(indexed.shard_keys, indexed.granules, strict=True))
+        extra = set(indexed.shard_keys) - set(records.shard_keys)
+        assert all([g["id"] for g in by_shard[k]] == ["MULTI"] for k in extra)
+
     def test_pinned_order_coarser_than_the_shards_still_refuses(self, hp_grid):
         # The pin is validated exactly as the records path validates it (#92),
         # and before any cover runs.

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -1343,9 +1343,10 @@ class TestLiveCover:
     cover the geometry column, intersect, then decode records for the hits. The
     oracle is the path it replaces -- ``pre_445_path`` restores the record-first
     ``_intersect_mortie`` build -- and the pin is the serialized manifest, so
-    "faster" cannot quietly become "different". The two intended divergences
-    (the MultiPolygon superset, inherited with the cover; the cover order, now
-    ``parent_order``) are pinned as divergences, each on its own.
+    "faster" cannot quietly become "different". The intended divergences (the
+    MultiPolygon superset, inherited with the cover; the cover order, now
+    ``parent_order``, and the superset it admits at coarse shard orders) are
+    pinned as divergences, each on its own.
     """
 
     @pytest.fixture
@@ -1417,6 +1418,38 @@ class TestLiveCover:
         assert orders == [11]
         assert sm.metadata["mortie_order"] == 11
         assert "footprint_cells" not in sm.metadata, "nothing was persisted"
+
+    def test_coarse_shard_order_covers_a_superset(self, monkeypatch):
+        # The order default is flat by MEASUREMENT, not identical by
+        # construction: mortie's coverage is conservative per order, so a cover
+        # at ``parent_order`` can keep a boundary cell that the chunk-order
+        # cover refined down does not -- never the reverse. Every production
+        # pair measured flat (9/13, 11/13, 8/12, 9/11: 0/200 rows differing over
+        # random polygons), so it takes a coarse grid to see the gap at all:
+        # parent 6 against chunk 10, one rectangle straddling an order-6 seam.
+        # The assertion is the DIRECTION -- a future change that made the
+        # default a subset (dropping a real granule/shard pair) fails here.
+        coarse = HealpixGrid(6, 12, layout="fullsphere", chunk_inner=10)
+        cat = _catalog([_item("G00", 86.389228, 88.222362, lat0=-61.180344, lat1=-60.706814)])
+        region = [
+            (
+                np.array([-62.0, -62.0, -60.0, -60.0, -62.0]),
+                np.array([85.0, 89.0, 89.0, 85.0, 85.0]),
+            )
+        ]
+        live = ShardMap.build(cat, coarse, region=region, backend="mortie")
+        monkeypatch.setattr(shardmap, "_live_cells_plan", lambda *a, **k: None)
+        oracle = ShardMap.build(cat, coarse, region=region, backend="mortie")
+        assert live.metadata["mortie_order"] == 6
+        assert oracle.metadata["mortie_order"] == 10
+        assert set(oracle.shard_keys) < set(live.shard_keys), (
+            "the coarse cover must be a STRICT superset on this fixture, or it has stopped "
+            "reproducing the divergence and no longer pins the direction"
+        )
+        assert len(live.shard_keys) == 4 and len(oracle.shard_keys) == 3
+        by_shard = dict(zip(live.shard_keys, live.granules, strict=True))
+        extra = set(live.shard_keys) - set(oracle.shard_keys)
+        assert all([g["id"] for g in by_shard[k]] == ["G00"] for k in extra)
 
     def test_pinned_order_is_honored_and_matches_the_oracle(self, hp_grid, tmp_path, monkeypatch):
         # An explicit order is a request for a cover at that order -- nothing is

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -1553,6 +1553,33 @@ class TestLiveCover:
         sm = ShardMap.build(_overlapping_catalog(n=4), hp_grid, backend="mortie")
         assert 0.05 <= sm.metadata["build_wall_s"] < 0.2
 
+    def test_the_budget_refusal_names_a_remedy_that_exists(self, hp_grid, monkeypatch):
+        # The cell-budget refusal is shared with the stored path, but its
+        # remedy is not: "re-index the catalog / drop the footprint_cells
+        # column" names two things an unindexed build does not have, and
+        # re-indexing would not move it anyway (the cover is flattened to
+        # ``parent_order`` whatever order it ran at). ``build`` knows which
+        # cover it holds, so the message must say so.
+        import mortie
+
+        cat = _overlapping_catalog(n=2)
+        indexed_cat = cat.index_footprints(11)
+
+        def boom(*args, **kwargs):
+            raise ValueError("MOC 0 would expand to more than 1048576 cells at order 11")
+
+        monkeypatch.setattr(mortie, "mocs_to_orders", boom)
+        with pytest.raises(ValueError) as live:
+            ShardMap.build(cat, hp_grid, backend="mortie")
+        with pytest.raises(ValueError) as stored:
+            ShardMap.build(indexed_cat, hp_grid, backend="mortie")
+        assert "footprint cover batch failed" in str(live.value)
+        assert "no footprint_cells column to re-cut or drop" in str(live.value)
+        assert "coarser parent_order" in str(live.value) and "parent_order 11" in str(live.value)
+        assert "Re-index the catalog" not in str(live.value)
+        assert "footprint_cells batch failed" in str(stored.value)
+        assert "Re-index the catalog at a coarser order" in str(stored.value)
+
     def test_empty_catalog_builds_an_empty_map(self, hp_grid):
         # ``filter_bbox`` can cut a catalog to nothing, and the records path
         # handled that by returning ``{}`` out of ``_flatten_rings``. The cover


### PR DESCRIPTION
Closes #445. Implements the [plan comment](https://github.com/englacial/zagg/issues/445#issuecomment-5310678860) as amended by espg in-session on 2026-08-16 (see **Design change** below).

Issue #439/PR #440 inverted the *indexed* path — intersect first, decode records for the hits only. The **unindexed** path kept the old order: `granule_records()` over every row, then cover each footprint from its decoded rings. On the 555,867-granule ATL03 clone against California that was 86.9 s to assign 2,357 granules, ~2.5x the cost of `index_footprints(9)` + an indexed query put together.

This makes an unindexed mortie `swath` build *build-an-ephemeral-index-and-query-it*: cover the WKB column once (`mortie.arrow.from_wkbs`, no records, no column), intersect positionally with `_intersect_footprint_cells`, then decode records for the hit rows only via `_hit_records`. **"Indexed" now means only that the cover was persisted** — one intersection engine, two ways of getting its input.

## Design change vs the plan comment: one stage, not two

The plan comment specified a two-stage coarse/fine cover, because the live path resolved its MOC order through `_resolve_mortie_order` (chunk order — o13 for the shipped ATL03 grids) and a whole-catalog o13 cover is not materializable (~9–13 GB against ~270–420 MB at o9).

espg challenged why o13 appears at all, and `_resolve_mortie_order`'s own docstring settles it: a shard map records **`parent_order` shard membership and nothing finer**, and the real-catalog order sweep (`bench/neon_order_sweep.py`) quoted there measures granules/shard **flat for every order >= `parent_order`** — "a finer MOC buys precision the order-`parent_order` shard cells can't see". So the cover runs at `parent_order`, the assignment is already exact, and the coarse/fine machinery is unnecessary. Implemented single-stage; the two-stage form was stripped.

Consequence worth flagging: an unpinned unindexed HEALPix build now records `metadata["mortie_order"] = parent_order` where it recorded the chunk order before. **Same assignment at the orders production runs, and a superset elsewhere — never a subset** (delta 5 below): flat by measurement at 9/13, 11/13, 8/12 and 9/11, up to 0.71% extra cells at coarse pairs like 3/7, because mortie's coverage is conservative per order and refining a fine cover down does not reproduce a coarse one. Fewer cover words either way. An explicit `mortie_order=` is still honored literally and still validated against `parent_order` (#92).

## Phases

- [x] **Phase 1** — `Catalog.cover_footprints(order)` in `sources.py` (the ephemeral cover: `granule_row_mask` screen + one `from_wkbs`, row-aligned ragged output). `index_footprints` refactored onto it, so the two cannot drift on the cover. `_live_cells_plan` + the `build` branch in `shardmap.py`, plus docstring updates (`build` Notes, `_intersect_footprint_cells`, `_resolve_mortie_order`).
- [x] **Phase 2** — tests: parity against the pre-#445 path, the order-default divergence, the pinned order, the exclusions, `total_granules`, records-for-hits-only, `build_wall_s`, the MultiPolygon superset.
- [x] **Phase 3** — `docs/api/catalog.md`: what indexing buys now that both paths share the cover.
- [x] **Phase 4** — empty-catalog edge case (`filter_bbox` can cut a catalog to nothing; the cover has to land where `_flatten_rings` did) + the clone-scale measurement below.

## Where it lives

The new cover is `Catalog.cover_footprints` in `src/zagg/catalog/sources.py`, deliberately **not** in `shardmap.py` (past the 1,200-line raise trigger; the split proposal flagged on PR #440 is still standing). It is `index_footprints` minus the column write — `index_footprints` now calls it, so there is one cover implementation, one screen, one row-aligned scatter.

`shardmap.py` still grew, from 1,647 to 1,759 lines (+112, of which ~95 is docstring/comment: `_live_cells_plan`'s rationale, the `build` Notes, the order-default note on `_resolve_mortie_order`). The executable addition is 11 lines of `_live_cells_plan` body plus a 5-line branch in `build`. Raised under "Questions for review" below.

## Measured (555,867-granule ATL03 clone, `demo_aoi("california")`, `HealpixGrid(9, 19, chunk_inner=13)`)

Same machine, same catalog, same AOI; "before" is `origin/main` (9538d24) run against this venv via `PYTHONPATH`, "after" is this branch. `build_wall_s` is the manifest's own number (cover/plan + intersection); "total" is the whole `ShardMap.build` call, so the difference is the record decode.

| build | resolved MOC order | `build_wall_s` | total `build()` | assignment digest |
| --- | --- | --- | --- | --- |
| before, default | 13 | 1055.9 s | **1075.0 s** | `dd43dd5f55a0f002` |
| before, `mortie_order=9` | 9 | 67.9 s | **86.6 s** | `dd43dd5f55a0f002` |
| after, default | 9 | 38.9 s | **39.3 s** | `dd43dd5f55a0f002` |
| after, `mortie_order=9` | 9 | 37.1 s | **37.4 s** | `dd43dd5f55a0f002` |
| after, default (repeat) | 9 | 36.7 s | **37.0 s** | `dd43dd5f55a0f002` |

Every run: 555,867 records considered, **2,357 granules assigned**, 2,726 shards, 191,219 pairs.

Two readings, because the pre-#445 default was not the pre-#445 *demo*:

- Against the demo's own call (`mortie_order=9`, what `demo/01_query.ipynb` and `data/build_aoi_shardmap.py` pass) this is **86.6 s -> ~37 s**, and 86.6 s reproduces the issue's 86.9 s measurement to within noise.
- Against the **default** call — no `mortie_order`, which resolved to the chunk order 13 — it is **1075 s -> ~39 s**, ~27x. That 1075 s is the cost espg's ruling removes: covering 555,867 quarter-orbit footprints at o13 (~9.3k MOC words each) to answer an order-9 question. Anyone who built unindexed without pinning the order was paying it.

The record decode is now ~0.3-0.4 s of the build (39.3 - 38.9) instead of ~19 s (86.6 - 67.9): 2,357 rows decoded instead of 555,867.

**Parity is exact at clone scale.** The digest above is a sha256 over `[[shard_key, [granule ids...]], ...]` of the whole manifest — every shard, every granule, in order. All five runs share one digest, so the new path reproduces the old one byte for byte on the real catalog (single-part footprints throughout), **including across the order change**: `before, default` covered at 13 and `after, default` covers at 9, and they agree. That is the order-sweep invariant (`granules/shard` flat for order >= `parent_order`) verified at 555,867 granules, not just on fixtures — a *measurement* at this order pair, not an identity in general; see delta 5.

## Semantics deltas (deliberate, disclosed)

1. **MultiPolygon superset.** `from_wkbs` covers the union of the parts inside each blob; `granule_records` reads only the largest part's exterior ring. The unindexed path now inherits the stored index's documented superset semantics — a multi-part footprint can assign to shards it did not before. Every CMR ATL03/06 granule is single-part (the same framing the stored path ships with), so no production build moves. Pinned by `TestLiveCover::test_multipolygon_is_a_superset_of_the_records_path`.
2. **Null geometry refuses by name.** `granule_row_mask` raises `ValueError` naming the count and the first offending row where the record loop raised `AttributeError` on `None.is_empty`. Both refuse — neither drops the granule silently — but the exception type on the unindexed mortie path changes. Pinned in `TestDeferredRecords::test_null_geometry_refuses_on_both_paths`, which also keeps the `AttributeError` pin on a record-decoding backend.
3. **`mortie_order` metadata** on unpinned unindexed HEALPix builds: chunk order -> `parent_order` (above).
4. **Cell-budget refusal.** `_intersect_footprint_cells` refuses the whole call where `_intersect_mortie` swallowed the refusal per ring and dropped that granule silently. That divergence was disclosed for the stored path in #400 and now reaches the unindexed one. It takes a single granule covering >1e6 shard cells inside the AOI; loud-over-silent is the intended trade. The refusal's *remedy* is path-aware (fold `81cea28`): the stored path still says re-index or drop the column, the live path says neither exists here and names what does — a coarser `parent_order`, or a narrower/split region — since the flattening target is `parent_order` whatever `mortie_order` was. Pinned by `TestLiveCover::test_the_budget_refusal_names_a_remedy_that_exists`.
5. **Coarse `parent_order` covers a superset.** The order default (delta 3) is flat *by measurement*, not identical by construction. mortie's coverage is conservative per order, so `cover(parent_order)` ⊇ `moc_to_order(cover(chunk_order), parent_order)`: refining a fine cover down does not reproduce a coarse one, and a boundary cell the fine cover misses can survive at the coarse one. **The direction never inverts** — a true granule/shard pair is never dropped, only extra ones admitted, the same conservative posture as the MultiPolygon superset (delta 1) and the AOI overhang (#101). A 200-polygon randomized sweep per config measured 0/200 rows differing at parent/chunk 9/13, 11/13, 8/12 and 9/11 (the production pairs, and the clone digest above agrees at 9/13), against 1–2 rows and up to 0.71% extra cells at 6/10, 5/9 and 3/7. Pinned by `TestLiveCover::test_coarse_shard_order_covers_a_superset` (parent 6 / chunk 10: 4 shards vs 3, strict superset).
6. **A pinned `mortie_order` puts an *indexed* catalog on the live cover too.** `_footprint_cells_plan` declines a pin (a persisted column cannot restate an arbitrary order) — and what catches that decline is now `_live_cells_plan`, not the geometry path it fell to pre-#445. So an indexed catalog built with `mortie_order=` is a third population whose assignment can move, inheriting deltas 1 and 2: measured on a two-part MultiPolygon at `HealpixGrid(11, 19, chunk_inner=13)` with `mortie_order=13`, **8 shards on `main` -> 13 here** for the multi-part granule. The pin is honored either way and `metadata["footprint_cells"]` still records `False`. This is a semantic choice the PR made implicitly rather than by design — raised as question 4 below for an explicit ruling. Pinned by `TestLiveCover::test_a_pinned_indexed_build_covers_live_too`.

Not changed: `total_granules` is still the records *considered* (screen popcount == the old `len(records)`), `granules_assigned`, per-shard granule order, and the manifest JSON otherwise.

## Paths deliberately left on the records-first build

`sibling_catalog` paired builds (pairing filters the record list, which positional alignment cannot represent — PR #432's resolution, and now pinned against *both* cover-first paths), `footprint="beams"` (the cover is the CMR swath, not the per-beam corridors of #65), the spherely backend (an exact-S2 run must not be silently swapped for a MOC one, espg/mortie#32), and rectilinear grids (no shard order for the cover to key to). `_intersect_mortie` therefore stays — it still serves beams, non-HEALPix grids, and `ShardMap.reproject`'s refine.

**A pinned `mortie_order` on an indexed catalog is *not* one of them** (delta 6): it declined the stored plan pre-#445 and fell to geometry, and it declines the stored plan now and covers live. Question 4 asks whether that should be gated back.

## How tested

- `tests/test_shardmap.py::TestLiveCover` (new, 14 tests). The oracle throughout is the path this replaces: `monkeypatch.setattr(shardmap, "_live_cells_plan", lambda *a, **k: None)` restores the pre-#445 `_intersect_mortie` build exactly, with no build kwarg that exists only for tests (the `pre_445_path` fixture wraps it).
  - `test_serializes_identically_to_the_pre_445_path` — same catalog/grid/AOI -> the same manifest JSON, key for key, over a fixture with a screened non-polygonal row and an AOI that discards most records. The grid is `chunk_inner=13, parent_order=11`, so the oracle covers at 13 and this path at 11: the byte-equality **is** the in-suite check of the order-sweep invariant.
  - `test_default_order_is_the_shard_order` — one cover, at `parent_order`, and nothing persisted.
  - `test_pinned_order_is_honored_and_matches_the_oracle` / `test_pinned_order_coarser_than_the_shards_still_refuses`.
  - `test_total_granules_counts_the_screen` (screened-row fixture, live == oracle == 6).
  - `test_records_are_decoded_for_the_hits_only` — spies on `granule_records`; exactly the assigned rows get decoded.
  - `test_build_wall_spans_the_cover_but_not_the_records` — sleeps on both sides, asserts the cover is inside `build_wall_s` and the record decode is outside (today's convention, #439).
  - `test_multipolygon_is_a_superset_of_the_records_path`, `test_gated_off_for_the_paths_that_need_records` (spherely / beams / rectilinear each fall through).
  - `test_coarse_shard_order_covers_a_superset` (fold `99db8d0`) — `HealpixGrid(6, 12, chunk_inner=10)`, one rectangle straddling an order-6 seam: the coarse cover's 4 shards **strictly contain** the chunk-order cover's 3. Pins the *direction* of delta 5, so a future change that made the default a subset fails here. The production pairs are flat, which is why the byte-equality test above cannot catch it.
  - `test_a_pinned_indexed_build_covers_live_too` (fold `11b35bc`) — delta 6: an indexed catalog with `mortie_order=13` serializes identically to the *unindexed* pinned build (minus the catalog's own `footprint_cells_order` key), is a strict superset of the pre-#445 records path on a MultiPolygon, and still records `footprint_cells: False`.
  - `test_the_budget_refusal_names_a_remedy_that_exists` (fold `81cea28`) — `mortie.mocs_to_orders` patched to refuse; the live build's message must not say "re-index"/"drop the column", and must name `parent_order 11` and the coarser-grid escape, while the indexed build's message is unchanged.
- `TestPairedAssetBuild::test_paired_build_skips_the_ephemeral_cover_too` — a paired build fails the test if it plans.
- `TestDeferredRecords` and `TestFootprintCells` run untouched apart from the two intended-divergence oracles (the MultiPolygon pair now compares against `pre_445_path`, since the live path shares the cover) and the null-geometry type above. `TestMortieOrder::test_default_keys_to_chunk_order` now pins `_resolve_mortie_order`'s contract directly *and* the build's recorded order beside it, so the two defaults cannot drift unnoticed.
- Full suite: **3,973 passed, 38 skipped, 1 failed** — the failure is `tests/test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds`, environmental and unrelated to this diff (`build_function.sh`'s `pip install` cannot resolve `zarr>=3.1.5` in this sandbox: *"Could not find a version that satisfies the requirement zarr>=3.1.5"*, the index only offering up to `3.0.0a5` for the interpreter it picks). It touches none of the four files this PR changes. Ruff check + format clean on all four; the one repo-wide `ruff check src tests` finding is `N818` on `src/zagg/registry.py:64` (`UnknownCapability`), pre-existing on `origin/main` and outside the PR-lint bot's `--select=E,F,W,I`. `pre-commit` mypy reports the same errors on these files before and after (all pre-existing, import-stub and `build`-local).
- CI on `08e75d5` is green (test 3.12 + 3.13, ruff, lambda build, docs). The first `test (3.12)` attempt failed on `tests/test_index.py::TestWorkerSeam::test_finish_granule_called_once_per_granule` — a pre-existing flake, unrelated to this diff: `process_shard` reads granules through a thread pool, so the recorded `finish_granule` order is nondeterministic, and the test asserts `calls == ["s3://a", "s3://b"]` (CI saw `["s3://b", "s3://a"]`). Nothing here touches `zagg/processing`; it passed on the previous head `bb7cf7c` and passes locally. Re-run only, not "fixed" — flagging it rather than touching it (CLAUDE.md §4).

## Questions for review

1. **`shardmap.py` is at 1,846 lines** (1,759 before the review fold, which was ~85% prose). It entered this PR at 1,647 — already past the 1,200 raise trigger, with a split proposal standing from PR #440. The new logic went to `sources.py` as directed and the executable addition here is ~25 lines; the rest is prose. Prefer it trimmed, or fold it into the standing split proposal?
2. **The `mortie_order` metadata change** (chunk order -> `parent_order`) is visible in every newly built unindexed manifest. Worth a note in the release notes, or is the docstring/PR record enough?
3. **`footprint_cells` metadata verdict.** Kept meaning "the *stored* column answered this build", so an unindexed cover-and-intersect build records no key at all (and an indexed catalog built with a pinned order still records `False`). The alternative reading — "this build was answered by a cover" — would now be true for both, but it would stop distinguishing the thing the operator can act on (did the index they paid for get used).
4. **Should a pinned build on an *indexed* catalog stay on the live cover?** (delta 6, and the one place this PR changed a semantic without deciding to.) `_footprint_cells_plan` declines a pin; pre-#445 that decline landed on `_intersect_mortie`, and now it lands on `_live_cells_plan`, moving the assignment (8 -> 13 shards on the MultiPolygon fixture). Two readings, and the PR currently ships (a):
   - **(a) as shipped** — "one intersection engine" is the point of the PR, so a pin covers live whether or not the catalog was indexed, and the *only* thing indexing changes is whether the cover was paid for in advance. Simple rule, uniform semantics, and the deltas are the ones already disclosed for every other cover-first build.
   - **(b) gate it** — add `getattr(catalog, "footprint_cells", None) is None` to `_live_cells_plan`'s engagement test, so an indexed catalog with a pin keeps `main`'s records-path assignment. Preserves behavior for an existing population, but makes "indexed" mean two different things depending on whether the caller pinned, and leaves a pinned indexed build paying the full record decode the PR exists to remove.

   Left as-is pending your call — the fold disclosed and tested the behavior rather than changing it.

