### PR TITLE
inline backend: evict the chunk-map walk's h5coro cache lines (issue #460)

### DIFF
--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -184,12 +184,45 @@ def _walk_chunk_btree(ds) -> list[tuple[tuple[int, ...], int, int, int]]:
     return entries
 
 
+def _cache_keys(h5obj) -> set:
+    """Snapshot of ``h5obj.cache``'s keys (empty for cache-less handles)."""
+    return set(getattr(h5obj, "cache", None) or ())
+
+
+def _evict_new_cache_lines(h5obj, before: set) -> int:
+    """Drop every h5coro cache line added since ``before`` was snapshotted.
+
+    The snapshot-and-evict half of issue #460: ``H5Coro.cache`` retains a full
+    ``cacheLineSize`` line (4 MiB default) for every byte range a cached
+    ``ioRequest`` touches, and releases nothing until granule close. A chunk
+    B-tree walk reads each node exactly once, but on a sparse file the nodes
+    rarely share a line (GEDI L1B ``rxwaveform``: 13,790 chunks → +531 MB
+    retained per beam group, ~4.2 GB per granule), so the walk's lines are
+    pure dead weight afterwards. Evicting them caps residency at one walk's
+    transient peak; a later read that does want an evicted line just
+    re-fetches it (B-tree nodes are not data, so in practice none does).
+    Only keys absent from ``before`` are dropped — pre-existing lines (the
+    front-of-file metadata block every parse shares) always survive. Returns
+    the number of lines evicted.
+    """
+    cache = getattr(h5obj, "cache", None)
+    if not cache:
+        return 0
+    added = [k for k in cache if k not in before]
+    for k in added:
+        cache.pop(k, None)
+    return len(added)
+
+
 def build_chunk_map(h5obj, path: str) -> ChunkMap:
     """Build a :class:`ChunkMap` for one dataset by walking its metadata.
 
     Metadata-only: no chunk is ever read or decompressed. A contiguous-layout
     dataset yields a single pseudo-chunk covering the full first axis
     (mirroring h5py's ``get_offset()`` treatment in the bench extractor).
+    Cache lines the B-tree walk pulls into ``h5obj.cache`` are evicted before
+    returning (issue #460) — the object-header lines the ``H5Dataset`` parse
+    touched stay cached, since every dataset in the group shares them.
 
     Raises ``KeyError`` for an absent path (h5coro's ``metaOnly`` traversal
     never raises on its own — it just leaves default metadata) and
@@ -200,7 +233,11 @@ def build_chunk_map(h5obj, path: str) -> ChunkMap:
     ds = H5Dataset(h5obj, path, earlyExit=True, metaOnly=True, enableAttributes=False)
     if ds.meta.typeSize == 0:
         raise KeyError(path)
-    return _chunk_map_from_dataset(h5obj, ds, path)
+    before = _cache_keys(h5obj)
+    try:
+        return _chunk_map_from_dataset(h5obj, ds, path)
+    finally:
+        _evict_new_cache_lines(h5obj, before)
 
 
 def _chunk_map_from_dataset(h5obj, ds, path: str) -> ChunkMap:

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -387,6 +387,13 @@ def full_granule_maps(h5obj, existing: dict[str, ChunkMap]) -> dict[str, ChunkMa
     for path, ds in _iter_datasets(h5obj):
         if path in maps:
             continue
+        # Per-dataset snapshot-and-evict, same as build_chunk_map (issue
+        # #460): this walk maps EVERY dataset in the granule, so unevicted it
+        # accumulates worst of all. Evicting after each dataset keeps the
+        # transient peak one walk deep; the enumeration's own object-header
+        # lines are in each snapshot (the generator parses the next node
+        # before the loop body runs) and stay cached for the datasets after.
+        before = _cache_keys(h5obj)
         try:
             maps[path] = _chunk_map_from_dataset(h5obj, ds, path)
         except ValueError:
@@ -397,6 +404,8 @@ def full_granule_maps(h5obj, existing: dict[str, ChunkMap]) -> dict[str, ChunkMa
             # there): drop just this dataset from the manifest instead of
             # sinking the whole granule's write-back.
             logger.warning(f"  write-back: no chunk map for {path} ({exc}); skipping")
+        finally:
+            _evict_new_cache_lines(h5obj, before)
     return maps
 
 

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -300,17 +300,25 @@ def build_chunk_map(h5obj, path: str, *, evict_into: set | None = None) -> Chunk
     ever touched across the group, against the hundreds of MB the unevicted
     walks stranded. The absent-path ``KeyError`` below returns before the
     snapshot on purpose: nothing walk-touched exists yet, and its parse lines
-    are retained by the same choice.
+    are retained by the same choice. That retention is exact only on the
+    immediate path (single-threaded); the deferred path below drops some parse
+    lines too, so the GEDI figure above — measured through it at the default
+    ``read_workers`` — is if anything the lower residency of the two.
 
     ``evict_into`` defers that eviction for a caller whose builds run
     concurrently on one handle: pass a set and the walk's keys are *added* to
     it (a GIL-atomic ``set.update``) instead of popped, for the caller to
     evict once its fan-out has joined — see :func:`_evict_deferred_lines`.
-    Keys other threads' reads happen to add inside the same window are
-    over-attributed to the walk, which is harmless: they are still this
-    group's lines and are dropped only after the pool joins. The default
-    (``None``) evicts immediately, which is what every single-threaded caller
-    wants (``_prebuild_group_maps``, the full-coverage walk, direct use).
+    The window is a plain before/after key diff, so lines *other threads* add
+    inside it are swept in as well — measurably, including other datasets'
+    object-header parse lines (review finding on PR #462: 23 of 40 concurrent
+    rounds on the test fixture). Those lines re-fetch on next touch (one small
+    ranged read each), and that bounded cost is the deliberate price of a
+    race-free drain: the alternative — subtracting a floor of every build's
+    ``before`` snapshot — is extra machinery to protect what is a memory *win*.
+    The default (``None``) evicts immediately, which is what every
+    single-threaded caller wants (``_prebuild_group_maps``, the full-coverage
+    walk, direct use).
 
     Raises ``KeyError`` for an absent path (h5coro's ``metaOnly`` traversal
     never raises on its own — it just leaves default metadata) and
@@ -435,7 +443,12 @@ def _iter_datasets(h5obj):
     whole enumeration is served from the front-of-file metadata block h5coro
     already cached — one ranged GET, no chunk data (issue #190; the full walk
     stays inside the single ~4 MiB cache line the config's read already paid
-    for, measured on real ATL03). A node whose ``typeSize == 0`` is a group
+    for, measured on real ATL03). Since issue #460 that "already cached" is a
+    best case rather than a guarantee: each group's deferred drain may have
+    swept out object-header lines the read had cached (see ``evict_into`` in
+    :func:`build_chunk_map`), so on a sparse file this walk re-fetches some of
+    them — bounded extra ranged reads, still no chunk data. A node whose
+    ``typeSize == 0`` is a group
     (or a typeless link) and is descended; anything else is a dataset yielded
     with the ``H5Dataset`` its classification already parsed, so the caller
     can build its chunk map without re-parsing the object header. Each node's

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -290,8 +290,17 @@ def build_chunk_map(h5obj, path: str, *, evict_into: set | None = None) -> Chunk
     dataset yields a single pseudo-chunk covering the full first axis
     (mirroring h5py's ``get_offset()`` treatment in the bench extractor).
     Cache lines the B-tree walk pulls into ``h5obj.cache`` are evicted before
-    returning (issue #460) — the object-header lines the ``H5Dataset`` parse
-    touched stay cached, since every dataset in the group shares them.
+    returning (issue #460); the lines the ``H5Dataset`` parse itself touched
+    are deliberately kept (the snapshot is taken after the parse). Parse-line
+    residency does grow per *distinct* dataset rather than being fully shared,
+    but it is bounded by the group's object-header / metadata footprint, not by
+    the chunk count: measured on a real GEDI L1B beam group (PR #462 evidence),
+    a whole group's read left **11 lines / 46 MB** resident at the 4 MiB
+    default — the data path's own lines included — out of **90 distinct lines**
+    ever touched across the group, against the hundreds of MB the unevicted
+    walks stranded. The absent-path ``KeyError`` below returns before the
+    snapshot on purpose: nothing walk-touched exists yet, and its parse lines
+    are retained by the same choice.
 
     ``evict_into`` defers that eviction for a caller whose builds run
     concurrently on one handle: pass a set and the walk's keys are *added* to

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -185,7 +185,12 @@ def _walk_chunk_btree(ds) -> list[tuple[tuple[int, ...], int, int, int]]:
 
 
 def _cache_keys(h5obj) -> set:
-    """Snapshot of ``h5obj.cache``'s keys (empty for cache-less handles)."""
+    """Snapshot of ``h5obj.cache``'s keys (empty for cache-less handles).
+
+    ``set(dict)`` is a single C-level copy, so it cannot observe a concurrent
+    insertion mid-iteration the way a Python-level comprehension can (review
+    finding on PR #462).
+    """
     return set(getattr(h5obj, "cache", None) or ())
 
 
@@ -204,11 +209,20 @@ def _evict_new_cache_lines(h5obj, before: set) -> int:
     Only keys absent from ``before`` are dropped — pre-existing lines (the
     front-of-file metadata block every parse shares) always survive. Returns
     the number of lines evicted.
+
+    Structurally non-raising, which matters because callers run it from a
+    ``finally`` where a raise would replace a successful ``ChunkMap`` return
+    with a housekeeping error (review finding on PR #462): ``list(cache)``
+    snapshots the keys in one C-level copy instead of iterating the live dict
+    (a Python-level comprehension can hit ``RuntimeError: dictionary changed
+    size during iteration``), and ``pop(k, None)`` cannot ``KeyError`` on a
+    line another thread already dropped. Both operations complete without
+    releasing the GIL, so no blanket ``except`` is needed here.
     """
     cache = getattr(h5obj, "cache", None)
     if not cache:
         return 0
-    added = [k for k in cache if k not in before]
+    added = [k for k in list(cache) if k not in before]
     for k in added:
         cache.pop(k, None)
     return len(added)

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -228,7 +228,36 @@ def _evict_new_cache_lines(h5obj, before: set) -> int:
     return len(added)
 
 
-def build_chunk_map(h5obj, path: str) -> ChunkMap:
+def _evict_deferred_lines(h5obj, deferred: set) -> int:
+    """Drop the cache lines a pooled ``read_fn`` fan-out deferred (issue #460).
+
+    :func:`build_chunk_map`'s immediate eviction is only safe on a handle no
+    other thread is reading: ``read_fn``'s lazy map builds run inside
+    ``_read_paths_pooled``'s thread pool (``data_source.read_workers``,
+    default 8, one shared ``h5obj`` — both the planned and the vlen route fan
+    out that way), and h5coro's cached ``ioRequest`` reads ``self.cache``
+    *outside* ``cache_locks``, so popping a line another thread is mid-read
+    raises there (review finding on PR #462, reproduced as a ``KeyError`` in
+    ``ioRequest`` plus silently-degraded ``H5Promise`` parses). Those builds
+    therefore only *record* their walk lines, and ``read_group`` evicts them
+    through this helper in a ``finally`` — after the route returned, so the
+    ``ThreadPoolExecutor`` context has joined and the handle is back to the
+    single worker thread that owns this granule (the ``_pending`` docstring's
+    "each granule is read by a single worker thread" invariant). Returns the
+    number of lines evicted; same non-raising discipline as
+    :func:`_evict_new_cache_lines`.
+    """
+    cache = getattr(h5obj, "cache", None)
+    if not cache or not deferred:
+        return 0
+    evicted = sum(cache.pop(k, None) is not None for k in list(deferred))
+    deferred.clear()
+    if evicted:
+        logger.debug(f"  chunk maps: evicted {evicted} deferred cache line(s) after the fan-out")
+    return evicted
+
+
+def build_chunk_map(h5obj, path: str, *, evict_into: set | None = None) -> ChunkMap:
     """Build a :class:`ChunkMap` for one dataset by walking its metadata.
 
     Metadata-only: no chunk is ever read or decompressed. A contiguous-layout
@@ -237,6 +266,16 @@ def build_chunk_map(h5obj, path: str) -> ChunkMap:
     Cache lines the B-tree walk pulls into ``h5obj.cache`` are evicted before
     returning (issue #460) — the object-header lines the ``H5Dataset`` parse
     touched stay cached, since every dataset in the group shares them.
+
+    ``evict_into`` defers that eviction for a caller whose builds run
+    concurrently on one handle: pass a set and the walk's keys are *added* to
+    it (a GIL-atomic ``set.update``) instead of popped, for the caller to
+    evict once its fan-out has joined — see :func:`_evict_deferred_lines`.
+    Keys other threads' reads happen to add inside the same window are
+    over-attributed to the walk, which is harmless: they are still this
+    group's lines and are dropped only after the pool joins. The default
+    (``None``) evicts immediately, which is what every single-threaded caller
+    wants (``_prebuild_group_maps``, the full-coverage walk, direct use).
 
     Raises ``KeyError`` for an absent path (h5coro's ``metaOnly`` traversal
     never raises on its own — it just leaves default metadata) and
@@ -251,9 +290,14 @@ def build_chunk_map(h5obj, path: str) -> ChunkMap:
     try:
         return _chunk_map_from_dataset(h5obj, ds, path)
     finally:
-        evicted = _evict_new_cache_lines(h5obj, before)
-        if evicted:
-            logger.debug(f"  chunk map {path}: evicted {evicted} cache line(s) the walk touched")
+        if evict_into is not None:
+            evict_into.update(_cache_keys(h5obj) - before)
+        else:
+            evicted = _evict_new_cache_lines(h5obj, before)
+            if evicted:
+                logger.debug(
+                    f"  chunk map {path}: evicted {evicted} cache line(s) the walk touched"
+                )
 
 
 def _chunk_map_from_dataset(h5obj, ds, path: str) -> ChunkMap:
@@ -728,17 +772,23 @@ class InlineIndex(VirtualIndex):
 
             if self.write_back:
                 self._prebuild_group_maps(h5obj, group, data_source)
-            return _vlen_read_group(
-                h5obj,
-                group,
-                data_source,
-                shard_key,
-                grid,
-                arrow=arrow,
-                read_fn=self._chunk_aligned_read_fn(h5obj, planned=True),
-                io_stats=io_stats,
-                siblings=siblings,
-            )
+            # read_fn is hoisted out of the call so the finally can reach its
+            # deferred cache lines (issue #460 — see _evict_deferred_lines).
+            read_fn = self._chunk_aligned_read_fn(h5obj, planned=True)
+            try:
+                return _vlen_read_group(
+                    h5obj,
+                    group,
+                    data_source,
+                    shard_key,
+                    grid,
+                    arrow=arrow,
+                    read_fn=read_fn,
+                    io_stats=io_stats,
+                    siblings=siblings,
+                )
+            finally:
+                _evict_deferred_lines(h5obj, read_fn.deferred_lines)
 
         rp = data_source.get("read_plan")
         # Two routes, one addressing seam (issue #170 phase 2): sources with a
@@ -758,8 +808,19 @@ class InlineIndex(VirtualIndex):
             # group's datasets to the granule manifest.
             self._prebuild_group_maps(h5obj, group, data_source)
         read_fn = self._chunk_aligned_read_fn(h5obj, planned=planned)
-        if planned:
-            return _planned_read_group(
+        try:
+            if planned:
+                return _planned_read_group(
+                    h5obj,
+                    group,
+                    data_source,
+                    shard_key,
+                    grid,
+                    arrow=arrow,
+                    read_fn=read_fn,
+                    io_stats=io_stats,
+                )
+            return _read_group_full(
                 h5obj,
                 group,
                 data_source,
@@ -769,16 +830,10 @@ class InlineIndex(VirtualIndex):
                 read_fn=read_fn,
                 io_stats=io_stats,
             )
-        return _read_group_full(
-            h5obj,
-            group,
-            data_source,
-            shard_key,
-            grid,
-            arrow=arrow,
-            read_fn=read_fn,
-            io_stats=io_stats,
-        )
+        finally:
+            # The route's pooled fan-out has joined here, so the lines its
+            # lazy chunk-map builds deferred can be dropped (issue #460).
+            _evict_deferred_lines(h5obj, read_fn.deferred_lines)
 
     def _chunk_aligned_read_fn(self, h5obj, *, planned=True):
         """Build the addressing seam: planned ranges, compiled decode.
@@ -807,7 +862,10 @@ class InlineIndex(VirtualIndex):
         THIS granule's pending sub-dict instead (``_pending_for`` — keyed per
         granule so concurrent in-flight granules never interleave, issue
         #180), accumulating the granule's maps across groups for
-        ``finish_granule`` to persist. Each dataset gets
+        ``finish_granule`` to persist. Those lazy builds defer their cache-line
+        eviction onto ``read_fn.deferred_lines`` (issue #460) because they run
+        across the read pool's threads; ``read_group`` drains it once the route
+        has joined. Each dataset gets
         its own single-dataset in-memory ``Index`` (~ms), so a spec hidefix
         rejects degrades that dataset alone.
 
@@ -839,6 +897,13 @@ class InlineIndex(VirtualIndex):
         # and degrade innocent paths with it (review finding, PR #173).
         indices: dict = {}
         direct: set[str] = set()  # datasets pinned to the h5coro decoder
+        # Cache lines the lazy builds below touched, evicted by ``read_group``
+        # once this callable's fan-out has joined (issue #460): these builds
+        # run on ``read_workers`` threads sharing one h5obj, where popping a
+        # line races h5coro's unlocked cached ``ioRequest`` — see
+        # :func:`_evict_deferred_lines`. Exposed on the callable so every
+        # route can drain it in a ``finally``.
+        deferred: set = set()
 
         def _vidx_for(path):
             vidx = indices.get(path)
@@ -888,7 +953,7 @@ class InlineIndex(VirtualIndex):
                     # boundary workaround is needed here.
                     return h5obj.readDatasets([path])[path]
                 try:
-                    cm = maps[path] = build_chunk_map(h5obj, path)
+                    cm = maps[path] = build_chunk_map(h5obj, path, evict_into=deferred)
                 except Exception:
                     if planned and hyperslice is not None:
                         # The planned route required the map before #170 too:
@@ -912,4 +977,5 @@ class InlineIndex(VirtualIndex):
                     )
             return _h5coro_read(path, hyperslice, cm)
 
+        read_fn.deferred_lines = deferred
         return read_fn

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -194,6 +194,33 @@ def _cache_keys(h5obj) -> set:
     return set(getattr(h5obj, "cache", None) or ())
 
 
+def _drop_cache_lines(h5obj, keys) -> int:
+    """Pop ``keys`` from ``h5obj.cache`` **and** their ``cache_locks`` entries.
+
+    ``H5Coro.cache_locks`` is a ``defaultdict(threading.Lock)`` keyed by the
+    same aligned offsets, so evicting the line alone still retains a ``Lock``
+    plus a dict slot for every line ever touched — ~13.8k entries for a GEDI
+    L1B beam group's ``rxwaveform`` B-tree, ~110k (order 15-20 MB) per granule
+    (review finding on PR #462). Pruning it is safe only because every eviction
+    point is single-threaded on the handle (immediate: ``_prebuild_group_maps``,
+    the full-coverage walk, direct use; deferred: after the read pool joined —
+    :func:`_evict_deferred_lines`). Were another thread mid-``ioRequest``, it
+    could hold the popped lock while a third thread took the fresh defaultdict
+    entry — two locks for one line, and a duplicate fetch. ``pop(k, None)`` on
+    both tables (``cache_locks`` is absent on stub handles) keeps this
+    non-raising. Returns the number of cache lines actually dropped.
+    """
+    cache = h5obj.cache
+    locks = getattr(h5obj, "cache_locks", None)
+    dropped = 0
+    for k in keys:
+        if cache.pop(k, None) is not None:
+            dropped += 1
+        if locks is not None:
+            locks.pop(k, None)
+    return dropped
+
+
 def _evict_new_cache_lines(h5obj, before: set) -> int:
     """Drop every h5coro cache line added since ``before`` was snapshotted.
 
@@ -207,8 +234,9 @@ def _evict_new_cache_lines(h5obj, before: set) -> int:
     transient peak; a later read that does want an evicted line just
     re-fetches it (B-tree nodes are not data, so in practice none does).
     Only keys absent from ``before`` are dropped — pre-existing lines (the
-    front-of-file metadata block every parse shares) always survive. Returns
-    the number of lines evicted.
+    front-of-file metadata block every parse shares) always survive, and each
+    dropped line takes its ``cache_locks`` entry with it
+    (:func:`_drop_cache_lines`). Returns the number of lines evicted.
 
     Structurally non-raising, which matters because callers run it from a
     ``finally`` where a raise would replace a successful ``ChunkMap`` return
@@ -223,9 +251,7 @@ def _evict_new_cache_lines(h5obj, before: set) -> int:
     if not cache:
         return 0
     added = [k for k in list(cache) if k not in before]
-    for k in added:
-        cache.pop(k, None)
-    return len(added)
+    return _drop_cache_lines(h5obj, added)
 
 
 def _evict_deferred_lines(h5obj, deferred: set) -> int:
@@ -250,7 +276,7 @@ def _evict_deferred_lines(h5obj, deferred: set) -> int:
     cache = getattr(h5obj, "cache", None)
     if not cache or not deferred:
         return 0
-    evicted = sum(cache.pop(k, None) is not None for k in list(deferred))
+    evicted = _drop_cache_lines(h5obj, list(deferred))
     deferred.clear()
     if evicted:
         logger.debug(f"  chunk maps: evicted {evicted} deferred cache line(s) after the fan-out")

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -237,7 +237,9 @@ def build_chunk_map(h5obj, path: str) -> ChunkMap:
     try:
         return _chunk_map_from_dataset(h5obj, ds, path)
     finally:
-        _evict_new_cache_lines(h5obj, before)
+        evicted = _evict_new_cache_lines(h5obj, before)
+        if evicted:
+            logger.debug(f"  chunk map {path}: evicted {evicted} cache line(s) the walk touched")
 
 
 def _chunk_map_from_dataset(h5obj, ds, path: str) -> ChunkMap:
@@ -405,7 +407,11 @@ def full_granule_maps(h5obj, existing: dict[str, ChunkMap]) -> dict[str, ChunkMa
             # sinking the whole granule's write-back.
             logger.warning(f"  write-back: no chunk map for {path} ({exc}); skipping")
         finally:
-            _evict_new_cache_lines(h5obj, before)
+            evicted = _evict_new_cache_lines(h5obj, before)
+            if evicted:
+                logger.debug(
+                    f"  write-back map {path}: evicted {evicted} cache line(s) the walk touched"
+                )
     return maps
 
 

--- a/src/zagg/index/inline.py
+++ b/src/zagg/index/inline.py
@@ -326,7 +326,19 @@ def build_chunk_map(h5obj, path: str, *, evict_into: set | None = None) -> Chunk
         return _chunk_map_from_dataset(h5obj, ds, path)
     finally:
         if evict_into is not None:
-            evict_into.update(_cache_keys(h5obj) - before)
+            added = _cache_keys(h5obj) - before
+            evict_into.update(added)
+            if added:
+                # Per-build attribution on the DEFERRED branch too (review
+                # finding on PR #462): with ``write_back`` off — the shipped
+                # default — every build goes through here, so without this line
+                # the only DEBUG record is ``_evict_deferred_lines``' group-level
+                # aggregate, which cannot single out the one pathological dataset
+                # (GEDI L1B's ``rxwaveform``) inside a group of dozens.
+                logger.debug(
+                    f"  chunk map {path}: walk touched {len(added)} cache line(s); "
+                    "deferred for post-read eviction"
+                )
         else:
             evicted = _evict_new_cache_lines(h5obj, before)
             if evicted:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1727,6 +1727,15 @@ class TestFullCoverageWalk:
         maps_ref = full_granule_maps(ref, read_ref)
         # Eviction actually removed the walks' lines...
         assert set(h5obj.cache) < set(ref.cache)
+        # ...and this is the many-distinct-datasets shape the GEDI residual
+        # lives in (review finding on PR #462): with the whole granule mapped,
+        # residency tracks the parses' object-header lines (a couple per
+        # dataset at the fixture's 512-B lines) and NOT the walks' per-B-tree-
+        # node lines. On GEDI L1B at the 4 MiB default those headers co-locate:
+        # 11 lines / 46 MB resident per beam group, 90 distinct lines touched.
+        assert len(maps) > 20  # every dataset in the granule, not just one
+        assert len(h5obj.cache) <= 2 * len(maps)  # parse-line growth only...
+        assert len(ref.cache) > 2 * len(maps)  # ...which the unevicted arm busts
         # ...and altered no map.
         assert set(maps) == set(maps_ref)
         for p in maps:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -445,6 +445,32 @@ def _open_fixture():
     return h5c.H5Coro(str(FIXTURE_H5), filedriver.FileDriver, errorChecking=True, verbose=False)
 
 
+def _open_fixture_small_lines(counting=False):
+    """Fixture handle with tiny (512-byte) cache lines, for the issue #460
+    eviction tests: at the default 4 MiB line the whole 86 KB fixture is one
+    cache line, so walk-added and pre-existing keys are indistinguishable; at
+    512 bytes the B-tree node lands on its own line(s), outside the
+    object-header metadata lines. ``counting=True`` wraps the driver so each
+    ranged read is counted (``h5obj.driver.reads``)."""
+    from h5coro import filedriver
+    from h5coro import h5coro as h5c
+
+    driver = filedriver.FileDriver
+    if counting:
+
+        class _CountingFileDriver(filedriver.FileDriver):
+            def __init__(self, resource, credentials):
+                super().__init__(resource, credentials)
+                self.reads = 0
+
+            def read(self, pos, size):
+                self.reads += 1
+                return super().read(pos, size)
+
+        driver = _CountingFileDriver
+    return h5c.H5Coro(str(FIXTURE_H5), driver, errorChecking=True, verbose=False, cacheLineSize=512)
+
+
 def _fixture_data_source(**extra):
     """ATL03-shaped hierarchical data_source over the fixture (mirrors the
     shipped atl03.yaml: photon base level, segment spatial index, TEP filter)."""
@@ -579,6 +605,76 @@ class TestChunkMap:
         assert not cm.starts_on_boundary(255)
         assert not cm.starts_on_boundary(257)
         assert not cm.starts_on_boundary(2432)  # dataset end, not a chunk start
+
+
+class TestChunkMapCacheEviction:
+    """Issue #460: the B-tree walk must not strand h5coro cache lines.
+
+    ``H5Coro.cache`` keeps a full cache line per touched byte range until
+    granule close; on sparse files (GEDI L1B) the walk's node lines stranded
+    ~4 MiB per chunk B-tree node (+531 MB per beam group). ``build_chunk_map``
+    now snapshots the cache keys after the object-header parse and evicts
+    every key the walk added.
+    """
+
+    PATH = "/gt1l/heights/h_ph"
+
+    def _unevicted_reference(self):
+        """Parse + raw (unevicted) walk on a fresh handle: returns the handle's
+        parse-line keys, the walk-added keys, and the resulting map."""
+        from h5coro.h5dataset import H5Dataset
+
+        from zagg.index.inline import _chunk_map_from_dataset
+
+        ref = _open_fixture_small_lines()
+        ds = H5Dataset(ref, self.PATH, earlyExit=True, metaOnly=True, enableAttributes=False)
+        parse_lines = set(ref.cache)
+        cm = _chunk_map_from_dataset(ref, ds, self.PATH)
+        walk_lines = set(ref.cache) - parse_lines
+        return parse_lines, walk_lines, cm
+
+    def test_walk_lines_evicted_preexisting_lines_survive(self):
+        h5obj = _open_fixture_small_lines()
+        pre = set(h5obj.cache)  # the open's superblock/root lines
+        assert pre
+        build_chunk_map(h5obj, self.PATH)
+        post = set(h5obj.cache)
+        assert pre <= post  # pre-existing lines are never evicted
+        parse_lines, walk_lines, _ = self._unevicted_reference()
+        assert walk_lines  # the fixture's B-tree node lives outside the metadata lines
+        assert post == parse_lines  # exactly the parse's lines are retained...
+        assert not post & walk_lines  # ...and none of the walk's
+
+    def test_map_identical_to_unevicted_walk(self):
+        cm = build_chunk_map(_open_fixture_small_lines(), self.PATH)
+        _, _, ref = self._unevicted_reference()
+        assert cm.raw == ref.raw
+        for f in ("elem_start", "elem_end", "byte_offset", "nbytes", "filter_mask"):
+            assert getattr(cm, f).tolist() == getattr(ref, f).tolist()
+        assert (cm.dims, cm.chunk_dims, cm.dtype, cm.gzip, cm.shuffle) == (
+            ref.dims,
+            ref.chunk_dims,
+            ref.dtype,
+            ref.gzip,
+            ref.shuffle,
+        )
+
+    def test_rebuild_refetches_only_the_walk_lines(self):
+        # The eviction's whole cost: a rebuild re-fetches the walk's lines
+        # (the parse's lines stayed cached), nothing else.
+        h5obj = _open_fixture_small_lines(counting=True)
+        first = build_chunk_map(h5obj, self.PATH)
+        r1 = h5obj.driver.reads
+        second = build_chunk_map(h5obj, self.PATH)
+        _, walk_lines, _ = self._unevicted_reference()
+        assert h5obj.driver.reads - r1 == len(walk_lines)
+        assert second.raw == first.raw
+
+    def test_cache_less_handle_is_a_noop(self):
+        from zagg.index.inline import _cache_keys, _evict_new_cache_lines
+
+        assert _cache_keys(object()) == set()
+        assert _evict_new_cache_lines(object(), set()) == 0
 
 
 class TestInlineReadGroup:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -690,6 +690,68 @@ class TestChunkMapCacheEviction:
                 build_chunk_map(h5obj, p)
             assert len(h5obj.cache) == baseline
 
+    def test_pooled_read_fn_defers_eviction_under_concurrency(self):
+        # Review finding on PR #462: read_fn's lazy map builds run across
+        # ``read_workers`` threads sharing one h5obj (_read_paths_pooled), and
+        # h5coro's cached ioRequest reads ``self.cache`` OUTSIDE cache_locks --
+        # so evicting there raced concurrent readDatasets (KeyError inside
+        # ioRequest, or a silently degraded H5Promise parse). read_fn now only
+        # records its lines; read_group drops them after the pool joins. This
+        # drives the real seam: read_fn hyperslices concurrently with plain
+        # readDatasets on one handle, with the switch interval tightened.
+        import sys
+        import threading
+        import time
+
+        from zagg.index.inline import _evict_deferred_lines
+
+        mapped = [f"/gt1l/heights/{n}" for n in ("h_ph", "lat_ph", "lon_ph", "delta_time")]
+        other = [f"/gt2l/heights/{n}" for n in ("h_ph", "lat_ph", "lon_ph", "delta_time")]
+        lo, hi = 300, 1500  # spans several 256-photon chunks, not chunk-aligned
+        ref = _open_fixture()
+        expect = {p: ref.readDatasets([p])[p] for p in mapped + other}
+
+        h5obj = _open_fixture_small_lines()
+        errors: list = []
+        deferred_seen: set = set()
+
+        def mapped_read(read_fn, path):
+            try:
+                got = read_fn(path, hyperslice=[(lo, hi)])
+                assert np.array_equal(got, expect[path][lo:hi]), path
+            except Exception as exc:
+                errors.append((path, repr(exc)))
+
+        def direct_read(path):
+            try:
+                assert np.array_equal(h5obj.readDatasets([path])[path], expect[path]), path
+            except Exception as exc:
+                errors.append((path, repr(exc)))
+
+        interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-7)
+        try:
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and not errors:
+                # A fresh read_fn per round: its map cache starts empty, so the
+                # lazy builds (and their deferred lines) happen again.
+                read_fn = InlineIndex()._chunk_aligned_read_fn(h5obj, planned=True)
+                threads = [threading.Thread(target=mapped_read, args=(read_fn, p)) for p in mapped]
+                threads += [threading.Thread(target=direct_read, args=(p,)) for p in other]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+                # Single-threaded again -- the point read_group evicts at.
+                lines = set(read_fn.deferred_lines)
+                deferred_seen |= lines
+                _evict_deferred_lines(h5obj, read_fn.deferred_lines)
+                assert not lines & set(h5obj.cache)  # every deferred line dropped
+        finally:
+            sys.setswitchinterval(interval)
+        assert not errors
+        assert deferred_seen  # the walks really did strand lines to evict
+
     def test_lines_touched_logged_at_debug(self, caplog):
         # Issue #460 phase 3: each map build reports the walk's cache-line
         # footprint at DEBUG, so a pathological granule is visible in logs.
@@ -1033,9 +1095,9 @@ class TestSelectionReads:
         built = []
         orig = inline_mod.build_chunk_map
 
-        def spy(h5obj, path):
+        def spy(h5obj, path, **kwargs):  # kwargs: evict_into (issue #460)
             built.append(path)
-            return orig(h5obj, path)
+            return orig(h5obj, path, **kwargs)
 
         monkeypatch.setattr(inline_mod, "build_chunk_map", spy)
         return built

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -763,6 +763,54 @@ class TestChunkMapCacheEviction:
         assert not errors
         assert deferred_seen  # the walks really did strand lines to evict
 
+    def test_read_group_drains_deferred_lines_on_the_planned_route(self, monkeypatch):
+        # Review finding on PR #462: nothing exercised ``read_group``'s
+        # ``finally`` drains, so removing them kept the suite green while
+        # restoring the full issue #460 leak (worse than pre-PR: the lazy builds
+        # now only RECORD their lines). Reference arm = the identical read with
+        # the drain neutralized; the discriminator is the scale-free strict
+        # subset, not a count.
+        import zagg.index.inline as inline_mod
+
+        ds = _fixture_data_source()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        h5obj = _open_fixture_small_lines()
+        df = InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid)
+
+        ref = _open_fixture_small_lines()
+        monkeypatch.setattr(inline_mod, "_evict_deferred_lines", lambda h5obj, deferred: 0)
+        df_ref = InlineIndex().read_group(ref, "gt1l", ds, 1, grid)
+
+        assert df is not None and len(df) > 0
+        pd.testing.assert_frame_equal(df, df_ref)  # the drain changes no output...
+        assert set(h5obj.cache) < set(ref.cache)  # ...and really does drop lines
+
+    def test_read_group_drains_deferred_lines_on_the_vlen_route(self, monkeypatch):
+        # The vlen dispatch (``coordinates.level`` set) is read_group's FIRST
+        # arm and the route issue #460 was filed against (GEDI L1B), yet no test
+        # reached its drain (review finding on PR #462). Stub the route itself so
+        # this stays a ~ms unit test of the dispatch: the stub does one read that
+        # forces a lazy map build (hence deferred lines), and by the time
+        # read_group returns the drain must have dropped them.
+        import zagg.processing.read_vlen as read_vlen_mod
+
+        seen: dict = {}
+
+        def stub(h5obj, group, data_source, shard_key, grid, *, read_fn=None, **kw):
+            read_fn(self.PATH, hyperslice=[(0, 10)])
+            seen["deferred"] = set(read_fn.deferred_lines)
+            return None
+
+        monkeypatch.setattr(read_vlen_mod, "_vlen_read_group", stub)
+        ds = _fixture_data_source()
+        ds["coordinates"] = dict(ds["coordinates"], level="segments")
+        h5obj = _open_fixture_small_lines()
+        grid = _LeafSetGrid(_UNALIGNED_LEAVES)
+        assert InlineIndex().read_group(h5obj, "gt1l", ds, 1, grid) is None
+        _, walk_lines, _ = self._unevicted_reference()
+        assert walk_lines and seen["deferred"] >= walk_lines  # deferred, not evicted...
+        assert not walk_lines & set(h5obj.cache)  # ...then drained by the finally
+
     def test_lines_touched_logged_at_debug(self, caplog):
         # Issue #460 phase 3: each map build reports the walk's cache-line
         # footprint at DEBUG, so a pathological granule is visible in logs.

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -679,16 +679,27 @@ class TestChunkMapCacheEviction:
     def test_cache_stays_flat_across_repeated_builds(self):
         # Issue #460 phase 3 guard: N successive build_chunk_map calls leave
         # len(h5obj.cache) flat. The leak this pins against was ~a cache line
-        # per B-tree node per build, retained until granule close.
+        # per B-tree node per build, retained until granule close. The lock
+        # table is pinned too (review finding on PR #462): cache_locks is a
+        # defaultdict keyed by the same offsets, so an eviction that left it
+        # alone kept a Lock + dict slot per line ever touched.
         h5obj = _open_fixture_small_lines()
         paths = ("/gt1l/heights/h_ph", "/gt1l/heights/lat_ph", "/gt1l/heights/signal_conf_ph")
         for p in paths:  # first round warms the shared object-header lines
             build_chunk_map(h5obj, p)
-        baseline = len(h5obj.cache)
+        baseline, baseline_locks = len(h5obj.cache), len(h5obj.cache_locks)
+        assert baseline_locks  # the walks really did populate the lock table
         for _ in range(5):
             for p in paths:
                 build_chunk_map(h5obj, p)
             assert len(h5obj.cache) == baseline
+            assert len(h5obj.cache_locks) == baseline_locks
+        # The counts alone are weak (a rebuild re-fetches the same offsets, so
+        # even an unpruned lock table stays flat across identical builds): pin
+        # that no evicted line is still holding a lock.
+        _, walk_lines, _ = self._unevicted_reference()
+        assert walk_lines and not walk_lines & set(h5obj.cache_locks)
+        assert set(h5obj.cache_locks) <= set(h5obj.cache)
 
     def test_pooled_read_fn_defers_eviction_under_concurrency(self):
         # Review finding on PR #462: read_fn's lazy map builds run across

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1607,6 +1607,34 @@ class TestFullCoverageWalk:
         assert "/gt2l/heights/lat_ph" in maps
         assert any("boom" in r.message for r in caplog.records)
 
+    def test_full_coverage_walk_evicts_its_cache_lines(self, monkeypatch):
+        # Issue #460 phase 2: the full-coverage walk maps EVERY dataset in the
+        # granule, so unevicted it accumulates walk lines worst of all. After
+        # the walk only pre-existing lines plus the enumeration's own
+        # object-header/metadata lines remain resident -- and eviction changes
+        # no map (identical to a walk with eviction disabled).
+        import zagg.index.inline as inline_mod
+        from zagg.index.inline import full_granule_maps
+
+        h5obj = _open_fixture_small_lines()
+        read = {"/gt1l/heights/h_ph": build_chunk_map(h5obj, "/gt1l/heights/h_ph")}
+        pre = set(h5obj.cache)
+        maps = full_granule_maps(h5obj, read)
+        assert pre <= set(h5obj.cache)  # pre-existing lines survive
+
+        # Reference arm: the identical read sequence with eviction off.
+        ref = _open_fixture_small_lines()
+        monkeypatch.setattr(inline_mod, "_evict_new_cache_lines", lambda *a: 0)
+        read_ref = {"/gt1l/heights/h_ph": build_chunk_map(ref, "/gt1l/heights/h_ph")}
+        maps_ref = full_granule_maps(ref, read_ref)
+        # Eviction actually removed the walks' lines...
+        assert set(h5obj.cache) < set(ref.cache)
+        # ...and altered no map.
+        assert set(maps) == set(maps_ref)
+        for p in maps:
+            a, b = maps[p], maps_ref[p]
+            assert a.raw == b.raw and a.dtype == b.dtype and a.dims == b.dims
+
 
 class TestInlineInterleavedGranules:
     """Issue #180 phase 1: with granule-level read concurrency the worker may

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1797,8 +1797,14 @@ class TestFullCoverageWalk:
         # node lines. On GEDI L1B at the 4 MiB default those headers co-locate:
         # 11 lines / 46 MB resident per beam group, 90 distinct lines touched.
         assert len(maps) > 20  # every dataset in the granule, not just one
-        assert len(h5obj.cache) <= 2 * len(maps)  # parse-line growth only...
-        assert len(ref.cache) > 2 * len(maps)  # ...which the unevicted arm busts
+        # Pin the WALK's lines directly rather than a count bound: a magic
+        # lines-per-dataset factor sat five lines from flipping either way on
+        # this fixture, and was carried by parse lines, not walk lines (second
+        # review finding on PR #462). These keys are scale-free -- the walk
+        # lines of a known dataset, present in the unevicted arm and gone here.
+        _, walk_lines, _ = TestChunkMapCacheEviction()._unevicted_reference()
+        assert walk_lines <= set(ref.cache)  # the unevicted arm strands them...
+        assert not walk_lines & set(h5obj.cache)  # ...and eviction dropped them
         # ...and altered no map.
         assert set(maps) == set(maps_ref)
         for p in maps:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -676,6 +676,31 @@ class TestChunkMapCacheEviction:
         assert _cache_keys(object()) == set()
         assert _evict_new_cache_lines(object(), set()) == 0
 
+    def test_cache_stays_flat_across_repeated_builds(self):
+        # Issue #460 phase 3 guard: N successive build_chunk_map calls leave
+        # len(h5obj.cache) flat. The leak this pins against was ~a cache line
+        # per B-tree node per build, retained until granule close.
+        h5obj = _open_fixture_small_lines()
+        paths = ("/gt1l/heights/h_ph", "/gt1l/heights/lat_ph", "/gt1l/heights/signal_conf_ph")
+        for p in paths:  # first round warms the shared object-header lines
+            build_chunk_map(h5obj, p)
+        baseline = len(h5obj.cache)
+        for _ in range(5):
+            for p in paths:
+                build_chunk_map(h5obj, p)
+            assert len(h5obj.cache) == baseline
+
+    def test_lines_touched_logged_at_debug(self, caplog):
+        # Issue #460 phase 3: each map build reports the walk's cache-line
+        # footprint at DEBUG, so a pathological granule is visible in logs.
+        h5obj = _open_fixture_small_lines()
+        with caplog.at_level("DEBUG", logger="zagg.index.inline"):
+            build_chunk_map(h5obj, self.PATH)
+        assert any(
+            "cache line" in r.message and self.PATH in r.message and "evicted" in r.message
+            for r in caplog.records
+        )
+
 
 class TestInlineReadGroup:
     def _read_both(self, group, leaves, arrow=False):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -822,6 +822,21 @@ class TestChunkMapCacheEviction:
             for r in caplog.records
         )
 
+    def test_deferred_lines_touched_logged_at_debug(self, caplog):
+        # Review finding on PR #462: the counter above only fires on the
+        # IMMEDIATE branch, which production never takes with ``write_back`` off
+        # (the shipped default) -- every default-config build defers. Drive the
+        # real seam (a read_fn lazy build) and pin the per-path record there too,
+        # so the group-level aggregate is not the only attribution.
+        h5obj = _open_fixture_small_lines()
+        read_fn = InlineIndex()._chunk_aligned_read_fn(h5obj, planned=True)
+        with caplog.at_level("DEBUG", logger="zagg.index.inline"):
+            read_fn(self.PATH, hyperslice=[(300, 1500)])
+        assert any(
+            "cache line" in r.message and self.PATH in r.message and "deferred" in r.message
+            for r in caplog.records
+        )
+
 
 class TestInlineReadGroup:
     def _read_both(self, group, leaves, arrow=False):


### PR DESCRIPTION
Closes #460

## What

The inline backend's chunk-map B-tree walk reads every node through h5coro's cached `ioRequest`, and `H5Coro.cache` retains a full 4 MiB cache line per touched byte range until granule close (`h5coro/h5coro.py` `ioRequest`, `CACHE_LINE_SIZE_DEFAULT = 0x400000`). On sparse files the nodes rarely share a line, so the walk strands ~a line per node: GEDI L1B `rxwaveform` (13,790 chunks) measured **+531 MB retained RSS per beam group**, ~4.2 GB/granule, OOM at every Lambda memory tier (the issue's diagnosis).

Fix per the [espg-directed plan](https://github.com/englacial/zagg/issues/460#issuecomment-5313837312): **snapshot-and-evict around the walk, zagg-side only** — snapshot `h5obj.cache` keys before the walk, drop every key the walk added once the `ChunkMap` is assembled. Pre-existing lines (the shared front-of-file metadata block) always survive; an evicted line a later read does want is simply re-fetched (B-tree nodes are metadata, not data, so in practice none is). After the review fold, eviction happens at two kinds of points, both single-threaded on the handle: immediately in `build_chunk_map` for its serial callers, and — for the lazy builds `read_fn` performs inside the pooled read fan-out — deferred to the end of `read_group`, after the thread pool has joined (evicting mid-pool races h5coro's unlocked cached reads; see the review thread).

## Phases

- [x] Phase 1 — snapshot-and-evict in `build_chunk_map` (`src/zagg/index/inline.py`): `_cache_keys` / `_evict_new_cache_lines` helpers, eviction scoped to the walk (the `H5Dataset` object-header parse's lines stay cached; measured bounded at ~tens of MB on GEDI, see evidence). Unit tests pin: walk-added lines evicted, pre-existing lines survive, map identical to an unevicted walk, rebuild re-fetches exactly the walk's lines.
- [x] Phase 2 — same eviction for the write-back full-coverage walk (`full_granule_maps` / `_iter_datasets`, the issue #190 path), per-dataset so the transient peak stays one walk deep.
- [x] Phase 3 — DEBUG-level lines-touched counter per map build + regression test asserting `len(h5obj.cache)` stays flat across N successive `build_chunk_map` calls.
- [x] Review fold, cycle 1 — all four findings folded (see the inline threads): live-dict snapshot fix, deferred eviction past the pooled fan-out + concurrency regression test, `cache_locks` pruned alongside, retained-parse-lines claim grounded with the GEDI measurement.
- [x] Review fold, cycle 2 — all four second-cycle findings folded: deferred-drain coverage on the planned and vlen routes (both tests fail with the drain neutralized), per-build DEBUG attribution on the deferred branch, honest wording for the concurrent sweep's scope, walk-line pins instead of count bounds.

## Acceptance evidence (real GEDI L1B over HTTPS)

Harness: `data/gedi_debug/gedi_drive_backend.py 0 0 BEAM0000` (real `InlineIndex.read_group`, EDL-authenticated HTTPS, granule `GEDI01_B_2019121080625_O02166_02_T05019_02_005_01_V002`), run unmodified for the before arm and as a scratch copy pointed at this branch's `src` for the after arm, augmented only to also report current RSS (`ps -o rss=`) and the post-group cache census. Identical output both arms: **rows=165506, distinct leaf cells=217**, `obs_read=310427`.

| metric (one beam group) | before (main) | after (this branch, post-fold) |
| --- | --- | --- |
| resident `h5obj.cache` lines after the group | **90 lines / 377 MB** (held to granule close) | **11 lines / 46 MB** |
| resident `cache_locks` entries | 90 | 11 (pruned with the lines) |
| peak RSS delta (`ru_maxrss`) | +525 MB (issue recorded +531) | +533 MB (the group's walk lines, freed when the pool joins) |
| current RSS after the group | 705 MB | 596 MB |

Notes: `ru_maxrss` is a high-water mark, so the transient walk (~90 scattered lines fetched once) keeps the *peak* similar by design — the plan's "transient peak becomes one walk's lines" (pre-fold, with immediate per-dataset eviction, the peak measured +420; the review fold's deferred eviction holds the group's walk lines until the read pool joins, trading that back for thread-safety). The retained-side win is the cache census: 377 MB → 46 MB per beam group, which is what accumulated ×8 beams ×`granule_workers` into the fleet OOM. The macOS current-RSS numbers understate the recovery because the allocator keeps freed pages resident (a probe run that cleared the entire cache *and* dropped the result dataframe recovered 0 MB of current RSS on macOS); on the Lambda fleet (glibc) freed 4 MiB blocks are returned via munmap.

## How it was tested

- `TestChunkMapCacheEviction` + full-coverage-walk eviction test in `tests/test_index.py`: real h5coro `H5Coro` over the committed fixture opened with **512-byte cache lines** (at the default 4 MiB the whole 86 KB fixture is one line, so walk-added vs pre-existing keys would be indistinguishable) plus a counting `FileDriver` subclass. Pins: retained key set == exactly the parse's lines and none of the walk's; map identical to an unevicted walk; rebuild's extra driver reads == exactly the walk's line count; `len(h5obj.cache)` (and `cache_locks`) flat across repeated builds; concurrency regression test driving `read_fn` lazy builds + `readDatasets` on one handle across threads.
- `pytest` full suite green locally except the known-environmental `test_lambda_build` failure (pre-existing, unrelated — Docker-dependent); `ruff check` / `ruff format --check` clean (see below), CI green on every push.

## Questions for review

- `ruff check src tests` reports one pre-existing finding on clean `origin/main`: `N818` on `UnknownCapability` (`src/zagg/registry.py:64`) — untouched here, flagged not fixed (per §4). The PR lint bot runs `--select=E,F,W,I` (no `N`), which is why it never surfaced on PRs.
- The upstream h5coro `caching=False` metadata-read mode (the structural fix) remains a follow-up to raise after this lands, per the plan.
- Standing from review cycle 2 (left by design, see the thread): under concurrent lazy builds the deferred drain can sweep another dataset's object-header lines (bounded re-fetch cost); making exact parse-line retention a hard invariant via a floor subtraction was declined as extra machinery — it becomes moot with the upstream `caching=False` mode.
