### PR TITLE
streaming: expose block_bytes; buffer_granules default 50 -> 20 (issue #474)

### DIFF
--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -729,8 +729,10 @@ neither gap and is safe now.
   it — no store carries a hash yet). Excluded as packaging: cell order (a
   resolution axis — D24), parent/shard order, `chunk_inner`/`sharded`
   (`sharded` amended below — the D19 hash epoch),
-  worker size, streaming mode (merge-vs-spill lands `np.isclose` and
-  shares one store, with the actual mode recorded per-run), and read
+  worker size, the whole `aggregation.streaming` block (mode AND its
+  sizing knobs, `buffer_granules`/`block_bytes` — merge-vs-spill lands
+  `np.isclose` and shares one store, with the actual mode recorded
+  per-run; see the law-equivalence contract below), and read
   knobs — hashing the whole template would have made o8 and o9 runs
   different products and blocked mixed-order processing.
   **Amended by the D19 hash epoch** (espg-ruled on-thread 2026-08-07 as
@@ -781,6 +783,31 @@ neither gap and is safe now.
   that granule is fetched"*) — see that clause. Operator
   consequences — every pre-epoch hash invalidated, and the three migration
   paths — are in `docs/hive_layout.md`, "Migration: the D19 hash epoch".
+
+  **Amended again — the streaming exclusion and its law-equivalence
+  contract** (the PR #475 D19 question, resolved 2026-08-17 as option (b);
+  the decision record is on that PR's thread; issue #474): the whole
+  `aggregation.streaming` block — `mode`, `buffer_granules`,
+  `block_bytes` — is excluded from the core as packaging
+  (`AGGREGATION_PACKAGING_KEYS`), landing the code on the side this
+  record already stated twice while `semantic_core` still hashed the
+  block as spelled. The exclusion holds **on condition of the
+  law-equivalence contract**: every streaming mode MUST produce output
+  within the documented approximation law of the pooled path — exact for
+  the single-block regime and the summation reducers, the
+  kway/`np.isclose` class across merge flushes and block closes — and a
+  mode that cannot maintain that law may not join the streaming block.
+  The contract, not the digest, is what makes one shared identity across
+  all streaming regimes honest; its enforcement is the cross-block suites
+  (`tests/test_spill_crossblock.py`, being extended to the temporal
+  channel by #477) and `tests/test_streaming.py`'s pooled-parity pins.
+  Store compatibility was priced at decision time: no long-lived store
+  carries a streaming-declared digest (the deployed stores age out on a
+  30-day cycle), so the epoch moves nothing that outlives it — and the
+  fat-shard rescue that motivated the knob (issue #474) stays deployable
+  on an existing store, where the as-spelled hash would have tripped the
+  frozen-key refusal.
+
   The hash is a
   **frozen manifest key** (reusing a name with different aggregation
   semantics refuses up front, like any frozen-key mismatch) and is
@@ -1189,7 +1216,9 @@ registry — CI coverage should be auditable against this list:
   members (cf. D24).
 - **Semantic-hash canonicalization** (D19): syntactic edits (whitespace,
   key order, comments) never change the hash; packaging-knob edits
-  (orders, chunking, worker size, streaming mode) never change the hash;
+  (orders, chunking, worker size, the `aggregation.streaming` block in
+  every spelling — the law-equivalence contract above is the exclusion's
+  condition) never change the hash;
   any semantic edit does; and, post-epoch (#415), a leaf-shaping `output`
   edit does while an explicit default hashes as absence. Name-grammar
   validation (base-component exclusion, URL-safe charset).

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -793,10 +793,17 @@ neither gap and is safe now.
   record already stated twice while `semantic_core` still hashed the
   block as spelled. The exclusion holds **on condition of the
   law-equivalence contract**: every streaming mode MUST produce output
-  within the documented approximation law of the pooled path — exact for
-  the single-block regime and the summation reducers, the
-  kway/`np.isclose` class across merge flushes and block closes — and a
-  mode that cannot maintain that law may not join the streaming block.
+  within the documented approximation law of the pooled path. Three law
+  classes are admitted, and a mode that cannot maintain the class its
+  channels fall in may not join the streaming block: (1) **exact** — the
+  single-block regime and the summation reducers; (2) the
+  **kway/`np.isclose`** class — the payload channel across merge flushes
+  and block closes; (3) the **channel-specific documented bounds** for
+  the companion channels, conservative rather than close — a located
+  companion word folds toward the contributors' common ancestor, so its
+  pin is an ancestor-or-equal hull bound (§9.1), and the packed
+  composition word keeps presence (`lane > 0`) exactly with counts within
+  one lane quantization (`tol = 1 + n / 255.0`) of pooled.
   The contract, not the digest, is what makes one shared identity across
   all streaming regimes honest; its enforcement is the cross-block suites
   (`tests/test_spill_crossblock.py`, being extended to the temporal

--- a/docs/design/sparse_coverage.md
+++ b/docs/design/sparse_coverage.md
@@ -805,9 +805,11 @@ neither gap and is safe now.
   composition word keeps presence (`lane > 0`) exactly with counts within
   one lane quantization (`tol = 1 + n / 255.0`) of pooled.
   The contract, not the digest, is what makes one shared identity across
-  all streaming regimes honest; its enforcement is the cross-block suites
-  (`tests/test_spill_crossblock.py`, being extended to the temporal
-  channel by #477) and `tests/test_streaming.py`'s pooled-parity pins.
+  all streaming regimes honest; its enforcement is the single-block
+  exactness pins (`tests/test_spill.py::TestSpillWorkerSingleBlock`), the
+  cross-block suites (`tests/test_spill_crossblock.py`, being extended to
+  the temporal channel by issue #477), and `tests/test_streaming.py`'s
+  pooled-parity pins.
   Store compatibility was priced at decision time: no long-lived store
   carries a streaming-declared digest (the deployed stores age out on a
   30-day cycle), so the epoch moves nothing that outlives it — and the

--- a/src/zagg/configs/atl03_tdigest_healpix_hive.yaml
+++ b/src/zagg/configs/atl03_tdigest_healpix_hive.yaml
@@ -47,7 +47,7 @@ aggregation:
                                # single-block regime; every reducer). Omit the block for
                                # the fully-pooled path; mode: merge folds incrementally
                                # (mergeable reducers only). Pairs with worker.extra_disk.
-                               # buffer_granules defaults to 50;
+                               # buffer_granules defaults to 20 (issue #474);
                                # block_bytes caps a spill block before it closes
                                # and folds (absent: disk-derived default).
   coordinates:

--- a/src/zagg/configs/atl03_tdigest_healpix_hive.yaml
+++ b/src/zagg/configs/atl03_tdigest_healpix_hive.yaml
@@ -47,7 +47,9 @@ aggregation:
                                # single-block regime; every reducer). Omit the block for
                                # the fully-pooled path; mode: merge folds incrementally
                                # (mergeable reducers only). Pairs with worker.extra_disk.
-                               # buffer_granules defaults to 50.
+                               # buffer_granules defaults to 50;
+                               # block_bytes caps a spill block before it closes
+                               # and folds (absent: disk-derived default).
   coordinates:
     morton:
       dtype: uint64

--- a/src/zagg/configs/atl03_tdigest_healpix_hive.yaml
+++ b/src/zagg/configs/atl03_tdigest_healpix_hive.yaml
@@ -49,7 +49,10 @@ aggregation:
                                # (mergeable reducers only). Pairs with worker.extra_disk.
                                # buffer_granules defaults to 20 (issue #474);
                                # block_bytes caps a spill block before it closes
-                               # and folds (absent: disk-derived default).
+                               # and folds (absent: disk-derived default). Keep it
+                               # at or below ~45% of the variant's ephemeral storage:
+                               # a closing block stays resident beside the filling
+                               # one, and the /tmp guard reserves both.
   coordinates:
     morton:
       dtype: uint64

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -467,8 +467,12 @@ def _default_block_bytes(n_partitions: int, tmp_dir: str | None = None) -> int:
     closing block beside the filling one, so the result is capped at 45% of
     the spill directory's current free space. A finer ``chunk_inner`` raises
     K and with it the usable block (the build unit is one partition, not the
-    block). Injectable for tests and ops via
-    ``SpillAggregator(block_bytes=...)``.
+    block). Overridable from **config** —
+    ``aggregation.streaming.block_bytes`` (issue #474), the route operators
+    take — and from ``SpillAggregator(block_bytes=...)`` for tests and ops.
+    An explicit value replaces this whole formula, 45% cap included, so the
+    constructor headroom-checks the pair it will actually hold (2x under
+    overlap); keep it at or below ~45% of the tier's ephemeral storage.
     """
     mem = _memory_budget_bytes()
     st = os.statvfs(tmp_dir or tempfile.gettempdir())
@@ -498,8 +502,8 @@ class SpillAggregator:
       the output is byte-identical to pooled **by construction**: the
       partition holds exactly the chunk's rows in global read order, so the
       stable sort reproduces the pooled per-cell slices bit for bit.
-    - **Multi block** (bytes hit the threshold — see
-      :func:`_default_block_bytes`): each closing block is reduced
+    - **Multi block** (bytes hit the threshold — ``aggregation.streaming.block_bytes``
+      when the config sets it, else :func:`_default_block_bytes`): each closing block is reduced
       partition-by-partition into running mergeable state (counts by
       summation, tdigests via ``merge_tdigests``/``merge_tdigests_kway`` —
       including located fields and ``build_tdigest_where`` strata, whose

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -98,7 +98,9 @@ class SpillReduceError(RuntimeError):
     """
 
 
-def check_tmp_headroom(need_bytes: int, tmp_dir: str | None = None) -> None:
+def check_tmp_headroom(
+    need_bytes: int, tmp_dir: str | None = None, from_config: bool = False
+) -> None:
     """Refuse to enable spill when ``/tmp`` cannot hold its working set.
 
     Standalone spill guard (issue #217 plan: written independently of the
@@ -106,14 +108,24 @@ def check_tmp_headroom(need_bytes: int, tmp_dir: str | None = None) -> None:
     config-style ``RuntimeError`` naming the deployment fix when the spill
     directory's free space is below ``need_bytes`` — typically the block
     threshold, the most a single spill block is allowed to grow.
+
+    ``from_config`` says the requirement is derived from an operator-set
+    ``aggregation.streaming.block_bytes`` (issue #474), which puts lowering
+    that knob at the head of the remedies — otherwise the message quotes a
+    number the operator controls without naming what controls it.
     """
     tmp_dir = tmp_dir or tempfile.gettempdir()
     st = os.statvfs(tmp_dir)
     avail = st.f_bavail * st.f_frsize
     if avail < need_bytes:
+        knob = (
+            "lower aggregation.streaming.block_bytes (this requirement is derived from it), "
+            if from_config
+            else ""
+        )
         raise RuntimeError(
             f"aggregation.streaming.mode: spill needs {need_bytes:,} bytes of free "
-            f"space in {tmp_dir!r} but only {avail:,} are available; deploy on a "
+            f"space in {tmp_dir!r} but only {avail:,} are available; {knob}deploy on a "
             f"function variant with larger ephemeral storage (the '-disk' variants, "
             f"e.g. process-shard-4096-disk) or fall back to mode: merge."
         )
@@ -594,10 +606,14 @@ class SpillAggregator:
             # the failure check_tmp_headroom exists to pre-empt (issue #474).
             self.block_bytes = int(block_bytes)
             resident = self.block_bytes * (2 if overlap else 1)
-            check_tmp_headroom(max(_MIN_SPILL_BYTES, resident), self.tmp_dir)
+            check_tmp_headroom(max(_MIN_SPILL_BYTES, resident), self.tmp_dir, from_config=True)
         else:
             check_tmp_headroom(_MIN_SPILL_BYTES, self.tmp_dir)
             self.block_bytes = _default_block_bytes(self._n_partitions, self.tmp_dir)
+        # Whether the threshold is the operator's (aggregation.streaming.block_bytes)
+        # or disk-derived — the overflow message only offers the knob when it is
+        # actually the thing that set the number (issue #474).
+        self._block_bytes_from_config = block_bytes is not None
         self._block = SpillBlock(self.tmp_dir)
         self._closed_blocks = 0
         self._finalized = False
@@ -754,6 +770,14 @@ class SpillAggregator:
         the sequential path. ``overlap=False`` reduces inline.
         """
         if not self._mergeable:
+            # The threshold is the operator's own number when it came from
+            # config, so raising it — the one remedy that keeps this shard in
+            # the exact single-block regime — leads the list (issue #474).
+            knob = (
+                "a larger aggregation.streaming.block_bytes (this threshold came from it), "
+                if self._block_bytes_from_config
+                else ""
+            )
             raise SpillOverflowError(
                 f"spill block hit the {self.block_bytes:,}-byte threshold but the "
                 f"config carries reducers with no cross-block fold law, so per-block "
@@ -761,8 +785,8 @@ class SpillAggregator:
                 f"fields — located, where-strata, pairwise — and the packed "
                 f"composition word; single-block spill is exact for every reducer). "
                 f"{self._fold_problems}. "
-                f"Remedies: a bigger memory tier, a '-disk' function variant with "
-                f"more ephemeral storage, or a finer parent_order (smaller shards)."
+                f"Remedies: {knob}a bigger memory tier, a '-disk' function variant "
+                f"with more ephemeral storage, or a finer parent_order (smaller shards)."
             )
         if self._closed_blocks == 0:
             # Once per shard, at the moment the exact regime is left (issue

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -586,8 +586,15 @@ class SpillAggregator:
         else:
             self._n_partitions = 1
         if block_bytes is not None:
+            # An explicit threshold skips _default_block_bytes' 45%-of-free-/tmp
+            # cap, so the guard has to reserve what the run actually holds: under
+            # overlap a CLOSING block is resident beside the FILLING one
+            # (_close_block), i.e. 2x. Without the doubling any value between
+            # ~50% and 100% of free /tmp passes here and then ENOSPCs mid-shard —
+            # the failure check_tmp_headroom exists to pre-empt (issue #474).
             self.block_bytes = int(block_bytes)
-            check_tmp_headroom(max(_MIN_SPILL_BYTES, self.block_bytes), self.tmp_dir)
+            resident = self.block_bytes * (2 if overlap else 1)
+            check_tmp_headroom(max(_MIN_SPILL_BYTES, resident), self.tmp_dir)
         else:
             check_tmp_headroom(_MIN_SPILL_BYTES, self.tmp_dir)
             self.block_bytes = _default_block_bytes(self._n_partitions, self.tmp_dir)

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -96,7 +96,7 @@ def get_streaming(config: PipelineConfig) -> dict | None:
     if block is None:
         return None
     if not isinstance(block, dict):
-        raise ValueError("aggregation.streaming must be a mapping, e.g. {buffer_granules: 50}")
+        raise ValueError("aggregation.streaming must be a mapping, e.g. {buffer_granules: 20}")
     unknown = set(block) - {"buffer_granules", "mode", "block_bytes"}
     if unknown:
         raise ValueError(
@@ -105,7 +105,11 @@ def get_streaming(config: PipelineConfig) -> dict | None:
             f"were the #260 arena knobs, removed after the issue #217 fleet A/B refuted "
             f"the arena — use mode: spill for the disk-backed path.)"
         )
-    buffer_granules = block.get("buffer_granules", 50)
+    # 20 (issue #474; was 50): the pre-flush buffer is the obs-proportional
+    # resident term that OOM'd obs-dense shards — worker memory tracks n_obs,
+    # and up to buffer_granules granules of post-filter rows sit in RAM before
+    # the first flush. 20 drops that term ~60% on the CA o9 fat shards.
+    buffer_granules = block.get("buffer_granules", 20)
     if not isinstance(buffer_granules, int) or buffer_granules < 1:
         raise ValueError(
             f"aggregation.streaming.buffer_granules must be a positive int "

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -73,14 +73,19 @@ _COMPOSITION_FUNCTION = "zagg.stats.composition.pack_composition"
 def get_streaming(config: PipelineConfig) -> dict | None:
     """Return the ``aggregation.streaming`` block, or ``None`` (pooled path).
 
-    The block is ``{"buffer_granules": int, "mode": "merge"|"spill"}``;
-    ``buffer_granules`` must be a positive int. ``mode`` (issue #217) picks
-    where a full buffer goes: ``"merge"`` (default — fold into running
-    per-cell state, today's behavior, mergeable reducers only) or ``"spill"``
-    (append the grouped buffer to per-partition ``/tmp`` files and aggregate
-    once after the reads — every pooled reducer, byte-identical to pooled in
-    the single-block regime; see :mod:`zagg.processing.spill`). Absent block
-    -> ``None`` so existing configs are untouched.
+    The block is ``{"buffer_granules": int, "mode": "merge"|"spill",
+    "block_bytes": int}``; ``buffer_granules`` and ``block_bytes`` must be
+    positive ints. ``mode`` (issue #217) picks where a full buffer goes:
+    ``"merge"`` (default — fold into running per-cell state, today's behavior,
+    mergeable reducers only) or ``"spill"`` (append the grouped buffer to
+    per-partition ``/tmp`` files and aggregate once after the reads — every
+    pooled reducer, byte-identical to pooled in the single-block regime; see
+    :mod:`zagg.processing.spill`). ``block_bytes`` (issue #474, spill only)
+    caps the spilled block before it closes and folds (issue #370) — the
+    principled bound on aggregate-phase memory for obs-dense shards. Absent it
+    stays ``None`` and the worker keeps the disk-derived default
+    (``_default_block_bytes``), unchanged. Absent block -> ``None`` so
+    existing configs are untouched.
 
     Unknown keys are rejected loudly (the #239 discipline): in particular the
     removed #260 arena knobs ``state_layout``/``arena_backing`` — the arena
@@ -92,13 +97,13 @@ def get_streaming(config: PipelineConfig) -> dict | None:
         return None
     if not isinstance(block, dict):
         raise ValueError("aggregation.streaming must be a mapping, e.g. {buffer_granules: 50}")
-    unknown = set(block) - {"buffer_granules", "mode"}
+    unknown = set(block) - {"buffer_granules", "mode", "block_bytes"}
     if unknown:
         raise ValueError(
             f"aggregation.streaming has unknown key(s) {sorted(unknown)}; the block "
-            f"takes buffer_granules and mode. (state_layout/arena_backing were the "
-            f"#260 arena knobs, removed after the issue #217 fleet A/B refuted the "
-            f"arena — use mode: spill for the disk-backed path.)"
+            f"takes buffer_granules, mode and block_bytes. (state_layout/arena_backing "
+            f"were the #260 arena knobs, removed after the issue #217 fleet A/B refuted "
+            f"the arena — use mode: spill for the disk-backed path.)"
         )
     buffer_granules = block.get("buffer_granules", 50)
     if not isinstance(buffer_granules, int) or buffer_granules < 1:
@@ -109,7 +114,20 @@ def get_streaming(config: PipelineConfig) -> dict | None:
     mode = block.get("mode", "merge")
     if mode not in ("merge", "spill"):
         raise ValueError(f"aggregation.streaming.mode must be 'merge' or 'spill' (got {mode!r})")
-    return {"buffer_granules": buffer_granules, "mode": mode}
+    block_bytes = block.get("block_bytes")
+    if block_bytes is not None:
+        if not isinstance(block_bytes, int) or block_bytes < 1:
+            raise ValueError(
+                f"aggregation.streaming.block_bytes must be a positive int (got {block_bytes!r})"
+            )
+        if mode != "spill":
+            # Merge mode has no spill blocks; a silently-ignored knob is the
+            # #239 failure mode, so refuse it where it can do nothing.
+            raise ValueError(
+                "aggregation.streaming.block_bytes only applies to mode: spill "
+                f"(got mode: {mode!r})"
+            )
+    return {"buffer_granules": buffer_granules, "mode": mode, "block_bytes": block_bytes}
 
 
 def validate_streaming(config: PipelineConfig) -> None:

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -70,6 +70,19 @@ _TDIGEST_SPILL_FUNCTIONS = (*_TDIGEST_FUNCTIONS, _TDIGEST_WHERE_FUNCTION)
 _COMPOSITION_FUNCTION = "zagg.stats.composition.pack_composition"
 
 
+def _positive_int(value) -> bool:
+    """True for a positive int — and ``bool`` is deliberately not one.
+
+    ``bool`` subclasses ``int``, so a bare ``isinstance(v, int)`` accepts
+    ``buffer_granules: true`` / ``block_bytes: true`` (PyYAML also resolves
+    ``yes``/``on`` to booleans) and the worker then runs with a threshold of
+    **1** — a 1-byte block closes on every flush, the maximally degraded fold
+    regime, from a knob name that reads enough like a flag to be a plausible
+    operator typo.
+    """
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 1
+
+
 def get_streaming(config: PipelineConfig) -> dict | None:
     """Return the ``aggregation.streaming`` block, or ``None`` (pooled path).
 
@@ -110,7 +123,7 @@ def get_streaming(config: PipelineConfig) -> dict | None:
     # and up to buffer_granules granules of post-filter rows sit in RAM before
     # the first flush. 20 drops that term ~60% on the CA o9 fat shards.
     buffer_granules = block.get("buffer_granules", 20)
-    if not isinstance(buffer_granules, int) or buffer_granules < 1:
+    if not _positive_int(buffer_granules):
         raise ValueError(
             f"aggregation.streaming.buffer_granules must be a positive int "
             f"(got {buffer_granules!r})"
@@ -120,7 +133,7 @@ def get_streaming(config: PipelineConfig) -> dict | None:
         raise ValueError(f"aggregation.streaming.mode must be 'merge' or 'spill' (got {mode!r})")
     block_bytes = block.get("block_bytes")
     if block_bytes is not None:
-        if not isinstance(block_bytes, int) or block_bytes < 1:
+        if not _positive_int(block_bytes):
             raise ValueError(
                 f"aggregation.streaming.block_bytes must be a positive int (got {block_bytes!r})"
             )

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -479,12 +479,18 @@ def process_shard(
 
     streaming_cfg = get_streaming(config)
     spill_mode = streaming_cfg is not None and streaming_cfg["mode"] == "spill"
-    if spill_mode:
-        buffered = SpillAggregator(config, grid, handoff, streaming_cfg["buffer_granules"])
-    elif streaming_cfg is not None:
-        buffered = StreamingAggregator(config, grid, handoff, streaming_cfg["buffer_granules"])
-    else:
+    if streaming_cfg is None:
         buffered = None
+    elif spill_mode:
+        buffered = SpillAggregator(
+            config,
+            grid,
+            handoff,
+            streaming_cfg["buffer_granules"],
+            block_bytes=streaming_cfg["block_bytes"],
+        )
+    else:
+        buffered = StreamingAggregator(config, grid, handoff, streaming_cfg["buffer_granules"])
 
     # Per-phase timing (issue #100; always-on collection since issue #297 —
     # the stats sidecar needs complete timings by default, and the cost is a

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -210,7 +210,9 @@ DATA_SOURCE_PACKAGING_KEYS = (
 #: packed composition word keeps presence exactly and counts within one lane
 #: quantization) — and a mode that cannot maintain the class its channels
 #: fall in may not join the block.
-#: Enforcement is ``tests/test_spill_crossblock.py``. The D19 record stated
+#: Enforcement is ``tests/test_spill.py::TestSpillWorkerSingleBlock`` (the
+#: exactness half), ``tests/test_spill_crossblock.py``, and
+#: ``tests/test_streaming.py``'s pooled-parity pins. The D19 record stated
 #: this acceptance property twice while the code hashed the block as spelled;
 #: the ruling lands the code on the record's side before any long-lived store
 #: carries a streaming-declared digest, so the epoch moves nothing that

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -216,9 +216,9 @@ DATA_SOURCE_PACKAGING_KEYS = (
 #: exactness half), ``tests/test_spill_crossblock.py``, and
 #: ``tests/test_streaming.py``'s pooled-parity pins. The D19 record stated
 #: this acceptance property twice while the code hashed the block as spelled;
-#: the ruling lands the code on the record's side before any long-lived store
-#: carries a streaming-declared digest, so the epoch moves nothing that
-#: outlives it.
+#: the ruling lands the code on the record's side before any **long-lived**
+#: store carries a streaming-declared digest (the deployed stores age out on
+#: a 30-day cycle), so the epoch moves nothing that outlives it.
 AGGREGATION_PACKAGING_KEYS = ("handoff", "streaming")
 
 #: Per-variable aggregation keys that are packaging (issue #424):

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -59,7 +59,10 @@ it declares is verified by READING the artifact instead — see
 :data:`OUTPUT_LEAF_SHAPING_KEYS`), ``emit_cell_ids`` (the issue #304 D16
 transition hatch — leaf-shaping, but scheduled for removal, so hashing it
 would strand stores whose digest no legal config reproduces; see
-:data:`GRID_LEAF_SHAPING_KEYS`), worker sizing, streaming mode, read knobs,
+:data:`GRID_LEAF_SHAPING_KEYS`), worker sizing, the whole
+``aggregation.streaming`` block (mode AND its sizing knobs, under the
+law-equivalence contract — espg-ruled 2026-08-17 on the PR #475 D19 question;
+see :data:`AGGREGATION_PACKAGING_KEYS`), read knobs,
 the credential mechanism and the byte-movement knobs
 (``credentials_provider``/``anonymous``/``source_region``/``read_workers``/
 ``write_buffer`` select how source bytes are fetched or moved, never what is
@@ -193,8 +196,21 @@ DATA_SOURCE_PACKAGING_KEYS = (
 )
 
 #: ``aggregation`` keys that are packaging: the per-cell carrier choice
-#: (issue #132) transports identical values either way.
-AGGREGATION_PACKAGING_KEYS = ("handoff",)
+#: (issue #132) transports identical values either way, and the whole
+#: ``streaming`` block — mode, ``buffer_granules``, ``block_bytes`` —
+#: **espg-ruled 2026-08-17** (the PR #475 D19 question, option (b)): every
+#: streaming regime shares one product identity, with bytes bounded by the
+#: **law-equivalence contract** (``docs/design/sparse_coverage.md``, D19):
+#: each streaming mode MUST land within the documented approximation law of
+#: the pooled path — exact for the single-block regime and the summation
+#: reducers, the kway/``np.isclose`` class across merge flushes and block
+#: closes — and a mode that cannot maintain that law may not join the block.
+#: Enforcement is ``tests/test_spill_crossblock.py``. The D19 record stated
+#: this acceptance property twice while the code hashed the block as spelled;
+#: the ruling lands the code on the record's side before any long-lived store
+#: carries a streaming-declared digest, so the epoch moves nothing that
+#: outlives it.
+AGGREGATION_PACKAGING_KEYS = ("handoff", "streaming")
 
 #: Per-variable aggregation keys that are packaging (issue #424):
 #: ``overview_delta`` shapes the pyramid/overview fold budget only — the

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -202,9 +202,14 @@ DATA_SOURCE_PACKAGING_KEYS = (
 #: streaming regime shares one product identity, with bytes bounded by the
 #: **law-equivalence contract** (``docs/design/sparse_coverage.md``, D19):
 #: each streaming mode MUST land within the documented approximation law of
-#: the pooled path — exact for the single-block regime and the summation
-#: reducers, the kway/``np.isclose`` class across merge flushes and block
-#: closes — and a mode that cannot maintain that law may not join the block.
+#: the pooled path, in one of three classes — exact (the single-block regime
+#: and the summation reducers), the kway/``np.isclose`` class (the payload
+#: channel across merge flushes and block closes), and the channel-specific
+#: documented bounds for the companion channels (a located word folds to the
+#: contributors' common ancestor, pinned as an ancestor-or-equal hull; the
+#: packed composition word keeps presence exactly and counts within one lane
+#: quantization) — and a mode that cannot maintain the class its channels
+#: fall in may not join the block.
 #: Enforcement is ``tests/test_spill_crossblock.py``. The D19 record stated
 #: this acceptance property twice while the code hashed the block as spelled;
 #: the ruling lands the code on the record's side before any long-lived store

--- a/src/zagg/semantics.py
+++ b/src/zagg/semantics.py
@@ -11,7 +11,9 @@ Included (the semantic core):
 
 - the ``aggregation`` block — functions, params, dtypes, fills, ragged kinds,
   declared coordinates, ``chunk_precompute`` — minus the ``handoff`` carrier
-  choice (arrow vs pandas is a worker-internal transport);
+  choice (arrow vs pandas is a worker-internal transport) and the whole
+  ``streaming`` block (every streaming regime shares one identity under the
+  law-equivalence contract — see the exclusions below);
 - the ``data_source`` **semantics** — which groups/variables/coordinates are
   read and how observations are filtered (``filters``/``quality_filter``,
   photon ``base_level``/``levels``, raster ``bands``/``nodata``/
@@ -556,8 +558,8 @@ def semantic_core(config: PipelineConfig) -> dict:
     """The output-defining subset of ``config`` (D19), as a plain dict.
 
     Deterministic given the config's semantics: two configs differing only in
-    packaging knobs (orders, chunking, worker size, read machinery, carrier)
-    map to the same core. ``None``-valued keys are pruned recursively so a
+    packaging knobs (orders, chunking, worker size, read machinery, carrier,
+    the ``aggregation.streaming`` block) map to the same core. ``None``-valued keys are pruned recursively so a
     YAML explicit-null hashes identically to an absent key (§8.3). The returned
     structure is JSON-serializable plain data (the YAML loader guarantees it).
     """

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -103,6 +103,27 @@ class TestCanonicalization:
         cfg.worker = {"memory": 8192, "extra_disk": True}
         assert semantic_hash(cfg) == base
 
+    def test_streaming_block_is_packaging_in_every_spelling(self):
+        # espg-ruled 2026-08-17 (the PR #475 D19 question, option (b)): the
+        # whole aggregation.streaming block is packaging, on condition of the
+        # law-equivalence contract (docs/design/sparse_coverage.md, D19) —
+        # every streaming regime lands within the documented approximation
+        # law of the pooled path, so all spellings share one identity. The
+        # design record stated this twice while the code hashed the block as
+        # spelled; this pin is the drift-proofing.
+        base = semantic_hash(_cfg())
+        spellings = [
+            {},
+            {"mode": "spill"},
+            {"mode": "merge", "buffer_granules": 7},
+            {"mode": "spill", "block_bytes": 1 << 26},
+            {"buffer_granules": 20},
+        ]
+        for block in spellings:
+            cfg = _cfg(aggregation__streaming=block)
+            assert semantic_hash(cfg) == base
+            assert "streaming" not in semantic_core(cfg)["aggregation"]
+
     def test_emit_cell_ids_is_packaging(self):
         # The issue #304 D16 transition hatch. It DOES add a `cell_ids` array
         # to every leaf, so it met the epoch's leaf-shaping criterion and was

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -20,6 +20,7 @@ which frame is scheduling-dependent and buffer/pool composition varies run to
 run (a trap first hit in the issue #217 arena A/B tests).
 """
 
+import inspect
 import tempfile
 
 import numpy as np
@@ -34,6 +35,7 @@ from zagg.processing.spill import (
     SpillBlock,
     SpillOverflowError,
     SpillReduceError,
+    _default_block_bytes,
     check_tmp_headroom,
     partition_ids,
 )
@@ -466,11 +468,16 @@ class TestSpillConfig:
         # (absent) keeps the disk-derived _default_block_bytes behavior.
         seen = {}
         real_init = SpillAggregator.__init__
+        # Bind through the real signature, not kwargs.get: a positional pass
+        # would otherwise record None and the absent-knob arm would still pass,
+        # a silent hole in exactly the seam this test guards.
+        sig = inspect.signature(real_init)
 
         def spy(agg, *args, **kwargs):
-            seen["block_bytes"] = kwargs.get("block_bytes")
+            seen["block_bytes"] = sig.bind(agg, *args, **kwargs).arguments.get("block_bytes")
             real_init(agg, *args, **kwargs)
             seen["resolved"] = agg.block_bytes
+            seen["agg"] = agg
 
         monkeypatch.setattr(SpillAggregator, "__init__", spy)
         streaming = {"mode": "spill"}
@@ -485,7 +492,10 @@ class TestSpillConfig:
         if block_bytes is not None:
             assert seen["resolved"] == block_bytes
         else:
-            assert seen["resolved"] > 0  # disk-derived default, unchanged
+            # The disk-derived default, exactly — `> 0` cannot fail, since
+            # _default_block_bytes is a max(1, ...).
+            agg = seen["agg"]
+            assert seen["resolved"] == _default_block_bytes(agg._n_partitions, agg.tmp_dir)
 
     def test_explicit_block_bytes_reserves_the_overlap_pair(self, monkeypatch, tmp_path):
         # issue #474: an explicit threshold skips _default_block_bytes' 45%

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -459,6 +459,34 @@ class TestSpillConfig:
         with pytest.raises(ValueError, match="unknown key"):
             get_streaming(_config(streaming={"mode": "spill", "state_layout": "arena"}))
 
+    @pytest.mark.parametrize("block_bytes", [None, 123456])
+    def test_block_bytes_reaches_the_worker_constructor(self, monkeypatch, block_bytes):
+        # issue #474: the config knob must thread through process_shard to the
+        # SpillAggregator construction — spied at the constructor seam. None
+        # (absent) keeps the disk-derived _default_block_bytes behavior.
+        seen = {}
+        real_init = SpillAggregator.__init__
+
+        def spy(agg, *args, **kwargs):
+            seen["block_bytes"] = kwargs.get("block_bytes")
+            real_init(agg, *args, **kwargs)
+            seen["resolved"] = agg.block_bytes
+
+        monkeypatch.setattr(SpillAggregator, "__init__", spy)
+        streaming = {"mode": "spill"}
+        if block_bytes is not None:
+            streaming["block_bytes"] = block_bytes
+        cfg = _config(streaming=streaming)
+        grid = _grid(cfg)
+        key = _shard_key()
+        dfs = _granule_dfs(grid, key, _CELL_LISTS[:2])
+        _run(monkeypatch, cfg, grid, key, dfs)
+        assert seen["block_bytes"] == block_bytes
+        if block_bytes is not None:
+            assert seen["resolved"] == block_bytes
+        else:
+            assert seen["resolved"] > 0  # disk-derived default, unchanged
+
     def test_spill_fold_state_carries_the_declared_delta(self):
         # Issue #424: the spill fold honors the field's declared δ (the 8,192
         # leaf budget), never the module default.

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -915,7 +915,24 @@ class TestSpillWorkerMultiBlock:
         )
         grid = _grid(cfg)
         dfs = _granule_dfs(grid, _shard_key(), _CELL_LISTS, seed=2)
-        with pytest.raises(SpillOverflowError, match="memory tier"):
+        with pytest.raises(SpillOverflowError, match="memory tier") as exc:
+            _run(monkeypatch, cfg, grid, _shard_key(), dfs)
+        # The derived threshold is nobody's config value, so the remedies list
+        # must not point at a knob the operator never set (issue #474).
+        assert "block_bytes" not in str(exc.value)
+
+    def test_overflow_names_the_config_knob_that_set_the_threshold(self, monkeypatch):
+        # issue #474: when the crossing came from aggregation.streaming.block_bytes,
+        # raising it is the one remedy that keeps the shard in the exact
+        # single-block regime — so it heads the list.
+        cfg = _config(
+            streaming={"buffer_granules": 1, "mode": "spill", "block_bytes": 1},
+            variables=_matrix_variables(),
+            chunk_precompute=_ANCHOR,
+        )
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, _shard_key(), _CELL_LISTS, seed=2)
+        with pytest.raises(SpillOverflowError, match="larger aggregation.streaming.block_bytes"):
             _run(monkeypatch, cfg, grid, _shard_key(), dfs)
 
     def test_overlap_reduce_error_raises_through_worker(self, monkeypatch):
@@ -1026,6 +1043,13 @@ class TestTmpGuard:
         monkeypatch.setattr(_os, "statvfs", lambda _p: _Tiny())
         with pytest.raises(RuntimeError, match="-disk"):
             check_tmp_headroom(10**9)
+        # The number is the operator's own when it came from config, so the
+        # remedy they control leads the list — and is absent otherwise (#474).
+        with pytest.raises(RuntimeError, match="lower aggregation.streaming.block_bytes"):
+            check_tmp_headroom(10**9, from_config=True)
+        with pytest.raises(RuntimeError) as exc:
+            check_tmp_headroom(10**9)
+        assert "block_bytes" not in str(exc.value)
 
     def test_happy_path_is_silent(self):
         check_tmp_headroom(1)

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -487,6 +487,40 @@ class TestSpillConfig:
         else:
             assert seen["resolved"] > 0  # disk-derived default, unchanged
 
+    def test_explicit_block_bytes_reserves_the_overlap_pair(self, monkeypatch, tmp_path):
+        # issue #474: an explicit threshold skips _default_block_bytes' 45%
+        # cap, and under overlap a closing block is resident beside the filling
+        # one — so the guard must reserve 2x. At 60% of free /tmp a 1x check
+        # passes and the run ENOSPCs mid-shard instead.
+        import os as _os
+
+        real = _os.statvfs(tempfile.gettempdir())
+        free = 1 << 30
+
+        class _Fake:
+            f_frsize = real.f_frsize
+            f_bavail = free // real.f_frsize
+
+        monkeypatch.setattr(_os, "statvfs", lambda _p: _Fake())
+        cfg = _config(streaming={"mode": "spill"})
+        block_bytes = int(0.6 * free)
+        with pytest.raises(RuntimeError, match="free space"):
+            SpillAggregator(
+                cfg, _grid(cfg), "pandas", 25, block_bytes=block_bytes, tmp_dir=str(tmp_path)
+            )
+        # overlap off keeps exactly one block resident, so the same value fits.
+        agg = SpillAggregator(
+            cfg,
+            _grid(cfg),
+            "pandas",
+            25,
+            block_bytes=block_bytes,
+            tmp_dir=str(tmp_path),
+            overlap=False,
+        )
+        assert agg.block_bytes == block_bytes
+        agg.close()
+
     def test_spill_fold_state_carries_the_declared_delta(self):
         # Issue #424: the spill fold honors the field's declared δ (the 8,192
         # leaf budget), never the module default.

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -908,3 +908,41 @@ class TestFoldRegimeVisibility:
             _, _, meta = _run(monkeypatch, cfg, grid, key, dfs)
         assert not any(self._MSG in r.message for r in caplog.records)
         assert meta["phase_timings"]["spill_blocks_closed"] == 0
+
+
+class TestConfigBlockBytes:
+    """``aggregation.streaming.block_bytes`` (issue #474): the fold-regime
+    threshold reachable from config — no monkeypatched ``_default_block_bytes``
+    — with the folded results matching pooled per the issue #370 laws."""
+
+    def test_small_block_bytes_engages_fold_and_folds_correctly(self, monkeypatch):
+        key = _shard_key()
+        spill = {"buffer_granules": 1, "mode": "spill", "block_bytes": 1}
+        pooled_cfg = _config(_variables())
+        spill_cfg = _config(_variables(), streaming=spill)
+        grid = _grid(pooled_cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=40, seed=13)
+        df_p, ragged_p, _ = _run(monkeypatch, pooled_cfg, grid, key, list(dfs))
+        df_s, ragged_s, meta = _run(monkeypatch, spill_cfg, _grid(spill_cfg), key, list(dfs))
+        # buffer_granules=1 + a 1-byte config threshold: every flush closes.
+        assert meta["phase_timings"]["spill_blocks_closed"] == len(_CELL_LISTS)
+        # Counts fold exactly; digests carry the exact total weight and stay
+        # within t-digest accuracy of pooled (issue #370 kway law).
+        pd.testing.assert_series_equal(df_p["count"], df_s["count"])
+        vals_p, idx_p = ragged_p["h_tdigest"]
+        vals_s, idx_s = ragged_s["h_tdigest"]
+        assert idx_p == idx_s
+        for dp, ds in zip(vals_p, vals_s, strict=True):
+            assert float(dp[:, 1].sum()) == float(ds[:, 1].sum())
+            for q in (0.1, 0.5, 0.9):
+                assert abs(quantile_from_tdigest(ds, q) - quantile_from_tdigest(dp, q)) < 1.0
+
+    def test_large_block_bytes_stays_single_block(self, monkeypatch):
+        # A generous config threshold keeps the exact single-block regime.
+        key = _shard_key()
+        spill = {"buffer_granules": 1, "mode": "spill", "block_bytes": 1 << 30}
+        cfg = _config(_variables(), streaming=spill)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=20, seed=5)
+        _, _, meta = _run(monkeypatch, cfg, grid, key, dfs)
+        assert meta["phase_timings"]["spill_blocks_closed"] == 0

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -939,8 +939,14 @@ class TestConfigBlockBytes:
 
     def test_large_block_bytes_stays_single_block(self, monkeypatch):
         # A generous config threshold keeps the exact single-block regime.
+        # 32 MiB, not something like 1 GiB: an explicit threshold is
+        # headroom-checked against the REAL $TMPDIR (the aggregator gets no
+        # tmp_dir), doubled for the overlap pair — so this demands exactly
+        # _MIN_SPILL_BYTES, the default path's own floor, instead of turning a
+        # small/full /tmp into a spurious "spill needs N bytes" failure. It is
+        # still ~4 orders of magnitude above the ~6 KB this test spills.
         key = _shard_key()
-        spill = {"buffer_granules": 1, "mode": "spill", "block_bytes": 1 << 30}
+        spill = {"buffer_granules": 1, "mode": "spill", "block_bytes": 1 << 25}
         cfg = _config(_variables(), streaming=spill)
         grid = _grid(cfg)
         dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=20, seed=5)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -66,27 +66,50 @@ class TestStreamingConfig:
         assert get_streaming(_config()) is None
 
     def test_block_defaults_buffer(self):
-        assert get_streaming(_config(streaming={})) == {"buffer_granules": 50, "mode": "merge"}
+        assert get_streaming(_config(streaming={})) == {
+            "buffer_granules": 50,
+            "mode": "merge",
+            "block_bytes": None,
+        }
 
     def test_explicit_buffer(self):
         assert get_streaming(_config(streaming={"buffer_granules": 7})) == {
             "buffer_granules": 7,
             "mode": "merge",
+            "block_bytes": None,
         }
 
-    @pytest.mark.parametrize(
-        "key", ["state_layout", "arena_backing", "block_bytes", "buffer_granuels"]
-    )
+    def test_explicit_block_bytes(self):
+        # issue #474: the fold-regime threshold is reachable from config.
+        assert get_streaming(_config(streaming={"mode": "spill", "block_bytes": 1 << 30})) == {
+            "buffer_granules": 50,
+            "mode": "spill",
+            "block_bytes": 1 << 30,
+        }
+
+    @pytest.mark.parametrize("key", ["state_layout", "arena_backing", "buffer_granuels"])
     def test_unknown_keys_rejected(self, key):
         # The removed #260 arena knobs (and any typo) must fail loudly, not
-        # silently run the dict path (#239 discipline).
-        with pytest.raises(ValueError, match="unknown key"):
+        # silently run the dict path (#239 discipline). The refusal names the
+        # full grammar, block_bytes included (issue #474).
+        with pytest.raises(ValueError, match="buffer_granules, mode and block_bytes"):
             get_streaming(_config(streaming={key: "arena"}))
 
     @pytest.mark.parametrize("bad", [0, -1, "50", 2.5])
     def test_bad_buffer_raises(self, bad):
         with pytest.raises(ValueError, match="buffer_granules"):
             get_streaming(_config(streaming={"buffer_granules": bad}))
+
+    @pytest.mark.parametrize("bad", [0, -1, "1048576", 2.5])
+    def test_bad_block_bytes_raises(self, bad):
+        with pytest.raises(ValueError, match="block_bytes"):
+            get_streaming(_config(streaming={"mode": "spill", "block_bytes": bad}))
+
+    def test_block_bytes_requires_spill_mode(self):
+        # Merge mode has no spill blocks; a silently-ignored knob is the #239
+        # failure mode.
+        with pytest.raises(ValueError, match="only applies to mode: spill"):
+            get_streaming(_config(streaming={"block_bytes": 1 << 20}))
 
     def test_non_mapping_block_raises(self):
         with pytest.raises(ValueError, match="mapping"):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -66,8 +66,10 @@ class TestStreamingConfig:
         assert get_streaming(_config()) is None
 
     def test_block_defaults_buffer(self):
+        # 20 since issue #474 (was 50): the pre-flush buffer is the
+        # obs-proportional resident term that OOM'd fat shards.
         assert get_streaming(_config(streaming={})) == {
-            "buffer_granules": 50,
+            "buffer_granules": 20,
             "mode": "merge",
             "block_bytes": None,
         }
@@ -82,7 +84,7 @@ class TestStreamingConfig:
     def test_explicit_block_bytes(self):
         # issue #474: the fold-regime threshold is reachable from config.
         assert get_streaming(_config(streaming={"mode": "spill", "block_bytes": 1 << 30})) == {
-            "buffer_granules": 50,
+            "buffer_granules": 20,
             "mode": "spill",
             "block_bytes": 1 << 30,
         }

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -97,12 +97,15 @@ class TestStreamingConfig:
         with pytest.raises(ValueError, match="buffer_granules, mode and block_bytes"):
             get_streaming(_config(streaming={key: "arena"}))
 
-    @pytest.mark.parametrize("bad", [0, -1, "50", 2.5])
+    # True/False are the bool arm: bool subclasses int, so a YAML `true` (or
+    # `yes`/`on`, which PyYAML also resolves to booleans) would otherwise
+    # validate and run as 1 — a 1-byte block closes on every flush.
+    @pytest.mark.parametrize("bad", [0, -1, "50", 2.5, True, False])
     def test_bad_buffer_raises(self, bad):
         with pytest.raises(ValueError, match="buffer_granules"):
             get_streaming(_config(streaming={"buffer_granules": bad}))
 
-    @pytest.mark.parametrize("bad", [0, -1, "1048576", 2.5])
+    @pytest.mark.parametrize("bad", [0, -1, "1048576", 2.5, True, False])
     def test_bad_block_bytes_raises(self, bad):
         with pytest.raises(ValueError, match="block_bytes"):
             get_streaming(_config(streaming={"mode": "spill", "block_bytes": bad}))


### PR DESCRIPTION
Closes #474

Espg-directed small-fix from the 2026-08-17 CA o9 fat-shard investigation ([issue #474](https://github.com/englacial/zagg/issues/474)): worker memory tracks observation volume, the resident term is the pre-flush buffer, and the fold-regime threshold (`block_bytes`) was unreachable from config.

## Phases

- [x] Phase 1 — expose `aggregation.streaming.block_bytes`: `get_streaming` accepts an optional positive int (spill-only; refused under `mode: merge` so it can never be silently ignored — the #239 discipline), the unknown-key refusal now names all three keys, and the worker threads it to the `SpillAggregator(...)` construction, whose signature already carried `block_bytes=` (`src/zagg/processing/spill.py` line 520). Absent keeps the disk-derived `_default_block_bytes` behavior byte-for-byte.
- [x] Phase 2 — `buffer_granules` default 50 → 20 (`get_streaming`), with every pinned 50 updated (module example, `tests/test_streaming.py` default pin, the `atl03_tdigest_healpix_hive.yaml` comment). The GEDI template pins 8 explicitly and is untouched.
- [x] Adversarial-review fold (6 inline findings + the D19 addendum below): bool refused for both streaming int knobs; the explicit-`block_bytes` `/tmp` guard now reserves the overlap pair; both spill failure messages name the knob when it set the number; `spill.py` docstrings and the template comment point at the config route; two test-strength/portability fixes.
- [x] Phase 3 — land the espg ruling on the D19 question (option (b), ruled in-session 2026-08-17 — see the ruling record below): `"streaming"` joins `AGGREGATION_PACKAGING_KEYS` so the whole block (`mode`, `buffer_granules`, `block_bytes`) leaves the semantic core; the **law-equivalence contract** is stated normatively in `docs/design/sparse_coverage.md` beside the D19 amendment record as the exclusion's condition; `tests/test_semantics.py` pins every spelling of the block to the bare config's hash; the `semantics.py` docstring/code contradiction is closed on the docstring's side.

## Approach

`get_streaming` stays the single validation point and now always returns `{"buffer_granules", "mode", "block_bytes"}` (`block_bytes: None` = disk-derived default), so the worker passes the key through unconditionally. The worker's aggregator dispatch was reshaped to `if streaming_cfg is None / elif spill_mode / else` — same behavior, and it lets mypy narrow `streaming_cfg` (net mypy error count in `worker.py` goes 16 → 15; the remaining 15 are pre-existing baseline).

Two behavioral points came out of the fold:

- **Both int knobs refuse `bool`.** `bool` subclasses `int`, so `block_bytes: true` (PyYAML also resolves `yes`/`on`) validated and ran as a **1-byte** threshold — a block close on every flush, the maximally degraded fold regime, from a knob name that reads like a flag. `_positive_int` in `streaming.py` now excludes `bool` for `buffer_granules` (the same pre-existing hole) and `block_bytes` alike.
- **An explicit `block_bytes` is headroom-checked for the pair it actually holds.** `_default_block_bytes` caps itself at 45% of free `/tmp` precisely because a *closing* block stays resident beside the *filling* one under overlap (`_close_block`); an explicit value skipped that cap and was checked 1x, so anything between ~50% and 100% of free `/tmp` passed construction and then ENOSPC'd mid-shard — the failure `check_tmp_headroom` exists to pre-empt. The explicit branch now checks `2 * block_bytes` when `overlap` is on (1x when off), and the template comment states the ~45% guidance.

## Tests

- `tests/test_streaming.py` — default pin now 20 with `block_bytes: None`; explicit `block_bytes` round-trips; bad type/value refusals (`0`, `-1`, `"1048576"`, `2.5`, **`True`/`False`**) on both `buffer_granules` and `block_bytes`; merge-mode refusal; unknown-key message names the full three-key grammar.
- `tests/test_spill.py::TestSpillConfig::test_block_bytes_reaches_the_worker_constructor` — seam-level spy on `SpillAggregator.__init__` through `process_shard`, binding through the real signature (so a positional pass cannot slip the absent-knob arm): explicit value arrives and is honored; absent arrives as `None` and resolves **exactly** to `_default_block_bytes(agg._n_partitions, agg.tmp_dir)`.
- `tests/test_spill.py::TestSpillConfig::test_explicit_block_bytes_reserves_the_overlap_pair` — at 60% of (faked) free `/tmp` the construction raises under overlap and succeeds with `overlap=False`.
- `tests/test_spill.py` — `check_tmp_headroom(..., from_config=True)` leads with "lower `aggregation.streaming.block_bytes`" and omits it otherwise; `SpillOverflowError` offers "a larger `aggregation.streaming.block_bytes`" only when the threshold came from config.
- `tests/test_spill_crossblock.py::TestConfigBlockBytes` — fold-regime smoke driven purely from config (no monkeypatched `_default_block_bytes`): `block_bytes: 1` + `buffer_granules: 1` closes a block per flush (`spill_blocks_closed == 5`), counts fold exactly vs pooled and digests carry exact total weight within t-digest accuracy (the issue #370 kway law); a generous `block_bytes` stays in the exact single-block regime (`spill_blocks_closed == 0`). That "generous" value is 32 MiB, not 1 GiB: an explicit threshold is headroom-checked against the real `$TMPDIR`, so the old `1 << 30` demanded a free GiB of the developer's own disk.

- `tests/test_semantics.py::TestCanonicalization::test_streaming_block_is_packaging_in_every_spelling` (phase 3) — absent, `{}`, `{mode: spill}`, `{mode: merge, buffer_granules: 7}`, `{mode: spill, block_bytes: 1<<26}`, and `{buffer_granules: 20}` all hash identically to the bare config, and `streaming` never appears in the core — the drift-proofing the review's D19 addendum flagged as missing. The existing golden hash pin (`fb15224f…`, no streaming declared) is untouched, as expected for a key-removal on configs that never carried the key.

Local: `ruff check` / `ruff format --check` clean on every touched file; `pytest tests/test_streaming.py tests/test_spill.py tests/test_spill_crossblock.py` = 141 passed; every `semantic_hash` consumer suite green after phase 3 (`test_semantics` 49, plus `test_spec_conformance`, `test_hive`, `test_config`, `test_dispatch`, `test_dedup`, `test_lifecycle`, `test_hive_windows`, `test_sweep_overview`, `test_column`, `test_lambda_handler`, `test_sweep_stage`, `test_client` = 1,381 passed / 1 skipped; no spec fixture declares `streaming`, so no fixture regeneration is triggered); full `pytest -q` on the final tree = 4,449 passed, 38 skipped, 1 failed (`test_lambda_build`, environmental — see below).

## D19 / semantic-hash finding — RULED, option (b), implemented in phase 3

**Ruling record (espg, in-session, 2026-08-17):** option (b) plus the **law-equivalence contract**. The whole `aggregation.streaming` block is excluded from the semantic core (`AGGREGATION_PACKAGING_KEYS = ("handoff", "streaming")`), on these criteria as ruled:

- the D19 design record already states the property twice as an acceptance property (cites below), so (b) lands the code on the record's side rather than amending the record;
- store compatibility is a non-issue at ruling time — the deployed stores age out on a 30-day cycle, so the epoch lands before the first long-lived external store and moves nothing that outlives it;
- the wanted, now-ratified property is that **all streaming regimes share one product identity with law-bounded bytes** — the contract, not the digest, is the guarantee. The contract is now normative in `docs/design/sparse_coverage.md` ("Amended again — the streaming exclusion and its law-equivalence contract"): every streaming mode MUST land within the documented approximation law of the pooled path (exact single-block/summation, kway/`np.isclose` across flushes and block closes); a mode that cannot maintain the law may not join the block. Enforcement: `tests/test_spill_crossblock.py` (being extended to the temporal channel by #477) and `tests/test_streaming.py`'s pooled-parity pins.

Phase 3 implements exactly this; the finding below stands as the record of what the code did before the ruling.

### The finding as originally reported

**`aggregation.streaming` DOES participate in the semantic core today — as declared (spelled), not resolved.** `semantic_core` folds `config.aggregation` minus only `AGGREGATION_PACKAGING_KEYS = ("handoff",)` (`src/zagg/semantics.py` lines 195–197 and 562–565); nothing strips `streaming`. Verified empirically: absent block, `{}`, `{buffer_granules: 50}`, `{buffer_granules: 20}`, and `{mode: spill}` all produce five distinct `semantic_hash` values.

This contradicts the module's own docstring, which lists "streaming mode" among "Excluded as packaging" (`src/zagg/semantics.py` line 62) — **and the D19 design record says it twice more, in stronger terms**:

- [`docs/design/sparse_coverage.md` L727-735](https://github.com/englacial/zagg/blob/claude/474-spill-knobs/docs/design/sparse_coverage.md#L727-L735) — "Excluded as packaging: cell order …, parent/shard order, `chunk_inner`/`sharded` …, worker size, **streaming mode** (merge-vs-spill lands `np.isclose` and shares one store, with the actual mode recorded per-run), and read knobs".
- [`docs/design/sparse_coverage.md` L1190-L1195](https://github.com/englacial/zagg/blob/claude/474-spill-knobs/docs/design/sparse_coverage.md#L1190-L1195), the D19 acceptance list — "packaging-knob edits (orders, chunking, worker size, **streaming mode**) never change the hash".

So option (b) below is not merely "matches the docstring" — it is what the design record states as an **acceptance property**, and option (a) means amending that record in the same breath. No test asserts the property today (`tests/test_semantics.py` never mentions `streaming`), which is how the code and the record drifted apart unnoticed.

Consequences as the code stands:

1. **This PR's default flip moves no existing hashes** — defaults resolve in `get_streaming`, not in the core, so a config that omits `buffer_granules` hashes identically before and after. But under `mode: merge` the flush cadence changes tdigest merge grouping, so the same identity can now produce (approximation-law-bounded) different bytes than a pre-#474 run — the bytes/identity tension `buffer_granules` always had, now exercised by a default change.
2. **Spelling an explicit default forks identity**: `{buffer_granules: 20}` hashes differently from the absent key even though the two are the same computation — the opposite of the resolved-not-spelled discipline the #415 epoch applies to hashed knobs.
3. **`block_bytes` straddles the packaging/identity line both ways**: declaring it changes the hash even at values that keep the exact single-block regime (byte-identical to pooled), while an actually-crossed threshold changes bytes under issue #370's fold laws.
4. **Under status quo (a), `block_bytes` cannot be added to an existing store — the manifest guard refuses.** `semantic_hash` is a FROZEN manifest key (`src/zagg/hive.py` `_FROZEN_MANIFEST_KEYS`, line 542–551) and `_frozen_matches` refuses an append when two hash-carrying manifests disagree (`hive.py` lines 565–581). Adding the knob changes the hash — measured on this branch against the shipped `atl03_tdigest_healpix_hive.yaml`, identical otherwise:

   ```
   {mode: spill}                       -> ee4f81c034c8a6f2…
   {mode: spill, block_bytes: 1<<30}   -> dc46e830522ba520…
   ```

   That is exactly the motivating workflow of #474: the five CA o9 fat shards failed **inside an existing store**, and the rescue is a re-dispatch of those shards into that store. Under (a) an operator who adds `block_bytes` to rescue them gets a frozen-key refusal instead, leaving only a fresh store or an out-of-band manifest edit.

Options (key membership is espg-ruled per the #420 epoch precedent — no hash change is made in this PR):

- **(a) status quo** — streaming hashes as spelled. Over-discriminating, which F1 records as the safe direction; but it contradicts the docstring *and* the D19 record, item (2)'s spelled-vs-absent fork stands, and item (4) means the #474 rescue path is not a config edit.
- **(b) add `"streaming"` to `AGGREGATION_PACKAGING_KEYS`** — matches the docstring and the design record's stated acceptance property; single-block spill is byte-identical to pooled so the packaging claim is honest there, but fold-regime and merge-mode runs would then produce different bytes under one identity (bounded by the t-digest/kway laws). A hash epoch: existing configs that declare `streaming` change digests. Allows the (4) rescue.
- **(c) split the block** — hash a resolved subset (e.g. `mode`, if a byte-affecting regime choice is deemed output-defining) and exclude the sizing knobs (`buffer_granules`, `block_bytes`) as packaging. Most precise, most machinery; the only option under which the (4) rescue is a config edit **without** a hash epoch for every `streaming`-declaring config.

## Questions for review — both ruled

1. ~~The D19 finding above — which option, (a)/(b)/(c)?~~ **Ruled: (b) + the law-equivalence contract** (espg, in-session 2026-08-17; record above). Implemented in phase 3; the #474 rescue path (item (4)) is now a plain config edit on an existing store.
2. ~~`block_bytes` under `mode: merge` is refused rather than ignored.~~ **Ruled: stays a loud refusal** (espg-endorsed, same session: explicit beats silently-ignored).

## Pre-existing failures observed (not touched, per §4)

- `ruff check src tests` on origin/main already fails: `N818` on `src/zagg/registry.py:64` (`UnknownCapability`), untouched here.
- `ruff format --check` already flags `tests/data/benchmark/README.md` (embedded snippet), untouched here.
- mypy baseline: 115 errors across 21 files on main (pre-commit's mypy hook is non-blocking); this PR reduces `worker.py`'s count by one.
- `test_lambda_build` (environmental) and `test_client_transport` (wall-clock flake) are known local failures unrelated to this change.

