### PR TITLE
spill: carry the temporal companion through the cross-block fold (issue #477)

### DIFF
--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -361,17 +361,21 @@ class _DigestField(NamedTuple):
     temporal: bool
 
 
-#: Emission key per companion-channel reducer kwarg, in the kernel's fixed
-#: return order ``(digest, locations, temporal)`` — the same channels in the
-#: same order ``sweep_overview.COMPANION_CHANNELS`` folds overviews by. The keys
-#: are ``_aggregate_chunk_cells``'s (``times``, not ``temporal``, for the §8.3
-#: sibling), which is the contract ``chunk_outputs`` returns under.
-_CHANNEL_EMIT = {"locations": "locations", "temporal": "times"}
+#: A digest field's companion channels in the kernel's FIXED return order
+#: ``(digest, locations, temporal)`` — the same channels in the same order
+#: ``sweep_overview.COMPANION_CHANNELS`` folds overviews by. Per entry: the
+#: declaring :class:`_DigestField` attribute, the reducer kwarg, and the
+#: ``chunk_outputs`` emission key (``_aggregate_chunk_cells``'s — ``times``, not
+#: ``temporal``, for the §8.3 sibling). The ONLY place that order lives: every
+#: fold site zips against this tuple, so none can drift on a dict's insertion
+#: order (``strict=True`` checks a zip's length, never its order, and the two
+#: word grammars accept each other's values, so a swap would be silent).
+_CHANNELS = (("location", "locations", "locations"), ("temporal", "temporal", "times"))
 
 
-def _channels(f: _DigestField) -> tuple[str, ...]:
-    """Reducer kwargs for the companion channels ``f`` declares, in kernel order."""
-    return ("locations",) * bool(f.location) + ("temporal",) * bool(f.temporal)
+def _channels(f: _DigestField) -> tuple[tuple[str, str], ...]:
+    """``(reducer kwarg, emission key)`` per channel ``f`` declares, in kernel order."""
+    return tuple((kwarg, emit) for attr, kwarg, emit in _CHANNELS if getattr(f, attr))
 
 
 def _resolve_param(param, cell_data: dict[str, np.ndarray]):
@@ -509,22 +513,19 @@ class SpillAggregator:
       :func:`_default_block_bytes`): each closing block is reduced
       partition-by-partition into running mergeable state (counts by
       summation, tdigests via ``merge_tdigests``/``merge_tdigests_kway`` —
-      including ``build_tdigest_where`` strata and companion-carrying fields,
-      whose per-block builds fold under the located/temporal overloads (issues
-      #370/#410) — and composition words via ``merge_composition_kway``),
-      collapsing merge rounds from N/buffer to ~spill/threshold. A
-      config with any reducer outside the ``validate_spill_fold`` surface
-      raises :class:`SpillOverflowError` at the first crossing instead of
-      silently approximating.
+      including ``build_tdigest_where`` strata and, under the :data:`_CHANNELS`
+      overloads, companion-carrying fields — and composition words via
+      ``merge_composition_kway``), collapsing merge rounds from N/buffer to
+      ~spill/threshold. A config with any reducer outside the
+      ``validate_spill_fold`` surface raises :class:`SpillOverflowError` at the
+      first crossing instead of silently approximating.
 
     ``chunk_outputs`` returns the 5-tuple ``_aggregate_chunk_cells`` contract
     (``stats_arrays, ragged_payloads, ragged_cell_indices, ragged_channels,
-    cells_with_data``) — one element more than StreamingAggregator, since
-    spill serves companion-carrying fields. Both §8 channels ride BOTH regimes
+    cells_with_data``) — one element more than StreamingAggregator, since spill
+    serves companion-carrying fields. Both :data:`_CHANNELS` ride BOTH regimes
     (issue #477): single-block through the pooled machinery unchanged,
-    multi-block through the per-channel fold state below — so a field may
-    declare ``location:`` and ``temporal: per-centroid`` together, each folded
-    in the same merge as the payload it describes.
+    multi-block through the per-channel fold state below.
     """
 
     def __init__(
@@ -621,15 +622,13 @@ class SpillAggregator:
         self._counts: dict[int, int] = {}
         self._digests: dict[str, dict[int, np.ndarray]] = {n: {} for n in self._digest_fields}
         # Companion-channel running state (issues #370/#410), per field and per
-        # DECLARED channel: the per-cell uint64 word vector row-aligned with the
-        # running digest — ``locations`` (the spilled per-observation morton
-        # column, issue #87) and ``temporal`` (the derived per-observation toc
-        # words, spec §8.3). The per-block build returns ``(digest, *words)`` and
-        # the fold laws carry every declared channel through the SAME
-        # merge_tdigests / merge_tdigests_kway call, so a field declaring both
-        # never has one channel folded against a partition the other did not see.
+        # DECLARED channel (:data:`_CHANNELS`): the per-cell uint64 word vector
+        # row-aligned with the running digest. Every channel rides the SAME
+        # merge_tdigests / merge_tdigests_kway call as its payload, so a field
+        # declaring both never has one folded against a partition the other
+        # did not see.
         self._digest_words: dict[str, dict[str, dict[int, np.ndarray]]] = {
-            n: {kw: {} for kw in _channels(f)} for n, f in self._digest_fields.items()
+            n: {kw: {} for kw, _ in _channels(f)} for n, f in self._digest_fields.items()
         }
         # Whether any field needs the derived toc word column at fold time.
         self._needs_toc = any(f.temporal for f in self._digest_fields.values())
@@ -666,11 +665,10 @@ class SpillAggregator:
         self._digest_parts: dict[str, dict[int, list[np.ndarray]]] = {
             n: {} for n, f in self._digest_fields.items() if not f.pairwise
         }
-        # Companion words stashed alongside (issues #370/#410), index-aligned
-        # with ``_digest_parts`` so the finalize k-way collapse folds every
-        # declared channel in the same order-independent pass.
+        # Companion words stashed alongside, index-aligned with ``_digest_parts``
+        # so the finalize k-way collapse folds every channel in the same pass.
         self._digest_word_parts: dict[str, dict[str, dict[int, list[np.ndarray]]]] = {
-            n: {kw: {} for kw in _channels(f)}
+            n: {kw: {} for kw, _ in _channels(f)}
             for n, f in self._digest_fields.items()
             if not f.pairwise
         }
@@ -845,17 +843,16 @@ class SpillAggregator:
         whether a ``where`` param happens to be present, so the fold can never
         substitute a reducer the config did not declare. A ``temporal:
         per-centroid`` field (spec §8.3) additionally rides the derived toc word
-        column, encoded per cell below (as the pooled path does) and passed as
-        the build's ``temporal=`` channel — and then, per the field's fold law: **k-way**
-        fields stash the block digest (+ every declared channel's words) for one
+        column, encoded per cell below as the pooled path does and passed as the
+        build's ``temporal=`` channel. Then, per the field's fold law: **k-way**
+        fields stash the block digest (+ every declared channel's words) for the
         order-independent collapse at finalize (:meth:`_finalize_kway`);
         **pairwise** fields merge it into the running digest here, the companion
-        overloads carrying the channels. Composition fields pack a per-block ``(word,
-        n_signal)`` pair (``pack_composition_n`` — the same predicate and
-        bytes as the pooled reducer) and stash it for the same finalize
-        collapse (``merge_composition_kway``). Either way it is one build round
-        per block instead of per buffer — the ~6x merge-CPU collapse the design targets
-        (issue #279).
+        overloads carrying the channels. Composition fields stash a per-block
+        ``pack_composition_n`` ``(word, n_signal)`` pair — the same predicate and
+        bytes as the pooled reducer — for the same finalize collapse
+        (``merge_composition_kway``). Either way it is one build round per block
+        instead of per buffer (the ~6x merge-CPU collapse of issue #279).
         """
         from zagg.processing.aggregate import _group_columns, _toc_word_column
 
@@ -885,9 +882,10 @@ class SpillAggregator:
                     cell_data[TOC_WORD_COLUMN] = _toc_word_column(cell_data, self.config)
                 for name, f in self._digest_fields.items():
                     values = cell_data[f.source]
+                    declared = _channels(f)  # every zip below is against THIS tuple
                     chans = {
                         kw: cell_data[f.location if kw == "locations" else TOC_WORD_COLUMN]
-                        for kw in _channels(f)
+                        for kw, _ in declared
                     }
                     if f.stratum:
                         where = _resolve_param(f.where, cell_data)
@@ -896,28 +894,28 @@ class SpillAggregator:
                         built = build_tdigest(values, delta=f.delta, **chans)
                     # ``(digest, *words)`` with any channel declared, the bare
                     # digest without — the kernel's arity contract.
-                    fresh, *words = built if chans else (built,)
+                    fresh, *words = built if declared else (built,)
                     if not f.pairwise:
                         self._digest_parts[name].setdefault(cell, []).append(fresh)
                         parts = self._digest_word_parts[name]
-                        for kw, vec in zip(chans, words, strict=True):
+                        for (kw, _), vec in zip(declared, words, strict=True):
                             parts[kw].setdefault(cell, []).append(vec)
                         continue
                     running = self._digest_words[name]
                     held = self._digests[name].get(cell)
                     if held is None:
                         self._digests[name][cell] = fresh
-                        for kw, vec in zip(chans, words, strict=True):
+                        for (kw, _), vec in zip(declared, words, strict=True):
                             running[kw][cell] = vec
-                    elif chans:
+                    elif declared:
                         # Both channels ride ONE merge (kwargs ``{kw}1``/``{kw}2``),
                         # so the words describe the digest this call produced.
                         pairs = {}
-                        for kw, vec in zip(chans, words, strict=True):
+                        for (kw, _), vec in zip(declared, words, strict=True):
                             pairs[f"{kw}1"], pairs[f"{kw}2"] = running[kw][cell], vec
                         merged, *merged_words = merge_tdigests(held, fresh, delta=f.delta, **pairs)
                         self._digests[name][cell] = merged
-                        for kw, vec in zip(chans, merged_words, strict=True):
+                        for (kw, _), vec in zip(declared, merged_words, strict=True):
                             running[kw][cell] = vec
                     else:
                         self._digests[name][cell] = merge_tdigests(held, fresh, delta=f.delta)
@@ -1002,10 +1000,10 @@ class SpillAggregator:
         associative), so the result does not depend on block reduce order — the
         property #280 relies on to parallelize the reducer. A companion-carrying
         field's word parts collapse in the SAME pass (the ``merge_tdigests_kway``
-        channel overloads), keeping every channel row-aligned with the payload —
-        and the channels are order-independent too, since the merge breaks
-        ``(mean, weight)`` ties on the words themselves, location tertiary and
-        toc quaternary (issues #370/#410). Composition parts collapse the same way
+        channel overloads, in :data:`_CHANNELS` order), keeping every channel
+        row-aligned with the payload — and order-independent too, since the merge
+        breaks ``(mean, weight)`` ties on the words themselves, location tertiary
+        and toc quaternary. Composition parts collapse the same way
         (``merge_composition_kway`` over the block ``(word, n_signal)`` pairs:
         one weighted lane mean, quantized once), so a reducer parallelized
         under #280 inherits the property on all three channels rather than
@@ -1015,16 +1013,17 @@ class SpillAggregator:
             f = self._digest_fields[name]
             dest = self._digests[name]
             word_parts = self._digest_word_parts[name]
-            if word_parts:
+            declared = _channels(f)  # ``_CHANNELS`` order, as in _fold_block
+            if declared:
                 dest_words = self._digest_words[name]
                 for cell, parts in cell_parts.items():
                     folded = merge_tdigests_kway(
                         parts,
                         delta=f.delta,
-                        **{kw: by_cell[cell] for kw, by_cell in word_parts.items()},
+                        **{kw: word_parts[kw][cell] for kw, _ in declared},
                     )
                     dest[cell] = folded[0]
-                    for kw, vec in zip(word_parts, folded[1:], strict=True):
+                    for (kw, _), vec in zip(declared, folded[1:], strict=True):
                         dest_words[kw][cell] = vec
                 for by_cell in word_parts.values():
                     by_cell.clear()
@@ -1151,10 +1150,10 @@ class SpillAggregator:
         ragged_cell_indices: dict[str, list[int]] = {n: [] for n in self._digest_fields}
         # Companion-carrying fields only: keyed presence tells the worker which
         # sibling slots to deliver, mirroring _aggregate_chunk_cells — the same
-        # emission keys (``locations``, ``times``) in the same order, so a folded
-        # chunk and a pooled one are indistinguishable to the writer.
+        # :data:`_CHANNELS` emission keys in the same order, so a folded chunk
+        # and a pooled one are indistinguishable to the writer.
         ragged_channels: dict[str, dict[str, list]] = {
-            n: {_CHANNEL_EMIT[kw]: [] for kw in _channels(f)}
+            n: {emit: [] for _, emit in _channels(f)}
             for n, f in self._digest_fields.items()
             if _channels(f)
         }
@@ -1179,8 +1178,9 @@ class SpillAggregator:
                     ragged_payloads[name].append(digest)
                     ragged_cell_indices[name].append(i)
                     if name in ragged_channels:
-                        for kw, by_cell in self._digest_words[name].items():
-                            ragged_channels[name][_CHANNEL_EMIT[kw]].append(by_cell[cell])
+                        running = self._digest_words[name]
+                        for kw, emit in _channels(self._digest_fields[name]):
+                            ragged_channels[name][emit].append(running[kw][cell])
         return stats_arrays, ragged_payloads, ragged_cell_indices, ragged_channels, cells_with_data
 
     def close(self) -> None:

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -66,6 +66,7 @@ from zagg.stats.tdigest import (
     merge_tdigests,
     merge_tdigests_kway,
 )
+from zagg.time_axis import TOC_SHAPE_PER_CENTROID, TOC_WORD_COLUMN
 
 logger = logging.getLogger(__name__)
 
@@ -337,6 +338,10 @@ class _DigestField(NamedTuple):
     ``where`` the field's raw ``where`` param (a column name or expression the
     fold resolves per cell, exactly like the pooled path) or ``None``.
 
+    ``temporal`` records the spec §8.3 ``temporal: per-centroid`` declaration
+    (issue #410): its words are the DERIVED toc column, not a read column, so
+    unlike ``location`` there is no column name to carry.
+
     ``stratum`` records that the DECLARED function is ``build_tdigest_where``
     and is what selects the reducer in :meth:`SpillAggregator._fold_block` —
     never ``where``'s presence. Keying on the param would let a config drop
@@ -353,6 +358,20 @@ class _DigestField(NamedTuple):
     location: str | None
     where: object | None
     stratum: bool
+    temporal: bool
+
+
+#: Emission key per companion-channel reducer kwarg, in the kernel's fixed
+#: return order ``(digest, locations, temporal)`` — the same channels in the
+#: same order ``sweep_overview.COMPANION_CHANNELS`` folds overviews by. The keys
+#: are ``_aggregate_chunk_cells``'s (``times``, not ``temporal``, for the §8.3
+#: sibling), which is the contract ``chunk_outputs`` returns under.
+_CHANNEL_EMIT = {"locations": "locations", "temporal": "times"}
+
+
+def _channels(f: _DigestField) -> tuple[str, ...]:
+    """Reducer kwargs for the companion channels ``f`` declares, in kernel order."""
+    return ("locations",) * bool(f.location) + ("temporal",) * bool(f.temporal)
 
 
 def _resolve_param(param, cell_data: dict[str, np.ndarray]):
@@ -490,9 +509,9 @@ class SpillAggregator:
       :func:`_default_block_bytes`): each closing block is reduced
       partition-by-partition into running mergeable state (counts by
       summation, tdigests via ``merge_tdigests``/``merge_tdigests_kway`` —
-      including located fields and ``build_tdigest_where`` strata, whose
-      per-block builds fold under the located overloads — and composition
-      words via ``merge_composition_kway``, issue #370),
+      including ``build_tdigest_where`` strata and companion-carrying fields,
+      whose per-block builds fold under the located/temporal overloads (issues
+      #370/#410) — and composition words via ``merge_composition_kway``),
       collapsing merge rounds from N/buffer to ~spill/threshold. A
       config with any reducer outside the ``validate_spill_fold`` surface
       raises :class:`SpillOverflowError` at the first crossing instead of
@@ -501,14 +520,11 @@ class SpillAggregator:
     ``chunk_outputs`` returns the 5-tuple ``_aggregate_chunk_cells`` contract
     (``stats_arrays, ragged_payloads, ragged_cell_indices, ragged_channels,
     cells_with_data``) — one element more than StreamingAggregator, since
-    spill serves located fields. The §8.3 temporal channel rides the SINGLE-BLOCK
-    regime exactly: ``validate_spill_fold`` is a *probe* here, not a refusal — a
-    ``temporal:`` config simply lands ``_mergeable = False``, so ``chunk_outputs``
-    routes to ``_aggregate_chunk_cells`` and the channel mapping carries ``times``
-    beside ``locations``. What refuses is a block CLOSE
-    (:class:`SpillOverflowError`, carrying ``_fold_problems``), because the
-    cross-block channel state is located-only — loudly, so nothing is silently
-    dropped (issue #410).
+    spill serves companion-carrying fields. Both §8 channels ride BOTH regimes
+    (issue #477): single-block through the pooled machinery unchanged,
+    multi-block through the per-channel fold state below — so a field may
+    declare ``location:`` and ``temporal: per-centroid`` together, each folded
+    in the same merge as the payload it describes.
     """
 
     def __init__(
@@ -571,6 +587,7 @@ class SpillAggregator:
                         location=sig["location"],
                         where=params.get("where"),
                         stratum=meta.get("function") == _TDIGEST_WHERE_FUNCTION,
+                        temporal=sig["temporal"] == TOC_SHAPE_PER_CENTROID,
                     )
                 elif meta.get("function") == _COMPOSITION_FUNCTION:
                     self._composition_fields[name] = (
@@ -603,14 +620,19 @@ class SpillAggregator:
         # Cross-block mergeable running state (only ever fed on block close).
         self._counts: dict[int, int] = {}
         self._digests: dict[str, dict[int, np.ndarray]] = {n: {} for n in self._digest_fields}
-        # Located channel running state (issue #370): per-cell uint64 location
-        # vectors row-aligned with the running digests, for fields declaring
-        # ``location:`` only — the per-block build returns (digest, locations)
-        # pairs and the fold laws carry the channel through the located
-        # merge_tdigests / merge_tdigests_kway overloads.
-        self._digest_locs: dict[str, dict[int, np.ndarray]] = {
-            n: {} for n, f in self._digest_fields.items() if f.location
+        # Companion-channel running state (issues #370/#410), per field and per
+        # DECLARED channel: the per-cell uint64 word vector row-aligned with the
+        # running digest — ``locations`` (the spilled per-observation morton
+        # column, issue #87) and ``temporal`` (the derived per-observation toc
+        # words, spec §8.3). The per-block build returns ``(digest, *words)`` and
+        # the fold laws carry every declared channel through the SAME
+        # merge_tdigests / merge_tdigests_kway call, so a field declaring both
+        # never has one channel folded against a partition the other did not see.
+        self._digest_words: dict[str, dict[str, dict[int, np.ndarray]]] = {
+            n: {kw: {} for kw in _channels(f)} for n, f in self._digest_fields.items()
         }
+        # Whether any field needs the derived toc word column at fold time.
+        self._needs_toc = any(f.temporal for f in self._digest_fields.values())
         # Composition state (issue #370): per-cell (word, n_signal), written
         # once at finalize from the per-block parts below.
         self._compositions: dict[str, dict[int, tuple[int, int]]] = {
@@ -644,11 +666,13 @@ class SpillAggregator:
         self._digest_parts: dict[str, dict[int, list[np.ndarray]]] = {
             n: {} for n, f in self._digest_fields.items() if not f.pairwise
         }
-        # Location parts stashed alongside (issue #370), index-aligned with
-        # ``_digest_parts`` so the finalize k-way collapse folds both channels
-        # in the same order-independent pass.
-        self._digest_loc_parts: dict[str, dict[int, list[np.ndarray]]] = {
-            n: {} for n, f in self._digest_fields.items() if not f.pairwise and f.location
+        # Companion words stashed alongside (issues #370/#410), index-aligned
+        # with ``_digest_parts`` so the finalize k-way collapse folds every
+        # declared channel in the same order-independent pass.
+        self._digest_word_parts: dict[str, dict[str, dict[int, list[np.ndarray]]]] = {
+            n: {kw: {} for kw in _channels(f)}
+            for n, f in self._digest_fields.items()
+            if not f.pairwise
         }
         # Per-flush unique cell words; unioned lazily by occupied_cells().
         self._occupied: list[np.ndarray] = []
@@ -751,8 +775,9 @@ class SpillAggregator:
                 f"spill block hit the {self.block_bytes:,}-byte threshold but the "
                 f"config carries reducers with no cross-block fold law, so per-block "
                 f"results cannot combine (the fold covers 'len'/'count', tdigest "
-                f"fields — located, where-strata, pairwise — and the packed "
-                f"composition word; single-block spill is exact for every reducer). "
+                f"fields — located, temporal, where-strata, pairwise — and the "
+                f"packed composition word; single-block spill is exact for every "
+                f"reducer). "
                 f"{self._fold_problems}. "
                 f"Remedies: a bigger memory tier, a '-disk' function variant with "
                 f"more ephemeral storage, or a finer parent_order (smaller shards)."
@@ -765,7 +790,8 @@ class SpillAggregator:
                 f"spill block threshold ({self.block_bytes:,} bytes) crossed: this "
                 f"shard leaves the exact single-block regime and its outputs now "
                 f"fold across blocks — digests merge under t-digest semantics, "
-                f"located centroids coarsen to common ancestors, composition takes "
+                f"located centroids coarsen to common ancestors, temporal words "
+                f"widen to their members' envelope, composition takes "
                 f"one k-way re-quantization; counts stay exact."
             )
         block = self._block
@@ -817,19 +843,21 @@ class SpillAggregator:
         strata, issue #370). Which of the two reducers runs is decided by the
         field's **declared function** (``_DigestField.stratum``), never by
         whether a ``where`` param happens to be present, so the fold can never
-        substitute a reducer the config did not declare — and then, per the
-        field's fold law: **k-way**
-        fields stash the block digest (+ locations) for one order-independent
-        collapse at finalize (:meth:`_finalize_kway`); **pairwise** fields
-        merge it into the running digest here, the located overload carrying
-        the location channel. Composition fields pack a per-block ``(word,
+        substitute a reducer the config did not declare. A ``temporal:
+        per-centroid`` field (spec §8.3) additionally rides the derived toc word
+        column, encoded once per partition below and passed as the build's
+        ``temporal=`` channel — and then, per the field's fold law: **k-way**
+        fields stash the block digest (+ every declared channel's words) for one
+        order-independent collapse at finalize (:meth:`_finalize_kway`);
+        **pairwise** fields merge it into the running digest here, the companion
+        overloads carrying the channels. Composition fields pack a per-block ``(word,
         n_signal)`` pair (``pack_composition_n`` — the same predicate and
         bytes as the pooled reducer) and stash it for the same finalize
         collapse (``merge_composition_kway``). Either way it is one build round
         per block instead of per buffer — the ~6x merge-CPU collapse the design targets
         (issue #279).
         """
-        from zagg.processing.aggregate import _group_columns
+        from zagg.processing.aggregate import _group_columns, _toc_word_column
 
         self._check_fold_columns(block.schema)
         for key in block.partition_keys():
@@ -838,6 +866,16 @@ class SpillAggregator:
             self.spill_read_s += time.perf_counter() - t0
             col_arrays, cell_to_slice = _group_columns(cols, cells)
             del cells, cols
+            if self._needs_toc:
+                # The derived toc word column (spec §8.3), encoded ONCE per
+                # partition rather than per cell: the conversion is elementwise
+                # over the declared clock column, so a cell's slice of it is
+                # exactly the vector ``calculate_cell_statistics`` derives for
+                # that cell pooled, and the encode stays one pass over the
+                # block's rows. It also keeps ``_resolve_param``'s namespace
+                # equal to the pooled one, which carries the column too.
+                toc = _toc_word_column(col_arrays, self.config)
+                col_arrays = {**col_arrays, TOC_WORD_COLUMN: toc}
             for cell, (start, end) in cell_to_slice.items():
                 self._counts[cell] = self._counts.get(cell, 0) + (end - start)
                 # One namespace per cell, not per field — the pooled path's
@@ -847,35 +885,40 @@ class SpillAggregator:
                 cell_data = {col: arr[start:end] for col, arr in col_arrays.items()}
                 for name, f in self._digest_fields.items():
                     values = cell_data[f.source]
-                    locs = cell_data[f.location] if f.location else None
+                    chans = {
+                        kw: cell_data[f.location if kw == "locations" else TOC_WORD_COLUMN]
+                        for kw in _channels(f)
+                    }
                     if f.stratum:
                         where = _resolve_param(f.where, cell_data)
-                        built = build_tdigest_where(
-                            values, delta=f.delta, where=where, locations=locs
-                        )
+                        built = build_tdigest_where(values, delta=f.delta, where=where, **chans)
                     else:
-                        built = build_tdigest(values, delta=f.delta, locations=locs)
-                    fresh, fresh_locs = built if f.location else (built, None)
+                        built = build_tdigest(values, delta=f.delta, **chans)
+                    # ``(digest, *words)`` with any channel declared, the bare
+                    # digest without — the kernel's arity contract.
+                    fresh, *words = built if chans else (built,)
                     if not f.pairwise:
                         self._digest_parts[name].setdefault(cell, []).append(fresh)
-                        if f.location:
-                            self._digest_loc_parts[name].setdefault(cell, []).append(fresh_locs)
+                        parts = self._digest_word_parts[name]
+                        for kw, vec in zip(chans, words, strict=True):
+                            parts[kw].setdefault(cell, []).append(vec)
                         continue
+                    running = self._digest_words[name]
                     held = self._digests[name].get(cell)
                     if held is None:
                         self._digests[name][cell] = fresh
-                        if f.location:
-                            self._digest_locs[name][cell] = fresh_locs
-                    elif f.location:
-                        merged, merged_locs = merge_tdigests(
-                            held,
-                            fresh,
-                            delta=f.delta,
-                            locations1=self._digest_locs[name][cell],
-                            locations2=fresh_locs,
-                        )
+                        for kw, vec in zip(chans, words, strict=True):
+                            running[kw][cell] = vec
+                    elif chans:
+                        # Both channels ride ONE merge (kwargs ``{kw}1``/``{kw}2``),
+                        # so the words describe the digest this call produced.
+                        pairs = {}
+                        for kw, vec in zip(chans, words, strict=True):
+                            pairs[f"{kw}1"], pairs[f"{kw}2"] = running[kw][cell], vec
+                        merged, *merged_words = merge_tdigests(held, fresh, delta=f.delta, **pairs)
                         self._digests[name][cell] = merged
-                        self._digest_locs[name][cell] = merged_locs
+                        for kw, vec in zip(chans, merged_words, strict=True):
+                            running[kw][cell] = vec
                     else:
                         self._digests[name][cell] = merge_tdigests(held, fresh, delta=f.delta)
                 for name, (source, params) in self._composition_fields.items():
@@ -905,6 +948,13 @@ class SpillAggregator:
         available = sorted(name for name, _ in schema or [])
         if not available:
             return
+        if self._needs_toc:
+            # The derived toc word column is not spilled — ``_fold_block``
+            # encodes it into the namespace per partition — but it IS resolvable
+            # there, as on the pooled path, so a ``where`` reading it is not a
+            # missing column. An absent CLOCK column is named by
+            # ``_toc_word_column`` itself, with the pooled path's message.
+            available = sorted([*available, TOC_WORD_COLUMN])
         for name, f in self._digest_fields.items():
             if f.source not in available:
                 raise ValueError(
@@ -950,12 +1000,12 @@ class SpillAggregator:
         Runs once, after the final block is folded and before the first emission.
         The single-pass k-way merge is order-independent (t-digest merge is not
         associative), so the result does not depend on block reduce order — the
-        property #280 relies on to parallelize the reducer. A located field's
-        location parts collapse in the same pass (the located
-        ``merge_tdigests_kway`` overload), keeping both channels row-aligned —
-        and the location channel is order-independent too, since the located
-        merge breaks ``(mean, weight)`` ties on the location word itself
-        (issue #370). Composition parts collapse the same way
+        property #280 relies on to parallelize the reducer. A companion-carrying
+        field's word parts collapse in the SAME pass (the ``merge_tdigests_kway``
+        channel overloads), keeping every channel row-aligned with the payload —
+        and the channels are order-independent too, since the merge breaks
+        ``(mean, weight)`` ties on the words themselves, location tertiary and
+        toc quaternary (issues #370/#410). Composition parts collapse the same way
         (``merge_composition_kway`` over the block ``(word, n_signal)`` pairs:
         one weighted lane mean, quantized once), so a reducer parallelized
         under #280 inherits the property on all three channels rather than
@@ -964,14 +1014,20 @@ class SpillAggregator:
         for name, cell_parts in self._digest_parts.items():
             f = self._digest_fields[name]
             dest = self._digests[name]
-            if f.location:
-                loc_parts = self._digest_loc_parts[name]
-                dest_locs = self._digest_locs[name]
+            word_parts = self._digest_word_parts[name]
+            if word_parts:
+                dest_words = self._digest_words[name]
                 for cell, parts in cell_parts.items():
-                    dest[cell], dest_locs[cell] = merge_tdigests_kway(
-                        parts, delta=f.delta, locations=loc_parts[cell]
+                    folded = merge_tdigests_kway(
+                        parts,
+                        delta=f.delta,
+                        **{kw: by_cell[cell] for kw, by_cell in word_parts.items()},
                     )
-                loc_parts.clear()
+                    dest[cell] = folded[0]
+                    for kw, vec in zip(word_parts, folded[1:], strict=True):
+                        dest_words[kw][cell] = vec
+                for by_cell in word_parts.values():
+                    by_cell.clear()
             else:
                 for cell, parts in cell_parts.items():
                     dest[cell] = merge_tdigests_kway(parts, delta=f.delta)
@@ -1093,14 +1149,14 @@ class SpillAggregator:
             stats_arrays[name] = np.full(n_cells, fill, dtype=dtype)
         ragged_payloads: dict[str, list] = {n: [] for n in self._digest_fields}
         ragged_cell_indices: dict[str, list[int]] = {n: [] for n in self._digest_fields}
-        # Located fields only (issue #87): keyed presence tells the worker to
-        # deliver the 3-tuple ragged contract, mirroring _aggregate_chunk_cells.
-        # ``temporal:`` never reaches here — not because the config was rejected,
-        # but because this method only runs when ``_mergeable``, and a
-        # ``temporal:`` field is outside the ``validate_spill_fold`` surface that
-        # sets it. So ``locations`` is the only channel this mapping ever carries.
+        # Companion-carrying fields only: keyed presence tells the worker which
+        # sibling slots to deliver, mirroring _aggregate_chunk_cells — the same
+        # emission keys (``locations``, ``times``) in the same order, so a folded
+        # chunk and a pooled one are indistinguishable to the writer.
         ragged_channels: dict[str, dict[str, list]] = {
-            n: {"locations": []} for n, f in self._digest_fields.items() if f.location
+            n: {_CHANNEL_EMIT[kw]: [] for kw in _channels(f)}
+            for n, f in self._digest_fields.items()
+            if _channels(f)
         }
         cells_with_data = 0
         for i, child in enumerate(children):
@@ -1123,7 +1179,8 @@ class SpillAggregator:
                     ragged_payloads[name].append(digest)
                     ragged_cell_indices[name].append(i)
                     if name in ragged_channels:
-                        ragged_channels[name]["locations"].append(self._digest_locs[name][cell])
+                        for kw, by_cell in self._digest_words[name].items():
+                            ragged_channels[name][_CHANNEL_EMIT[kw]].append(by_cell[cell])
         return stats_arrays, ragged_payloads, ragged_cell_indices, ragged_channels, cells_with_data
 
     def close(self) -> None:

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -845,8 +845,8 @@ class SpillAggregator:
         whether a ``where`` param happens to be present, so the fold can never
         substitute a reducer the config did not declare. A ``temporal:
         per-centroid`` field (spec §8.3) additionally rides the derived toc word
-        column, encoded once per partition below and passed as the build's
-        ``temporal=`` channel — and then, per the field's fold law: **k-way**
+        column, encoded per cell below (as the pooled path does) and passed as
+        the build's ``temporal=`` channel — and then, per the field's fold law: **k-way**
         fields stash the block digest (+ every declared channel's words) for one
         order-independent collapse at finalize (:meth:`_finalize_kway`);
         **pairwise** fields merge it into the running digest here, the companion
@@ -866,16 +866,6 @@ class SpillAggregator:
             self.spill_read_s += time.perf_counter() - t0
             col_arrays, cell_to_slice = _group_columns(cols, cells)
             del cells, cols
-            if self._needs_toc:
-                # The derived toc word column (spec §8.3), encoded ONCE per
-                # partition rather than per cell: the conversion is elementwise
-                # over the declared clock column, so a cell's slice of it is
-                # exactly the vector ``calculate_cell_statistics`` derives for
-                # that cell pooled, and the encode stays one pass over the
-                # block's rows. It also keeps ``_resolve_param``'s namespace
-                # equal to the pooled one, which carries the column too.
-                toc = _toc_word_column(col_arrays, self.config)
-                col_arrays = {**col_arrays, TOC_WORD_COLUMN: toc}
             for cell, (start, end) in cell_to_slice.items():
                 self._counts[cell] = self._counts.get(cell, 0) + (end - start)
                 # One namespace per cell, not per field — the pooled path's
@@ -883,6 +873,16 @@ class SpillAggregator:
                 # and the strata config declares two complementary `where`
                 # fields over the same source.
                 cell_data = {col: arr[start:end] for col, arr in col_arrays.items()}
+                if self._needs_toc:
+                    # The derived toc word column (spec §8.3), encoded where the
+                    # pooled path encodes it — right after the namespace is
+                    # built (``calculate_cell_statistics``) — so the two
+                    # ``cell_data`` dicts match and a ``where`` reading the
+                    # column resolves identically. Per cell, not once per
+                    # partition: this path exists because memory is scarce, and
+                    # the encode's transient allocation is unbudgeted by
+                    # ``_default_block_bytes`` / ``_BUILD_MULT``.
+                    cell_data[TOC_WORD_COLUMN] = _toc_word_column(cell_data, self.config)
                 for name, f in self._digest_fields.items():
                     values = cell_data[f.source]
                     chans = {

--- a/src/zagg/processing/spill.py
+++ b/src/zagg/processing/spill.py
@@ -931,28 +931,27 @@ class SpillAggregator:
 
         Covers every column the fold resolves out of the block: a field's
         ``source`` and ``location``, a stratum's ``where``, and a composition
-        field's ``conf_*`` params (the hand-written ones — five per field — and
-        the ones whose failure mode is worst; see :func:`_unresolvable_names`).
-        A column the block never carried would surface as a bare
-        ``KeyError`` raised on the overlap reducer thread, which
-        :meth:`_join_reducer` re-wraps as :class:`SpillReduceError` with the real
-        cause reachable only via ``__cause__`` — a materially worse diagnostic
-        than ``calculate_cell_statistics``'s named ``ValueError`` for the same
-        config error, and one that only appears on shards big enough to close a
-        block. Checked once per block against the block schema, off the per-cell
-        loop. An empty block (nothing appended, so no schema) has nothing to
-        fold and nothing to check.
+        field's ``conf_*`` params (see :func:`_unresolvable_names`). A column the
+        block never carried would otherwise surface as a bare ``KeyError`` on the
+        overlap reducer thread, which :meth:`_join_reducer` re-wraps as
+        :class:`SpillReduceError` with the real cause reachable only via
+        ``__cause__`` — materially worse than ``calculate_cell_statistics``'s
+        named ``ValueError`` for the same config error, and visible only on
+        shards big enough to close a block. Checked once per block against the
+        block schema, off the per-cell loop; an empty block has nothing to check.
         """
         available = sorted(name for name, _ in schema or [])
         if not available:
             return
-        if self._needs_toc:
-            # The derived toc word column is not spilled — ``_fold_block``
-            # encodes it into the namespace per partition — but it IS resolvable
-            # there, as on the pooled path, so a ``where`` reading it is not a
-            # missing column. An absent CLOCK column is named by
-            # ``_toc_word_column`` itself, with the pooled path's message.
-            available = sorted([*available, TOC_WORD_COLUMN])
+        # The derived toc word column is not spilled — ``_fold_block`` encodes it
+        # per cell — but it IS resolvable there, as on the pooled path, so a
+        # ``where`` reading it is not a missing column. It stays OUT of
+        # ``available``, which is the block's true contents: the source/location
+        # messages must not advertise ``toc_word``, and a ``location: toc_word``
+        # must still raise here rather than reach ``mortie.common_ancestor``. An
+        # absent CLOCK column is named by ``_toc_word_column``, with the pooled
+        # path's message.
+        resolvable = sorted([*available, TOC_WORD_COLUMN]) if self._needs_toc else available
         for name, f in self._digest_fields.items():
             if f.source not in available:
                 raise ValueError(
@@ -965,7 +964,7 @@ class SpillAggregator:
                     f"column is not in the spilled block (available: {available}); "
                     f"per-observation mortons require a HEALPix grid"
                 )
-            missing = _unresolvable_names(f.where, available)
+            missing = _unresolvable_names(f.where, resolvable)
             if missing:
                 raise ValueError(
                     f"ragged field {name!r} declares where: {f.where!r}, which names "
@@ -984,7 +983,7 @@ class SpillAggregator:
             # _resolve_param as a literal string and dies inside
             # np.column_stack naming neither the field nor the column.
             for pname, pval in params.items():
-                missing = _unresolvable_names(pval, available) if pname.startswith("conf_") else ()
+                missing = _unresolvable_names(pval, resolvable) if pname.startswith("conf_") else ()
                 if missing:
                     raise ValueError(
                         f"field {name!r} param {pname}: {pval!r} names {list(missing)}, "

--- a/src/zagg/processing/streaming.py
+++ b/src/zagg/processing/streaming.py
@@ -20,11 +20,12 @@ validated up front (:func:`validate_streaming`):
   the shard fits in a single buffer, since one flush == one pooled build).
 
 Everything else (expressions, vector fields, ``resolution: chunk`` companions,
-``chunk_precompute``) has no incremental-merge story and raises. Located
-ragged fields, ``build_tdigest_where`` strata, and the packed composition word
+``chunk_precompute``) has no incremental-merge story and raises. Companion-
+carrying ragged fields (located and ``temporal: per-centroid``),
+``build_tdigest_where`` strata, and the packed composition word
 also raise **here** (per-flush folding would degrade locations continuously /
 re-quantize lanes per flush) but fold on the spill path's rare block closes —
-:func:`validate_spill_fold`, issue #370. A fixed-size
+:func:`validate_spill_fold`, issues #370/#477. A fixed-size
 buffer is used rather than pure granule-by-granule updates because each flush
 costs one merge round over the touched cells (~10 µs/cell, see
 ``zagg/stats/tdigest.py``): near 88S a tangent-running granule touches most of
@@ -42,6 +43,7 @@ from zagg.config import (
     get_output_signature,
 )
 from zagg.stats.tdigest import _DEFAULT_DELTA, build_tdigest, merge_tdigests
+from zagg.time_axis import TOC_SHAPE_PER_CENTROID
 
 #: Ragged reducers with a cross-block merge law wired up. ``build_tdigest`` folds
 #: k-way (order-independent) on the spill path; ``build_tdigest_pairwise`` folds
@@ -131,8 +133,9 @@ def validate_streaming(config: PipelineConfig) -> None:
             problems.append(
                 f"field '{name}': temporal companions (temporal: {sig['temporal']!r}) cannot "
                 f"stream under mode: merge — the running merged state carries no companion "
-                f"channel, so the §8.3 sibling would be stamped and left empty; run the "
-                f"pooled path (no aggregation.streaming block)"
+                f"channel, so the §8.3 sibling would be stamped and left empty; use "
+                f"mode: spill, whose block close folds a 'per-centroid' companion "
+                f"(issue #477), or run the pooled path (no aggregation.streaming block)"
             )
         elif "expression" in meta:
             problems.append(f"field '{name}': expression fields cannot stream")
@@ -208,9 +211,11 @@ def validate_spill_fold(config: PipelineConfig) -> None:
     :func:`validate_streaming` (``mode: merge``): merge mode folds every
     ``buffer_granules`` flush, so a located field's centroid locations would
     coarsen continuously, whereas spill folds only on the rare block close.
-    Accepted here beyond the merge-mode set: **located** ragged fields (the
-    located ``merge_tdigests``/``merge_tdigests_kway`` overloads carry the
-    channel), **``build_tdigest_where`` strata** (row selection precedes
+    Accepted here beyond the merge-mode set: **located** ragged fields and
+    **``temporal: per-centroid``** ones (the ``merge_tdigests`` /
+    ``merge_tdigests_kway`` channel overloads carry both, in one merge, so a
+    field declaring both keeps its siblings row-aligned — issues #370/#477),
+    **``build_tdigest_where`` strata** (row selection precedes
     the build, so per-block stratum digests merge like any digest), and the
     **packed composition word** (``merge_composition_kway`` over the per-block
     ``(word, n_signal)`` pairs — presence exact, counts within one
@@ -234,18 +239,19 @@ def validate_spill_fold(config: PipelineConfig) -> None:
         problems.append("chunk_precompute is chunk-scoped and has no cross-block fold")
     for name, meta in get_agg_fields(config).items():
         sig = get_output_signature(meta)
-        if sig["temporal"] is not None:
-            # The words THEMSELVES fold exactly (the §8.2 join is associative,
-            # commutative and idempotent), but the block close's per-field channel
-            # state is located-only today, so a temporal field would emit a
-            # companion missing every block past the first — a §8.3 row-alignment
-            # break, not an approximation. Refuse until the channel is threaded
-            # through the close (issue #410).
+        if sig["temporal"] not in (None, TOC_SHAPE_PER_CENTROID):
+            # ``per-centroid`` folds: the block close carries the channel beside
+            # the located one and both ride one merge (issue #477). The other
+            # shapes do not — a ``per-cell`` companion is a scalar reducer over
+            # the derived word column (``zagg.stats.toc.cell_envelope``), which
+            # has no per-block accumulator here, and the scalar branch below
+            # would report it as an unmergeable function rather than naming the
+            # companion that put it there. Refuse by name (spec §8.2, #410).
             problems.append(
-                f"field '{name}': temporal companions (temporal: {sig['temporal']!r}) have "
-                f"no cross-block fold state yet — the spill block close carries the located "
-                f"channel only; run the pooled path (no aggregation.streaming block) for a "
-                f"temporal store (spec §8.2/§8.3, issue #410)"
+                f"field '{name}': temporal companions of shape {sig['temporal']!r} have no "
+                f"cross-block fold state — the spill block close folds 'per-centroid' "
+                f"companions only; run the pooled path (no aggregation.streaming block) "
+                f"for this store (spec §8.2/§8.3, issues #410/#477)"
             )
         elif "expression" in meta:
             problems.append(f"field '{name}': expression fields have no cross-block fold")

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -639,9 +639,16 @@ class TestTemporalMultiBlock:
         for cell_i, digest, words in zip(idx, vals, times, strict=True):
             assert words.dtype == np.uint64
             assert words.shape == (len(digest),)
-            _assert_envelope_conservation(
-                words, _contributor_times(dfs, grid, int(children[cell_i]))
-            )
+            contributors = _contributor_times(dfs, grid, int(children[cell_i]))
+            _assert_envelope_conservation(words, contributors)
+            # Both claims above are UPPER bounds — a fold that widened every
+            # centroid to the whole-cell envelope would satisfy them. The floor
+            # is the weight-1 rows: a centroid holding a single observation must
+            # still carry that observation's exact instant, never a range.
+            singles = words[digest[:, 1] == 1.0]
+            assert len(singles) > 0, "no weight-1 centroid survived the fold"
+            assert not mortie.toc_is_range(singles).any(), "a weight-1 word widened to a range"
+            assert np.isin(singles, contributors).all(), "a weight-1 word is no contributor's"
             merged |= bool(mortie.toc_is_range(words).any())
         # δ=16 over 300 observations per cell: compression is real, so at least
         # one stored word must be a RANGE — otherwise conservation above would be

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -23,6 +23,7 @@ from zagg.processing.spill import SpillAggregator
 from zagg.processing.streaming import validate_spill_fold, validate_streaming
 from zagg.stats.composition import counts_from_composition, unpack_composition
 from zagg.stats.tdigest import quantile_from_tdigest
+from zagg.time_axis import TOC_WORD_COLUMN
 
 _CREDS = {"accessKeyId": "a", "secretAccessKey": "s", "sessionToken": "t"}
 
@@ -1066,6 +1067,22 @@ class TestFoldColumnDiagnostics:
         cols = {"h_ph": np.ones(1, np.float32), "delta_time": np.ones(1, np.float64)}
         agg = self._agg_with_block(variables, cols)
         agg._fold_block(agg._block)  # no raise
+        agg.close()
+
+    def test_location_may_not_name_the_derived_word_column(self):
+        # ... but toc_word is resolvable, not spilled: it must stay out of the
+        # source/location membership checks. Widening the one `available` list
+        # for every check let a `location: toc_word` slip past this named raise
+        # into mortie.common_ancestor, and made the message advertise a column
+        # the block never carried.
+        variables = _variables(located=True, temporal=True)
+        variables["h_tdigest"]["location"] = TOC_WORD_COLUMN
+        cols = {"h_ph": np.ones(1, np.float32), "delta_time": np.ones(1, np.float64)}
+        agg = self._agg_with_block(variables, cols)
+        with pytest.raises(ValueError, match="h_tdigest.*location: 'toc_word'.*spilled block") as e:
+            agg._fold_block(agg._block)
+        listed = str(e.value).split("available: ", 1)[1]
+        assert TOC_WORD_COLUMN not in listed, f"the message advertises a column never spilled: {e}"
         agg.close()
 
     def test_expression_over_spilled_columns_passes(self):

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -144,13 +144,24 @@ def _point_leafs(grid, cell, n, rng):
 
 
 def _granule_dfs(
-    grid, shard_key, cell_idx_lists, obs_per_cell=60, seed=0, conf=False, nan_cells=(), times=False
+    grid,
+    shard_key,
+    cell_idx_lists,
+    obs_per_cell=60,
+    seed=0,
+    conf=False,
+    nan_cells=(),
+    times=False,
+    nan_frac=0.0,
 ):
     """One DataFrame per granule; real order-29 point leafs per chosen cell.
 
     ``conf=True`` adds the five ``signal_conf_*`` columns (ATL03's ``-1..4``
     range) for composition tests. Cells in ``nan_cells`` get all-NaN heights
-    (an empty digest but a nonzero count). ``times=True`` adds the
+    (an empty digest but a nonzero count); ``nan_frac`` instead NaNs a scattered
+    ~fraction of every OTHER cell's rows, leaving each cell partially finite —
+    the case where a payload/companion misalignment over the reducer's
+    ``[finite]`` mask is observable. ``times=True`` adds the
     ``delta_time`` clock column ``_TIME_SOURCE`` declares — one granule per
     DAY, rows a millisecond apart within it, so every granule (and therefore
     every forced block) covers a disjoint instant range: a cross-block fold
@@ -166,6 +177,8 @@ def _granule_dfs(
             vals = rng.normal(0.0, 10.0, obs_per_cell).astype(np.float32)
             if ci in nan_cells:
                 vals[:] = np.nan
+            elif nan_frac:
+                vals[rng.random(obs_per_cell) < nan_frac] = np.nan
             h.append(vals)
             leaf.append(_point_leafs(grid, int(children[ci]), obs_per_cell, rng))
         cols = {"h_ph": np.concatenate(h), "leaf_id": np.concatenate(leaf)}
@@ -250,12 +263,18 @@ def _contributor_times(dfs, grid, cell, mask_fn=None):
     clock, which is the ONE conversion both paths use — so this is the raw
     instant set the fold's per-centroid envelopes must account for, not a
     re-derivation of them.
+
+    Restricted to rows with a FINITE ``h_ph``: ``build_tdigest`` drops non-finite
+    values along with the companion rows that go with them, so a non-finite row's
+    instant is never stored, and including it here would compare the output
+    against an observation no path ever kept.
     """
     from zagg.time_axis import observation_words
 
     out = []
     for df in dfs:
         keep = np.asarray(grid.cells_of(df["leaf_id"].values)) == cell
+        keep = keep & np.isfinite(df["h_ph"].values)
         if mask_fn is not None:
             keep = keep & mask_fn(df)
         out.append(
@@ -271,13 +290,18 @@ def _assert_envelope_conservation(times, contributors):
 
     Membership per centroid is not observable from the output (as with
     locations), so pin the two statements that are — both EXACT at any fold
-    depth, because the §8.2 join is a semilattice and a fold partitions the
-    members:
+    depth over the rows the reducer keeps, because the §8.2 join is a semilattice
+    and a fold partitions the members:
 
     (a) the join over the stored per-centroid words equals the join over the raw
     observation words — no instant dropped by a block close, none invented; and
     (b) every stored word's ``[start, end)`` lies inside that whole envelope,
     which is what a reader's §8.3 containment claim rests on.
+
+    "Every observation" means every FINITE-valued one: ``build_tdigest`` drops
+    non-finite values and their companion rows, so ``contributors`` must come
+    from :func:`_contributor_times`, which masks the same way. Both claims are
+    upper bounds — a caller wanting a floor pins the weight-1 rows too.
     """
     import mortie
 
@@ -672,6 +696,44 @@ class TestTemporalMultiBlock:
             instants = _contributor_times(dfs, grid, cell)
             np.testing.assert_array_equal(np.sort(words), np.sort(instants))
             keys = values.astype(np.float32)
+            assert len(np.unique(keys)) == len(keys)
+            value_to_word = dict(zip(keys.tolist(), instants.tolist(), strict=True))
+            for centroid, word in zip(digest, words, strict=True):
+                assert value_to_word[float(centroid[0])] == int(word)
+
+    def test_partially_nan_cells_keep_the_channel_row_aligned(self, monkeypatch):
+        # build_tdigest drops non-finite VALUES and the companion rows that go
+        # with them. A whole-NaN cell cannot catch a [finite]-mask misalignment
+        # between payload and companion — nothing survives to align — but a
+        # PARTIALLY NaN one can: the surviving instants must be exactly the
+        # finite rows', paired with the finite rows' own values.
+        key = _shard_key()
+        cfg = _config(_variables(temporal=True, delta=512), streaming=_SPILL)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(
+            grid, key, _CELL_LISTS, obs_per_cell=20, seed=26, times=True, nan_frac=0.4
+        )
+        _force_tiny_blocks(monkeypatch)
+        df_out, ragged, meta = _run(monkeypatch, cfg, grid, key, list(dfs))
+        assert meta["phase_timings"]["spill_blocks_closed"] == len(_CELL_LISTS)
+        children = np.asarray(grid.children(key), dtype=np.uint64)
+        vals, idx, _, times = _channels_of(ragged["h_tdigest"])
+        assert len(vals) > 0
+        for cell_i, digest, words in zip(idx, vals, times, strict=True):
+            cell = int(children[cell_i])
+            values, _ = _contributor_rows(dfs, grid, cell)
+            finite = np.isfinite(values)
+            assert finite.any() and not finite.all(), "the cell is not partially NaN"
+            # The count is over every row; the digest only over the finite ones.
+            assert int(df_out["count"].values[cell_i]) == len(values)
+            assert words.shape == (len(digest),)
+            assert len(digest) == int(finite.sum())
+            # δ=512 over ≤60 rows: nothing merges, so each centroid is one finite
+            # observation and its word is that row's exact instant.
+            assert (digest[:, 1] == 1.0).all()
+            instants = _contributor_times(dfs, grid, cell)
+            np.testing.assert_array_equal(np.sort(words), np.sort(instants))
+            keys = values[finite]
             assert len(np.unique(keys)) == len(keys)
             value_to_word = dict(zip(keys.tolist(), instants.tolist(), strict=True))
             for centroid, word in zip(digest, words, strict=True):

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -242,6 +242,66 @@ def _assert_ancestor_or_equal(locs, contributors):
         )
 
 
+def _contributor_times(dfs, grid, cell, mask_fn=None):
+    """Every toc word the granules contribute to ``cell``, encoded as pooled does.
+
+    Straight through :func:`zagg.time_axis.observation_words` with the declared
+    clock, which is the ONE conversion both paths use — so this is the raw
+    instant set the fold's per-centroid envelopes must account for, not a
+    re-derivation of them.
+    """
+    from zagg.time_axis import observation_words
+
+    out = []
+    for df in dfs:
+        keep = np.asarray(grid.cells_of(df["leaf_id"].values)) == cell
+        if mask_fn is not None:
+            keep = keep & mask_fn(df)
+        out.append(
+            observation_words(
+                df["delta_time"].values[keep], epoch=_EPOCH, scale="gps", units="seconds"
+            )
+        )
+    return np.concatenate(out)
+
+
+def _assert_envelope_conservation(times, contributors):
+    """The folded words account for every observation, and escape none of them.
+
+    Membership per centroid is not observable from the output (as with
+    locations), so pin the two statements that are — both EXACT at any fold
+    depth, because the §8.2 join is a semilattice and a fold partitions the
+    members:
+
+    (a) the join over the stored per-centroid words equals the join over the raw
+    observation words — no instant dropped by a block close, none invented; and
+    (b) every stored word's ``[start, end)`` lies inside that whole envelope,
+    which is what a reader's §8.3 containment claim rests on.
+    """
+    import mortie
+
+    from zagg.stats.toc import cell_envelope
+
+    times = np.asarray(times, dtype=np.uint64)
+    contributors = np.asarray(contributors, dtype=np.uint64)
+    whole = int(cell_envelope(contributors))
+    assert int(cell_envelope(times)) == whole, "the folded words lost or gained an instant"
+    lo, hi = (int(b[0]) for b in mortie.toc2time(np.array([whole], dtype=np.uint64)))
+    starts, ends = mortie.toc2time(times)
+    assert int(starts.min()) >= lo and int(ends.max()) <= hi, "a folded word escapes the envelope"
+
+
+def _channels_of(entry):
+    """``(payloads, cell_indices, locations, times)`` from any ragged arity.
+
+    Through the production normalizer rather than a local unpack, so the test
+    reads the sink entry by the same contract the writer does.
+    """
+    from zagg.processing.write import _ragged_entry
+
+    return _ragged_entry(entry)
+
+
 def _pooled_build(meta, n=8):
     """Call one ragged field's declared reducer exactly as the pooled path does.
 
@@ -542,6 +602,162 @@ class TestLocatedMultiBlock:
         assert len(ragged["h_tdigest"]) == 3  # located 3-tuple delivered
 
 
+class TestTemporalMultiBlock:
+    """The §8.3 per-centroid companion across forced block closes (issue #477).
+
+    Each granule covers its own day (``_granule_dfs(times=True)``) and
+    ``_force_tiny_blocks`` closes a block per flush, so every emitted centroid
+    that spans more than one granule spans more than one block: a channel that
+    was dropped, truncated, or paired with the wrong partition could not still
+    envelope its members.
+    """
+
+    def _run_spill(self, monkeypatch, seed, located=False, pairwise=False, delta=16, obs=60):
+        key = _shard_key()
+        cfg = _config(
+            _variables(located=located, pairwise=pairwise, delta=delta, temporal=True),
+            streaming=_SPILL,
+        )
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=obs, seed=seed, times=True)
+        _force_tiny_blocks(monkeypatch)
+        df_out, ragged, meta = _run(monkeypatch, cfg, grid, key, list(dfs))
+        assert meta["phase_timings"]["spill_blocks_closed"] == len(_CELL_LISTS)
+        return grid, key, dfs, ragged
+
+    @pytest.mark.parametrize("pairwise", [False, True])
+    def test_envelope_conservation_across_block_closes(self, monkeypatch, pairwise):
+        grid, key, dfs, ragged = self._run_spill(monkeypatch, seed=21, pairwise=pairwise)
+        import mortie
+
+        vals, idx, locs, times = _channels_of(ragged["h_tdigest"])
+        assert locs is None  # temporal-only: no location slot claimed
+        assert len(times) == len(vals) > 0
+        children = np.asarray(grid.children(key), dtype=np.uint64)
+        merged = False
+        for cell_i, digest, words in zip(idx, vals, times, strict=True):
+            assert words.dtype == np.uint64
+            assert words.shape == (len(digest),)
+            _assert_envelope_conservation(
+                words, _contributor_times(dfs, grid, int(children[cell_i]))
+            )
+            merged |= bool(mortie.toc_is_range(words).any())
+        # δ=16 over 300 observations per cell: compression is real, so at least
+        # one stored word must be a RANGE — otherwise conservation above would be
+        # trivially satisfied by untouched per-observation timestamps.
+        assert merged, "no centroid merged; the fold was not exercised"
+
+    def test_below_knee_words_are_the_exact_observation_instants(self, monkeypatch):
+        # n <= delta across every block: no compression anywhere, every centroid
+        # is weight 1, and its word is that observation's exact timestamp. The
+        # multiset check alone is permutation-invariant, so the per-row map is
+        # what pins the channel's alignment to the payload (mirrors the located
+        # below-knee test one channel over).
+        grid, key, dfs, ragged = self._run_spill(monkeypatch, seed=22, delta=512, obs=20)
+        vals, idx, _, times = _channels_of(ragged["h_tdigest"])
+        children = np.asarray(grid.children(key), dtype=np.uint64)
+        assert len(vals) > 0
+        for cell_i, digest, words in zip(idx, vals, times, strict=True):
+            assert (digest[:, 1] == 1.0).all()
+            cell = int(children[cell_i])
+            values, _ = _contributor_rows(dfs, grid, cell)
+            instants = _contributor_times(dfs, grid, cell)
+            np.testing.assert_array_equal(np.sort(words), np.sort(instants))
+            keys = values.astype(np.float32)
+            assert len(np.unique(keys)) == len(keys)
+            value_to_word = dict(zip(keys.tolist(), instants.tolist(), strict=True))
+            for centroid, word in zip(digest, words, strict=True):
+                assert value_to_word[float(centroid[0])] == int(word)
+
+    def test_kway_fold_is_block_order_independent(self, monkeypatch):
+        # The k-way collapse is one pass over all parts, so permuting the block
+        # (== granule) order permutes only the parts list: payload AND companion
+        # bytes must come back identical. The channel would break this if its
+        # ties were resolved by input position rather than by the word.
+        key = _shard_key()
+        cfg = _config(_variables(temporal=True, located=True), streaming=_SPILL)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=60, seed=23, times=True)
+        _force_tiny_blocks(monkeypatch)
+        forward = _run(monkeypatch, cfg, grid, key, list(dfs))
+        reverse = _run(monkeypatch, cfg, _grid(cfg), key, list(reversed(dfs)))
+        pd.testing.assert_frame_equal(forward[0], reverse[0])
+        f_vals, f_idx, f_locs, f_times = _channels_of(forward[1]["h_tdigest"])
+        r_vals, r_idx, r_locs, r_times = _channels_of(reverse[1]["h_tdigest"])
+        assert f_idx == r_idx
+        for a, b in zip(f_vals, r_vals, strict=True):
+            np.testing.assert_array_equal(a, b)
+        for a, b in zip(f_times, r_times, strict=True):
+            np.testing.assert_array_equal(a, b)
+        for a, b in zip(f_locs, r_locs, strict=True):
+            np.testing.assert_array_equal(a, b)
+
+    def test_cell_envelope_agrees_with_pooled(self, monkeypatch):
+        # The cross-regime statement §8.3 licenses: the folded centroid
+        # partition differs from pooled's (t-digest merge is approximate across
+        # fold orders), so the WORDS differ — but the cell-level join over them
+        # is the same token either way, and the digest stays within the fold
+        # law's bounds (exact total weight, close quantiles).
+        from zagg.stats.toc import cell_envelope
+
+        key = _shard_key()
+        pooled_cfg = _config(_variables(temporal=True))
+        spill_cfg = _config(_variables(temporal=True), streaming=_SPILL)
+        grid = _grid(pooled_cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=100, seed=24, times=True)
+        df_p, ragged_p, _ = _run(monkeypatch, pooled_cfg, grid, key, list(dfs))
+        _force_tiny_blocks(monkeypatch)
+        df_s, ragged_s, _ = _run(monkeypatch, spill_cfg, _grid(spill_cfg), key, list(dfs))
+        pd.testing.assert_series_equal(df_p["count"], df_s["count"])
+        vals_p, idx_p, _, times_p = _channels_of(ragged_p["h_tdigest"])
+        vals_s, idx_s, _, times_s = _channels_of(ragged_s["h_tdigest"])
+        assert idx_p == idx_s
+        for dp, ds, tp, ts in zip(vals_p, vals_s, times_p, times_s, strict=True):
+            assert int(cell_envelope(tp)) == int(cell_envelope(ts))
+            assert float(dp[:, 1].sum()) == float(ds[:, 1].sum())
+            for q in (0.1, 0.5, 0.9):
+                assert abs(quantile_from_tdigest(ds, q) - quantile_from_tdigest(dp, q)) < 1.0
+
+    def test_located_and_temporal_ride_the_same_fold(self, monkeypatch):
+        # The CA shape (issue #477's blocked config): build_tdigest_where strata
+        # carrying BOTH channels. Each stratum's siblings must stay row-aligned
+        # with its own payload, with each channel bounded by that stratum's own
+        # contributors — a channel folded against the other's partition, or
+        # against the unmasked population, would fail one of the two.
+        key = _shard_key()
+        cfg = _config(_variables(strata=True, located=True, temporal=True), streaming=_SPILL)
+        grid = _grid(cfg)
+        dfs = _granule_dfs(grid, key, _CELL_LISTS, obs_per_cell=100, seed=25, times=True)
+        _force_tiny_blocks(monkeypatch)
+        _, ragged, meta = _run(monkeypatch, cfg, grid, key, list(dfs))
+        assert meta["phase_timings"]["spill_blocks_closed"] == len(_CELL_LISTS)
+        children = np.asarray(grid.children(key), dtype=np.uint64)
+        for name, mask_fn in (
+            ("h_sig", lambda df: df["h_ph"].values > 0),
+            ("h_noise", lambda df: ~(df["h_ph"].values > 0)),
+        ):
+            vals, idx, locs, times = _channels_of(ragged[name])
+            assert len(vals) == len(locs) == len(times) > 0
+            for cell_i, digest, cell_locs, words in zip(idx, vals, locs, times, strict=True):
+                cell = int(children[cell_i])
+                assert cell_locs.shape == words.shape == (len(digest),)
+                _assert_ancestor_or_equal(cell_locs, _contributors(dfs, grid, cell, mask_fn))
+                _assert_envelope_conservation(words, _contributor_times(dfs, grid, cell, mask_fn))
+
+    def test_the_derived_word_column_is_never_spilled(self, monkeypatch):
+        # The channel costs the spill record nothing beyond the clock column the
+        # config already reads: the toc words are DERIVED at fold time, so
+        # ``toc_word`` must not appear in the block schema.
+        cfg = _config(_variables(temporal=True), streaming=_SPILL)
+        grid = _grid(cfg)
+        df = _granule_dfs(grid, _shard_key(), [[0, 4]], obs_per_cell=5, seed=1, times=True)[0]
+        agg = SpillAggregator(cfg, grid, "pandas", 1)
+        agg.add_read(df)
+        agg.flush()
+        assert [name for name, _ in agg._block.schema] == ["h_ph", "leaf_id", "delta_time"]
+        agg.close()
+
+
 class TestStrataMultiBlock:
     """build_tdigest_where strata across forced block closes."""
 
@@ -830,6 +1046,26 @@ class TestFoldColumnDiagnostics:
         agg = self._agg_with_block(variables, {"h_ph": np.zeros(1, np.float32)})
         with pytest.raises(ValueError, match="h_sig.*where: 'flag > 0'.*\\['flag'\\]"):
             agg._fold_block(agg._block)
+        agg.close()
+
+    def test_missing_clock_column_named(self):
+        # The temporal channel's words are derived from output.time_source.field,
+        # which is a read column like any other: a block that never carried it
+        # must fail with the POOLED path's named message, not a bare KeyError.
+        agg = self._agg_with_block(_variables(temporal=True), {"h_ph": np.zeros(1, np.float32)})
+        with pytest.raises(ValueError, match="output.time_source.field 'delta_time' is not"):
+            agg._fold_block(agg._block)
+        agg.close()
+
+    def test_where_may_read_the_derived_word_column(self):
+        # The fold's namespace carries the derived toc_word column exactly as
+        # the pooled one does, so a where expression over it must resolve rather
+        # than be reported as a column the block never carried.
+        variables = _variables(strata=True, temporal=True)
+        variables["h_sig"]["params"] = {**variables["h_sig"]["params"], "where": "toc_word > 0"}
+        cols = {"h_ph": np.ones(1, np.float32), "delta_time": np.ones(1, np.float64)}
+        agg = self._agg_with_block(variables, cols)
+        agg._fold_block(agg._block)  # no raise
         agg.close()
 
     def test_expression_over_spilled_columns_passes(self):

--- a/tests/test_spill_crossblock.py
+++ b/tests/test_spill_crossblock.py
@@ -55,7 +55,7 @@ def _composition_field(threshold=2):
     }
 
 
-def _variables(located=False, strata=False, pairwise=False, delta=16):
+def _variables(located=False, strata=False, pairwise=False, delta=16, temporal=False):
     fn = "zagg.stats.tdigest.build_tdigest" + ("_pairwise" if pairwise else "")
     base = {
         "kind": "ragged",
@@ -68,6 +68,8 @@ def _variables(located=False, strata=False, pairwise=False, delta=16):
     }
     if located:
         base["location"] = "leaf_id"
+    if temporal:
+        base["temporal"] = "per-centroid"
     variables = {
         "count": {"function": "len", "source": "h_ph", "dtype": "int32", "fill_value": 0},
     }
@@ -81,10 +83,19 @@ def _variables(located=False, strata=False, pairwise=False, delta=16):
     return variables
 
 
+#: The declared clock a ``temporal:`` config encodes its words from (§8.3): a
+#: base-rate ``delta_time`` column on a continuous scale, epoched at the ATL03
+#: mission epoch. Materialized by ``_config`` only when a field declares a
+#: companion, so every pre-#410 config in this module is untouched.
+_EPOCH = "2018-01-01T00:00:00"
+_TIME_SOURCE = {"field": "delta_time", "epoch": _EPOCH, "scale": "gps", "units": "seconds"}
+
+
 def _config(variables, streaming=None):
     agg = {"variables": variables}
     if streaming is not None:
         agg["streaming"] = streaming
+    output = {"time_source": _TIME_SOURCE} if _has_temporal(variables) else {}
     return PipelineConfig(
         data_source={
             "reader": "h5coro",
@@ -94,7 +105,12 @@ def _config(variables, streaming=None):
             "shard_workers": 1,
         },
         aggregation=agg,
+        output=output,
     )
+
+
+def _has_temporal(variables) -> bool:
+    return any(v.get("temporal") for v in variables.values())
 
 
 _SPILL = {"buffer_granules": 1, "mode": "spill"}
@@ -127,18 +143,22 @@ def _point_leafs(grid, cell, n, rng):
 
 
 def _granule_dfs(
-    grid, shard_key, cell_idx_lists, obs_per_cell=60, seed=0, conf=False, nan_cells=()
+    grid, shard_key, cell_idx_lists, obs_per_cell=60, seed=0, conf=False, nan_cells=(), times=False
 ):
     """One DataFrame per granule; real order-29 point leafs per chosen cell.
 
     ``conf=True`` adds the five ``signal_conf_*`` columns (ATL03's ``-1..4``
     range) for composition tests. Cells in ``nan_cells`` get all-NaN heights
-    (an empty digest but a nonzero count).
+    (an empty digest but a nonzero count). ``times=True`` adds the
+    ``delta_time`` clock column ``_TIME_SOURCE`` declares — one granule per
+    DAY, rows a millisecond apart within it, so every granule (and therefore
+    every forced block) covers a disjoint instant range: a cross-block fold
+    that dropped or mispaired a block's words could not still envelope them.
     """
     rng = np.random.default_rng(seed)
     children = np.asarray(grid.children(shard_key), dtype=np.uint64)
     dfs = []
-    for idxs in cell_idx_lists:
+    for g, idxs in enumerate(cell_idx_lists):
         n = obs_per_cell * len(idxs)
         h, leaf = [], []
         for ci in idxs:
@@ -148,6 +168,8 @@ def _granule_dfs(
             h.append(vals)
             leaf.append(_point_leafs(grid, int(children[ci]), obs_per_cell, rng))
         cols = {"h_ph": np.concatenate(h), "leaf_id": np.concatenate(leaf)}
+        if times:
+            cols["delta_time"] = 86400.0 * (g + 1) + 1e-3 * np.arange(n, dtype=np.float64)
         if conf:
             for name in _CONF_COLS:
                 cols[name] = rng.integers(-1, 5, n).astype(np.int8)
@@ -290,26 +312,42 @@ class TestSpillFoldProbe:
         with pytest.raises(ValueError, match="chunk_precompute.*no cross-block fold"):
             validate_spill_fold(cfg)
 
-    def test_temporal_companion_has_no_cross_block_fold_yet(self):
-        # The toc join itself is exact and fold-tree independent (spec §8.2), but
-        # the block close's per-field channel state is located-only, so a
-        # temporal field would emit a companion missing every block past the
-        # first — a §8.3 row-alignment break. Named, not silently approximated.
-        variables = _variables(located=True)
-        variables["h_tdigest"]["temporal"] = "per-centroid"
-        with pytest.raises(ValueError, match="temporal companions.*no cross-block fold state"):
-            validate_spill_fold(_config(variables, streaming=_SPILL))
+    @pytest.mark.parametrize("located", [False, True])
+    def test_per_centroid_temporal_config_is_mergeable(self, located):
+        # The refusal-removal pin (issue #477): the per-centroid companion has a
+        # cross-block fold state now, alone and beside the located channel, so
+        # the probe accepts it and the field classifies with both channels.
+        cfg = _config(_variables(located=located, temporal=True), streaming=_SPILL)
+        validate_spill_fold(cfg)  # no raise
+        agg = SpillAggregator(cfg, _grid(cfg), "pandas", 1)
+        assert agg._mergeable
+        f = agg._digest_fields["h_tdigest"]
+        assert f.temporal and bool(f.location) == located
+        agg.close()
 
-    def test_temporal_refusal_names_the_pooled_path(self):
+    def test_per_cell_temporal_still_has_no_cross_block_fold(self):
+        # Only the per-centroid shape folds. A per-cell companion is a scalar
+        # reducer over the derived word column with no per-block accumulator
+        # here, and it must be refused BY NAME rather than reported as a plain
+        # unmergeable scalar function.
         variables = _variables()
-        variables["h_tdigest"]["temporal"] = "per-centroid"
-        with pytest.raises(ValueError, match="run the pooled path"):
+        variables["observed"] = {
+            "function": "zagg.stats.toc.cell_envelope",
+            "source": "toc_word",
+            "dtype": "uint64",
+            "fill_value": 0,
+            "temporal": "per-cell",
+        }
+        with pytest.raises(ValueError, match="'observed'.*'per-cell'.*no cross-block fold state"):
             validate_spill_fold(_config(variables, streaming=_SPILL))
 
     def test_temporal_cannot_stream_under_merge_mode_either(self):
-        variables = _variables()
-        variables["h_tdigest"]["temporal"] = "per-centroid"
+        # mode: merge carries no companion channel at all, so it still refuses —
+        # and now routes to the mode that folds one.
+        variables = _variables(temporal=True)
         with pytest.raises(ValueError, match="temporal companions.*cannot stream"):
+            validate_streaming(_config(variables))
+        with pytest.raises(ValueError, match="mode: spill"):
             validate_streaming(_config(variables))
 
     def test_mis_declared_inner_shape_still_has_no_fold(self):


### PR DESCRIPTION
Closes #477. Refs #410/#463 (channel + law), #370 (fold regime), #474/#475 (the knob this unblocks), #279 (kway lineage).

## What this does

`SpillAggregator`'s cross-block close carried the **located** channel only, so `_mergeable` classified any `temporal:` field as unfoldable and `block_bytes` (#474/#475) refused every temporal store — including all of California — with

> field 'h_tdigest_signal': temporal companions (temporal: 'per-centroid') have no cross-block fold state yet …

This carries the §8.3 per-centroid companion through the same seam, one channel over.

**The carry.** The per-block build already returns `(digest, *words)` and the merge laws already take both channels (`merge_tdigests(..., temporal1=, temporal2=)`, `merge_tdigests_kway(..., temporal=)` — shipped in #463, the overview folds are the working call site). So the change is state + plumbing, not algebra:

- `_DigestField` gains `temporal: bool` (the §8.3 declaration; unlike `location` there is no column name — the words are *derived*).
- The two located-only dicts become **per-channel** ones keyed by reducer kwarg:
  `_digest_locs` → `_digest_words[field][kwarg][cell]` (running, pairwise fields) and
  `_digest_loc_parts` → `_digest_word_parts[field][kwarg][cell]` (k-way parts).
  One module-level table, `_CHANNELS = (("location", "locations", "locations"), ("temporal", "temporal", "times"))`, carries the declaration attr, the reducer kwarg and the emission key in the kernel's fixed return order — mirroring `sweep_overview.COMPANION_CHANNELS`'s shape. Every fold and emission site zips the kernel's returned words against that table, so the ordering claim is structural rather than dict-insertion order.
- `_fold_block` derives the toc word column **per cell**, into `cell_data` before params resolve — exactly where `calculate_cell_statistics` does it (`aggregate.py:487`) — and passes each declared channel to `build_tdigest` / `build_tdigest_where`; every declared channel then rides **one** merge (pairwise) or **one** k-way collapse (`_finalize_kway`), so a field carrying both never gets one channel folded against a partition the other did not see.
- `_chunk_outputs_merged` emits `ragged_channels` with `_aggregate_chunk_cells`'s own keys (`locations`, `times`), so a folded chunk and a pooled one are indistinguishable to the writer.
- `validate_spill_fold` lifts the `per-centroid` refusal (keeping a *named* one for `per-cell`, which is a scalar reducer over the word column with no per-block accumulator here); the merge-mode message now routes to `mode: spill` the way the located one does.

The derived column lands in `cell_data`, which keeps `_resolve_param`'s namespace equal to the pooled one (which also carries `toc_word`), so a `where` reading it resolves identically. `_check_fold_columns` accordingly resolves params against `available + toc_word` while `source:` / `location:` still check the **true spilled-column list**, so neither the diagnostics nor their messages loosen. An absent *clock* column is named by `_toc_word_column` itself, with the pooled path's message.

**Not touched:** no wire format, no attrs grammar, no `spec` marker — so no `docs/specification.md` change and **no committed fixture bytes move**. The spill fold regime is documented as *not* byte-identical to single-block (§2.3 / #370), so no §7 conformance fixture covers it; `tests/data/spec/` is untouched by design.

## Phases

- [x] **Phase 1** — carry the channel through the close: per-channel fold state, derived toc column, k-way + pairwise folds, emission keys; lift the `per-centroid` refusal and update the refusal text; re-pin the two probe tests.
- [x] **Phase 2** — tests: envelope conservation across a forced block close, k-way order-independence, dual-channel (located + temporal), pooled cross-check within the fold-law bounds.
- [x] **Phase 3** — empirical check on the local spill harness with the temporal fold arm on; adversarial review + fold (six findings, all answered on-thread).

## Interaction with #475 (`claude/474-spill-knobs`)

**#475 is open and also touches `spill.py`/`streaming.py`.** This branch is based on `main`, which does **not** carry #475 yet, and the diff is kept minimal on the shared surface: #475 owns `__init__`'s knob plumbing / `_default_block_bytes`, while this PR owns the fold state and `_fold_block`/`_finalize_kway`/`_chunk_outputs_merged`. The one line they could both touch is the `SpillOverflowError` message. **#475 merges first**; expect to sync this branch onto it before it is ready (the #457 two-green-PRs lesson — two independently green PRs on one file are not a green merge).

Note also `src/zagg/processing/spill.py` lands at **1,198 lines**, under the 1,200 raise trigger (espg standing ruling, #351/#358) — prose trimmed rather than the module split. See "Questions for review".

## Testing

Full suite after the fold: **4,445 passed, 38 skipped, 1 failed** — the failure being the known environmental `test_lambda_build::TestFunctionBuild::test_function_build_succeeds`. `ruff check` / `ruff format --check` clean on everything this PR touches. Known pre-existing and left alone: `test_lambda_build` (environmental), `test_client_transport` (wall-clock flake), ruff `N818` in `registry.py`, and the `tests/data/benchmark/README.md` format drift.

The new coverage lives in `tests/test_spill_crossblock.py::TestTemporalMultiBlock`; each test asserts `spill_blocks_closed == len(_CELL_LISTS)`, and each granule covers its own day, so every multi-granule centroid genuinely spans blocks. Details, mutation checks and the harness numbers are in the thread.

## Questions for review

- **`spill.py` is at 1,198 lines — 2 under the 1,200 raise trigger.** The self-review flagged that as "heading past 1,200" and worth a decision now rather than at the next PR that touches this file. The §4 ruling pre-approves overages *below* 1,200, so this PR is inside it and did not split anything; the next feature on this module will not be. Splitting it (the obvious seam is `SpillBlock` + `_Partition` + `check_tmp_headroom` into a `spill_block.py`, leaving `SpillAggregator`) is a mechanical but reviewer-visible change and is deliberately **not** in this PR.
- The `per-cell` companion shape stays refused (named). Folding it is genuinely easy — the §8.2 join is a semilattice, so per-block cell envelopes join exactly — but it needs a third field class in the fold (a scalar-word accumulator beside `_composition_fields`) and no shipped config pairs it with `mode: spill`. Left out as scope; say the word if it should ride along.
