### PR TITLE
pin the owner-map test harness against packaged-config filter drift

### DIFF
--- a/tests/test_read_vlen.py
+++ b/tests/test_read_vlen.py
@@ -907,6 +907,17 @@ class TestOwnerMapReuse:
         from zagg.config import default_config
 
         ds = dict(default_config("gedi01b_waveform_healpix_hive").data_source)
+        # Pin the filter list explicitly (issue #457): this class tests owner-map
+        # DERIVATION counts, not filter policy, and its expected rows were sized
+        # to the quality gate. Inheriting the packaged config's filters let the
+        # #450 science-knob change (gates dropped, espg ruling) shift the row
+        # universe under the #454 pins -- a semantic conflict CI never saw
+        # because each PR was green alone. The six-companion count test below
+        # deliberately KEEPS the live-config coupling; this one must not.
+        ds["filters"] = [
+            {"asset": "l2a", "dataset": "/{group}/quality_flag", "op": "eq", "value": 1},
+            {"asset": "l2a", "dataset": "/{group}/sensitivity", "op": "ge", "value": 0.9},
+        ]
         if read_plan:
             ds["read_plan"] = read_plan
         return ds
@@ -935,7 +946,11 @@ class TestOwnerMapReuse:
         assert calls == [], f"a coordinates-level consumer re-derived the owner map: {calls}"
 
     def test_the_template_hangs_six_companions_off_the_coordinates_level(self):
-        ds = self._template_ds()
+        from zagg.config import default_config
+
+        # LIVE config on purpose: this test tracks the real template's shape
+        # (companion count, filter levels), unlike the pinned harness above.
+        ds = dict(default_config("gedi01b_waveform_healpix_hive").data_source)
         shot_vars = ds["levels"][ds["coordinates"]["level"]]["variables"]
         # The count the finding is scaled by: six re-derivations, not one.
         assert len(shot_vars) == 6


### PR DESCRIPTION
Closes #457

Main is red after the #450 + #454 merges — a semantic conflict CI never saw because each PR was green alone. `TestOwnerMapReuse::test_coordinates_level_consumers_derive_no_owner_map` computed its expected rows through `_template_ds()`, which inherits the LIVE packaged gedi config's filters; PR #450's espg-ruled gate drop (quality_flag/sensitivity removed) changed the row universe under PR #454's pins (shot 102 passes the remaining gates; shot 104's sensitivity failure no longer applies on the full arm).

**Fix**: `_template_ds` pins its `filters` explicitly to the two-gate list its fixtures were sized to — the class tests owner-map **derivation counts**, not filter policy, and must not move when science knobs do. `test_the_template_hangs_six_companions_off_the_coordinates_level` deliberately keeps the live-config coupling (it exists to track the real template) and gets the config directly.

Production code untouched — test-only. `tests/test_read_vlen.py`: 80 passed locally; ruff check/format clean.

This unblocks the 0.46.0 release: once merged, main's Tests go green and the tag can be re-cut (or re-run) at espg's discretion.

## Phases
- [x] Pin the harness filters; decouple the live-config test (this PR)

## How tested
- `pytest tests/test_read_vlen.py` → 80 passed (was 2 failed on main)
- ruff check + format clean on the touched file