### PR TITLE
small fixes 2026-08-17: read-plan 1-element runs, GEDI template right-sizing

### DIFF
--- a/src/zagg/configs/gedi01b_waveform_healpix_hive.yaml
+++ b/src/zagg/configs/gedi01b_waveform_healpix_hive.yaml
@@ -22,8 +22,10 @@ data_source:
                                  # workers=4 on the 4096-disk tier runs 300 s/shard
                                  # at 60% memory (vs 587-757 s serial on 8192,
                                  # run 8344cde5) for identical output. If a denser
-                                 # AOI pinches 4096 at workers=4, drop
-                                 # shard_workers to 2 BEFORE raising the tier.
+                                 # AOI pinches 4096 on MEMORY at workers=4, drop
+                                 # shard_workers to 2 before raising the tier --
+                                 # but not for a SpillOverflowError, which this
+                                 # knob cannot move (see worker.extra_disk).
   reader: h5coro
   driver: s3
   # DAAC S3 credentials are per-DAAC: GEDI is LP DAAC's lp-prod-protected,
@@ -229,7 +231,36 @@ worker:
                                  # max_memory 2,464 MB / container HWM 2,472 MB
                                  # (60% of tier), $0.069/run vs $0.286 at
                                  # 8192/serial (run 8344cde5), identical output.
-                                 # Fallback ladder: drop shard_workers to 2
-                                 # before raising the tier.
-  extra_disk: true               # the -disk twin: spill needs up to 2.5 GB /tmp
-                                 # per shard (aggregation.streaming.mode: spill)
+                                 # Fallback ladder, BY FAILURE MODE:
+                                 #   memory pinch (OOM / container HWM near the
+                                 #     tier) -> shard_workers 4 -> 2, then raise
+                                 #     the tier; shard_workers is what bounds
+                                 #     concurrent in-memory read buffers.
+                                 #   SpillOverflowError (block close, see below)
+                                 #     -> the 8192-disk tier (10240 MB /tmp,
+                                 #     4608 MB threshold) or a finer
+                                 #     parent_order. shard_workers is INERT for
+                                 #     this one: it does not change total
+                                 #     spilled bytes, only in-flight buffers.
+  extra_disk: true               # the -disk twin sizes /tmp at memory + 2048 MB,
+                                 # so 6144 MB here. The spill block-close
+                                 # threshold is min(0.2 x memory x K, 0.45 x free
+                                 # /tmp); K = 4^(12-9) = 64 puts the memory term
+                                 # at ~52 GB, so /tmp always dominates -> ~2765
+                                 # MB. Measured spill is 1.6-2.5 GB/shard (run
+                                 # 8344cde5), a ~1.16x margin on the worst shard,
+                                 # and f_bavail is read live so anything else in
+                                 # /tmp eats into it. Clearing the threshold for
+                                 # a 2.5 GB block needs ~5.6 GB free /tmp, not
+                                 # 2.5 GB: /tmp holds the closing block beside
+                                 # the filling one, which is what the 45% is for.
+                                 # This is a cliff, not a slope, because the
+                                 # config is EXACT-SINGLE-BLOCK-ONLY --
+                                 # validate_spill_fold rejects it
+                                 # (build_waveform_digest and the
+                                 # single_shot_value companions have no
+                                 # cross-block fold law), so a threshold
+                                 # crossing raises SpillOverflowError instead of
+                                 # degrading. spill_blocks_closed: 0 is a
+                                 # PRECONDITION of these results, not merely an
+                                 # observation of them.

--- a/src/zagg/configs/gedi01b_waveform_healpix_hive.yaml
+++ b/src/zagg/configs/gedi01b_waveform_healpix_hive.yaml
@@ -18,7 +18,12 @@
 # would make `op: le, value: 0` admit or reject every shot), is what to check
 # there first.
 data_source:
-  granule_workers: 4
+  shard_workers: 4               # measured optimized envelope (run 5d081b68):
+                                 # workers=4 on the 4096-disk tier runs 300 s/shard
+                                 # at 60% memory (vs 587-757 s serial on 8192,
+                                 # run 8344cde5) for identical output. If a denser
+                                 # AOI pinches 4096 at workers=4, drop
+                                 # shard_workers to 2 BEFORE raising the tier.
   reader: h5coro
   driver: s3
   # DAAC S3 credentials are per-DAAC: GEDI is LP DAAC's lp-prod-protected,
@@ -26,8 +31,12 @@ data_source:
   # body, so every granule read raises memoryview(None) and the shard reports
   # "No data after filtering" (issue #449, first-fleet-run failure).
   credentials_provider: lpdaac
-  # No index block: the hierarchical route is the pinned baseline for the
-  # first GEDI builds; the vlen route also runs behind index: inline.
+  index:
+    backend: hierarchical      # pinned: an ABSENT block resolves to inline since
+                               # issue #170, and inline's chunk-map B-tree walk
+                               # strands 4 MiB h5coro cache lines on GEDI (issue
+                               # #460). Re-benchmark inline on GEDI after #460
+                               # lands before flipping.
   groups: [BEAM0000, BEAM0001, BEAM0010, BEAM0011, BEAM0101, BEAM0110, BEAM1000, BEAM1011]
   coordinates:
     # The base (sample) level carries no native coordinates: lat/lon expand
@@ -108,9 +117,17 @@ data_source:
     pad: 1
 
 aggregation:
-  # Pooled (no streaming block): o9 shards are light at GEDI density, and the
-  # flux field's composability is `none` initially (issue #422 -- no pyramid,
-  # no spill whitelist growth). Promote alongside overviews when needed.
+  # o9 shards are NOT light at GEDI density: the first successful run (run
+  # 8344cde5, issue #460) read 50-82 M rows/shard pre-clip (21-33 M kept) --
+  # the pooled-mode assumption here reasoned about post-clip density and was
+  # wrong four failure rounds running (#448/#449/#452/#460). Spill wrote
+  # 1.6-2.5 GB /tmp per shard with spill_blocks_closed: 0 (exact single-block
+  # regime, pooled-identical results). Pairs with worker.extra_disk below.
+  streaming:
+    mode: spill
+    buffer_granules: 8           # optimized probe (run 5d081b68): 8 with
+                                 # shard_workers 4 held container HWM at 2,472 MB
+                                 # (60% of the 4096 tier), identical output
   coordinates:
     morton:
       dtype: uint64
@@ -206,4 +223,13 @@ output:
   pyramid: false                 # composability none initially (issue #422)
 
 worker:
-  memory: 2048                   # pooled path, no spill: the light variant
+  memory: 4096                   # optimized probe (run 5d081b68, 4/4 green):
+                                 # process-shard-4096-disk at shard_workers 4 /
+                                 # buffer_granules 8 -> 300 s/shard, worker
+                                 # max_memory 2,464 MB / container HWM 2,472 MB
+                                 # (60% of tier), $0.069/run vs $0.286 at
+                                 # 8192/serial (run 8344cde5), identical output.
+                                 # Fallback ladder: drop shard_workers to 2
+                                 # before raising the tier.
+  extra_disk: true               # the -disk twin: spill needs up to 2.5 GB /tmp
+                                 # per shard (aggregation.streaming.mode: spill)

--- a/src/zagg/configs/gedi01b_waveform_healpix_hive.yaml
+++ b/src/zagg/configs/gedi01b_waveform_healpix_hive.yaml
@@ -121,8 +121,11 @@ data_source:
 aggregation:
   # o9 shards are NOT light at GEDI density: the first successful run (run
   # 8344cde5, issue #460) read 50-82 M rows/shard pre-clip (21-33 M kept) --
-  # the pooled-mode assumption here reasoned about post-clip density and was
-  # wrong four failure rounds running (#448/#449/#452/#460). Spill wrote
+  # the pooled-mode assumption here reasoned about post-clip density and
+  # undersized the envelope. The other GEDI failure rounds had unrelated
+  # causes (issue #449 DAAC credentials, issue #452 read-plan striding, issue
+  # #460 inline cache-line residency -- the index.backend: hierarchical pin
+  # above is what unblocked that one, not this streaming block). Spill wrote
   # 1.6-2.5 GB /tmp per shard with spill_blocks_closed: 0 (exact single-block
   # regime, pooled-identical results). Pairs with worker.extra_disk below.
   streaming:

--- a/src/zagg/read_plan.py
+++ b/src/zagg/read_plan.py
@@ -239,15 +239,44 @@ def execute_read_plan(plan: ReadPlan, read_fn, dataset_path: str, dtype) -> np.n
     np.ndarray
         Concatenated data for all runs in the plan, or an empty array if the
         plan matched nothing. If ``plan.full_read``, returns the full dataset.
+
+    Raises
+    ------
+    ValueError
+        If ``read_fn`` returns ``None`` -- h5coro's read-failure signal.
     """
     if plan.full_read:
-        return np.asarray(read_fn(dataset_path, hyperslice=None), dtype=dtype)
+        return np.asarray(
+            _require_read(read_fn(dataset_path, hyperslice=None), dataset_path, None), dtype=dtype
+        )
     if not plan.parent_runs:
         return np.empty(0, dtype=dtype)
-    # h5coro's readDatasets returns a 0-d array for a single-element
-    # hyperslice; np.atleast_1d keeps concatenate from raising on it.
+    # h5coro returns shape ``(1,)`` -- NOT a 0-d array -- for a single-element
+    # hyperslice: ``h5dataset.py`` reshapes only when ``ndims > 1``. So the
+    # ``np.atleast_1d`` below is cheap defense against a ``read_fn`` wrapper
+    # that hands back a scalar, not a fix for the reader itself.
+    #
+    # What actually produces a 0-d array is a FAILED read: h5coro warns and
+    # substitutes a null dataset, and ``np.asarray(None, dtype)`` is 0-d
+    # (``array(nan)`` for a float dtype). ``np.concatenate`` used to reject
+    # that as a side effect; ``_require_read`` now rejects it on purpose, so
+    # widening can never fabricate a NaN row and silently drop the group. A
+    # read that comes back SHORT is caught one level up, by the consumer that
+    # knows the declared extent (``read_vlen._read_group``, issue #452).
     parts = [
-        np.atleast_1d(np.asarray(read_fn(dataset_path, hyperslice=chunk), dtype=dtype))
+        np.atleast_1d(
+            np.asarray(
+                _require_read(read_fn(dataset_path, hyperslice=chunk), dataset_path, chunk),
+                dtype=dtype,
+            )
+        )
         for chunk in plan.chunk_lists
     ]
     return np.concatenate(parts)
+
+
+def _require_read(raw, dataset_path, hyperslice):
+    """Reject a ``None`` read (h5coro's failure signal) before dtype coercion."""
+    if raw is None:
+        raise ValueError(f"read returned None for {dataset_path} (hyperslice={hyperslice})")
+    return raw

--- a/src/zagg/read_plan.py
+++ b/src/zagg/read_plan.py
@@ -244,8 +244,10 @@ def execute_read_plan(plan: ReadPlan, read_fn, dataset_path: str, dtype) -> np.n
         return np.asarray(read_fn(dataset_path, hyperslice=None), dtype=dtype)
     if not plan.parent_runs:
         return np.empty(0, dtype=dtype)
+    # h5coro's readDatasets returns a 0-d array for a single-element
+    # hyperslice; np.atleast_1d keeps concatenate from raising on it.
     parts = [
-        np.asarray(read_fn(dataset_path, hyperslice=chunk), dtype=dtype)
+        np.atleast_1d(np.asarray(read_fn(dataset_path, hyperslice=chunk), dtype=dtype))
         for chunk in plan.chunk_lists
     ]
     return np.concatenate(parts)

--- a/src/zagg/runner.py
+++ b/src/zagg/runner.py
@@ -2751,6 +2751,12 @@ def _clamped_data_source(data_source: dict, n_granules: int) -> dict | None:
     caller then passes the shared config through untouched, keeping unclamped
     cell payloads byte-identical. Just the simple ``min()`` policy; the
     worker still resolves the value through its ``_granule_workers`` guard.
+
+    The write-back uses whichever key the source dict carries — canonical
+    ``shard_workers`` if present, else the legacy ``granule_workers``. Writing
+    the legacy name unconditionally would leave both keys in the merged dict,
+    and ``_granule_workers`` prefers the canonical one, so the clamp would be
+    a silent no-op for any config using ``shard_workers``.
     """
     from zagg.processing.worker import _granule_workers
 
@@ -2758,7 +2764,8 @@ def _clamped_data_source(data_source: dict, n_granules: int) -> dict | None:
     clamped = min(k, max(int(n_granules), 1))
     if clamped == k:
         return None
-    return {**data_source, "granule_workers": clamped}
+    key = "shard_workers" if "shard_workers" in data_source else "granule_workers"
+    return {**data_source, key: clamped}
 
 
 def _check_signature(grid, catalog_data: dict) -> None:

--- a/tests/test_read_plan.py
+++ b/tests/test_read_plan.py
@@ -250,6 +250,41 @@ class TestExecuteReadPlan:
         expected = np.concatenate([data[5:10], data[20:25]])
         np.testing.assert_array_equal(out, expected)
 
+    def test_single_element_run_zero_dim_part(self):
+        # h5coro's readDatasets returns a 0-d array (numpy scalar) for a
+        # single-element hyperslice; np.concatenate raises on 0-d inputs
+        # ("zero-dimensional arrays cannot be concatenated"). Regression for
+        # the 2026-08-17 GEDI fleet run, which dropped 26 group reads this way.
+        data = np.arange(100.0, dtype=np.float32)
+        plan = self._make_plan([(42, 43)])
+
+        def read_fn(path, hyperslice=None):
+            lo, hi = hyperslice[0]
+            if hi - lo == 1:
+                return data[lo]  # 0-d numpy scalar, as h5coro returns
+            return data[lo:hi]
+
+        out = execute_read_plan(plan, read_fn, "/h", np.float32)
+        assert out.ndim == 1
+        np.testing.assert_array_equal(out, data[42:43])
+
+    def test_mixed_single_and_multi_element_runs(self):
+        # A single-element run alongside normal runs: order and values of the
+        # multi-element parts must be unchanged.
+        data = np.arange(100.0, dtype=np.float32)
+        plan = self._make_plan([(5, 10), (42, 43), (20, 25)])
+
+        def read_fn(path, hyperslice=None):
+            lo, hi = hyperslice[0]
+            if hi - lo == 1:
+                return data[lo]  # 0-d numpy scalar
+            return data[lo:hi]
+
+        out = execute_read_plan(plan, read_fn, "/h", np.float32)
+        expected = np.concatenate([data[5:10], data[42:43], data[20:25]])
+        assert out.dtype == np.float32
+        np.testing.assert_array_equal(out, expected)
+
     def test_full_read_plan_calls_without_hyperslice(self):
         data = np.arange(50.0, dtype=np.float32)
         plan = ReadPlan(

--- a/tests/test_read_plan.py
+++ b/tests/test_read_plan.py
@@ -251,17 +251,19 @@ class TestExecuteReadPlan:
         np.testing.assert_array_equal(out, expected)
 
     def test_single_element_run_zero_dim_part(self):
-        # h5coro's readDatasets returns a 0-d array (numpy scalar) for a
-        # single-element hyperslice; np.concatenate raises on 0-d inputs
-        # ("zero-dimensional arrays cannot be concatenated"). Regression for
-        # the 2026-08-17 GEDI fleet run, which dropped 26 group reads this way.
+        # h5coro itself returns shape (1,) for a single-element hyperslice
+        # (h5dataset.py reshapes only when ndims > 1), so this fake stands in
+        # for a scalar-returning ``read_fn`` WRAPPER, not for h5coro: a bridge
+        # that indexes rather than slices hands back a 0-d numpy scalar, and
+        # np.concatenate rejects 0-d inputs ("zero-dimensional arrays cannot be
+        # concatenated"). Pin that atleast_1d absorbs it.
         data = np.arange(100.0, dtype=np.float32)
         plan = self._make_plan([(42, 43)])
 
         def read_fn(path, hyperslice=None):
             lo, hi = hyperslice[0]
             if hi - lo == 1:
-                return data[lo]  # 0-d numpy scalar, as h5coro returns
+                return data[lo]  # 0-d numpy scalar from a wrapper that indexes
             return data[lo:hi]
 
         out = execute_read_plan(plan, read_fn, "/h", np.float32)
@@ -269,7 +271,8 @@ class TestExecuteReadPlan:
         np.testing.assert_array_equal(out, data[42:43])
 
     def test_mixed_single_and_multi_element_runs(self):
-        # A single-element run alongside normal runs: order and values of the
+        # A scalar-returning single-element run (see above -- a wrapper's shape,
+        # not h5coro's) alongside normal runs: order and values of the
         # multi-element parts must be unchanged.
         data = np.arange(100.0, dtype=np.float32)
         plan = self._make_plan([(5, 10), (42, 43), (20, 25)])
@@ -299,6 +302,25 @@ class TestExecuteReadPlan:
         plan = ReadPlan(parent_runs=[], base_slices=[], chunk_lists=[], full_read=True)
         with pytest.raises(ValueError, match="returned None"):
             execute_read_plan(plan, lambda *a, **k: None, "/h", np.float32)
+
+    def test_two_dim_parts_keep_their_columns(self):
+        # 2-D datasets really do flow through here: _select_column/_predicate_mask
+        # in processing/read.py take a ``column`` selector into an N-D array
+        # (ATL03 signal_conf_ph is (n, 5)), and h5coro returns (1, 5) for a
+        # single-row hyperslice. atleast_1d is a no-op on 2-D -- pin that, so a
+        # later reshape/ravel-flavored normalization can't silently flatten
+        # (n, 5) to (5n,) and resurface as "'column' set but array is 1-D".
+        data = np.arange(100.0, dtype=np.float32).reshape(20, 5)
+        plan = self._make_plan([(2, 5), (12, 13), (17, 20)])
+
+        def read_fn(path, hyperslice=None):
+            lo, hi = hyperslice[0]
+            return data[lo:hi]  # (k, 5), incl. the single-row (1, 5) part
+
+        out = execute_read_plan(plan, read_fn, "/h", np.float32)
+        assert out.shape == (7, 5)
+        expected = np.concatenate([data[2:5], data[12:13], data[17:20]])
+        np.testing.assert_array_equal(out, expected)
 
     def test_full_read_plan_calls_without_hyperslice(self):
         data = np.arange(50.0, dtype=np.float32)

--- a/tests/test_read_plan.py
+++ b/tests/test_read_plan.py
@@ -285,6 +285,21 @@ class TestExecuteReadPlan:
         assert out.dtype == np.float32
         np.testing.assert_array_equal(out, expected)
 
+    def test_none_read_still_raises(self):
+        # A FAILED h5coro read returns None (h5promise substitutes a null
+        # dataset); np.asarray(None, float32) is a 0-d NaN, which the
+        # concatenate used to reject as a side effect. Pin that None stays a
+        # loud error rather than a widened, fabricated NaN row -- the
+        # chunk-boundary guard in tests/test_index.py relies on the raise.
+        plan = self._make_plan([(42, 43)])
+        with pytest.raises(ValueError, match="returned None"):
+            execute_read_plan(plan, lambda *a, **k: None, "/h", np.float32)
+
+    def test_none_full_read_raises(self):
+        plan = ReadPlan(parent_runs=[], base_slices=[], chunk_lists=[], full_read=True)
+        with pytest.raises(ValueError, match="returned None"):
+            execute_read_plan(plan, lambda *a, **k: None, "/h", np.float32)
+
     def test_full_read_plan_calls_without_hyperslice(self):
         data = np.arange(50.0, dtype=np.float32)
         plan = ReadPlan(

--- a/tests/test_read_vlen.py
+++ b/tests/test_read_vlen.py
@@ -803,12 +803,28 @@ class TestGediTemplate:
         assert grid["sharded"] is True
         assert cfg.output["store_layout"] == "hive"
         assert cfg.output["pyramid"] is False
-        assert "streaming" not in cfg.aggregation  # pooled; composability none
         flux = cfg.aggregation["variables"]["rx_flux"]
         assert flux["params"]["delta"] == 8192
         assert "operating_point" in flux["attrs"]  # clip provenance
         assert flux["attrs"]["gain_name"]
         assert len(cfg.data_source["groups"]) == 8
+
+    def test_measured_envelope(self, cfg):
+        # Measured right-sizing (issue #460), pinned so the envelope cannot
+        # drift back to the pre-measurement guesses. Optimized probe run
+        # 5d081b68 (4/4 green, identical output to the serial baseline run
+        # 8344cde5): 4096-disk tier at workers=4 / buffer 8 runs 300 s/shard
+        # at 60% memory (container HWM 2,472 MB) for a quarter the cost.
+        assert cfg.data_source["shard_workers"] == 4
+        assert "granule_workers" not in cfg.data_source  # canonical key only
+        # An absent index block resolves to inline since issue #170; the GEDI
+        # baseline is explicitly pinned hierarchical (issue #460).
+        assert cfg.data_source["index"] == {"backend": "hierarchical"}
+        # 50-82 M rows/shard pre-clip: spill, not pooled (1.6-2.5 GB /tmp,
+        # single-block regime).
+        assert cfg.aggregation["streaming"] == {"mode": "spill", "buffer_granules": 8}
+        # Spill needs the -disk twin at every tier.
+        assert cfg.worker == {"memory": 4096, "extra_disk": True}
 
     def test_filters_are_validity_gates_only(self, cfg):
         # espg ruling 2026-08-17 (refs #425 / issue #422): the template filters

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1538,6 +1538,23 @@ class TestClampedDataSource:
 
         assert _clamped_data_source({"granule_workers": 1}, 5) is None
 
+    def test_canonical_key_written_back(self):
+        # The clamp must write back the key the worker actually reads. Writing
+        # the legacy name next to a canonical shard_workers leaves both in the
+        # dict, and _granule_workers prefers the canonical one -- so the clamp
+        # would go silently quiet for shipped configs on the canonical name.
+        from zagg.processing.worker import _granule_workers
+        from zagg.runner import _clamped_data_source
+
+        ds = {"shard_workers": 4}
+        assert _clamped_data_source(ds, 1) == {"shard_workers": 1}
+        assert _granule_workers(_clamped_data_source(ds, 1)) == 1
+        assert _granule_workers(_clamped_data_source(ds, 2)) == 2
+        assert _clamped_data_source(ds, 4) is None
+        assert ds == {"shard_workers": 4}  # never mutated in place
+        # Legacy-key configs keep the legacy name (no canonical key injected).
+        assert _clamped_data_source({"granule_workers": 4}, 1) == {"granule_workers": 1}
+
 
 class TestSummaryKeysByteIdentical:
     """The dispatch refactor (#63) must leave the run-summary dict keys -- and


### PR DESCRIPTION
Refs #460, Refs #425

Two espg-directed small fixes from today's GEDI flux runs (serial baseline run `8344cde5` and optimized probe `5d081b68`, both 4/4 shards green; prior failure rounds: #448 / #449 / #452 / #460).

## Phases

- [x] Phase 1 — `execute_read_plan`: survive genuine 0-d parts, keep failed (`None`) reads loud (issue #425) — reviewed, findings folded
- [x] Phase 2 — right-size `src/zagg/configs/gedi01b_waveform_healpix_hive.yaml` to the measured envelope + pin test (issue #460) — reviewed, findings folded

## Phase 1: 0-d parts made `np.concatenate` drop group reads

`execute_read_plan` (`src/zagg/read_plan.py`) built its parts with `np.asarray(read_fn(...), dtype)` and `np.concatenate`d them; a 0-d part raised `ValueError: zero-dimensional arrays cannot be concatenated`. On today's fleet run the error path was warn-and-continue, so **26 group reads were silently dropped** (e.g. `Error reading track BEAM0101: zero-dimensional arrays cannot be concatenated`, request `d9b1a833`, log group `/aws/lambda/process-shard-8192-disk`).

The adversarial review sharpened the mechanism (see the inline threads): h5coro returns shape `(1,)` for a single-element hyperslice — the actual 0-d source is a **failed h5coro read**, which comes back `None` and coerces to a 0-d NaN under `np.asarray(..., float)`. The fleet hit this via reads running off the link extent (the striding bug fixed for the local path in #452). The concatenate raise was accidentally load-bearing: `tests/test_index.py`'s chunk-boundary guard relied on it to keep a `None` read from becoming silent NaN data.

Shipped behavior, pinned by tests written failing-first:

- `None` from `read_fn` now raises an explicit `ValueError` on **both** exits (per-chunk and `full_read`) — a failed read stays loud instead of fabricating a NaN row.
- Genuine 0-d numeric parts (defensive, for scalar-returning `read_fn` wrappers) are promoted with `np.atleast_1d` and concatenate correctly; multi-element and 2-D (column-selector) parts are unchanged.

## Phase 2: GEDI template right-sizing

The template shipped the pre-measurement guesses (pooled aggregation, `granule_workers: 4`, 2048 MB, no index pin, a stale "hierarchical is the default" comment — absent `index` resolves to **inline** since #170, `src/zagg/index/__init__.py:235`). Measured envelope, optimized probe run `5d081b68` (identical output to the serial baseline: 23,353,274 obs / 27,727 cells on the reference shard):

| knob | before | after | evidence |
|---|---|---|---|
| `data_source.shard_workers` | `granule_workers: 4` (legacy key) | `4` (canonical key) | 300 s/shard at the 4096-disk tier vs 587–757 s serial on 8192 (`8344cde5`) |
| `data_source.index` | absent (= inline since #170) | `{backend: hierarchical}` pinned | inline's chunk-map B-tree walk strands 4 MiB h5coro cache lines; re-benchmark after #460 lands |
| `aggregation.streaming` | absent (pooled) | `{mode: spill, buffer_granules: 8}` | 50–82 M rows/shard pre-clip (21–33 M kept) — the pooled comment reasoned post-clip and was wrong four rounds running; spill wrote 1.6–2.5 GB /tmp, `spill_blocks_closed: 0` |
| `worker` | `memory: 2048` | `memory: 4096` + `extra_disk: true` | worker max_memory 2,464 MB / container HWM 2,472 MB (60% of tier); $0.069/run vs $0.286 at 8192/serial |

Fallback ladder (in the template comment, split by failure mode per review): a memory pinch drops `shard_workers` 4 → 2 before raising the tier; a `SpillOverflowError` needs the 8192-disk tier (worker count is inert for spill volume — the single-block threshold at 4096-disk is ~2,765 MB vs 1.6–2.5 GB measured spill, and these reducers cannot cross-block fold). `TestGediTemplate::test_measured_envelope` pins all four knobs.

**Clamp bug found by the phase-2 review (folded in `349f7e38`):** this template is the first shipped config on the canonical `shard_workers` key, and the issue #184 per-cell clamp (`runner.py` `_clamped_data_source`) wrote its clamped value back under the *legacy* `granule_workers` key while the worker prefers the canonical one — so the clamp was silently ignored for canonical-key configs. The write-back now targets whichever key the source dict carries; regression test in `tests/test_runner.py`.

**Interaction note:** a separate in-flight kernel PR adds temporal/toc keys to this same template file. This PR touches only the keys above; whichever lands second rebases mechanically.

## How tested

- `tests/test_read_plan.py`: regression tests written first and confirmed failing (0-d part → `ValueError` at the concatenate); now cover single-element runs, mixed runs, `None` on both exits, and 2-D parts. `tests/test_index.py` chunk-boundary guard green again.
- `tests/test_read_vlen.py::TestGediTemplate::test_measured_envelope` pins the four template knobs; template loads through `default_config` + `validate_config`.
- Local: `ruff check` / `ruff format --check` on all touched files, full `pytest` 4,16x passed. Known pre-existing local-only issues, not touched per §4: `test_lambda_build` (shells to `deployment/aws/build_function.sh`), `test_client_transport` poller wall-clock flake, a ruff N818 on `src/zagg/registry.py` and a format diff in `tests/data/benchmark/README.md` that appear only under the local ruff version (both files untouched by this PR).

## Questions for review

- **Rerun of affected stores:** every store written while the phase-1 bug was live silently dropped any group read whose h5coro read failed. The first flux store `serc_gedi_flux.zarr` is ~2% short (26 dropped group reads). Rerun the 4 shards to backfill, or accept the first store as a shakedown artifact and only rerun forward?
- **Per-part planned-extent check (review finding 1, declined in fold):** a length check of each part against the plan preempts the truncated-dataset contract pinned in `8cb820f5` (#452) — the fold left it standing rather than rewording that committed contract. Follow-up: add the missing length check to `read.py`'s planned arm and decide which arm owns the "does not tile the declared base extent" wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qr6qZXy6dQRh8XGejzQKd
