### PR TITLE
small fixes 2026-08-17 (4): shipped S2 pyramid opt-out, deliberate shardmap re-pin driver

### DIFF
--- a/src/zagg/configs/sentinel2_l2a.yaml
+++ b/src/zagg/configs/sentinel2_l2a.yaml
@@ -38,14 +38,7 @@ output:
   # int64 microseconds cannot state and a toc word can. Output-defining: a
   # store born on toc is a different product from a legacy-axis one.
   time_encoding: toc
-  # Overview family OFF, declared rather than left absent (issue #459): an
-  # absent key means the every-2-orders default is ON (`get_pyramid` -> {}), so
-  # every raster run dispatches a rollup sweep whose overview family generates
-  # nothing -- raster fields have no fold law (issue #399 ruled option (b), a
-  # raster column writer, and it is unimplemented; raster leaves stay
-  # column-less by construction, PR #416 phase 5). Mirrors the benchmark leg's
-  # opt-out in tests/data/benchmark/configs/s2_neon_o9.yaml (issue #201).
-  pyramid: false
+  pyramid: false                 # overview family off: raster leaves are column-less (issue #399, issue #459)
   grid:
     type: healpix
     parent_order: 11

--- a/src/zagg/configs/sentinel2_l2a.yaml
+++ b/src/zagg/configs/sentinel2_l2a.yaml
@@ -38,6 +38,14 @@ output:
   # int64 microseconds cannot state and a toc word can. Output-defining: a
   # store born on toc is a different product from a legacy-axis one.
   time_encoding: toc
+  # Overview family OFF, declared rather than left absent (issue #459): an
+  # absent key means the every-2-orders default is ON (`get_pyramid` -> {}), so
+  # every raster run dispatches a rollup sweep whose overview family generates
+  # nothing -- raster fields have no fold law (issue #399 ruled option (b), a
+  # raster column writer, and it is unimplemented; raster leaves stay
+  # column-less by construction, PR #416 phase 5). Mirrors the benchmark leg's
+  # opt-out in tests/data/benchmark/configs/s2_neon_o9.yaml (issue #201).
+  pyramid: false
   grid:
     type: healpix
     parent_order: 11

--- a/tests/data/benchmark/README.md
+++ b/tests/data/benchmark/README.md
@@ -179,6 +179,20 @@ places the panel.
    print(bench_metrics.select_densest_shard(sm))   # -> (shard_key, n_granules)
    ```
 
+   > **Re-pinning a map that already exists** is one command:
+   > `tools/repin_benchmark_shardmaps.py` (issue #444) rebuilds through the
+   > drift check's own recipe, selects the pin (nested rule included), prunes
+   > the ring maps, and writes the map plus its `targets.json`
+   > `shard_key`/`n_granules`. It re-pins **deliberately** — the drift check
+   > stays the accident detector — so run it only when a convention or grammar
+   > change makes the committed words wrong. `--check` rebuilds and reports the
+   > differences without writing. The entry's `note` is prose: restate it by
+   > hand in the same commit.
+   >
+   > ```bash
+   > uv run python tools/repin_benchmark_shardmaps.py --check healpix_o9_88s
+   > ```
+
    > **The committed maps span two granule-record schemas.** The five
    > `sm_healpix_*.json` maps were last rebuilt after issue #246, so their
    > granule records carry `time_start`/`time_end` (and their `metadata` a

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -101,60 +101,73 @@ def _config_for_shardmap(sm_key: str) -> Path:
     raise AssertionError(f"no target references shardmap '{sm_key}'")
 
 
-@pytest.mark.slow
-@needs_cmr
-@pytest.mark.parametrize("sm_key", list(MANIFEST["shardmaps"]))
-def test_pinned_shardmap_no_drift(sm_key):
+def rebuild_shardmap(sm_key: str, sm_meta: dict):
+    """Rebuild one shard map from its ``targets.json`` entry — THE recipe.
+
+    Entry config → grid; the entry's resolved AOI/temporal/CMR (a per-entry
+    override, issue #121, over the top-level manifest default — NEON entries
+    carry none); the committed map's ``metadata.backend``; and either the
+    committed ``catalog_parquet`` snapshot when the entry carries one or a live
+    CMR fetch when it does not.
+
+    Build-once catalog (issue #148): an entry carrying ``catalog_parquet``
+    rebuilds from the committed stac-geoparquet snapshot instead of re-fetching
+    CMR — the rebuild is then deterministic and offline, per the catalog design
+    (fetch once, save the parquet, reuse). Regenerate the snapshot only to
+    deliberately re-pin.
+
+    Shared with the issue #444 re-pin driver rather than restated there: the
+    drift guard and its deliberate counterpart must build the same way, and a
+    second copy of this recipe is exactly what would let them drift apart.
+    """
     from zagg.catalog import load_polygon, polygon_to_bbox
     from zagg.catalog.shardmap import ShardMap
     from zagg.catalog.sources import Catalog, CMRSource, Query
     from zagg.config import load_config
     from zagg.grids import from_config
 
-    sm_meta = MANIFEST["shardmaps"][sm_key]
-    committed = json.loads((BENCH / sm_meta["path"]).read_text())
-    backend = committed["metadata"]["backend"]
-    if backend == "spherely":
-        pytest.importorskip("spherely")
-
-    cfg = load_config(str(_config_for_shardmap(sm_key)))
-    grid = from_config(cfg)
-    # Resolve this shard map's AOI/temporal/CMR: a per-entry override (issue #121)
-    # falls back to the top-level manifest default. NEON entries have no override.
+    backend = json.loads((BENCH / sm_meta["path"]).read_text())["metadata"]["backend"]
+    grid = from_config(load_config(str(_config_for_shardmap(sm_key))))
     aoi, temporal, cmr = resolve_aoi_temporal_cmr(sm_meta)
     # aoi.file is relative to the manifest dir, like the config/shardmap paths.
     parts = load_polygon(str(BENCH / aoi["file"]))
-
     if sm_meta.get("catalog_parquet"):
-        # Build-once catalog (issue #148): an entry carrying ``catalog_parquet``
-        # rebuilds from the committed stac-geoparquet snapshot instead of
-        # re-fetching CMR -- the drift check then guards the shardmap build +
-        # pin deterministically and offline, per the catalog design (fetch
-        # once, save the parquet, reuse). Regenerate the snapshot only to
-        # deliberately re-pin.
         catalog = Catalog.from_geoparquet(str(BENCH / sm_meta["catalog_parquet"]))
     else:
-        query = Query(
-            cmr["short_name"],
-            cmr["version"],
-            temporal["start"],
-            temporal["end"],
-            region=polygon_to_bbox(parts),
-            provider=cmr["provider"],
+        catalog = CMRSource().fetch(
+            Query(
+                cmr["short_name"],
+                cmr["version"],
+                temporal["start"],
+                temporal["end"],
+                region=polygon_to_bbox(parts),
+                provider=cmr["provider"],
+            )
         )
-        catalog = CMRSource().fetch(query)
-    rebuilt = ShardMap.build(
-        catalog, grid, region=parts, backend=backend, footprint=cmr["footprint"]
-    )
+    return ShardMap.build(catalog, grid, region=parts, backend=backend, footprint=cmr["footprint"])
 
-    # A nested pin (issue #148: the 88S o10 stress shard is the densest o10
-    # shard INSIDE the pinned o9 stress shard, so one o9 extraction pass covers
-    # both orders) is compared against the same nested quantity, not the global
-    # densest — otherwise a correct rebuild would read as drift.
+
+def select_pin(rebuilt, sm_meta: dict, parent_key: int | None = None) -> tuple[int, int]:
+    """The ``(shard_key, n_granules)`` pin for a rebuilt map — THE pin rule.
+
+    A nested pin (issue #148: the 88S o10 stress shard is the densest o10 shard
+    INSIDE the pinned o9 stress shard, so one o9 extraction pass covers both
+    orders) is selected over the shards nested in the parent's pin, never the
+    global densest — otherwise a correct rebuild would read as drift.
+
+    ``parent_key`` lets the issue #444 driver extract against a parent pin it
+    has just rewritten on disk; the guard passes none and reads the manifest as
+    loaded at import. Shared with that driver for the same reason as
+    :func:`rebuild_shardmap`.
+    """
+    from zagg.config import load_config
+    from zagg.grids import from_config
+
     shard_keys, granules = rebuilt.shard_keys, rebuilt.granules
     nested_in = sm_meta.get("nested_in")
     if nested_in:
-        parent_key = int(MANIFEST["shardmaps"][nested_in]["shard_key"])
+        if parent_key is None:
+            parent_key = int(MANIFEST["shardmaps"][nested_in]["shard_key"])
         parent_grid = from_config(load_config(str(_config_for_shardmap(nested_in))))
         keep = [
             i
@@ -163,8 +176,19 @@ def test_pinned_shardmap_no_drift(sm_key):
         ]
         shard_keys = [shard_keys[i] for i in keep]
         granules = [granules[i] for i in keep]
+    return bench_metrics.select_densest_shard({"shard_keys": shard_keys, "granules": granules})
 
-    key, n = bench_metrics.select_densest_shard({"shard_keys": shard_keys, "granules": granules})
+
+@pytest.mark.slow
+@needs_cmr
+@pytest.mark.parametrize("sm_key", list(MANIFEST["shardmaps"]))
+def test_pinned_shardmap_no_drift(sm_key):
+    sm_meta = MANIFEST["shardmaps"][sm_key]
+    committed = json.loads((BENCH / sm_meta["path"]).read_text())
+    if committed["metadata"]["backend"] == "spherely":
+        pytest.importorskip("spherely")
+
+    key, n = select_pin(rebuild_shardmap(sm_key, sm_meta), sm_meta)
     pinned_n = sm_meta["n_granules"]
     # Tie-tolerant: the densest *count* is the stable quantity; an equally-dense
     # reselection (different key, same count) is fine -- a count drift is not.

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -384,6 +384,61 @@ def test_repin_targets_write_back_is_anchored_on_the_key():
     assert maps["child"] == json.loads(text)["shardmaps"]["child"]
 
 
+def test_repin_orders_by_nesting_depth():
+    """Depth, not a parent/child boolean -- a grandchild must follow its parent."""
+    driver = _driver()
+    known = {"a": {}, "b": {"nested_in": "a"}, "c": {"nested_in": "b"}}
+
+    assert [driver.nesting_depth(known, k) for k in ("a", "b", "c")] == [0, 1, 2]
+    assert sorted("cab", key=lambda k: driver.nesting_depth(known, k)) == ["a", "b", "c"]
+    with pytest.raises(ValueError, match="cycle"):
+        driver.nesting_depth({"x": {"nested_in": "y"}, "y": {"nested_in": "x"}}, "x")
+
+
+def test_repin_writes_parents_before_children(monkeypatch, tmp_path):
+    """``main()``'s write path, and the ordering claim it rests on.
+
+    A ``nested_in`` child extracts against its parent's pin as it stands on
+    disk (issue #148), so a child re-pinned FIRST would be extracted against
+    the parent's stale shard and commit a wrong fixture -- one the drift
+    guard's +/-1 count tolerance need not catch. ``repin`` is stubbed, so this
+    pins the ordering and the write-back without two shard-map builds.
+    """
+    driver = _driver()
+    bench = tmp_path / "benchmark"
+    (bench / "shardmaps").mkdir(parents=True)
+    (bench / "targets.json").write_text((BENCH / "targets.json").read_text())
+    monkeypatch.setattr(driver, "BENCH", bench)
+    monkeypatch.setattr(driver, "TARGETS", bench / "targets.json")
+
+    class _Stub:
+        metadata: dict = {}
+
+        def to_json(self, path):
+            Path(path).write_text("{}")
+
+    seen = []
+
+    def fake_repin(sm_key):
+        # record the parent pin VISIBLE ON DISK as this entry is re-pinned
+        seen.append((sm_key, int(driver.entry("healpix_o9_88s")["shard_key"])))
+        return _Stub(), 4242 if sm_key == "healpix_o9_88s" else 99, 7
+
+    monkeypatch.setattr(driver, "repin", fake_repin)
+    monkeypatch.setattr(driver, "differences", lambda sm_key, mapped: [])
+
+    assert driver.main(["healpix_o10_88s", "healpix_o9_88s"]) == 0
+
+    assert [k for k, _ in seen] == ["healpix_o9_88s", "healpix_o10_88s"]
+    # the child was extracted against the parent's NEW pin, not the run's start state
+    assert seen[1][1] == 4242
+    maps = json.loads((bench / "targets.json").read_text())["shardmaps"]
+    assert (maps["healpix_o9_88s"]["shard_key"], maps["healpix_o9_88s"]["n_granules"]) == (4242, 7)
+    assert (maps["healpix_o10_88s"]["shard_key"], maps["healpix_o10_88s"]["n_granules"]) == (99, 7)
+    # ...and the prose the driver refuses to write is still the committed prose
+    assert maps["healpix_o10_88s"]["note"] == MANIFEST["shardmaps"]["healpix_o10_88s"]["note"]
+
+
 def test_repin_refuses_an_unknown_shardmap(capsys):
     driver = _driver()
     with pytest.raises(SystemExit):

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -61,13 +61,13 @@ def resolve_aoi_temporal_cmr(sm_meta: dict) -> tuple[dict, dict, dict]:
     )
 
 
-pytestmark = [
-    pytest.mark.slow,
-    pytest.mark.skipif(
-        os.environ.get("ZAGG_BENCHMARK_DRIFT") != "1",
-        reason="set ZAGG_BENCHMARK_DRIFT=1 to run the CMR shard-map drift check",
-    ),
-]
+#: The network gate is the drift check's own, not the module's (it was
+#: module-level while the drift check was the only test here): the issue #444
+#: re-pin-driver tests below rebuild from the committed catalogs and need no CMR.
+needs_cmr = pytest.mark.skipif(
+    os.environ.get("ZAGG_BENCHMARK_DRIFT") != "1",
+    reason="set ZAGG_BENCHMARK_DRIFT=1 to run the CMR shard-map drift check",
+)
 
 
 def _containing_shard(parent_grid, shard_key: int) -> int:
@@ -101,6 +101,8 @@ def _config_for_shardmap(sm_key: str) -> Path:
     raise AssertionError(f"no target references shardmap '{sm_key}'")
 
 
+@pytest.mark.slow
+@needs_cmr
 @pytest.mark.parametrize("sm_key", list(MANIFEST["shardmaps"]))
 def test_pinned_shardmap_no_drift(sm_key):
     from zagg.catalog import load_polygon, polygon_to_bbox
@@ -170,3 +172,92 @@ def test_pinned_shardmap_no_drift(sm_key):
         f"{sm_key}: densest granule count drifted {pinned_n} -> {n} "
         f"(rebuilt densest shard {key}). Re-pin the shard map + targets.json."
     )
+
+
+# -- the deliberate re-pin driver (issue #444) --------------------------------
+#
+# ``tools/repin_benchmark_shardmaps.py`` is the counterpart of the drift check
+# above: the guard detects an accidental move, the driver makes a deliberate
+# one. It imports the guard's recipe helpers, so these tests pin the parts the
+# guard does not exercise -- the pruning, the pin write-back, and the claim the
+# driver exists to support: that it reproduces the PR #441 artifacts from the
+# committed catalogs.
+
+OFFLINE_PINS = [k for k, v in MANIFEST["shardmaps"].items() if v.get("catalog_parquet")]
+
+
+def _driver():
+    """The re-pin driver, imported from ``tools/`` (not an installed module)."""
+    sys.path.insert(0, str(REPO / "tools"))
+    import repin_benchmark_shardmaps
+
+    return repin_benchmark_shardmaps
+
+
+def _without_volatile(text: str, volatile) -> str:
+    """A written map's text minus the metadata lines a rebuild legitimately moves."""
+    return "".join(
+        line
+        for line in text.splitlines(keepends=True)
+        if not any(f'"{k}"' in line for k in volatile)
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("sm_key", OFFLINE_PINS)
+def test_offline_pin_reproduces_committed_map(sm_key, tmp_path):
+    """The driver reproduces the PR #441 artifacts from the committed catalogs.
+
+    The acceptance test issue #444 asks for, and the reason it can only cover
+    the ``catalog_parquet`` (88S ring) entries: the NEON trio rebuilds from CMR
+    by design -- an ATL03 footprint quad blankets the whole NEON box, so a local
+    full-catalog snapshot over-includes (``tests/data/benchmark/README.md``).
+
+    Byte-for-byte over the whole written manifest -- every granule record,
+    ``shard_keys``, ``grid_signature``, and the metadata the build derives --
+    except the two keys a faithful rebuild still moves, which are asserted
+    separately below.
+    """
+    driver = _driver()
+    mapped, key, n = driver.repin(sm_key)
+    sm_meta = MANIFEST["shardmaps"][sm_key]
+    assert (key, n) == (sm_meta["shard_key"], sm_meta["n_granules"])
+
+    written = tmp_path / "rebuilt.json"
+    mapped.to_json(str(written))
+    assert _without_volatile(written.read_text(), driver.VOLATILE_META) == _without_volatile(
+        (BENCH / sm_meta["path"]).read_text(), driver.VOLATILE_META
+    )
+
+    from zagg.config import load_config
+    from zagg.grids import from_config
+
+    # The one live divergence, and why it is not a pin move: PR #447 made the
+    # unpinned HEALPix ``swath`` cover order the SHARD order, where the
+    # committed maps recorded the chunk order they were built at. The
+    # assignment is unchanged -- which is what the byte comparison above just
+    # showed, over the same catalog.
+    grid = from_config(load_config(str(_config_for_shardmap(sm_key))))
+    assert mapped.metadata["mortie_order"] == grid.parent_order
+
+
+def test_repin_updates_only_the_pin_literals_in_targets():
+    # The write-back is surgical because targets.json is hand-formatted (compact
+    # inline ``worker`` objects survive a re-pin); the entry's prose ``note`` is
+    # the re-pinner's to restate, not the driver's to rewrite.
+    driver = _driver()
+    text = (BENCH / "targets.json").read_text()
+    out = driver.update_targets(text, "healpix_o9", 4242, 7)
+
+    entry = json.loads(out)["shardmaps"]["healpix_o9"]
+    assert (entry["shard_key"], entry["n_granules"]) == (4242, 7)
+    assert entry["note"] == MANIFEST["shardmaps"]["healpix_o9"]["note"]
+    changed = [(a, b) for a, b in zip(text.splitlines(), out.splitlines(), strict=True) if a != b]
+    assert len(changed) == 2, changed
+
+
+def test_repin_refuses_an_unknown_shardmap(capsys):
+    driver = _driver()
+    with pytest.raises(SystemExit):
+        driver.main(["--check", "healpix_o42"])
+    assert "unknown shard map(s) ['healpix_o42']" in capsys.readouterr().err

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -203,10 +203,11 @@ def test_pinned_shardmap_no_drift(sm_key):
 #
 # ``tools/repin_benchmark_shardmaps.py`` is the counterpart of the drift check
 # above: the guard detects an accidental move, the driver makes a deliberate
-# one. It imports the guard's recipe helpers, so these tests pin the parts the
-# guard does not exercise -- the pruning, the pin write-back, and the claim the
-# driver exists to support: that it reproduces the PR #441 artifacts from the
-# committed catalogs.
+# one. It CALLS ``rebuild_shardmap`` and ``select_pin`` above, so the rebuild
+# and the pin rule are already covered by the drift check; these tests pin the
+# parts they do not reach -- the pruning, the pin write-back, the re-pin
+# ordering, and the claim the driver exists to support: that it reproduces the
+# PR #441 artifacts from the committed catalogs.
 
 OFFLINE_PINS = [k for k, v in MANIFEST["shardmaps"].items() if v.get("catalog_parquet")]
 

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -211,9 +211,18 @@ def test_pinned_shardmap_no_drift(sm_key):
 OFFLINE_PINS = [k for k, v in MANIFEST["shardmaps"].items() if v.get("catalog_parquet")]
 
 
+# ``tools/`` is not an installed package, so it goes on the path ONCE here --
+# matching the ``bench_metrics`` pattern above -- rather than on every
+# ``_driver()`` call, which stacked one identical entry per test.
+sys.path.insert(0, str(REPO / "tools"))
+
+
 def _driver():
-    """The re-pin driver, imported from ``tools/`` (not an installed module)."""
-    sys.path.insert(0, str(REPO / "tools"))
+    """The re-pin driver, imported from ``tools/`` (not an installed module).
+
+    The import itself stays lazy: the driver imports THIS module for the
+    rebuild recipe, so importing it at module scope would be circular.
+    """
     import repin_benchmark_shardmaps
 
     return repin_benchmark_shardmaps

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -35,6 +35,7 @@ granules, so it is built on the fly at dispatch
 import json
 import os
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -278,6 +279,34 @@ def test_repin_updates_only_the_pin_literals_in_targets():
     assert entry["note"] == MANIFEST["shardmaps"]["healpix_o9"]["note"]
     changed = [(a, b) for a, b in zip(text.splitlines(), out.splitlines(), strict=True) if a != b]
     assert len(changed) == 2, changed
+
+
+def test_repin_prune_slices_the_aoi_mask_with_the_shard_keys():
+    """The prune is the one place the driver hand-rebuilds a ``ShardMap``.
+
+    ``aoi_mask`` is parallel to ``shard_keys`` (issue #101), so it has to be
+    sliced with them. Latent today -- no committed benchmark map carries one,
+    the strict-AOI arm building its mask at dispatch instead
+    (``run_benchmark._shardmap_with_mask``, issue #202) -- but a field dropped
+    here would be written out as a maskless map without a word.
+    """
+    from zagg.catalog.shardmap import ShardMap
+
+    driver = _driver()
+    rebuilt = ShardMap(
+        {"grid": "healpix"},
+        [10, 11],
+        [[{"granule": "a"}], [{"granule": "b"}]],
+        {"total_shards": 2},
+        aoi_mask=[[1, 2], [3, 4]],
+    )
+    pruned = driver.prune_to_pin(rebuilt, 11, "pruned to the pinned shard")
+
+    assert (pruned.shard_keys, pruned.granules) == ([11], [[{"granule": "b"}]])
+    assert pruned.aoi_mask == [[3, 4]]
+    # metadata stays the FULL build's, plus the carried note
+    assert pruned.metadata == {"total_shards": 2, "pruned": "pruned to the pinned shard"}
+    assert driver.prune_to_pin(replace(rebuilt, aoi_mask=None), 10, "note").aoi_mask is None
 
 
 def test_repin_targets_write_back_is_anchored_on_the_key():

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -259,8 +259,8 @@ def test_offline_pin_reproduces_committed_map(sm_key, tmp_path):
 
     written = tmp_path / "rebuilt.json"
     mapped.to_json(str(written))
-    assert _without_volatile(written.read_text(), driver.VOLATILE_META) == _without_volatile(
-        (BENCH / sm_meta["path"]).read_text(), driver.VOLATILE_META
+    assert _without_volatile(written.read_text(), driver.EXCUSED_META) == _without_volatile(
+        (BENCH / sm_meta["path"]).read_text(), driver.EXCUSED_META
     )
 
     from zagg.config import load_config
@@ -273,6 +273,13 @@ def test_offline_pin_reproduces_committed_map(sm_key, tmp_path):
     # showed, over the same catalog.
     grid = from_config(load_config(str(_config_for_shardmap(sm_key))))
     assert mapped.metadata["mortie_order"] == grid.parent_order
+    # ...and the OTHER side, which nothing else constrains. ``mortie_order`` is
+    # deterministic on both sides, so its exemption is a stale-fixture excuse
+    # with an expiry, not a standing licence: pinning the committed value makes
+    # this test fail at the next deliberate re-pin, when ``STALE_META`` must be
+    # emptied rather than left to mask a genuine regression.
+    assert json.loads((BENCH / sm_meta["path"]).read_text())["metadata"]["mortie_order"] == 13
+    assert driver.STALE_META == ("mortie_order",)
 
 
 def test_repin_updates_only_the_pin_literals_in_targets():

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -280,6 +280,38 @@ def test_repin_updates_only_the_pin_literals_in_targets():
     assert len(changed) == 2, changed
 
 
+def test_repin_targets_write_back_is_anchored_on_the_key():
+    """The entry is located by KEY, not by any occurrence of its name.
+
+    An entry name also appears as a ``"nested_in"`` VALUE (``healpix_o10_88s``
+    names ``healpix_o9_88s`` that way today). Today's manifest writes the parent
+    first, so an unanchored search happens to land right; it stops doing so the
+    moment a child precedes its parent, which the nested-pin design invites (an
+    o11 nested in an o10). Here the child comes first and carries an inner
+    object, so the unanchored form splices that object instead — silently, since
+    it too has the two literals to restate.
+    """
+    driver = _driver()
+    text = json.dumps(
+        {
+            "shardmaps": {
+                "child": {
+                    "nested_in": "parent",
+                    "provisional": {"shard_key": 1, "n_granules": 2},
+                    "shard_key": 3,
+                    "n_granules": 4,
+                },
+                "parent": {"shard_key": 5, "n_granules": 6},
+            }
+        },
+        indent=2,
+    )
+    maps = json.loads(driver.update_targets(text, "parent", 4242, 7))["shardmaps"]
+
+    assert maps["parent"] == {"shard_key": 4242, "n_granules": 7}
+    assert maps["child"] == json.loads(text)["shardmaps"]["child"]
+
+
 def test_repin_refuses_an_unknown_shardmap(capsys):
     driver = _driver()
     with pytest.raises(SystemExit):

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -229,12 +229,25 @@ def _driver():
 
 
 def _without_volatile(text: str, volatile) -> str:
-    """A written map's text minus the metadata lines a rebuild legitimately moves."""
-    return "".join(
-        line
-        for line in text.splitlines(keepends=True)
-        if not any(f'"{k}"' in line for k in volatile)
+    """A written map's text minus the metadata lines a rebuild legitimately moves.
+
+    Line-oriented on purpose: what issue #444 asks for is "byte-identically",
+    which a parsed comparison would soften to structural equality. The cost is
+    a silent dependency on ``ShardMap.to_json`` pretty-printing one metadata key
+    per line -- were it ever to emit compact JSON, the whole map would become a
+    single line carrying ``"build_wall_s"``, both sides would filter down to
+    ``""``, and the acceptance test would pass while comparing NOTHING.
+
+    So the filter checks its own work: exactly one line per excused key, no
+    more (a key string surfacing inside a granule record) and no less.
+    """
+    lines = text.splitlines(keepends=True)
+    kept = [line for line in lines if not any(f'"{k}"' in line for k in volatile)]
+    assert len(lines) - len(kept) == len(volatile), (
+        f"expected one line per excused metadata key, dropped {len(lines) - len(kept)} of "
+        f"{len(lines)} -- has ShardMap.to_json stopped pretty-printing?"
     )
+    return "".join(kept)
 
 
 @pytest.mark.slow

--- a/tests/test_benchmark_shardmap.py
+++ b/tests/test_benchmark_shardmap.py
@@ -210,6 +210,15 @@ def test_pinned_shardmap_no_drift(sm_key):
 
 OFFLINE_PINS = [k for k, v in MANIFEST["shardmaps"].items() if v.get("catalog_parquet")]
 
+#: The metadata keys the byte comparison below excuses, pinned HERE rather than
+#: imported from the driver. The driver's ``EXCUSED_META`` has a second job --
+#: labelling ``--check`` output -- so someone quieting a noisy check by
+#: appending a key to it would silently widen this acceptance test's blind spot,
+#: with nothing failing. That is precisely the relaxation issue #444's
+#: "byte-identically" exists to prevent, so widening it has to be a deliberate
+#: edit here too.
+EXCUSED_META = ("build_wall_s", "mortie_order")
+
 
 # ``tools/`` is not an installed package, so it goes on the path ONCE here --
 # matching the ``bench_metrics`` pattern above -- rather than on every
@@ -270,10 +279,15 @@ def test_offline_pin_reproduces_committed_map(sm_key, tmp_path):
     sm_meta = MANIFEST["shardmaps"][sm_key]
     assert (key, n) == (sm_meta["shard_key"], sm_meta["n_granules"])
 
+    # The driver may not widen this test's exemption on its own (see EXCUSED_META).
+    assert tuple(driver.EXCUSED_META) == EXCUSED_META, (
+        "the driver's excused-metadata set moved -- restate it here deliberately"
+    )
+
     written = tmp_path / "rebuilt.json"
     mapped.to_json(str(written))
-    assert _without_volatile(written.read_text(), driver.EXCUSED_META) == _without_volatile(
-        (BENCH / sm_meta["path"]).read_text(), driver.EXCUSED_META
+    assert _without_volatile(written.read_text(), EXCUSED_META) == _without_volatile(
+        (BENCH / sm_meta["path"]).read_text(), EXCUSED_META
     )
 
     from zagg.config import load_config

--- a/tests/test_raster_runner.py
+++ b/tests/test_raster_runner.py
@@ -966,6 +966,19 @@ class TestShippedTemplate:
         assert cfg.data_source["bands"]["scl"]["dtype"] == "uint8"
         assert cfg.output["grid"]["child_order"] == 19
 
+    def test_sentinel2_l2a_config_declares_the_overview_family_off(self):
+        # Issue #459: an ABSENT output.pyramid resolves to the every-2-orders
+        # default schedule (``get_pyramid`` -> ``{}``), so a raster run
+        # dispatches an overview family that generates nothing -- raster leaves
+        # are column-less by construction (issue #399 option (b), unimplemented).
+        # The shipped template declares the opt-out rather than inheriting the
+        # default, and ``None`` is the "family OFF" resolution.
+        from zagg.config import get_pyramid
+
+        cfg = default_config("sentinel2_l2a")
+        assert cfg.output["pyramid"] is False
+        assert get_pyramid(cfg) is None
+
 
 class TestRasterHiveLocalBackend:
     """Local raster hive runs (issue #247 phase 3): manifest, leaves, coverage."""

--- a/tools/repin_benchmark_shardmaps.py
+++ b/tools/repin_benchmark_shardmaps.py
@@ -48,9 +48,11 @@ Run from a zagg checkout::
     uv run python tools/repin_benchmark_shardmaps.py --check healpix_o9_88s
     uv run python tools/repin_benchmark_shardmaps.py healpix_o9_88s healpix_o10_88s
 
-The ``sm_rect_*`` entries declare the ``spherely`` backend, the non-PyPI
-exact-S2 fork (README): without it installed ``ShardMap.build`` raises rather
-than quietly rebuilding them on the mortie backend.
+Every ``targets.json`` shard map is HEALPix today, so every re-pin runs on the
+mortie backend. If a rectilinear map is ever added to the manifest, re-pinning
+it will need the non-PyPI exact-S2 ``spherely`` fork installed (README): the
+rebuild takes the committed map's own ``metadata.backend``, so ``ShardMap.build``
+raises rather than quietly falling back to mortie.
 """
 
 from __future__ import annotations

--- a/tools/repin_benchmark_shardmaps.py
+++ b/tools/repin_benchmark_shardmaps.py
@@ -1,0 +1,237 @@
+"""DELIBERATELY re-pin the benchmark shard-map fixtures (issue #444).
+
+The pins under ``tests/data/benchmark/`` — the committed
+``shardmaps/sm_*.json`` maps plus their ``targets.json`` ``shard_key`` /
+``n_granules`` entries — move only on purpose. A run of this script IS that
+purpose: a convention or grammar change made the old words wrong (the authalic
+latitude flip, issue #438 / PR #441, is the case it was written from) and the
+pins are being restated against it. Nothing here detects drift. The accident
+detector is and stays ``tests/test_benchmark_shardmap.py::
+test_pinned_shardmap_no_drift``, which rebuilds the same maps and fails loudly
+when a pin moves on its own; this script is that guard's deliberate
+counterpart, and it IMPORTS the guard's recipe helpers (manifest
+AOI/temporal/CMR resolution, the config lookup, the ``nested_in`` containment
+rule) so the two cannot drift apart.
+
+One run, per shard-map entry named on the command line:
+
+1. rebuilds the map through the guard's recipe — the entry's config for the
+   grid, its resolved AOI/temporal/CMR (per-entry override over the top-level
+   manifest default), the committed map's ``metadata.backend``, and either the
+   committed ``catalog_parquet`` snapshot when the entry carries one (offline)
+   or a live CMR fetch when it does not;
+2. selects the pin with ``bench_metrics.select_densest_shard`` — for a
+   ``nested_in`` entry over the finer shards inside the pinned parent shard
+   only, never the global densest;
+3. prunes the written map to the pinned shard when the committed map is pruned
+   (``metadata.pruned`` — the 88S ring maps, whose full form is hundreds of MB
+   of JSON), carrying that note over verbatim: it is editorial prose, not a
+   derived quantity;
+4. writes the map and updates the entry's ``shard_key`` / ``n_granules`` in
+   ``targets.json``, leaving every other byte of that hand-formatted file
+   alone. The entry's ``note`` is prose and is NOT rewritten — restate it in
+   the same commit.
+
+``--check`` stops after (3) and reports how the rebuild differs from the
+committed bytes instead of writing anything.
+``tests/test_benchmark_shardmap.py::test_offline_pin_reproduces_committed_map``
+is that path as an acceptance test over the two offline entries. The NEON trio
+cannot be checked offline: an ATL03 footprint quad blankets the whole NEON box,
+so a local full-catalog snapshot over-includes and inflates the pins
+(``tests/data/benchmark/README.md``, "Reproducing / re-pinning the NEON maps")
+— they need the live fetch, which is why only the ring entries carry
+``catalog_parquet``.
+
+Run from a zagg checkout::
+
+    uv run python tools/repin_benchmark_shardmaps.py --check healpix_o9_88s
+    uv run python tools/repin_benchmark_shardmaps.py healpix_o9_88s healpix_o10_88s
+
+The ``sm_rect_*`` entries declare the ``spherely`` backend, the non-PyPI
+exact-S2 fork (README): without it installed ``ShardMap.build`` raises rather
+than quietly rebuilding them on the mortie backend.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BENCH = REPO / "tests" / "data" / "benchmark"
+TARGETS = BENCH / "targets.json"
+# The drift guard owns the rebuild recipe; importing it (rather than restating
+# it) is what keeps this driver on the guard's rails. ``bench_metrics``, beside
+# it under ``.github/scripts``, owns the densest-shard pin rule.
+sys.path.insert(0, str(REPO / "tests"))
+sys.path.insert(0, str(REPO / ".github" / "scripts"))
+
+import bench_metrics  # noqa: E402
+import test_benchmark_shardmap as drift  # noqa: E402
+
+from zagg.catalog import load_polygon, polygon_to_bbox  # noqa: E402
+from zagg.catalog.shardmap import ShardMap  # noqa: E402
+from zagg.catalog.sources import Catalog, CMRSource, Query  # noqa: E402
+from zagg.config import load_config  # noqa: E402
+from zagg.grids import from_config  # noqa: E402
+
+#: Metadata keys a faithful rebuild may still move, reported by ``--check`` as
+#: such rather than as a changed pin: the build's own wall clock, and the MOC
+#: cover order, whose unpinned default became the shard order in PR #447 (the
+#: committed maps predate it; the assignment it produces is unchanged).
+VOLATILE_META = ("build_wall_s", "mortie_order")
+
+
+def entry(sm_key: str) -> dict:
+    """One shard-map entry, read from ``targets.json`` as it stands NOW.
+
+    Deliberately not ``drift.MANIFEST`` (loaded once at import): re-pinning a
+    parent and its ``nested_in`` child in one run has to extract the child
+    against the parent's freshly written pin, not the one this process started
+    with. The top-level ``aoi``/``temporal``/``cmr`` defaults the guard
+    resolves against are never rewritten here, so those stay the guard's.
+    """
+    return json.loads(TARGETS.read_text())["shardmaps"][sm_key]
+
+
+def committed(sm_key: str) -> dict:
+    """The committed shard map an entry points at, as JSON."""
+    return json.loads((BENCH / entry(sm_key)["path"]).read_text())
+
+
+def rebuild(sm_key: str) -> ShardMap:
+    """The full rebuilt map for one ``targets.json`` shard-map entry."""
+    sm_meta = entry(sm_key)
+    backend = committed(sm_key)["metadata"]["backend"]
+    grid = from_config(load_config(str(drift._config_for_shardmap(sm_key))))
+    aoi, temporal, cmr = drift.resolve_aoi_temporal_cmr(sm_meta)
+    parts = load_polygon(str(BENCH / aoi["file"]))
+    if sm_meta.get("catalog_parquet"):
+        catalog = Catalog.from_geoparquet(str(BENCH / sm_meta["catalog_parquet"]))
+    else:
+        catalog = CMRSource().fetch(
+            Query(
+                cmr["short_name"],
+                cmr["version"],
+                temporal["start"],
+                temporal["end"],
+                region=polygon_to_bbox(parts),
+                provider=cmr["provider"],
+            )
+        )
+    return ShardMap.build(catalog, grid, region=parts, backend=backend, footprint=cmr["footprint"])
+
+
+def repin(sm_key: str) -> tuple[ShardMap, int, int]:
+    """``(map to write, shard_key, n_granules)`` for one entry.
+
+    The written map is the rebuild pruned to the pinned shard when the
+    committed map is pruned, and the whole rebuild otherwise. Either way
+    ``metadata`` is the FULL build's (``total_shards`` / ``total_pairs`` count
+    the ring, not the surviving shard), matching the committed maps.
+    """
+    sm_meta = entry(sm_key)
+    rebuilt = rebuild(sm_key)
+    shard_keys, granules = rebuilt.shard_keys, rebuilt.granules
+    nested_in = sm_meta.get("nested_in")
+    if nested_in:
+        # The nested pin (issue #148) is the densest finer shard INSIDE the
+        # pinned parent, so one parent extraction pass covers both orders.
+        parent_key = int(entry(nested_in)["shard_key"])
+        parent_grid = from_config(load_config(str(drift._config_for_shardmap(nested_in))))
+        keep = [
+            i
+            for i, k in enumerate(shard_keys)
+            if drift._containing_shard(parent_grid, int(k)) == parent_key
+        ]
+        shard_keys = [shard_keys[i] for i in keep]
+        granules = [granules[i] for i in keep]
+    key, n = bench_metrics.select_densest_shard({"shard_keys": shard_keys, "granules": granules})
+    note = committed(sm_key)["metadata"].get("pruned")
+    if note is None:
+        return rebuilt, key, n
+    i = [j for j, k in enumerate(shard_keys) if int(k) == key][0]
+    pruned = ShardMap(
+        rebuilt.grid_signature,
+        [shard_keys[i]],
+        [granules[i]],
+        {**rebuilt.metadata, "pruned": note},
+    )
+    return pruned, key, n
+
+
+def differences(sm_key: str, mapped: ShardMap) -> list[str]:
+    """How a rebuilt map differs from the committed one, key by key."""
+    old_map = committed(sm_key)
+    out = []
+    for key in ("grid_signature", "shard_keys", "granules"):
+        if getattr(mapped, key) != old_map[key]:
+            out.append(f"{key} differs")
+    old, new = old_map["metadata"], mapped.metadata
+    for key in sorted(set(old) | set(new)):
+        if old.get(key) != new.get(key):
+            volatile = " (volatile)" if key in VOLATILE_META else ""
+            out.append(f"metadata.{key}: {old.get(key)!r} -> {new.get(key)!r}{volatile}")
+    return out
+
+
+def update_targets(text: str, sm_key: str, key: int, n: int) -> str:
+    """Restate one shard-map entry's pin literals in ``targets.json`` text.
+
+    Surgical rather than a load/dump round trip: the manifest is hand-formatted
+    (compact inline ``worker`` objects), so re-serializing would churn lines
+    this re-pin does not touch. The entry's prose ``note`` is left alone.
+    """
+    decoder = json.JSONDecoder()
+    maps_at = text.index("{", text.index('"shardmaps"'))
+    _, maps_end = decoder.raw_decode(text, maps_at)
+    entry_at = text.index("{", text.index(f'"{sm_key}"', maps_at, maps_end))
+    _, entry_end = decoder.raw_decode(text, entry_at)
+    entry = text[entry_at:entry_end]
+    for field, value in (("shard_key", key), ("n_granules", n)):
+        entry, hits = re.subn(rf'("{field}":\s*)\d+', rf"\g<1>{value}", entry, count=1)
+        if hits != 1:
+            raise ValueError(f"targets.json entry {sm_key!r} has no {field} literal to restate")
+    return text[:entry_at] + entry + text[entry_end:]
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "shardmaps",
+        nargs="+",
+        help="shard-map entry names from targets.json (e.g. healpix_o9_88s). "
+        "Re-pin only what you mean to commit — each map is a deliberate move.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="rebuild and report differences against the committed bytes; write nothing.",
+    )
+    args = parser.parse_args(argv)
+    known = json.loads(TARGETS.read_text())["shardmaps"]
+    unknown = sorted(set(args.shardmaps) - set(known))
+    if unknown:
+        parser.error(f"unknown shard map(s) {unknown} (known: {sorted(known)})")
+    # A nested entry extracts against its parent's pin, so re-pin parents first
+    # even when the command line names them the other way round.
+    for sm_key in sorted(args.shardmaps, key=lambda k: bool(known[k].get("nested_in"))):
+        mapped, key, n = repin(sm_key)
+        print(f"{sm_key}: pin {key} at {n} granules")
+        for line in differences(sm_key, mapped) or ["identical to the committed map"]:
+            print(f"  {line}")
+        if args.check:
+            continue
+        path = entry(sm_key)["path"]
+        mapped.to_json(str(BENCH / path))
+        TARGETS.write_text(update_targets(TARGETS.read_text(), sm_key, key, n))
+        print(f"  wrote {path} + its targets.json pin")
+        print("  restate the entry's note by hand — this driver does not write prose")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repin_benchmark_shardmaps.py
+++ b/tools/repin_benchmark_shardmaps.py
@@ -204,6 +204,24 @@ def update_targets(text: str, sm_key: str, key: int, n: int) -> str:
     return text[:entry_at] + entry + text[entry_end:]
 
 
+def nesting_depth(known: dict, sm_key: str) -> int:
+    """How many ``nested_in`` hops separate an entry from an unnested ancestor.
+
+    Re-pin order keys on this depth rather than on a parent/child boolean: a
+    grandchild (an o11 nested in an o10 nested in an o9 — the nested-pin design
+    of issue #148 does not forbid it) sorts EQUAL to its own parent under a
+    boolean, leaving whatever order the command line happened to give, which
+    can be the wrong one.
+    """
+    seen: list[str] = []
+    while known[sm_key].get("nested_in"):
+        seen.append(sm_key)
+        sm_key = known[sm_key]["nested_in"]
+        if sm_key in seen:
+            raise ValueError(f"targets.json nested_in cycle at {sm_key!r}")
+    return len(seen)
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -222,9 +240,11 @@ def main(argv=None) -> int:
     unknown = sorted(set(args.shardmaps) - set(known))
     if unknown:
         parser.error(f"unknown shard map(s) {unknown} (known: {sorted(known)})")
-    # A nested entry extracts against its parent's pin, so re-pin parents first
-    # even when the command line names them the other way round.
-    for sm_key in sorted(args.shardmaps, key=lambda k: bool(known[k].get("nested_in"))):
+    # A nested entry extracts against its parent's pin as it stands on disk, so
+    # re-pin shallowest-first even when the command line names them the other
+    # way round -- a child re-pinned before its parent would extract against
+    # the STALE parent shard and commit a wrong fixture.
+    for sm_key in sorted(args.shardmaps, key=lambda k: nesting_depth(known, k)):
         mapped, key, n = repin(sm_key)
         print(f"{sm_key}: pin {key} at {n} granules")
         for line in differences(sm_key, mapped) or ["identical to the committed map"]:

--- a/tools/repin_benchmark_shardmaps.py
+++ b/tools/repin_benchmark_shardmaps.py
@@ -106,6 +106,12 @@ def prune_to_pin(rebuilt: ShardMap, key: int, note: str) -> ShardMap:
     ``total_pairs`` count the ring, not the surviving shard), matching the
     committed maps, and ``note`` is carried over verbatim: it is editorial
     prose, not a derived quantity.
+
+    ``aoi_mask`` is sliced with ``shard_keys`` rather than dropped: it is
+    documented as parallel to them (``ShardMap``), so positional construction
+    would silently write a maskless map, and slicing it wrong would be worse
+    still. No committed benchmark map carries one today (the strict-AOI arm
+    builds its mask at dispatch), so this is the latent case, not a live one.
     """
     i = [j for j, k in enumerate(rebuilt.shard_keys) if int(k) == key][0]
     return ShardMap(
@@ -113,6 +119,7 @@ def prune_to_pin(rebuilt: ShardMap, key: int, note: str) -> ShardMap:
         [rebuilt.shard_keys[i]],
         [rebuilt.granules[i]],
         {**rebuilt.metadata, "pruned": note},
+        aoi_mask=None if rebuilt.aoi_mask is None else [rebuilt.aoi_mask[i]],
     )
 
 

--- a/tools/repin_benchmark_shardmaps.py
+++ b/tools/repin_benchmark_shardmaps.py
@@ -159,11 +159,17 @@ def update_targets(text: str, sm_key: str, key: int, n: int) -> str:
     Surgical rather than a load/dump round trip: the manifest is hand-formatted
     (compact inline ``worker`` objects), so re-serializing would churn lines
     this re-pin does not touch. The entry's prose ``note`` is left alone.
+
+    The entry is located on ``"<key>":`` WITH the colon, which only a JSON key
+    can be followed by: a bare ``"<key>"`` also matches a ``"nested_in"``
+    *value* (``healpix_o10_88s`` names ``healpix_o9_88s`` that way), so the
+    unanchored form would rewrite the wrong entry whenever a child happened to
+    be written before its parent.
     """
     decoder = json.JSONDecoder()
     maps_at = text.index("{", text.index('"shardmaps"'))
     _, maps_end = decoder.raw_decode(text, maps_at)
-    entry_at = text.index("{", text.index(f'"{sm_key}"', maps_at, maps_end))
+    entry_at = text.index("{", text.index(f'"{sm_key}":', maps_at, maps_end))
     _, entry_end = decoder.raw_decode(text, entry_at)
     entry = text[entry_at:entry_end]
     for field, value in (("shard_key", key), ("n_granules", n)):

--- a/tools/repin_benchmark_shardmaps.py
+++ b/tools/repin_benchmark_shardmaps.py
@@ -74,11 +74,27 @@ import test_benchmark_shardmap as drift  # noqa: E402
 
 from zagg.catalog.shardmap import ShardMap  # noqa: E402
 
-#: Metadata keys a faithful rebuild may still move, reported by ``--check`` as
-#: such rather than as a changed pin: the build's own wall clock, and the MOC
-#: cover order, whose unpinned default became the shard order in PR #447 (the
-#: committed maps predate it; the assignment it produces is unchanged).
-VOLATILE_META = ("build_wall_s", "mortie_order")
+#: Genuinely volatile: the build's own wall clock, different every run.
+#: Legitimately excused from the comparison forever.
+VOLATILE_META = ("build_wall_s",)
+
+#: NOT volatile — deterministic on both sides, and simply STALE in the
+#: committed bytes: PR #447 made the unpinned HEALPix cover order the SHARD
+#: order, where the committed maps recorded the chunk order they were built at
+#: (13 -> the grid's 9/10). The assignment it produces is unchanged.
+#:
+#: This exemption is meant to EXPIRE. The next deliberate re-pin — a run of
+#: this script — writes the current value and makes both sides agree, at which
+#: point the exemption stops excusing a known delta and starts masking a real
+#: regression. ``test_offline_pin_reproduces_committed_map`` pins the stale
+#: committed value so it fails loudly then and this tuple gets emptied.
+STALE_META = ("mortie_order",)
+
+#: How ``--check`` labels a metadata key that moved without the pin moving.
+EXCUSED_META = {
+    **{k: " (volatile)" for k in VOLATILE_META},
+    **{k: " (stale committed value, drop at the next re-pin)" for k in STALE_META},
+}
 
 
 def entry(sm_key: str) -> dict:
@@ -157,8 +173,8 @@ def differences(sm_key: str, mapped: ShardMap) -> list[str]:
     old, new = old_map["metadata"], mapped.metadata
     for key in sorted(set(old) | set(new)):
         if old.get(key) != new.get(key):
-            volatile = " (volatile)" if key in VOLATILE_META else ""
-            out.append(f"metadata.{key}: {old.get(key)!r} -> {new.get(key)!r}{volatile}")
+            why = EXCUSED_META.get(key, "")
+            out.append(f"metadata.{key}: {old.get(key)!r} -> {new.get(key)!r}{why}")
     return out
 
 

--- a/tools/repin_benchmark_shardmaps.py
+++ b/tools/repin_benchmark_shardmaps.py
@@ -9,20 +9,21 @@ pins are being restated against it. Nothing here detects drift. The accident
 detector is and stays ``tests/test_benchmark_shardmap.py::
 test_pinned_shardmap_no_drift``, which rebuilds the same maps and fails loudly
 when a pin moves on its own; this script is that guard's deliberate
-counterpart, and it IMPORTS the guard's recipe helpers (manifest
-AOI/temporal/CMR resolution, the config lookup, the ``nested_in`` containment
-rule) so the two cannot drift apart.
+counterpart, and it CALLS the guard's own rebuild and pin functions —
+``drift.rebuild_shardmap`` and ``drift.select_pin`` — rather than restating
+them, so the two cannot build or pin differently. A second copy of the recipe
+is precisely what let the uncommitted scratch driver drift off the guard.
 
 One run, per shard-map entry named on the command line:
 
-1. rebuilds the map through the guard's recipe — the entry's config for the
-   grid, its resolved AOI/temporal/CMR (per-entry override over the top-level
-   manifest default), the committed map's ``metadata.backend``, and either the
-   committed ``catalog_parquet`` snapshot when the entry carries one (offline)
-   or a live CMR fetch when it does not;
-2. selects the pin with ``bench_metrics.select_densest_shard`` — for a
-   ``nested_in`` entry over the finer shards inside the pinned parent shard
-   only, never the global densest;
+1. rebuilds the map with ``drift.rebuild_shardmap`` — the entry's config for
+   the grid, its resolved AOI/temporal/CMR (per-entry override over the
+   top-level manifest default), the committed map's ``metadata.backend``, and
+   either the committed ``catalog_parquet`` snapshot when the entry carries one
+   (offline) or a live CMR fetch when it does not;
+2. selects the pin with ``drift.select_pin`` — for a ``nested_in`` entry over
+   the finer shards inside the pinned parent shard only, never the global
+   densest, and against the parent's pin as it stands on disk NOW;
 3. prunes the written map to the pinned shard when the committed map is pruned
    (``metadata.pruned`` — the 88S ring maps, whose full form is hundreds of MB
    of JSON), carrying that note over verbatim: it is editorial prose, not a
@@ -63,20 +64,13 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 BENCH = REPO / "tests" / "data" / "benchmark"
 TARGETS = BENCH / "targets.json"
-# The drift guard owns the rebuild recipe; importing it (rather than restating
-# it) is what keeps this driver on the guard's rails. ``bench_metrics``, beside
-# it under ``.github/scripts``, owns the densest-shard pin rule.
+# The drift guard owns the rebuild recipe and the pin rule; CALLING them
+# (rather than restating them) is what keeps this driver on the guard's rails.
 sys.path.insert(0, str(REPO / "tests"))
-sys.path.insert(0, str(REPO / ".github" / "scripts"))
 
-import bench_metrics  # noqa: E402
 import test_benchmark_shardmap as drift  # noqa: E402
 
-from zagg.catalog import load_polygon, polygon_to_bbox  # noqa: E402
 from zagg.catalog.shardmap import ShardMap  # noqa: E402
-from zagg.catalog.sources import Catalog, CMRSource, Query  # noqa: E402
-from zagg.config import load_config  # noqa: E402
-from zagg.grids import from_config  # noqa: E402
 
 #: Metadata keys a faithful rebuild may still move, reported by ``--check`` as
 #: such rather than as a changed pin: the build's own wall clock, and the MOC
@@ -102,65 +96,46 @@ def committed(sm_key: str) -> dict:
     return json.loads((BENCH / entry(sm_key)["path"]).read_text())
 
 
-def rebuild(sm_key: str) -> ShardMap:
-    """The full rebuilt map for one ``targets.json`` shard-map entry."""
-    sm_meta = entry(sm_key)
-    backend = committed(sm_key)["metadata"]["backend"]
-    grid = from_config(load_config(str(drift._config_for_shardmap(sm_key))))
-    aoi, temporal, cmr = drift.resolve_aoi_temporal_cmr(sm_meta)
-    parts = load_polygon(str(BENCH / aoi["file"]))
-    if sm_meta.get("catalog_parquet"):
-        catalog = Catalog.from_geoparquet(str(BENCH / sm_meta["catalog_parquet"]))
-    else:
-        catalog = CMRSource().fetch(
-            Query(
-                cmr["short_name"],
-                cmr["version"],
-                temporal["start"],
-                temporal["end"],
-                region=polygon_to_bbox(parts),
-                provider=cmr["provider"],
-            )
-        )
-    return ShardMap.build(catalog, grid, region=parts, backend=backend, footprint=cmr["footprint"])
+def prune_to_pin(rebuilt: ShardMap, key: int, note: str) -> ShardMap:
+    """The rebuild reduced to its pinned shard, carrying ``metadata.pruned``.
+
+    The 88S ring maps are committed pruned — their full form is hundreds of MB
+    of JSON. ``metadata`` stays the FULL build's (``total_shards`` /
+    ``total_pairs`` count the ring, not the surviving shard), matching the
+    committed maps, and ``note`` is carried over verbatim: it is editorial
+    prose, not a derived quantity.
+    """
+    i = [j for j, k in enumerate(rebuilt.shard_keys) if int(k) == key][0]
+    return ShardMap(
+        rebuilt.grid_signature,
+        [rebuilt.shard_keys[i]],
+        [rebuilt.granules[i]],
+        {**rebuilt.metadata, "pruned": note},
+    )
 
 
 def repin(sm_key: str) -> tuple[ShardMap, int, int]:
     """``(map to write, shard_key, n_granules)`` for one entry.
 
+    The rebuild and the pin rule are the guard's — ``drift.rebuild_shardmap``
+    and ``drift.select_pin`` — called, not restated, so this driver cannot
+    build or pin differently from the accident detector. Only the parent-pin
+    source differs: a ``nested_in`` child extracts against the parent's pin as
+    it stands on disk NOW, which is the parent's FRESH pin when both are
+    re-pinned in one run.
+
     The written map is the rebuild pruned to the pinned shard when the
-    committed map is pruned, and the whole rebuild otherwise. Either way
-    ``metadata`` is the FULL build's (``total_shards`` / ``total_pairs`` count
-    the ring, not the surviving shard), matching the committed maps.
+    committed map is pruned, and the whole rebuild otherwise.
     """
     sm_meta = entry(sm_key)
-    rebuilt = rebuild(sm_key)
-    shard_keys, granules = rebuilt.shard_keys, rebuilt.granules
+    rebuilt = drift.rebuild_shardmap(sm_key, sm_meta)
     nested_in = sm_meta.get("nested_in")
-    if nested_in:
-        # The nested pin (issue #148) is the densest finer shard INSIDE the
-        # pinned parent, so one parent extraction pass covers both orders.
-        parent_key = int(entry(nested_in)["shard_key"])
-        parent_grid = from_config(load_config(str(drift._config_for_shardmap(nested_in))))
-        keep = [
-            i
-            for i, k in enumerate(shard_keys)
-            if drift._containing_shard(parent_grid, int(k)) == parent_key
-        ]
-        shard_keys = [shard_keys[i] for i in keep]
-        granules = [granules[i] for i in keep]
-    key, n = bench_metrics.select_densest_shard({"shard_keys": shard_keys, "granules": granules})
+    parent_key = int(entry(nested_in)["shard_key"]) if nested_in else None
+    key, n = drift.select_pin(rebuilt, sm_meta, parent_key)
     note = committed(sm_key)["metadata"].get("pruned")
     if note is None:
         return rebuilt, key, n
-    i = [j for j, k in enumerate(shard_keys) if int(k) == key][0]
-    pruned = ShardMap(
-        rebuilt.grid_signature,
-        [shard_keys[i]],
-        [granules[i]],
-        {**rebuilt.metadata, "pruned": note},
-    )
-    return pruned, key, n
+    return prune_to_pin(rebuilt, key, note), key, n
 
 
 def differences(sm_key: str, mapped: ShardMap) -> list[str]:


### PR DESCRIPTION
Closes #459. Closes #444.

The **fourth** small-fixes bundle of 2026-08-17 — `claude/small-fixes-2026-08-17` and the `-2` / `-3` suffixes are taken by open PRs today, hence `-4`. Two independent one-issue commits with no shared files: #459 touches the shipped S2 config and its runner test; #444 adds a `tools/` script and touches the benchmark drift-test module plus the benchmark README.

## Phases

- [x] **#459** — declare `pyramid: false` on the shipped `sentinel2_l2a.yaml`, with a test pinning the resolution (`2893d6a`)
- [x] **#444** — commit the deliberate re-pin driver for the benchmark shardmap fixtures, with the offline reproduction of the PR #441 artifacts as its acceptance test (`89f20f4`)
- [x] **adversarial self-review folded** — 10 inline findings, all folded (`d8518c2`, `32f2b99`, `844348c`, `0aa3358`, `ba246df`, `84678a4`, `4a96fd5`, `1c49621`, `967f9ae`, `db14b48`, `0b4f9e2`)

## #459 — the shipped S2 config declares the overview family OFF

An absent `output.pyramid` is not "no pyramid": `config.get_pyramid` maps absent → `{}` (the every-2-orders default schedule) and only an explicit `false` → `None` (family off). The shipped `src/zagg/configs/sentinel2_l2a.yaml` carried no key, so every raster run built a manifest declaring five overview levels with **zero** fields to fold. Measured on this branch with `sweep_overview.build_pyramid_block(cfg, shard_order=11, chunk_order=11)`:

```
before: {"spec": "zagg-pyramid/1", "overview": {"spacing": 2, "orders": [9, 7, 5, 3, 1],
         "all_time": false, "fold_source": "cascade", "exact_levels": 1, "fields": {}}}
after : {"spec": "zagg-pyramid/1", "overview": {"orders": []}}
```

`fields: {}` is the tell — a raster config declares no aggregation fields, so there is nothing composable, and the sweep's overview family bails at run time with *"no composable fields declared; nothing to generate"* (`src/zagg/sweep_overview.py`). Raster leaves are column-less by construction: issue #399 ruled option (b) (a raster column writer) and it is unimplemented; PR #416 phase 5 records raster as column-less with a clean seam for it. So the declaration promised readers a five-level ladder that cannot exist, which is the harm.

**What this does NOT do is suppress a dispatch.** The self-review caught an overstatement in the original comment here and it is corrected: the sweep dispatcher's gate is `store_layout == "hive" and get_sweep(config)`, and nothing in that expression reads `output.pyramid`. This config resolves to `store_layout: hive` and `get_sweep → True` both before and after the change, verified by running it. Setting `pyramid: false` suppresses **zero** dispatches; it changes the manifest declaration, and that is the whole — and sufficient — win.

The fix is the bench config's opt-out, restated on the shipped template in the one-line form all seven sibling opt-outs use (`atl03_tdigest_healpix_hive.yaml:83`, `atl03_tdigest_strata_healpix.yaml:157`, `gedi01b_waveform_healpix_hive.yaml:206`, `s2_neon_o9.yaml:32`, and the three benchmark configs):

```yaml
  pyramid: false                 # overview family off: raster leaves are column-less (issue #399, issue #459)
```

**Product identity does not move.** `output.pyramid` is not in `semantic_core`, so the shipped config's D19 hash is `65a66c75262e90b5a6b34a8a194873b508bac61c54ee66b2ab6730da3b1626c9` before and after — the same hash PR #455 quotes for the shipped config.

**Test** (`tests/test_raster_runner.py::TestShippedTemplate`, written failing-first — it fails `KeyError: 'pyramid'` with the YAML change reverted):

```python
def test_sentinel2_l2a_config_declares_the_overview_family_off(self):
    cfg = default_config("sentinel2_l2a")
    assert cfg.output["pyramid"] is False
    assert get_pyramid(cfg) is None
```

It asserts the *resolution* (`None`), not just the literal, so the knob's absent-vs-false asymmetry is what the test is about.

### Merge-order note for PR #455 — not a dependency, no `blocked` label

Issue #459 item (2) asks to adjust PR #455's parity assertion `assert "pyramid" not in shipped.output`. **That assertion does not exist on `main`**: PR #455 is open and unmerged, and on the merge-base (`d35e576`) `git grep 'shipped.output'` returns nothing while `git grep 'pyramid.*not in'` finds only manifest assertions in `tests/test_sweep_overview.py`. The test PR #455 adds it to, `test_s2_neon_o9_tracks_the_shipped_sentinel2_config` in `tests/test_raster_benchmark.py`, is likewise absent there. So this PR implements against main's actual state and brings its own test instead.

Whichever of the two lands **second** must reconcile that test to the new end state: with both configs declaring `pyramid: false`, the one-sided pair

```python
assert bench.output["pyramid"] is False
assert "pyramid" not in shipped.output
```

should become the strictly stronger form — drop `pyramid` from that test's divergence-budget exemption and let the effective-config dict comparison (`b == s`) cover it, leaving `parent_order` as the whole budget, which is what its comment claims. No `blocked` label and no `Blocked by`: neither PR needs the other's code, and this one lands independently.

## #444 — a committed, deliberate re-pin driver

`tools/repin_benchmark_shardmaps.py`, per the PR #441 Q5 ruling. Its docstring leads with what it is: the pins move **only on purpose**, a run of the script *is* that purpose, and nothing in it detects drift — `test_pinned_shardmap_no_drift` stays the accident detector.

It is the guard's deliberate counterpart, so **the rebuild recipe and the pin rule now live in the guard module and are called from both sides**:

- `rebuild_shardmap(sm_key, sm_meta)` — the entry's config → grid, its resolved AOI/temporal/CMR, the committed map's `metadata.backend`, and the `catalog_parquet`-vs-live-CMR branch, plus the `ShardMap.build(...)` call.
- `select_pin(rebuilt, sm_meta, parent_key=None)` — the `nested_in` extraction.

The self-review's first finding was that the original commit claimed this ("so the two cannot drift apart") while actually restating the recipe in the driver — importing only three small helpers. That is now fixed rather than reworded: `test_pinned_shardmap_no_drift` is `select_pin(rebuild_shardmap(sm_key, sm_meta), sm_meta)` plus its tie-tolerant assert, and `repin()` is those same two calls plus the pruning. Adding an argument to `ShardMap.build` now moves both sides at once, which is the property the claim was about.

One run, per named entry: rebuild through `drift.rebuild_shardmap` → select the pin with `drift.select_pin` → prune to the pinned shard when the committed map is pruned, carrying `metadata.pruned` over verbatim (editorial prose, not a derived quantity) → write the map and restate `shard_key` / `n_granules` in `targets.json`.

Three details worth reading:

- **The `targets.json` write-back is surgical.** The manifest is hand-formatted (its `worker` objects are compact inline), so a `json.load`/`dumps` round trip would churn four unrelated blocks. `update_targets` slices the entry with `json.JSONDecoder().raw_decode` and rewrites only the two numeric literals. It locates the entry by searching for the quoted entry name **followed by a colon** — the bare quoted name also matches a `nested_in` *value*, so the unanchored form rewrites the wrong entry as soon as a child precedes its parent in the file.
- **Parents before children.** A `nested_in` entry extracts against its parent's pin, so entries are re-pinned in **`nested_in`-depth order** regardless of command-line order, and every read of the pin goes back to `targets.json` on disk — a one-run `healpix_o9_88s healpix_o10_88s` re-pin nests the child in the parent's *new* shard, which is what PR #441 did by hand. Depth rather than a parent/child boolean, so a grandchild sorts strictly after its parent instead of tying with it; the walk raises on a `nested_in` cycle.
- **Prose is not written.** The entry `note` fields carry the reasoning of each pin; the driver prints a reminder to restate them in the same commit rather than generating them.

### Acceptance test: the offline pins reproduce PR #441 byte-for-byte

`tests/test_benchmark_shardmap.py::test_offline_pin_reproduces_committed_map`, over the two entries carrying `catalog_parquet` (`healpix_o9_88s`, `healpix_o10_88s` — the nested one). It runs `driver.repin(...)`, writes the map through the real `ShardMap.to_json`, and compares the written text to the committed file **line for line**, so every granule record, `shard_keys`, `grid_signature` and derived metadata is in scope. The pin itself is asserted against `targets.json`. Both pass.

The comparison stays line-oriented on purpose — issue #444's word is "byte-identically", which a parsed comparison would soften to structural equality — but the filter now asserts it dropped exactly one line per excused key, so it cannot degenerate to a vacuous empty-vs-empty pass if `ShardMap.to_json` ever stops pretty-printing. The excused set is also **pinned in the test module** rather than imported from the driver, so widening the driver's own exemption cannot silently widen this test's blind spot.

The NEON trio cannot be covered offline and this is by design, not an omission: an ATL03 footprint quad blankets the whole NEON box, so a local full-catalog snapshot over-includes and inflates the pins (README, *"Reproducing / re-pinning the NEON maps"*) — which is exactly why only the ring entries carry `catalog_parquet`.

**Two metadata keys are excluded from the byte comparison, and they are different animals.** The self-review's fourth finding was that calling both "volatile" flattens that, so they are now split:

- `VOLATILE_META = ("build_wall_s",)` — the build's own wall clock, genuinely different every run, excused forever.
- `STALE_META = ("mortie_order",)` — **not** volatile. Deterministic on both sides; it moved once because **PR #447** made the unpinned HEALPix `swath` cover order the *shard* order, where the committed maps recorded the chunk order they were built at. The committed bytes are simply stale relative to it.

```
$ uv run python tools/repin_benchmark_shardmaps.py --check healpix_o9_88s
healpix_o9_88s: pin 11530143033882312713 at 5536 granules
  metadata.build_wall_s: 65.918 -> 12.875 (volatile)
  metadata.mortie_order: 13 -> 9 (stale committed value, drop at the next re-pin)
```

That second exemption is meant to **expire**, so the acceptance test now pins the committed value (`== 13`) as well as the derivational one (`== grid.parent_order`). The next deliberate re-pin makes both sides agree, this assertion fails loudly, and `STALE_META` has to be emptied in the same commit rather than left to mask a genuine future regression. Nothing constrained the committed side before.

Nothing else moves — same pin, same 5,536 granules, same 564 shards / 2,065,142 pairs, byte-identical granule records. That is PR #447's "measurably identical at production order pairs" claim, now standing on the two heaviest committed fixtures.

Also in this phase: the drift module's network gate moved from module-level `pytestmark` onto the drift test itself (it was module-level while that was the only test in the file), so the offline driver tests run in the ordinary suite; and `tests/data/benchmark/README.md` gained a short pointer to the driver beside the manual CLI route it documents.

## How tested

- Full suite on this branch, `uv run pytest -q -p no:randomly`: **4171 passed, 38 skipped, 0 failed** in 620 s.
- Baseline on a clean `origin/main` checkout (`d35e576`), same command: **4162 passed, 38 skipped, 0 failed** in 577 s. Note this does **not** reproduce the two failures this run was told to expect (`test_lambda_build.py::TestFunctionBuild::test_function_build_succeeds` and `test_client_transport.py::TestStatusPoller::test_invoke_fault_burns_an_attempt_and_retries`) — both pass here, so no pre-existing failure is being carried.
- Nine new tests over the two phases: phase 1's config test; phase 2's two acceptance params and two driver tests; and four added folding the review — the `targets.json` key-anchor regression, the `aoi_mask` prune slice, the nesting-depth ordering, and `main()`'s write path.
- `uv run ruff check src tests tools`: reports only the **pre-existing** `N818` on `src/zagg/registry.py:64` (`UnknownCapability`), unchanged on `origin/main` and outside the PR lint bot's `--select=E,F,W,I` set — flagged, not "fixed" (§4).
- `uv run ruff format --check src tests tools`: one **pre-existing** finding, the python code fence in `tests/data/benchmark/README.md` at line 179 (present on `origin/main` — confirmed with `git show d35e576:tests/data/benchmark/README.md`, and flagged the same way in PR #441). This PR's README addition is prose plus a bash fence and does not touch it.
- Phase 2's module including the slow arm, `pytest tests/test_benchmark_shardmap.py -p no:randomly`: **6 passed, 5 skipped** in 64.7 s (the 5 skips are the CMR drift check, unset `ZAGG_BENCHMARK_DRIFT`).
- Driver CLI smoke test on the final tree, `uv run python tools/repin_benchmark_shardmaps.py --check healpix_o9_88s`: reproduces pin `11530143033882312713` at 5,536 granules with only the two excused metadata deltas.
- Failing-first checks: phase 1's test fails `KeyError: 'pyramid'` with the YAML hunk stashed. The key-anchor regression test was likewise verified failing-first by reverting only the colon in `update_targets`, giving `assert {'shard_key': 5, 'n_granules': 6} == {'shard_key': 4242, 'n_granules': 7}`.

## Questions for review

1. **Issue #459 item (3) — the sweep-dispatcher hardening is scope creep, and here is the reasoning rather than a silent drop.** The dispatcher's gate is `store_layout == "hive" and get_sweep(config)`, at **four** call sites in `runner.py` (line 1173 local raster, 1611 Lambda raster, 3328 local point, 4201 Lambda point — the original wording of this question said "both dispatch sites", which the self-review corrected). The sweep runs **four** families — `stats`, `moc`, `submap`, `overview` (`sweep.DEFAULT_FAMILIES`). Only `overview` is the no-op; the `sweep_stats_*.json` the live run wrote is the `stats` family working as intended, so "skip stores with zero composable fields" would drop three families that do real work. Suppressing only the overview family from the dispatcher means reading the store manifest there — a remote read on the D8 no-PUT path — to learn something the worker already checks and logs, and the saving is one fire-and-forget Event invoke per run. Meanwhile this PR's one-line config fix already removes the false declaration, which was the reader-facing half. If you want the dispatch suppressed anyway, say which: (1) config-side — `get_pyramid(config) is None` ⇒ pass a `families=` list on the sweep event that omits `overview` (the event carries no families block today, so this is new wire surface); or (2) worker-side — turn `sweep_overview`'s existing "nothing to generate" log into an early return before the plans are built. Both are follow-up-issue sized, not this bundle's, and both now touch four gates rather than two.
2. **The acceptance test costs ~65 s of shard-map building on every CI run.** It is `@pytest.mark.slow`, but nothing deselects `slow` — `test.yml` runs plain `uv run pytest`. Measured on one machine: the two params take ~65 s run on their own, and the full suite went 577 s (clean `main`) → 620 s (this branch). That felt like the right trade for the one test that proves the driver reproduces the committed artifacts, and it matches how the other offline shard-map builds are marked (`test_full_aoi_benchmark.py`, `test_raster_benchmark.py`). Alternatives if you disagree: gate it behind an env var like the drift check (it then effectively never runs), or keep only the `healpix_o9_88s` arm (~30 s) and lose coverage of the `nested_in` extraction, which is the driver's fiddliest part.
3. **The driver imports the guard, and now depends on it more heavily.** `tools/repin_benchmark_shardmaps.py` imports `tests/test_benchmark_shardmap.py` for `rebuild_shardmap` and `select_pin` (`tests/test_benchmark.py` already treats that module as a library, so the direction is established). Folding the self-review's first finding made this a real single source rather than a claimed one — which also means a `tools/` script now depends on a test module for its core logic, not just for three helpers. If those two functions should instead move somewhere neutral — `.github/scripts/bench_metrics.py` beside `select_densest_shard` is the obvious candidate — that is a mechanical follow-up, not a redesign, and it is more clearly worth doing now than it was before.
4. **`metadata.pruned` and the entry `note`s are carried, not generated.** The driver copies the committed `pruned` note verbatim and refuses to touch `note`, printing a reminder instead. If a re-pin should be able to restate the ring counts inside that prose automatically (they are derived — 564 shards / 2.07M pairs today), say so and it can template the numeric parts.