### PR TITLE
aggregate: hoist per-cell toc encode + batch segmented reduces (issue #476)

### DIFF
--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -990,11 +990,16 @@ def _aggregate_chunk_cells(
     # ``build_tdigest`` inside defers its ``tocs_reduce``/``common_ancestor``
     # partition and the context exit runs ONE fold per channel over the whole
     # chunk, filling the collected vectors in place — byte-identically, before
-    # anything reads them (the ragged writer runs after this returns).
+    # anything reads them (the ragged writer runs after this returns). Armed only
+    # when a field actually declares a companion channel, so a config predating
+    # issue #87/#410 never sees the ContextVar and an arbitrary config-resolved
+    # reducer can only meet a placeholder on the configs that ask for one.
+    from contextlib import nullcontext
+
     from zagg.stats.tdigest import batched_companion_folds
 
     cells_with_data = 0
-    with batched_companion_folds():
+    with batched_companion_folds() if ragged_channels else nullcontext():
         for i, child_morton in enumerate(children):
             child_key = int(child_morton)
             if child_key in cell_to_slice:

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -40,16 +40,18 @@ def _temporal_fields(agg_fields: dict) -> dict[str, str]:
     }
 
 
-def _toc_word_column(cell_data: dict, config) -> np.ndarray:
-    """Encode this cell's observation times as toc words (spec §8.3, #410).
+def _checked_toc_source(columns, config) -> dict:
+    """The validated clock declaration for a temporal companion (spec §8.3, #410).
 
-    The single conversion point: the declared ``output.time_source`` column
-    through :func:`zagg.time_axis.observation_words`. Both companion shapes read
-    the result — a ``per-centroid`` field as the reducer's ``temporal=`` channel,
-    a ``per-cell`` field as its ``source`` column — so one store can never carry
-    two clocks.
+    The refusal seam both encode routes share: a declared companion with no
+    ``output.time_source`` block is the §8.3 no-clock error (config validation is
+    the front door, but a config built without it must still fail loudly rather
+    than write an empty companion), and a declared clock whose column was not
+    read names itself. ``columns`` only needs membership + iteration, so either
+    a per-cell namespace or the pooled column dict can be checked without
+    gathering anything.
     """
-    from zagg.time_axis import observation_words, toc_source
+    from zagg.time_axis import toc_source
 
     source = toc_source(config)
     if source is None:
@@ -58,18 +60,87 @@ def _toc_word_column(cell_data: dict, config) -> np.ndarray:
             "clock — declare output.time_source {field, epoch, scale, units} (spec §8.3, "
             "issue #410)"
         )
-    if source["field"] not in cell_data:
+    if source["field"] not in columns:
         raise ValueError(
             f"output.time_source.field {source['field']!r} is not in the cell data "
-            f"(available: {sorted(cell_data)}); a temporal companion needs the declared "
+            f"(available: {sorted(columns)}); a temporal companion needs the declared "
             f"time column read at base rate"
         )
+    return source
+
+
+def _toc_word_column(cell_data: dict, config) -> np.ndarray:
+    """Encode this cell's observation times as toc words (spec §8.3, #410).
+
+    The single conversion point: the declared ``output.time_source`` column
+    through :func:`zagg.time_axis.observation_words`. Both companion shapes read
+    the result — a ``per-centroid`` field as the reducer's ``temporal=`` channel,
+    a ``per-cell`` field as its ``source`` column — so one store can never carry
+    two clocks. The chunk path encodes through :func:`_chunk_toc_words` instead
+    (one pass per chunk, issue #476); this per-cell route remains for direct
+    :func:`calculate_cell_statistics` callers.
+    """
+    from zagg.time_axis import observation_words
+
+    source = _checked_toc_source(cell_data, config)
     return observation_words(
         cell_data[source["field"]],
         epoch=source["epoch"],
         scale=source["scale"],
         units=source["units"],
     )
+
+
+def _chunk_toc_words(
+    col_arrays: dict[str, np.ndarray],
+    cell_to_slice: dict[int, tuple[int, int]],
+    children: np.ndarray,
+    config,
+) -> dict[int, np.ndarray]:
+    """Encode one chunk's toc words in ONE pass and split them per cell (#476).
+
+    Per-chunk hoist of :func:`_toc_word_column`: gather the declared
+    ``output.time_source`` column over the chunk's populated cells, encode it
+    through one :func:`zagg.time_axis.observation_words` call, and slice the
+    result back per cell. The encode is element-wise, so each cell's words are
+    byte-identical to the per-cell encode this replaces — only the call count
+    collapses (issue #476 measured 28,515 per-cell encodes at 0.21 ms against
+    one pooled pass over the same rows).
+
+    Returns ``{cell_key: words}`` for exactly the chunk's populated cells. A
+    chunk with no populated cells returns ``{}`` before touching the clock
+    declaration — matching the per-cell path, where an empty cell never reaches
+    the encode — while any populated cell runs the §8.3 refusal checks
+    (:func:`_checked_toc_source`) exactly as the per-cell route did.
+    """
+    present: list[tuple[int, int, int]] = []
+    for child in children:
+        key = int(child)
+        sl = cell_to_slice.get(key)
+        if sl is not None:
+            present.append((key, *sl))
+    if not present:
+        return {}
+    from zagg.time_axis import observation_words
+
+    source = _checked_toc_source(col_arrays, config)
+    col = col_arrays[source["field"]]
+    if len(present) == 1:
+        _, start, end = present[0]
+        gathered = col[start:end]
+    else:
+        idx = np.concatenate([np.arange(start, end) for _, start, end in present])
+        gathered = col[idx]
+    words = observation_words(
+        gathered, epoch=source["epoch"], scale=source["scale"], units=source["units"]
+    )
+    out: dict[int, np.ndarray] = {}
+    pos = 0
+    for key, start, end in present:
+        n = end - start
+        out[key] = words[pos : pos + n]
+        pos += n
+    return out
 
 
 def _rss_mb() -> float:
@@ -478,12 +549,14 @@ def calculate_cell_statistics(
         0,
     )
     # The derived toc word column (spec §8.2/§8.3, issue #410): one word per
-    # observation, encoded here rather than in the read path so every route into
-    # the aggregation (pooled, spill read-back, per-chunk precompute) gets it
-    # from ONE conversion, and so the total encode work is exactly one pass over
-    # the shard's rows. Materialized only when a field declares a companion, so
+    # observation, from ONE conversion point whichever route reaches the
+    # aggregation. The chunk path (``_aggregate_chunk_cells`` — pooled and spill
+    # read-back alike) pre-encodes it once per chunk (``_chunk_toc_words``,
+    # issue #476) and injects it at ``cell_data`` construction, so this per-cell
+    # encode — and its dict copy — only runs for direct callers whose namespace
+    # lacks the column. Materialized only when a field declares a companion, so
     # a config written before #410 takes the code path it always did.
-    if n_obs and _temporal_fields(agg_fields):
+    if n_obs and TOC_WORD_COLUMN not in cell_data and _temporal_fields(agg_fields):
         cell_data = {**cell_data, TOC_WORD_COLUMN: _toc_word_column(cell_data, config)}
     if n_obs == 0:
         # Empty cell: every agg field gets its sentinel EXCEPT a field whose
@@ -873,6 +946,19 @@ def _aggregate_chunk_cells(
 
     _empty: dict[str, np.ndarray] = {col: arr[:0] for col, arr in col_arrays.items()}
 
+    # Per-chunk toc encode (issue #476): when a field declares a temporal
+    # companion, encode the whole chunk's words in one pass and hand each
+    # populated cell its slice at namespace construction — the per-cell encode
+    # (and its dict copy) in ``calculate_cell_statistics`` then never runs on
+    # this path. Both callers (the worker's pooled loop and the spill
+    # read-back, which is per chunk by construction) get the hoist here, so
+    # chunk boundaries are respected at any chunks_per_shard.
+    cell_toc = (
+        _chunk_toc_words(col_arrays, cell_to_slice, children, config)
+        if _temporal_fields(agg_fields)
+        else None
+    )
+
     cells_with_data = 0
     for i, child_morton in enumerate(children):
         child_key = int(child_morton)
@@ -881,6 +967,8 @@ def _aggregate_chunk_cells(
             cell_data: dict[str, np.ndarray] = {
                 col: arr[start:end] for col, arr in col_arrays.items()
             }
+            if cell_toc is not None:
+                cell_data[TOC_WORD_COLUMN] = cell_toc[child_key]
             cells_with_data += 1
         else:
             cell_data = _empty

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -96,6 +96,7 @@ def _chunk_toc_words(
     cell_to_slice: dict[int, tuple[int, int]],
     children: np.ndarray,
     config,
+    pooled: dict[str, np.ndarray] | None = None,
 ) -> dict[int, np.ndarray]:
     """Encode one chunk's toc words in ONE pass and split them per cell (#476).
 
@@ -106,6 +107,13 @@ def _chunk_toc_words(
     byte-identical to the per-cell encode this replaces — only the call count
     collapses (issue #476 measured 28,515 per-cell encodes at 0.21 ms against
     one pooled pass over the same rows).
+
+    ``pooled`` is :func:`_pool_chunk_columns`' output for the same ``children``,
+    when the caller already has it: both walk ``children`` in order and take the
+    same ``cell_to_slice`` slices, so the pooled clock column IS this gather and
+    reusing it skips a second index build and column copy per chunk (review
+    finding, PR #478). Without it the index is built here — the direct-call route
+    (tests, any caller without the pooled dict).
 
     Returns ``{cell_key: words}`` for exactly the chunk's populated cells. A
     chunk with no populated cells returns ``{}`` before touching the clock
@@ -124,13 +132,21 @@ def _chunk_toc_words(
     from zagg.time_axis import observation_words
 
     source = _checked_toc_source(col_arrays, config)
-    col = col_arrays[source["field"]]
-    if len(present) == 1:
+    n_rows = sum(end - start for _, start, end in present)
+    if pooled is not None:
+        gathered = pooled[source["field"]]
+        if len(gathered) != n_rows:
+            raise ValueError(
+                f"pooled chunk columns hold {len(gathered)} rows but this chunk's cells "
+                f"span {n_rows}; the pooled columns must be _pool_chunk_columns' output "
+                "for the same children"
+            )
+    elif len(present) == 1:
         _, start, end = present[0]
-        gathered = col[start:end]
+        gathered = col_arrays[source["field"]][start:end]
     else:
         idx = np.concatenate([np.arange(start, end) for _, start, end in present])
-        gathered = col[idx]
+        gathered = col_arrays[source["field"]][idx]
     words = observation_words(
         gathered, epoch=source["epoch"], scale=source["scale"], units=source["units"]
     )
@@ -896,6 +912,7 @@ def _aggregate_chunk_cells(
     config: PipelineConfig,
     data_vars,
     agg_fields: dict,
+    chunk_pooled: dict | None = None,
 ):
     """Compute per-cell stats for one chunk's ``children`` (default numpy path).
 
@@ -916,6 +933,10 @@ def _aggregate_chunk_cells(
     (issue #87) and ``times`` (spec §8.3, issue #410), each index-aligned with
     that field's payloads. A field declaring no companion has no entry, so a
     config written before either channel produces the same empty mapping.
+
+    ``chunk_pooled`` is the caller's :func:`_pool_chunk_columns` output for these
+    same ``children`` (both worker call sites build it for the chunk precompute
+    anyway); it lets the toc hoist reuse that gather instead of rebuilding it.
     """
     children = np.asarray(children)
     n_cells = len(children)
@@ -960,7 +981,7 @@ def _aggregate_chunk_cells(
     # read-back, which is per chunk by construction) get the hoist here, so
     # chunk boundaries are respected at any chunks_per_shard.
     cell_toc = (
-        _chunk_toc_words(col_arrays, cell_to_slice, children, config)
+        _chunk_toc_words(col_arrays, cell_to_slice, children, config, pooled=chunk_pooled)
         if _temporal_fields(agg_fields)
         else None
     )

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -959,56 +959,64 @@ def _aggregate_chunk_cells(
         else None
     )
 
+    # Batch the per-centroid companion folds across the loop (issue #476): each
+    # ``build_tdigest`` inside defers its ``tocs_reduce``/``common_ancestor``
+    # partition and the context exit runs ONE fold per channel over the whole
+    # chunk, filling the collected vectors in place — byte-identically, before
+    # anything reads them (the ragged writer runs after this returns).
+    from zagg.stats.tdigest import batched_companion_folds
+
     cells_with_data = 0
-    for i, child_morton in enumerate(children):
-        child_key = int(child_morton)
-        if child_key in cell_to_slice:
-            start, end = cell_to_slice[child_key]
-            cell_data: dict[str, np.ndarray] = {
-                col: arr[start:end] for col, arr in col_arrays.items()
-            }
-            if cell_toc is not None:
-                cell_data[TOC_WORD_COLUMN] = cell_toc[child_key]
-            cells_with_data += 1
-        else:
-            cell_data = _empty
-        # Inject the chunk-level scalars into this cell's namespace (no-op when
-        # empty, so non-precompute configs are unchanged).
-        cell_namespace: dict[str, Any] = (
-            {**cell_data, **chunk_scalars} if chunk_scalars else cell_data
-        )
-        stats = calculate_cell_statistics(
-            cell_namespace, value_col="h_li", sigma_col="s_li", config=config
-        )
-        for key, value in stats.items():
-            if key in ragged_payloads:
-                # Ragged field: collect non-empty payloads with their chunk-local
-                # cell index. Empty cells (``_empty_cell_value`` -> []) are skipped.
-                # A companion-carrying field delivers ``(payload, *channel words)``
-                # in the kernel's fixed order; the words are collected
-                # index-aligned with the payloads.
-                if isinstance(value, tuple):
-                    payload, *words = value
-                else:
-                    payload, words = np.asarray(value), []
-                if payload.size == 0:
-                    continue
-                # Fail fast if the value's arity disagrees with the declared
-                # signature (empty cells are exempt, having been skipped above) —
-                # a silent mismatch would surface much later as a length error in
-                # the ragged writer, or as a companion silently dropped.
-                channels = ragged_channels.get(key, {})
-                if len(channels) != len(words):
-                    raise ValueError(
-                        f"ragged field {key!r}: the reducer returned {len(words)} companion "
-                        f"channel(s) but the declared signature has {len(channels)} "
-                        f"({sorted(channels) or 'none'})"
-                    )
-                ragged_payloads[key].append(payload)
-                ragged_cell_indices[key].append(i)
-                for channel, word_vector in zip(channels.values(), words, strict=True):
-                    channel.append(word_vector)
+    with batched_companion_folds():
+        for i, child_morton in enumerate(children):
+            child_key = int(child_morton)
+            if child_key in cell_to_slice:
+                start, end = cell_to_slice[child_key]
+                cell_data: dict[str, np.ndarray] = {
+                    col: arr[start:end] for col, arr in col_arrays.items()
+                }
+                if cell_toc is not None:
+                    cell_data[TOC_WORD_COLUMN] = cell_toc[child_key]
+                cells_with_data += 1
             else:
-                stats_arrays[key][i] = value
+                cell_data = _empty
+            # Inject the chunk-level scalars into this cell's namespace (no-op when
+            # empty, so non-precompute configs are unchanged).
+            cell_namespace: dict[str, Any] = (
+                {**cell_data, **chunk_scalars} if chunk_scalars else cell_data
+            )
+            stats = calculate_cell_statistics(
+                cell_namespace, value_col="h_li", sigma_col="s_li", config=config
+            )
+            for key, value in stats.items():
+                if key in ragged_payloads:
+                    # Ragged field: collect non-empty payloads with their chunk-local
+                    # cell index. Empty cells (``_empty_cell_value`` -> []) are skipped.
+                    # A companion-carrying field delivers ``(payload, *channel words)``
+                    # in the kernel's fixed order; the words are collected
+                    # index-aligned with the payloads.
+                    if isinstance(value, tuple):
+                        payload, *words = value
+                    else:
+                        payload, words = np.asarray(value), []
+                    if payload.size == 0:
+                        continue
+                    # Fail fast if the value's arity disagrees with the declared
+                    # signature (empty cells are exempt, having been skipped above) —
+                    # a silent mismatch would surface much later as a length error in
+                    # the ragged writer, or as a companion silently dropped.
+                    channels = ragged_channels.get(key, {})
+                    if len(channels) != len(words):
+                        raise ValueError(
+                            f"ragged field {key!r}: the reducer returned {len(words)} "
+                            f"companion channel(s) but the declared signature has "
+                            f"{len(channels)} ({sorted(channels) or 'none'})"
+                        )
+                    ragged_payloads[key].append(payload)
+                    ragged_cell_indices[key].append(i)
+                    for channel, word_vector in zip(channels.values(), words, strict=True):
+                        channel.append(word_vector)
+                else:
+                    stats_arrays[key][i] = value
 
     return stats_arrays, ragged_payloads, ragged_cell_indices, ragged_channels, cells_with_data

--- a/src/zagg/processing/aggregate.py
+++ b/src/zagg/processing/aggregate.py
@@ -668,6 +668,12 @@ def calculate_cell_statistics(
             payload = _coerce_ragged_value(payload, sig)
             out = []
             for label, channel in zip(channels, words, strict=True):
+                # Must not copy: under ``batched_companion_folds`` (issue #476) the
+                # reducer hands back a contiguous uint64 placeholder the batch fills
+                # in place at the flush, so this normalization has to be identity —
+                # which it is for the contiguous uint64 vectors the build_tdigest
+                # family returns. A copy here would strand the flush on an orphan
+                # (see ``_CompanionBatch``).
                 channel = np.ascontiguousarray(np.asarray(channel))
                 if channel.dtype != np.uint64:
                     # A silent uint64 cast would wrap negative/float garbage into

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -1017,6 +1017,7 @@ class SpillAggregator:
             self.config,
             self._data_vars,
             agg_fields,
+            chunk_pooled=chunk_pooled,
         )
 
     def _load_partition(self, key: int) -> None:

--- a/src/zagg/processing/worker.py
+++ b/src/zagg/processing/worker.py
@@ -924,6 +924,9 @@ def process_shard(
                 config,
                 data_vars,
                 agg_fields,
+                # Already gathered for the precompute above — the toc hoist reuses
+                # it instead of rebuilding the same index (review finding, PR #478).
+                chunk_pooled=chunk_pooled,
             )
         cells_with_data += cwd
         # Strict-AOI per-cell mask (issue #101): expand the shard's manifest payload

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -211,6 +211,16 @@ class _CompanionBatch:
 
     def defer(self, fold: _ChannelFold, words: np.ndarray, starts, n: int) -> np.ndarray:
         starts = np.asarray(starts, dtype=np.int64)
+        # The concatenation is a valid segmented layout only if each deferral's
+        # partition starts at 0 (``_compress`` guarantees it). Neither fold would
+        # catch a violation — the exact-cover check still passes, the offending
+        # rows just fold into the previous entry's last centroid — so make the
+        # invariant load-bearing rather than documented (O(1) per deferral).
+        if len(starts) and starts[0] != 0:
+            raise ValueError(
+                f"deferred companion fold got starts[0]={int(starts[0])}; the cross-cell "
+                "batch requires each centroid partition to start at 0 (see _compress)"
+            )
         out = np.empty(len(starts), dtype=np.uint64)
         rows = self._rows.get(fold, 0)
         # The declared ``n`` rides along rather than being re-derived from

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -97,6 +97,11 @@ _ChannelFold = Callable[[np.ndarray, np.ndarray, int], np.ndarray]
 #: One deferred fold: member words, offset-adjusted starts, placeholder, declared n.
 _Deferred = tuple[np.ndarray, np.ndarray, np.ndarray, int]
 
+#: Deferred member rows per channel before the batch folds mid-loop, bounding the
+#: words it pins to ~8 MB per channel (issue #476 review finding). The folds are
+#: segment-local, so the cut point cannot change an output word.
+_BATCH_ROW_CAP = 1_000_000
+
 __all__ = [
     "build_tdigest",
     "build_tdigest_pairwise",
@@ -195,7 +200,9 @@ class _CompanionBatch:
     its own member slice — and ``_compress`` always emits starts partitioning
     ``[0, n)`` from 0, so the concatenation is itself a valid ``(words,
     starts, n)`` fold input and the batched result is byte-for-byte the
-    per-call results, sliced back apart.
+    per-call results, sliced back apart.  The same segment-locality bounds the
+    memory: a channel that reaches ``_BATCH_ROW_CAP`` deferred rows folds mid-loop
+    (:meth:`flush_detached`) instead of holding the whole chunk's words.
 
     Correctness requires deferred outputs to be **write-only and un-copied
     until the flush**, which holds for the one activation site
@@ -242,7 +249,29 @@ class _CompanionBatch:
         # partition on the single-entry arm.
         self._pending.setdefault(fold, []).append((words[:n], starts + rows, out, n))
         self._rows[fold] = rows + n
+        # Bound the held member words (review finding, PR #478): the batch pins a
+        # copy of every deferral's words until its flush, which at 1.5 M obs is
+        # ~12 MB per channel for a whole chunk. Folding mid-loop at the cap is
+        # byte-identical — the folds are segment-local, so where the batch is cut
+        # cannot move an output word — and keeps essentially the whole FFI win
+        # (one crossing per _BATCH_ROW_CAP rows rather than one per cell-field).
+        if self._rows[fold] >= _BATCH_ROW_CAP:
+            self.flush_detached()
         return out
+
+    def flush_detached(self) -> None:
+        """Flush from *inside* the context: deactivate the batch, then fold.
+
+        ``flush`` calls the real folds, which re-enter :func:`_centroid_ancestors`
+        / :func:`_centroid_envelopes` — with the batch still installed they would
+        defer straight back into it (and recurse). Deactivating first is exactly
+        what :func:`batched_companion_folds` does at exit.
+        """
+        token = _FOLD_BATCH.set(None)
+        try:
+            self.flush()
+        finally:
+            _FOLD_BATCH.reset(token)
 
     def flush(self) -> None:
         """Run each channel's fold once over its concatenated deferrals."""

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -84,6 +84,8 @@ that order.
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import overload
 
 import numpy as np
@@ -178,6 +180,88 @@ def _compress(
     return out_means, out_weights, starts
 
 
+class _CompanionBatch:
+    """Cross-cell batcher for the per-centroid companion folds (issue #476).
+
+    Inside :func:`batched_companion_folds`, each :func:`_centroid_ancestors` /
+    :func:`_centroid_envelopes` call *defers*: it hands back an unfilled
+    ``uint64`` placeholder of the right length and records its ``(member
+    words, offset-adjusted starts)``. The flush then runs the real fold ONCE
+    per channel over the concatenated layout and fills every placeholder in
+    place.  Both folds are segment-independent — each output word reduces over
+    its own member slice — and ``_compress`` always emits starts partitioning
+    ``[0, n)`` from 0, so the concatenation is itself a valid ``(words,
+    starts, n)`` fold input and the batched result is byte-for-byte the
+    per-call results, sliced back apart.
+
+    Correctness requires deferred outputs to be **write-only until the
+    flush**, which holds for the one activation site
+    (``_aggregate_chunk_cells``' per-cell loop): the channel vectors are only
+    collected for the ragged writer, which runs after that function returns.
+    """
+
+    def __init__(self) -> None:
+        #: fold -> [(member words, offset-adjusted starts, placeholder)]
+        self._pending: dict[_ChannelFold, list[tuple[np.ndarray, np.ndarray, np.ndarray]]] = {}
+        #: fold -> running member-row count (the next deferral's offset)
+        self._rows: dict[_ChannelFold, int] = {}
+
+    def defer(self, fold: _ChannelFold, words: np.ndarray, starts, n: int) -> np.ndarray:
+        starts = np.asarray(starts, dtype=np.int64)
+        out = np.empty(len(starts), dtype=np.uint64)
+        rows = self._rows.get(fold, 0)
+        self._pending.setdefault(fold, []).append((words[:n], starts + rows, out))
+        self._rows[fold] = rows + n
+        return out
+
+    def flush(self) -> None:
+        """Run each channel's fold once over its concatenated deferrals."""
+        for fold, entries in self._pending.items():
+            if len(entries) == 1:
+                words, starts, out = entries[0]
+                out[:] = fold(words, starts, len(words))
+                continue
+            words_all = np.concatenate([w for w, _, _ in entries])
+            starts_all = np.concatenate([s for _, s, _ in entries])
+            reduced = fold(words_all, starts_all, self._rows[fold])
+            pos = 0
+            for _, _, out in entries:
+                out[:] = reduced[pos : pos + len(out)]
+                pos += len(out)
+        self._pending.clear()
+        self._rows.clear()
+
+
+#: The active cross-cell fold batch; ``None`` outside ``batched_companion_folds``.
+_FOLD_BATCH: ContextVar[_CompanionBatch | None] = ContextVar("_FOLD_BATCH", default=None)
+
+
+@contextmanager
+def batched_companion_folds():
+    """Defer the per-centroid companion folds; run each once per channel at exit.
+
+    The issue #476 hoist: at CA shard shape the per-cell loop makes ~46k
+    segmented ``mortie.tocs_reduce`` calls (one per populated cell-field) whose
+    cost is Python/FFI dispatch, not reduction — under this context they
+    collapse to one call per channel per chunk, byte-identically (see
+    :class:`_CompanionBatch`).  Activated by ``_aggregate_chunk_cells`` around
+    its per-cell loop; nested activation is a passthrough into the outer batch's
+    scope.  The flush runs only on a clean exit — after an exception the
+    placeholders are never read, so they are dropped, and the batch is always
+    deactivated before flushing so the folds it runs execute for real.
+    """
+    if _FOLD_BATCH.get() is not None:
+        yield
+        return
+    batch = _CompanionBatch()
+    token = _FOLD_BATCH.set(batch)
+    try:
+        yield
+    finally:
+        _FOLD_BATCH.reset(token)
+    batch.flush()
+
+
 def _centroid_ancestors(locations: np.ndarray, starts: np.ndarray, n: int) -> np.ndarray:
     """Reduce per-member morton locations to one enclosing cell per centroid.
 
@@ -198,7 +282,14 @@ def _centroid_ancestors(locations: np.ndarray, starts: np.ndarray, n: int) -> np
     prefix raises), so the copy-through keeps that guarantee by validating the
     whole singleton set in one kernel pass; otherwise a bad word would raise
     only in the compressed regime.
+
+    Under :func:`batched_companion_folds` the call defers instead (issue
+    #476): the singleton validation and the multi-member loop then run once
+    over the whole batch's concatenated partition, byte-identically.
     """
+    batch = _FOLD_BATCH.get()
+    if batch is not None:
+        return batch.defer(_centroid_ancestors, locations, starts, n)
     from mortie import common_ancestor, validate_morton
 
     starts = np.asarray(starts, dtype=np.int64)
@@ -244,7 +335,14 @@ def _centroid_envelopes(temporal: np.ndarray, starts: np.ndarray, n: int) -> np.
     The reserved-``0`` refusal lives in :func:`_check_words`, which every caller
     passes its words through — including the merge arms that pass a channel
     straight back without reducing it.
+
+    Under :func:`batched_companion_folds` the call defers instead (issue
+    #476): one ``tocs_reduce`` then crosses into Rust per batch rather than
+    per cell-field, byte-identically (the reduce is segmented).
     """
+    batch = _FOLD_BATCH.get()
+    if batch is not None:
+        return batch.defer(_centroid_envelopes, temporal, starts, n)
     from mortie import tocs_reduce
 
     starts = np.asarray(starts, dtype=np.int64)

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -94,6 +94,9 @@ import numpy as np
 #: map ``_compress`` returns -> one word per output centroid.
 _ChannelFold = Callable[[np.ndarray, np.ndarray, int], np.ndarray]
 
+#: One deferred fold: member words, offset-adjusted starts, placeholder, declared n.
+_Deferred = tuple[np.ndarray, np.ndarray, np.ndarray, int]
+
 __all__ = [
     "build_tdigest",
     "build_tdigest_pairwise",
@@ -186,7 +189,7 @@ class _CompanionBatch:
     Inside :func:`batched_companion_folds`, each :func:`_centroid_ancestors` /
     :func:`_centroid_envelopes` call *defers*: it hands back an unfilled
     ``uint64`` placeholder of the right length and records its ``(member
-    words, offset-adjusted starts)``. The flush then runs the real fold ONCE
+    words, offset-adjusted starts, n)``. The flush then runs the real fold ONCE
     per channel over the concatenated layout and fills every placeholder in
     place.  Both folds are segment-independent — each output word reduces over
     its own member slice — and ``_compress`` always emits starts partitioning
@@ -201,8 +204,8 @@ class _CompanionBatch:
     """
 
     def __init__(self) -> None:
-        #: fold -> [(member words, offset-adjusted starts, placeholder)]
-        self._pending: dict[_ChannelFold, list[tuple[np.ndarray, np.ndarray, np.ndarray]]] = {}
+        #: fold -> its deferrals, in call order
+        self._pending: dict[_ChannelFold, list[_Deferred]] = {}
         #: fold -> running member-row count (the next deferral's offset)
         self._rows: dict[_ChannelFold, int] = {}
 
@@ -210,7 +213,12 @@ class _CompanionBatch:
         starts = np.asarray(starts, dtype=np.int64)
         out = np.empty(len(starts), dtype=np.uint64)
         rows = self._rows.get(fold, 0)
-        self._pending.setdefault(fold, []).append((words[:n], starts + rows, out))
+        # The declared ``n`` rides along rather than being re-derived from
+        # ``len(words)`` at the flush: the two agree for every current caller, but a
+        # deferral whose ``n`` overruns its words must fail where the unbatched call
+        # would (mortie's exact-cover check) rather than silently fold a different
+        # partition on the single-entry arm.
+        self._pending.setdefault(fold, []).append((words[:n], starts + rows, out, n))
         self._rows[fold] = rows + n
         return out
 
@@ -218,14 +226,14 @@ class _CompanionBatch:
         """Run each channel's fold once over its concatenated deferrals."""
         for fold, entries in self._pending.items():
             if len(entries) == 1:
-                words, starts, out = entries[0]
-                out[:] = fold(words, starts, len(words))
+                words, starts, out, n = entries[0]
+                out[:] = fold(words, starts, n)
                 continue
-            words_all = np.concatenate([w for w, _, _ in entries])
-            starts_all = np.concatenate([s for _, s, _ in entries])
+            words_all = np.concatenate([w for w, _, _, _ in entries])
+            starts_all = np.concatenate([s for _, s, _, _ in entries])
             reduced = fold(words_all, starts_all, self._rows[fold])
             pos = 0
-            for _, _, out in entries:
+            for _, _, out, _ in entries:
                 out[:] = reduced[pos : pos + len(out)]
                 pos += len(out)
         self._pending.clear()

--- a/src/zagg/stats/tdigest.py
+++ b/src/zagg/stats/tdigest.py
@@ -197,10 +197,15 @@ class _CompanionBatch:
     starts, n)`` fold input and the batched result is byte-for-byte the
     per-call results, sliced back apart.
 
-    Correctness requires deferred outputs to be **write-only until the
-    flush**, which holds for the one activation site
+    Correctness requires deferred outputs to be **write-only and un-copied
+    until the flush**, which holds for the one activation site
     (``_aggregate_chunk_cells``' per-cell loop): the channel vectors are only
-    collected for the ragged writer, which runs after that function returns.
+    collected for the ragged writer, which runs after that function returns, and
+    the one normalization on the way there (``np.ascontiguousarray`` in
+    ``calculate_cell_statistics``) is identity-preserving for the contiguous
+    ``uint64`` placeholder handed out here.  A reducer that returned a *copy*
+    would strand the flush on an orphan, which is why the placeholder is
+    ``zeros`` (a refusable reserved word) rather than ``empty``.
     """
 
     def __init__(self) -> None:
@@ -221,7 +226,14 @@ class _CompanionBatch:
                 f"deferred companion fold got starts[0]={int(starts[0])}; the cross-cell "
                 "batch requires each centroid partition to start at 0 (see _compress)"
             )
-        out = np.empty(len(starts), dtype=np.uint64)
+        # ``zeros``, not ``empty``: if a placeholder ever escapes the flush (a
+        # reducer that copies its channel instead of handing the vector straight
+        # back — see the ``ascontiguousarray`` note in ``calculate_cell_statistics``)
+        # the unfilled vector reads as spec 8.2's reserved unobserved word, which
+        # ``_check_words``/``zagg.stats.toc`` refuse outright, rather than as
+        # plausible-looking uninitialized bytes. A calloc of <= delta words is free
+        # against the fold it replaces.
+        out = np.zeros(len(starts), dtype=np.uint64)
         rows = self._rows.get(fold, 0)
         # The declared ``n`` rides along rather than being re-derived from
         # ``len(words)`` at the flush: the two agree for every current caller, but a

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2191,6 +2191,24 @@ class TestTemporalCompanionProduction:
             per_cell = _toc_word_column({col: arr[start:end] for col, arr in cols.items()}, cfg)
             np.testing.assert_array_equal(by_cell[key], per_cell)
 
+    def test_the_pooled_gather_is_the_same_gather(self):
+        # Both callers pool the chunk's columns for the precompute one statement
+        # earlier, walking the same children in the same order — so reusing that
+        # column instead of rebuilding the index must not move a byte, while a
+        # pooled dict built for other children is refused rather than trusted.
+        from zagg.processing.aggregate import _chunk_toc_words, _pool_chunk_columns
+
+        cfg, children, cols, cell_to_slice = self._grouped()
+        pooled = _pool_chunk_columns(cols, cell_to_slice, children)
+        built = _chunk_toc_words(cols, cell_to_slice, children, cfg)
+        reused = _chunk_toc_words(cols, cell_to_slice, children, cfg, pooled=pooled)
+        assert set(built) == set(reused) == set(cell_to_slice)
+        for key in built:
+            np.testing.assert_array_equal(built[key], reused[key])
+        stale = {name: arr[:-1] for name, arr in pooled.items()}
+        with pytest.raises(ValueError, match="pooled chunk columns hold"):
+            _chunk_toc_words(cols, cell_to_slice, children, cfg, pooled=stale)
+
     def test_chunk_path_never_encodes_per_cell(self, monkeypatch):
         # The chunk path injects the pre-encoded column, so the per-cell encode
         # (and its dict copy) must not run — while the emitted words stay

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2166,6 +2166,95 @@ class TestTemporalCompanionProduction:
         assert slots == (None, [1])
         assert _ragged_entry((["v"], [0], *slots)) == (["v"], [0], None, [1])
 
+    # -- the per-chunk toc encode hoist (issue #476) -------------------------
+
+    def _grouped(self, n=60):
+        from zagg.processing.aggregate import _group_columns
+
+        cfg = self._cfg()
+        grid = HealpixGrid(6, 8, layout="fullsphere", config=cfg)
+        cell = self._cell(n)
+        cells = grid.cells_of(cell["leaf_id"])
+        children = np.unique(cells)
+        cols, cell_to_slice = _group_columns(dict(cell), cells)
+        return cfg, children, cols, cell_to_slice
+
+    def test_chunk_encode_matches_the_per_cell_encode(self):
+        # The hoisted one-pass encode is element-wise, so each cell's slice must
+        # be byte-identical to encoding that cell's rows alone (issue #476).
+        from zagg.processing.aggregate import _chunk_toc_words, _toc_word_column
+
+        cfg, children, cols, cell_to_slice = self._grouped()
+        by_cell = _chunk_toc_words(cols, cell_to_slice, children, cfg)
+        assert set(by_cell) == set(cell_to_slice)
+        for key, (start, end) in cell_to_slice.items():
+            per_cell = _toc_word_column({col: arr[start:end] for col, arr in cols.items()}, cfg)
+            np.testing.assert_array_equal(by_cell[key], per_cell)
+
+    def test_chunk_path_never_encodes_per_cell(self, monkeypatch):
+        # The chunk path injects the pre-encoded column, so the per-cell encode
+        # (and its dict copy) must not run — while the emitted words stay
+        # byte-identical to the per-cell route (issue #476).
+        import zagg.processing.aggregate as agg_mod
+        from zagg.processing.aggregate import _aggregate_chunk_cells
+
+        cfg, children, cols, cell_to_slice = self._grouped()
+        agg_fields = get_agg_fields(cfg)
+        calls = []
+        orig = agg_mod._toc_word_column
+        monkeypatch.setattr(
+            agg_mod, "_toc_word_column", lambda *a, **k: calls.append(1) or orig(*a, **k)
+        )
+        stats, payloads, idx, channels, _ = _aggregate_chunk_cells(
+            children, cols, cell_to_slice, {}, cfg, ["h_tdigest", "observed"], agg_fields
+        )
+        assert calls == [], "the chunk path must not fall back to the per-cell encode"
+        for j, i in enumerate(idx["h_tdigest"]):
+            start, end = cell_to_slice[int(children[i])]
+            cell = {col: arr[start:end] for col, arr in cols.items()}
+            digest, locs, times = calculate_cell_statistics(cell, config=cfg)["h_tdigest"]
+            np.testing.assert_array_equal(payloads["h_tdigest"][j], digest)
+            np.testing.assert_array_equal(channels["h_tdigest"]["locations"][j], locs)
+            np.testing.assert_array_equal(channels["h_tdigest"]["times"][j], times)
+            assert stats["observed"][i] == calculate_cell_statistics(cell, config=cfg)["observed"]
+
+    def test_no_clock_refused_on_the_chunk_path(self):
+        # §8.3's refusal stays reachable after the hoist: a populated chunk with
+        # a declared companion but no clock fails exactly as the per-cell route.
+        from zagg.processing.aggregate import _aggregate_chunk_cells
+
+        cfg, children, cols, cell_to_slice = self._grouped()
+        del cfg.output["time_source"]
+        with pytest.raises(ValueError, match="no per-observation clock"):
+            _aggregate_chunk_cells(
+                children,
+                cols,
+                cell_to_slice,
+                {},
+                cfg,
+                ["h_tdigest", "observed"],
+                get_agg_fields(cfg),
+            )
+
+    def test_all_empty_chunk_needs_no_clock(self):
+        # Parity with the per-cell route, where an empty cell never reaches the
+        # encode: a chunk with no populated cells must not demand a clock.
+        from zagg.processing.aggregate import _aggregate_chunk_cells
+
+        cfg, children, cols, cell_to_slice = self._grouped()
+        del cfg.output["time_source"]
+        empty_cols = {col: arr[:0] for col, arr in cols.items()}
+        stats, payloads, idx, channels, cwd = _aggregate_chunk_cells(
+            children,
+            empty_cols,
+            {},
+            {},
+            cfg,
+            ["h_tdigest", "observed"],
+            get_agg_fields(cfg),
+        )
+        assert cwd == 0 and payloads["h_tdigest"] == []
+
 
 class TestRaggedChunkCompanion:
     """Issue #82 phase 4c: a ``kind: ragged`` + ``resolution: chunk`` field stores

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2236,6 +2236,31 @@ class TestTemporalCompanionProduction:
             np.testing.assert_array_equal(channels["h_tdigest"]["times"][j], times)
             assert stats["observed"][i] == calculate_cell_statistics(cell, config=cfg)["observed"]
 
+    def test_the_batch_is_armed_only_for_companion_configs(self, monkeypatch):
+        # No declared channel, no deferral machinery: a config predating issue
+        # #87/#410 must never see the ContextVar, so an arbitrary reducer can
+        # only meet a placeholder on the configs that ask for one.
+        import zagg.stats.tdigest as td_mod
+        from zagg.processing.aggregate import _aggregate_chunk_cells
+
+        calls: list[int] = []
+        orig = td_mod.batched_companion_folds
+        monkeypatch.setattr(td_mod, "batched_companion_folds", lambda: calls.append(1) or orig())
+        cfg, children, cols, cell_to_slice = self._grouped()
+        _aggregate_chunk_cells(
+            children, cols, cell_to_slice, {}, cfg, ["h_tdigest", "observed"], get_agg_fields(cfg)
+        )
+        assert calls == [1]
+        plain = self._cfg()
+        del plain.aggregation["variables"]["h_tdigest"]["location"]
+        del plain.aggregation["variables"]["h_tdigest"]["temporal"]
+        del plain.aggregation["variables"]["observed"]
+        calls.clear()
+        _aggregate_chunk_cells(
+            children, cols, cell_to_slice, {}, plain, ["h_tdigest"], get_agg_fields(plain)
+        )
+        assert calls == []
+
     def test_no_clock_refused_on_the_chunk_path(self):
         # §8.3's refusal stays reachable after the hoist: a populated chunk with
         # a declared companion but no clock fails exactly as the per-cell route.

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -2036,7 +2036,7 @@ class TestTemporalCompanionProduction:
             },
         )
 
-    def _cell(self, n=200):
+    def _cell(self, n=200, spread=1e-4):
         from conftest import point_words
 
         rng = np.random.default_rng(410)
@@ -2044,7 +2044,9 @@ class TestTemporalCompanionProduction:
         return {
             "h_li": h,
             "delta_time": 3.0 * np.arange(n, dtype=np.float64),
-            "leaf_id": point_words(n, seed=7),
+            # The default jitter keeps every point in one cell; a wider spread
+            # populates several, for the multi-chunk shapes below.
+            "leaf_id": point_words(n, seed=7, spread=spread),
         }
 
     def test_the_config_validates(self):
@@ -2168,16 +2170,23 @@ class TestTemporalCompanionProduction:
 
     # -- the per-chunk toc encode hoist (issue #476) -------------------------
 
-    def _grouped(self, n=60):
+    def _grouped(self, n=60, spread=1e-4):
         from zagg.processing.aggregate import _group_columns
 
         cfg = self._cfg()
         grid = HealpixGrid(6, 8, layout="fullsphere", config=cfg)
-        cell = self._cell(n)
+        cell = self._cell(n, spread=spread)
         cells = grid.cells_of(cell["leaf_id"])
         children = np.unique(cells)
         cols, cell_to_slice = _group_columns(dict(cell), cells)
         return cfg, children, cols, cell_to_slice
+
+    def _unoccupied(self, n=6):
+        """Cell ids of the same grid holding none of the shard's rows."""
+        from conftest import point_words
+
+        grid = HealpixGrid(6, 8, layout="fullsphere", config=self._cfg())
+        return np.unique(grid.cells_of(point_words(n, seed=99, lat0=-30.0, lon0=200.0)))
 
     def test_chunk_encode_matches_the_per_cell_encode(self):
         # The hoisted one-pass encode is element-wise, so each cell's slice must
@@ -2281,22 +2290,58 @@ class TestTemporalCompanionProduction:
 
     def test_all_empty_chunk_needs_no_clock(self):
         # Parity with the per-cell route, where an empty cell never reaches the
-        # encode: a chunk with no populated cells must not demand a clock.
+        # encode: a chunk with no populated cells must not demand a clock. The
+        # shape the multi-chunk path actually produces — shard-level columns and
+        # cell_to_slice, a chunk whose children are all unoccupied — is where the
+        # ``present`` filter is doing the work.
         from zagg.processing.aggregate import _aggregate_chunk_cells
 
-        cfg, children, cols, cell_to_slice = self._grouped()
+        cfg, _, cols, cell_to_slice = self._grouped()
         del cfg.output["time_source"]
-        empty_cols = {col: arr[:0] for col, arr in cols.items()}
-        stats, payloads, idx, channels, cwd = _aggregate_chunk_cells(
-            children,
-            empty_cols,
-            {},
+        empty_chunk = self._unoccupied()
+        assert cell_to_slice and not set(map(int, empty_chunk)) & set(cell_to_slice)
+        _, payloads, idx, _, cwd = _aggregate_chunk_cells(
+            empty_chunk,
+            cols,
+            cell_to_slice,
             {},
             cfg,
             ["h_tdigest", "observed"],
             get_agg_fields(cfg),
         )
-        assert cwd == 0 and payloads["h_tdigest"] == []
+        assert cwd == 0 and payloads["h_tdigest"] == [] and idx["h_tdigest"] == []
+
+    def test_partial_chunks_split_the_shard_columns(self):
+        # chunks_per_shard > 1 is how the worker actually calls this: shard-level
+        # col_arrays/cell_to_slice with per-chunk children covering only part of
+        # the populated cells (plus unoccupied ones). Each chunk's payloads and
+        # both channels must stay byte-equal to the per-cell route — the encode's
+        # ``present`` filter and its slice accounting are all that stand between.
+        from zagg.processing.aggregate import _aggregate_chunk_cells
+
+        cfg, children, cols, cell_to_slice = self._grouped(240, spread=0.5)
+        assert len(cell_to_slice) > 3, "need several populated cells for a partial chunk"
+        agg_fields = get_agg_fields(cfg)
+        half = len(children) // 2
+        chunks = [
+            np.concatenate([children[:half], self._unoccupied(2)]),
+            children[half:],
+        ]
+        seen = 0
+        for chunk in chunks:
+            _, payloads, idx, channels, cwd = _aggregate_chunk_cells(
+                chunk, cols, cell_to_slice, {}, cfg, ["h_tdigest", "observed"], agg_fields
+            )
+            assert cwd == sum(int(c) in cell_to_slice for c in chunk)
+            seen += cwd
+            for j, i in enumerate(idx["h_tdigest"]):
+                start, end = cell_to_slice[int(chunk[i])]
+                cell = {col: arr[start:end] for col, arr in cols.items()}
+                digest, locs, times = calculate_cell_statistics(cell, config=cfg)["h_tdigest"]
+                np.testing.assert_array_equal(payloads["h_tdigest"][j], digest)
+                np.testing.assert_array_equal(channels["h_tdigest"]["locations"][j], locs)
+                np.testing.assert_array_equal(channels["h_tdigest"]["times"][j], times)
+        assert seen == len(cell_to_slice), "every populated cell lands in exactly one chunk"
 
 
 class TestRaggedChunkCompanion:

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -303,7 +303,33 @@ def _pairwise_variables(delta=256):
     return variables
 
 
-def _config(streaming=None, variables=None, chunk_precompute=None):
+def _companion_variables(delta=256):
+    """Like :func:`_base_variables` but carrying both companion channels: the
+    located morton words (issue #87) and the per-centroid toc words (§8.3)."""
+    variables = _base_variables(delta=delta)
+    variables["h_tdigest"].update({"location": "leaf_id", "temporal": "per-centroid"})
+    return variables
+
+
+#: The clock ``temporal: per-centroid`` derives its words from (spec §8.3).
+_TIME_SOURCE = {
+    "time_source": {
+        "field": "delta_time",
+        "epoch": "2018-01-01T00:00:00",
+        "scale": "gps",
+        "units": "seconds",
+    }
+}
+
+
+def _with_clock(dfs, step=3.0):
+    """Give each fake granule the per-observation clock column, in read order."""
+    for j, df in enumerate(dfs):
+        df["delta_time"] = 1.0e6 * (j + 1) + step * np.arange(len(df), dtype=np.float64)
+    return dfs
+
+
+def _config(streaming=None, variables=None, chunk_precompute=None, output=None):
     agg = {"variables": variables or _base_variables()}
     if streaming is not None:
         agg["streaming"] = streaming
@@ -322,6 +348,7 @@ def _config(streaming=None, variables=None, chunk_precompute=None):
             "shard_workers": 1,
         },
         aggregation=agg,
+        **({"output": output} if output is not None else {}),
     )
 
 
@@ -435,9 +462,15 @@ def _assert_ragged_identical(ragged_p, ragged_s):
         assert idx_p == idx_s
         for a, b in zip(pay_p, pay_s, strict=True):
             np.testing.assert_array_equal(a, b)
+        # Every channel slot, not just the first: a companion-carrying field can
+        # deliver locations AND times (spec §8.3), and a temporal-only field
+        # carries an explicit None location slot.
         assert len(locs_p) == len(locs_s)
-        if locs_p:
-            for a, b in zip(locs_p[0], locs_s[0], strict=True):
+        for chan_p, chan_s in zip(locs_p, locs_s, strict=True):
+            if chan_p is None or chan_s is None:
+                assert chan_p is None and chan_s is None
+                continue
+            for a, b in zip(chan_p, chan_s, strict=True):
                 np.testing.assert_array_equal(a, b)
 
 
@@ -602,6 +635,33 @@ class TestSpillWorkerSingleBlock:
         )
         pd.testing.assert_frame_equal(df_p, df_s)
         _assert_ragged_identical(ragged_p, ragged_s)
+
+    def test_companion_channels_byte_identical_to_pooled(self, monkeypatch):
+        # ``_chunk_outputs_exact`` is the one spill arm that reaches
+        # ``_aggregate_chunk_cells`` with a companion-carrying field, so it
+        # inherits both issue #476 hoists (the per-chunk toc encode and the
+        # batched folds) over read-back columns rather than read-path ones.
+        # Both channels must land byte-for-byte on the pooled route's.
+        key = _shard_key()
+        results = []
+        for streaming in (None, {"buffer_granules": 2, "mode": "spill"}):
+            cfg = _config(
+                streaming=streaming, variables=_companion_variables(), output=_TIME_SOURCE
+            )
+            grid = _grid(cfg)
+            dfs = _with_clock(_granule_dfs(grid, key, _CELL_LISTS, seed=7))
+            results.append(_run(monkeypatch, cfg, grid, key, dfs, profile=streaming is not None))
+        (df_p, ragged_p, meta_p), (df_s, ragged_s, meta_s) = results
+        # Single-block regime -> the read-back (exact) arm, not the merged one.
+        assert meta_s["phase_timings"]["spill_bytes"] > 0
+        assert meta_s["phase_timings"]["spill_blocks_closed"] == 0
+        # (payloads, cell indices, locations, times) — the channels must be there
+        # for the comparison to mean anything.
+        assert len(ragged_p["h_tdigest"]) == 4
+        assert any(len(w) for w in ragged_p["h_tdigest"][3])
+        _assert_carrier_identical(df_p, df_s)
+        _assert_ragged_identical(ragged_p, ragged_s)
+        assert meta_p["cells_with_data"] == meta_s["cells_with_data"]
 
     def test_k_gt_1_chunks_byte_identical_to_pooled(self, monkeypatch):
         # K=4 partitions: each chunk's outputs come from its own partition.

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -1270,6 +1270,21 @@ class TestBatchedCompanionFolds:
             with batched_companion_folds():
                 _centroid_ancestors(locs, starts, 6)
 
+    def test_the_placeholder_survives_the_aggregate_normalization(self):
+        # ``calculate_cell_statistics`` normalizes every channel with
+        # ``np.ascontiguousarray`` before collecting it, and the flush fills the
+        # placeholder in place afterwards — so that call must be identity here.
+        # Unfilled, the placeholder reads as the reserved 0 word (refusable),
+        # never as uninitialized bytes.
+        from zagg.stats.tdigest import batched_companion_folds
+
+        v, lo, t, d = self._cells()[1]
+        with batched_companion_folds():
+            _, locs, times = build_tdigest(v, delta=d, locations=lo, temporal=t)
+            for channel in (locs, times):
+                assert np.ascontiguousarray(np.asarray(channel)) is channel
+                assert not channel.any(), "a deferred placeholder must read as reserved 0"
+
     def test_batch_deactivates_after_exit(self):
         # The context always resets, so a later unbatched call folds for real.
         from zagg.stats.tdigest import batched_companion_folds

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -1259,6 +1259,17 @@ class TestBatchedCompanionFolds:
             with batched_companion_folds():
                 _centroid_envelopes(words, starts, 9)
 
+    def test_a_partition_not_starting_at_zero_is_refused(self):
+        # The concatenation rebases on each entry's rows, so a partition that
+        # does not start at 0 would silently fold its first rows into the
+        # previous entry's last centroid — neither fold notices.
+        from zagg.stats.tdigest import _centroid_ancestors, batched_companion_folds
+
+        locs, starts = _point_words(6, seed=3), np.array([1, 4], dtype=np.int64)
+        with pytest.raises(ValueError, match="requires each centroid partition to start at 0"):
+            with batched_companion_folds():
+                _centroid_ancestors(locs, starts, 6)
+
     def test_batch_deactivates_after_exit(self):
         # The context always resets, so a later unbatched call folds for real.
         from zagg.stats.tdigest import batched_companion_folds

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -1246,6 +1246,19 @@ class TestBatchedCompanionFolds:
                 raise RuntimeError("boom")
         assert calls == [], "a failed loop must not fold its abandoned placeholders"
 
+    def test_single_entry_flush_folds_with_the_declared_n(self):
+        # A lone deferral must fold with the ``n`` it declared, not with
+        # ``len(words)``: a partition overrunning its words has to fail exactly
+        # where the unbatched call does, not silently fold a truncated one.
+        from zagg.stats.tdigest import _centroid_envelopes, batched_companion_folds
+
+        words, starts = _toc_words(6), np.array([0, 3], dtype=np.int64)
+        with pytest.raises(ValueError, match="exceeds word array length"):
+            _centroid_envelopes(words, starts, 9)
+        with pytest.raises(ValueError, match="exceeds word array length"):
+            with batched_companion_folds():
+                _centroid_envelopes(words, starts, 9)
+
     def test_batch_deactivates_after_exit(self):
         # The context always resets, so a later unbatched call folds for real.
         from zagg.stats.tdigest import batched_companion_folds

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -1285,6 +1285,29 @@ class TestBatchedCompanionFolds:
                 assert np.ascontiguousarray(np.asarray(channel)) is channel
                 assert not channel.any(), "a deferred placeholder must read as reserved 0"
 
+    def test_row_cap_folds_mid_loop_byte_for_byte(self, monkeypatch):
+        # The cap bounds the words the batch pins; the folds are segment-local,
+        # so cutting the batch mid-loop must not move a byte — and the flush it
+        # triggers has to run for real (batch deactivated), not re-defer.
+        import mortie
+
+        import zagg.stats.tdigest as td_mod
+        from zagg.stats.tdigest import batched_companion_folds
+
+        cells = self._cells()
+        plain = [build_tdigest(v, delta=d, locations=lo, temporal=t) for v, lo, t, d in cells]
+        crossings = []
+        orig = mortie.tocs_reduce
+        monkeypatch.setattr(mortie, "tocs_reduce", lambda *a: crossings.append(1) or orig(*a))
+        monkeypatch.setattr(td_mod, "_BATCH_ROW_CAP", 40)
+        with batched_companion_folds():
+            batched = [build_tdigest(v, delta=d, locations=lo, temporal=t) for v, lo, t, d in cells]
+        assert len(crossings) > 1, "a tiny cap must fold more than once"
+        for (pd_, pl, pt), (bd, bl, bt) in zip(plain, batched, strict=True):
+            np.testing.assert_array_equal(pd_, bd)
+            np.testing.assert_array_equal(pl, bl)
+            np.testing.assert_array_equal(pt, bt)
+
     def test_batch_deactivates_after_exit(self):
         # The context always resets, so a later unbatched call folds for real.
         from zagg.stats.tdigest import batched_companion_folds

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -1153,3 +1153,105 @@ class TestTemporalMergeLaws:
         np.testing.assert_array_equal(out_d, d)
         np.testing.assert_array_equal(out_t, t)
         assert out_t is not t
+
+
+class TestBatchedCompanionFolds:
+    """Cross-cell fold batching (issue #476): identical bytes, one FFI crossing."""
+
+    @staticmethod
+    def _cells(deltas=(4, 512, 32), seed=476):
+        # Varied sizes and deltas so the batch spans singleton-only partitions
+        # (n <= delta) AND compressed multi-member ones, on both channels.
+        rng = np.random.default_rng(seed)
+        cells = []
+        for j, delta in enumerate(deltas):
+            n = 30 + 40 * j
+            cells.append(
+                (
+                    rng.standard_normal(n),
+                    _point_words(n, seed=seed + j),
+                    _toc_words(n),
+                    delta,
+                )
+            )
+        return cells
+
+    def test_batched_matches_unbatched_byte_for_byte(self):
+        from zagg.stats.tdigest import batched_companion_folds
+
+        cells = self._cells()
+        plain = [build_tdigest(v, delta=d, locations=lo, temporal=t) for v, lo, t, d in cells]
+        with batched_companion_folds():
+            batched = [build_tdigest(v, delta=d, locations=lo, temporal=t) for v, lo, t, d in cells]
+        for (pd_, pl, pt), (bd, bl, bt) in zip(plain, batched, strict=True):
+            np.testing.assert_array_equal(pd_, bd)
+            np.testing.assert_array_equal(pl, bl)
+            np.testing.assert_array_equal(pt, bt)
+
+    def test_one_reduce_crossing_per_channel(self, monkeypatch):
+        import mortie
+
+        from zagg.stats.tdigest import batched_companion_folds
+
+        counts = {"tocs_reduce": 0, "validate_morton": 0}
+        orig_reduce, orig_validate = mortie.tocs_reduce, mortie.validate_morton
+        monkeypatch.setattr(
+            mortie,
+            "tocs_reduce",
+            lambda *a: (
+                counts.__setitem__("tocs_reduce", counts["tocs_reduce"] + 1) or orig_reduce(*a)
+            ),
+        )
+        monkeypatch.setattr(
+            mortie,
+            "validate_morton",
+            lambda *a: (
+                counts.__setitem__("validate_morton", counts["validate_morton"] + 1)
+                or orig_validate(*a)
+            ),
+        )
+        with batched_companion_folds():
+            for v, lo, t, d in self._cells():
+                build_tdigest(v, delta=d, locations=lo, temporal=t)
+            assert counts == {"tocs_reduce": 0, "validate_morton": 0}, (
+                "folds must defer until the context exits"
+            )
+        assert counts["tocs_reduce"] == 1
+        assert counts["validate_morton"] == 1
+
+    def test_nested_context_is_a_passthrough(self):
+        from zagg.stats.tdigest import batched_companion_folds
+
+        v, lo, t, d = self._cells()[1]
+        plain_d, plain_l, plain_t = build_tdigest(v, delta=d, locations=lo, temporal=t)
+        with batched_companion_folds():
+            with batched_companion_folds():
+                bd, bl, bt = build_tdigest(v, delta=d, locations=lo, temporal=t)
+        np.testing.assert_array_equal(plain_d, bd)
+        np.testing.assert_array_equal(plain_l, bl)
+        np.testing.assert_array_equal(plain_t, bt)
+
+    def test_exception_skips_the_flush(self, monkeypatch):
+        import mortie
+
+        from zagg.stats.tdigest import batched_companion_folds
+
+        calls = []
+        orig = mortie.tocs_reduce
+        monkeypatch.setattr(mortie, "tocs_reduce", lambda *a: calls.append(1) or orig(*a))
+        with pytest.raises(RuntimeError, match="boom"):
+            with batched_companion_folds():
+                v, lo, t, d = self._cells()[0]
+                build_tdigest(v, delta=d, temporal=t)
+                raise RuntimeError("boom")
+        assert calls == [], "a failed loop must not fold its abandoned placeholders"
+
+    def test_batch_deactivates_after_exit(self):
+        # The context always resets, so a later unbatched call folds for real.
+        from zagg.stats.tdigest import batched_companion_folds
+
+        with batched_companion_folds():
+            pass
+        v, lo, t, d = self._cells()[2]
+        _, _, times = build_tdigest(v, delta=d, locations=lo, temporal=t)
+        assert times.dtype == np.uint64 and len(times) > 0


### PR DESCRIPTION
Closes #476

Three scheduling hoists in the aggregate path that remove per-cell Python/FFI overhead from the temporal channel. **Pure scheduling — byte output is identical**; `tests/data/spec/` fixtures and the tdigest law tests are the acceptance gate, and no fixture is regenerated.

## Phases

- [x] **Phase 1 — hoist the toc-word encode to once per chunk** (6918923f). `_chunk_toc_words` (a sibling of `_eval_chunk_precompute`, called from `_aggregate_chunk_cells` so the worker's pooled loop and the spill read-back (`_chunk_outputs_exact`) both get it) gathers the declared `output.time_source` column over the chunk's populated cells, encodes it in one `observation_words` pass, and hands each cell its slice at namespace construction. The per-cell `_toc_word_column` — and its `{**cell_data, ...}` dict copy (hoist 3) — now runs only for direct `calculate_cell_statistics` callers. The §8.3 no-clock refusal moved into the shared `_checked_toc_source` seam, reachable from both routes (worker-side refusal stays per the #472 split; `test_no_clock_refused_on_the_chunk_path` pins it). **Review fold:** `_chunk_toc_words` now takes the caller's `_pool_chunk_columns` output (`chunk_pooled=`; both call sites already build it for the chunk precompute) instead of rebuilding the identical gather index — both walk `children` in order over the same `cell_to_slice` slices, so the pooled clock column *is* that gather (46dddd6b).
- [x] **Phase 2 — batch the per-centroid companion folds across cells** (1678aa73). A deferred-placeholder batch in `zagg.stats.tdigest` (`_CompanionBatch` + `batched_companion_folds`, ContextVar-gated, active only around `_aggregate_chunk_cells`' per-cell loop): each `_centroid_envelopes` / `_centroid_ancestors` call inside hands back an unfilled uint64 placeholder and records its (member words, offset-adjusted starts); context exit runs ONE fold per channel over the concatenated layout and fills every placeholder in place, before anything reads them. `_centroid_ancestors`' vectorized singleton path composes with the same batching (the issue's "take it if natural" clause), so `validate_morton` collapses to one pass per chunk too. Flush is skipped on exception; merge paths (pyramid fold, spill cross-block) never run inside the context and are untouched. **Review fold:** the context is armed only when the chunk actually carries a companion channel (233b34da); each deferral carries its declared `n` and is refused unless its partition starts at 0 (02c0c379, 577c8e4a); the placeholder is `zeros` — §8.2's refusable reserved word — rather than `empty`, with the no-copy coupling to `calculate_cell_statistics`' `ascontiguousarray` stated and pinned (417750fc); and `_BATCH_ROW_CAP` (1e6 deferred member rows per channel) folds mid-loop so the words the batch pins stay bounded (fe358a16).
- [x] **Phase 3 — before/after harness numbers + byte-identity oracle + full-suite verification** (tables below).

## Why this is byte-identical (approach)

The toc encode is element-wise, and both companion folds are segment-independent (`tocs_reduce` is a segmented reduce; each centroid's ancestor reduces over its own member slice). `_compress` always emits starts partitioning `[0, n)` from 0, so concatenated offset-adjusted starts form a valid single segmented layout whose result is exactly the per-cell results, sliced back apart. Nothing reads a deferred vector before the flush: the only reducers that produce channel words are the `build_tdigest` family, whose outputs are collected (shape/dtype checks only) for the ragged writer, which runs after `_aggregate_chunk_cells` returns; `cell_envelope` (the per-cell scalar reducer whose result IS read in-loop) uses `mortie.toc_reduce` directly and never defers.

## Before/after (`uv run python scratch_agg_profile.py 30 cur`, 29 granules, 1.50 M obs, 28,515 cells, same machine)

| | before (d52e3063) | after (1678aa73) |
|---|---|---|
| **aggregate** | **34.6 s** | **20.6 s** (−40%) |
| `calculate_cell_statistics` | 33.01 s / 28,515 calls | 18.64 s / 28,515 calls |
| `_toc_word_column` | 6.00 s / 28,515 calls | — (0 calls on the chunk path) |
| `mortie.time2toc` | 2.26 s / 28,515 calls | 0.005 s / **1 call** |
| `mortie.tocs_reduce` | 2.87 s / 46,072 calls | 0.05 s / **2 calls** (the 1e6-row cap) |
| `mortie.validate_morton` | 0.30 s / 46,072 calls | 0.06 s / **2 calls** (the 1e6-row cap) |
| `_centroid_envelopes` | 3.11 s | 0.40 s (deferral only) |
| `_centroid_ancestors` | 3.21 s | 0.74 s (deferral only) |
| tracemalloc peak | 120 MB | 219 MB (capped batch; 287 MB pre-cap — see note) |

The after column is re-measured on the folded head beaae7a8 (pre-fold 1678aa73 measured 21.5 s with 1 crossing per channel and 287 MB traced peak). The issue's target was ~24 s from 34 s; measured 20.6 s. Memory note: the batch holds each cell's filtered member words until its flush (~8 B × rows × channels), the same order as one extra pooled uint64 column per channel; pre-cap that meant a whole chunk's worth (~12 MB per channel here) and process RSS high-water moved 619 → 697 MB on this 1.5 M-obs shard. The review fold added `_BATCH_ROW_CAP` = 1e6 member rows per channel (fe358a16): a channel that reaches it folds mid-loop — byte-identically, the folds being segment-local — so the held words are bounded at ~8 MB per channel at any chunk size, at the cost of one extra FFI crossing per 1e6 rows (on this shard: 2 per channel instead of 1, exactly what the table shows), and the traced peak drops 287 → 219 MB.

## Byte-identity evidence

- **Re-verified on the folded head** (beaae7a8, all 7 fold commits in): the same sha256 oracle against main — all output-surface hashes identical again.
- **Direct oracle at scale**: the same 29-granule read+aggregate run under main's zagg and this branch, sha256 over every output surface — all dense fields, every ragged field's payloads + cell indices + `locations` + `times` channels (1,497,596 obs, 28,515 cells): **all hashes identical** (script: `byte_check.py`, session scratchpad; e.g. `dense:composition` = `c3c34a96…` on both arms).
- `tests/test_spec_conformance.py` green with **no fixture regenerated** (`git diff --stat` touches only `aggregate.py`, `tdigest.py`, and the two test files).
- tdigest law tests (kway order-independence, singleton preservation, located/temporal channels) and `test_stats_toc` green.
- New tests pin the equivalences directly: chunk-encode slices byte-equal to the per-cell encode; the chunk path never falls back to the per-cell encode while emitting byte-identical payloads/channels; batched folds byte-equal to unbatched across mixed singleton/compressed partitions; exactly one `tocs_reduce`/`validate_morton` crossing per batch; flush skipped on exception; nested context passthrough; §8.3 refusal reachable on the chunk path; all-empty chunk demands no clock. Added in the review fold: the reused pooled gather equals the rebuilt one (and a mismatched pooled dict is refused); a **partial chunk** — shard-level columns with per-chunk `children` covering only part of the populated cells plus unoccupied ones — byte-equal to the per-cell route on payloads and both channels, with the all-empty-chunk case reworked to that same realistic shape; the **spill read-back arm** (`_chunk_outputs_exact`) byte-equal to pooled on both channels over read-back columns; the row cap folding mid-loop byte-identically; a lone deferral honouring its declared `n`; a partition not starting at 0 refused; the placeholder surviving `ascontiguousarray` un-copied; the batch armed only for companion-carrying configs.

## Testing

Full suite in the worktree: **4,442 passed, 38 skipped, 1 failed** — the one failure is the known pre-existing environmental `test_lambda_build::TestFunctionBuild::test_function_build_succeeds` (Docker layer build; fails identically on main on this machine). Affected suites (`test_processing`, `test_spec_conformance`, `test_stats_toc`, `test_tdigest`, `test_spill`, `test_spill_crossblock`, `test_sweep_overview`, `test_pyramid`) all green (`test_client_transport`'s known wall-clock flake did not trip this run).

Re-run after the review fold (`uv run pytest tests/ -q --ignore=tests/test_lambda_build.py`): **4,417 passed, 37 skipped, 0 failed**; `tests/data/spec/` still untouched. `ruff check` / `ruff format --check` clean on every file the fold touched (`aggregate.py`, `worker.py`, `spill.py`, `tdigest.py`, `test_processing.py`, `test_tdigest.py`, `test_spill.py`).

## Review fold (round 1)

All seven inline findings folded, one commit each:

| finding | resolution |
|---|---|
| single-entry flush folded with `len(words)`, not the recorded `n` | the declared `n` rides in the entry tuple; both arms make the call the unbatched route would — 02c0c379 |
| `defer()` had no `starts[0] == 0` guard | O(1) `ValueError` per deferral — 577c8e4a |
| `np.empty` placeholder + unpinned no-copy coupling at `aggregate.py`'s `ascontiguousarray` | `np.zeros` (an escaped placeholder then reads as §8.2's refusable reserved word instead of uninitialized bytes) + the coupling stated at both ends + a test pinning that the normalization is identity — 417750fc |
| `_chunk_toc_words` rebuilt the gather its callers just built | `chunk_pooled=` kwarg wired from both call sites; falls back to building the index for direct callers — 46dddd6b |
| batch armed for every config | armed only when the chunk declares a companion channel — 233b34da |
| batch memory unbounded | `_BATCH_ROW_CAP` mid-loop flush, batch deactivated across it so the folds run for real — fe358a16 |
| test gaps (partial chunk, realistic all-empty chunk, spill temporal) | all three added — beaae7a8 |

## Questions for review

- Pre-existing `N818` in `src/zagg/registry.py` (`ruff check src` on main fails the same way; the PR lint bot selects `E,F,W,I` so CI is unaffected). Not touched here.


