### PR TITLE
shardmap: refuse per-shard granule basename collisions at construction (issue #468)

### DIFF
--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -162,33 +162,20 @@ def _granule_entry(rec: dict) -> dict:
     return entry
 
 
-def _recorded_identity(entry: dict, canonicalize=None) -> tuple:
-    """What a shard entry will be RECORDED as, and what actually names it.
+def _recorded_identity(entry: dict, canonicalize=None) -> tuple[str | None, tuple]:
+    """``(canonical, distinguishing)`` for one shard entry.
 
-    ``canonicalize`` lets a caller in a hot loop hoist the
-    :func:`zagg.telemetry.canonical_granule_id` import out of the per-entry path.
+    ``canonical`` is the granule id the leaf's D20 sidecar will carry — the
+    basename of the href the runner resolves (:func:`zagg.telemetry.canonical_granule_id`),
+    falling back to the id, then the datetime, for the raster entries that carry
+    no href. ``None`` when there is nothing to canonicalize.
 
-    Returns ``(canonical, distinguishing)``: the canonical granule id the leaf's
-    D20 sidecar will carry for this entry (:func:`zagg.telemetry.canonical_granule_id`
-    of the href the runner resolves — ``zagg.runner._resolve_urls`` picks ``s3``
-    or ``https`` by ``data_source.driver``, and the two spellings of one granule
-    agree on the basename by construction), paired with everything that
-    distinguishes one granule from another here. ``(None, ...)`` for an entry
-    with nothing to canonicalize.
+    ``distinguishing`` is what separates one granule from another. ``datetime``
+    counts because :func:`zagg.telemetry.raster_granule_ids` records two
+    acquisitions sharing an item id as one id; the sibling ``assets`` do not,
+    because a record's identity is the primary alone (issue #425).
 
-    Keyed on the href rather than on ``entry["id"]`` because the href is what the
-    recorded identity is actually derived from; for every catalog zagg reads the
-    two agree (that agreement is *why* ``rec["id"]`` equals the basename — see
-    :func:`zagg.telemetry.canonical_granule_id`), so on real catalogs the choice
-    is not observable. Raster entries carry no href, and their identity is the
-    STAC item id or the acquisition datetime (:func:`zagg.telemetry.raster_granule_ids`)
-    — which is why ``datetime`` distinguishes too: two acquisitions sharing an item
-    id record as one id there, so leaving it out let exactly the collapse this
-    guards against pass as one granule listed twice.
-
-    The sibling ``assets`` (issue #425) are deliberately not distinguishing: a
-    record's granule identity is the **primary alone**, which is the invariant
-    :func:`zagg.telemetry.canonical_granule_id` records.
+    ``canonicalize`` lets a hot loop hoist the import out of the per-entry path.
     """
     if canonicalize is None:
         from zagg.telemetry import canonical_granule_id as canonicalize
@@ -205,12 +192,11 @@ def _recorded_identity(entry: dict, canonicalize=None) -> tuple:
 
 
 def _collision_label(entry: dict) -> str:
-    """How to name one colliding entry so the operator can tell the pair apart.
+    """Name one colliding entry by what tells it apart from its partner.
 
-    The href when there is one — the prefix is what differs, and it is what the
-    remedy acts on. A raster entry has none, and both members of such a pair
-    carry the SAME id (that is the collapse), so naming them by id twice says
-    nothing; the acquisition datetime is what separates them.
+    The href when there is one — the prefix is what differs and what the remedy
+    acts on. A raster pair has no href and both members carry the same id (that
+    IS the collapse), so the datetime is the only thing left that separates them.
     """
     href = entry.get("s3") or entry.get("https")
     if href:
@@ -223,22 +209,18 @@ def _collision_label(entry: dict) -> str:
 def _refuse_basename_collisions(shard_keys, granules) -> None:
     """Refuse a map whose recorded granule identity is not per-shard unique (#468).
 
-    Post-#420 a granule's recorded identity is its driver-stripped basename, so
-    two granules of one shard differing only in href prefix collapse onto ONE
-    recorded id — the leaf then reads a genuine contraction as duplicate drift
-    and rewrites. PR #420 question (6) priced that and ruled it acceptable
-    ([option (a)](https://github.com/englacial/zagg/pull/420#issuecomment-5317015792))
-    **because** every catalog zagg reads names granules globally uniquely. This
-    enforces that "because" where the invariant is owned — at construction —
-    instead of guarding its violation at the leaf gate, which is what makes the
-    leaf-side predicate variants (question (6) options (b)/(c)) unnecessary.
+    Two granules of one shard whose recorded ids collapse onto one make the
+    shard's catalog identity name fewer granules than it reads. PR #420 question
+    (6) ruled the leaf-gate consequence acceptable *because* every catalog zagg
+    reads names granules globally uniquely; this enforces that "because" where
+    the invariant is owned rather than assuming it.
 
     Entries agreeing on every distinguishing field (:func:`_recorded_identity`)
-    are one granule listed twice and pass: :meth:`ShardMap.reproject`'s coarsen
-    unions the granule lists of sibling shards, where a granule spanning several
-    children legitimately arrives more than once.
+    are one granule listed twice and pass — coarsen unions sibling shards, where
+    a granule spanning several children legitimately arrives more than once.
     """
-    collisions = []
+    n_collisions = 0
+    shown: list = []
     # Imported once rather than per entry: this runs over every granule of every
     # shard, 555,867 of them at clone scale.
     from zagg.telemetry import canonical_granule_id
@@ -247,31 +229,29 @@ def _refuse_basename_collisions(shard_keys, granules) -> None:
         by_canonical: dict = {}
         for entry in entries:
             canonical, distinguishing = _recorded_identity(entry, canonical_granule_id)
+            # Empty as well as absent: an id of ``"/"`` canonicalizes to ``""``,
+            # and reporting ``''`` as the collapsed id is exactly the
+            # silently-wrong identity ``canonical_granule_id`` refuses to mint.
             if not canonical:
-                # Empty as well as absent: an id of ``"/"`` canonicalizes to
-                # ``""``, and ``canonical_granule_id`` refuses to mint an
-                # identity from an empty name precisely so nothing gets a
-                # silently-wrong one -- reporting ``''`` as the collapsed id
-                # would be exactly that.
                 continue
             by_canonical.setdefault(canonical, {})[distinguishing] = _collision_label(entry)
-        collisions += sorted(
-            (key, canonical, sorted(named.values()))
-            for canonical, named in by_canonical.items()
-            if len(named) > 1
-        )
-    if not collisions:
+        # Filtered before sorting -- on every catalog zagg reads the filter
+        # discards all of them, so sorting first is a per-shard sort of nothing.
+        # Only the first few groups are retained: the message prints three, and a
+        # wholly mis-scoped catalog has one group per granule.
+        found = sorted((c, sorted(n.values())) for c, n in by_canonical.items() if len(n) > 1)
+        n_collisions += len(found)
+        shown += [(key, c, named) for c, named in found[: max(0, 4 - len(shown))]]
+    if not n_collisions:
         return
-    shown = "; ".join(
-        f"shard {k} {canonical!r} <- {named}" for k, canonical, named in collisions[:3]
-    )
+    listed = "; ".join(f"shard {k} {c!r} <- {named}" for k, c, named in shown[:3])
     raise ValueError(
-        f"ShardMap: {len(collisions)} per-shard granule identity collision(s) — granules "
+        f"ShardMap: {n_collisions} per-shard granule identity collision(s) — granules "
         f"assigned to one shard record as ONE granule id, so the shard's catalog identity "
         f"names fewer granules than it reads (issue #468). Usually one basename under two "
         f"key prefixes, in which case re-scope the catalog query so each granule appears "
         f"once, or de-collide the basenames; the entries below are named by whatever "
-        f"separates them: {shown}{' ...' if len(collisions) > 3 else ''}"
+        f"separates them: {listed}{' ...' if n_collisions > 3 else ''}"
     )
 
 

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -162,8 +162,11 @@ def _granule_entry(rec: dict) -> dict:
     return entry
 
 
-def _recorded_identity(entry: dict):
+def _recorded_identity(entry: dict, canonicalize=None) -> tuple:
     """What a shard entry will be RECORDED as, and what actually names it.
+
+    ``canonicalize`` lets a caller in a hot loop hoist the
+    :func:`zagg.telemetry.canonical_granule_id` import out of the per-entry path.
 
     Returns ``(canonical, distinguishing)``: the canonical granule id the leaf's
     D20 sidecar will carry for this entry (:func:`zagg.telemetry.canonical_granule_id`
@@ -187,17 +190,34 @@ def _recorded_identity(entry: dict):
     record's granule identity is the **primary alone**, which is the invariant
     :func:`zagg.telemetry.canonical_granule_id` records.
     """
-    from zagg.telemetry import canonical_granule_id
+    if canonicalize is None:
+        from zagg.telemetry import canonical_granule_id as canonicalize
 
     href = entry.get("s3") or entry.get("https")
     named = href or entry.get("id") or entry.get("datetime")
-    canonical = canonical_granule_id(named) if named else None
+    canonical = canonicalize(named) if named else None
     return canonical, (
         entry.get("id"),
         entry.get("s3"),
         entry.get("https"),
         entry.get("datetime"),
     )
+
+
+def _collision_label(entry: dict) -> str:
+    """How to name one colliding entry so the operator can tell the pair apart.
+
+    The href when there is one — the prefix is what differs, and it is what the
+    remedy acts on. A raster entry has none, and both members of such a pair
+    carry the SAME id (that is the collapse), so naming them by id twice says
+    nothing; the acquisition datetime is what separates them.
+    """
+    href = entry.get("s3") or entry.get("https")
+    if href:
+        return str(href)
+    if entry.get("id") and entry.get("datetime"):
+        return f"{entry['id']} @ {entry['datetime']}"
+    return str(entry.get("id") or entry.get("datetime"))
 
 
 def _refuse_basename_collisions(shard_keys, granules) -> None:
@@ -219,10 +239,14 @@ def _refuse_basename_collisions(shard_keys, granules) -> None:
     children legitimately arrives more than once.
     """
     collisions = []
+    # Imported once rather than per entry: this runs over every granule of every
+    # shard, 555,867 of them at clone scale.
+    from zagg.telemetry import canonical_granule_id
+
     for key, entries in zip(shard_keys, granules):
         by_canonical: dict = {}
         for entry in entries:
-            canonical, distinguishing = _recorded_identity(entry)
+            canonical, distinguishing = _recorded_identity(entry, canonical_granule_id)
             if not canonical:
                 # Empty as well as absent: an id of ``"/"`` canonicalizes to
                 # ``""``, and ``canonical_granule_id`` refuses to mint an
@@ -230,26 +254,24 @@ def _refuse_basename_collisions(shard_keys, granules) -> None:
                 # silently-wrong one -- reporting ``''`` as the collapsed id
                 # would be exactly that.
                 continue
-            by_canonical.setdefault(canonical, {})[distinguishing] = (
-                entry.get("s3") or entry.get("https") or entry.get("id") or entry.get("datetime")
-            )
-        collisions += [
-            (key, canonical, sorted(str(h) for h in named.values()))
-            for canonical, named in sorted(by_canonical.items())
+            by_canonical.setdefault(canonical, {})[distinguishing] = _collision_label(entry)
+        collisions += sorted(
+            (key, canonical, sorted(named.values()))
+            for canonical, named in by_canonical.items()
             if len(named) > 1
-        ]
+        )
     if not collisions:
         return
     shown = "; ".join(
-        f"shard {k} {canonical!r} <- {hrefs}" for k, canonical, hrefs in collisions[:3]
+        f"shard {k} {canonical!r} <- {named}" for k, canonical, named in collisions[:3]
     )
     raise ValueError(
         f"ShardMap: {len(collisions)} per-shard granule identity collision(s) — granules "
-        f"assigned to one shard share a basename across different prefixes, so they "
-        f"collapse onto a single recorded granule id and the shard's catalog identity "
-        f"names fewer granules than it reads (issue #468). Re-scope the catalog query so "
-        f"each granule appears once, or de-collide the basenames: "
-        f"{shown}{' ...' if len(collisions) > 3 else ''}"
+        f"assigned to one shard record as ONE granule id, so the shard's catalog identity "
+        f"names fewer granules than it reads (issue #468). Usually one basename under two "
+        f"key prefixes, in which case re-scope the catalog query so each granule appears "
+        f"once, or de-collide the basenames; the entries below are named by whatever "
+        f"separates them: {shown}{' ...' if len(collisions) > 3 else ''}"
     )
 
 

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -162,6 +162,84 @@ def _granule_entry(rec: dict) -> dict:
     return entry
 
 
+def _recorded_identity(entry: dict):
+    """What a shard entry will be RECORDED as, and what actually names it.
+
+    Returns ``(canonical, distinguishing)``: the canonical granule id the leaf's
+    D20 sidecar will carry for this entry (:func:`zagg.telemetry.canonical_granule_id`
+    of the href the runner resolves — ``zagg.runner._resolve_urls`` picks ``s3``
+    or ``https`` by ``data_source.driver``, and the two spellings of one granule
+    agree on the basename by construction), paired with everything that
+    distinguishes one granule from another here. ``(None, ...)`` for an entry
+    with nothing to canonicalize.
+
+    Keyed on the href rather than on ``entry["id"]`` because the href is what the
+    recorded identity is actually derived from; for every catalog zagg reads the
+    two agree (that agreement is *why* ``rec["id"]`` equals the basename — see
+    :func:`zagg.telemetry.canonical_granule_id`), so on real catalogs the choice
+    is not observable. Raster entries carry no href, and their identity is the
+    STAC item id or the acquisition datetime (:func:`zagg.telemetry.raster_granule_ids`).
+
+    The sibling ``assets`` (issue #425) are deliberately not distinguishing: a
+    record's granule identity is the **primary alone**, which is the invariant
+    :func:`zagg.telemetry.canonical_granule_id` records.
+    """
+    from zagg.telemetry import canonical_granule_id
+
+    href = entry.get("s3") or entry.get("https")
+    named = href or entry.get("id") or entry.get("datetime")
+    canonical = canonical_granule_id(named) if named else None
+    return canonical, (entry.get("id"), entry.get("s3"), entry.get("https"))
+
+
+def _refuse_basename_collisions(shard_keys, granules) -> None:
+    """Refuse a map whose recorded granule identity is not per-shard unique (#468).
+
+    Post-#420 a granule's recorded identity is its driver-stripped basename, so
+    two granules of one shard differing only in href prefix collapse onto ONE
+    recorded id — the leaf then reads a genuine contraction as duplicate drift
+    and rewrites. PR #420 question (6) priced that and ruled it acceptable
+    ([option (a)](https://github.com/englacial/zagg/pull/420#issuecomment-5317015792))
+    **because** every catalog zagg reads names granules globally uniquely. This
+    enforces that "because" where the invariant is owned — at construction —
+    instead of guarding its violation at the leaf gate, which is what makes the
+    leaf-side predicate variants (question (6) options (b)/(c)) unnecessary.
+
+    Entries agreeing on ``(id, s3, https)`` are one granule listed twice and
+    pass: :meth:`ShardMap.reproject`'s coarsen unions the granule lists of
+    sibling shards, where a granule spanning several children legitimately
+    arrives more than once.
+    """
+    collisions = []
+    for key, entries in zip(shard_keys, granules):
+        by_canonical: dict = {}
+        for entry in entries:
+            canonical, distinguishing = _recorded_identity(entry)
+            if canonical is None:
+                continue
+            by_canonical.setdefault(canonical, {})[distinguishing] = (
+                entry.get("s3") or entry.get("https") or entry.get("id")
+            )
+        collisions += [
+            (key, canonical, sorted(str(h) for h in named.values()))
+            for canonical, named in sorted(by_canonical.items())
+            if len(named) > 1
+        ]
+    if not collisions:
+        return
+    shown = "; ".join(
+        f"shard {k} {canonical!r} <- {hrefs}" for k, canonical, hrefs in collisions[:3]
+    )
+    raise ValueError(
+        f"ShardMap: {len(collisions)} per-shard granule identity collision(s) — granules "
+        f"assigned to one shard share a basename across different prefixes, so they "
+        f"collapse onto a single recorded granule id and the shard's catalog identity "
+        f"names fewer granules than it reads (issue #468). Re-scope the catalog query so "
+        f"each granule appears once, or de-collide the basenames: "
+        f"{shown}{' ...' if len(collisions) > 3 else ''}"
+    )
+
+
 #: Granule-id core for the catalog-time sibling join (issue #425): the
 #: datetime / orbit / sub-orbit-granule / track fields shared between the
 #: products of one acquisition (GEDI01_B_* and GEDI02_A_* of the same
@@ -1503,6 +1581,10 @@ class ShardMap:
 
         shard_keys = sorted(shard_to_idx)
         granules = [[_granule_entry(records[i]) for i in shard_to_idx[k]] for k in shard_keys]
+        # The per-shard identity invariant is owned here (issue #468): refuse a
+        # build whose shards name two granules the same, rather than leaving it
+        # to be discovered as duplicate drift at the leaf gate.
+        _refuse_basename_collisions(shard_keys, granules)
         meta = {
             **(catalog.metadata or {}),
             "backend": chosen,
@@ -1660,10 +1742,17 @@ class ShardMap:
             new_keys = sorted(groups)
             new_granules = []
             for k in new_keys:
+                # Keyed on what distinguishes one granule from another, not on
+                # the id alone: coarsening merges sibling shards, so a basename
+                # collision that was cross-shard at the source order lands
+                # in-shard here, and an id-keyed dedup would drop one of the two
+                # rather than let the check below name it (issue #468). A
+                # granule spanning several children still counts once.
                 seen: dict = {}
                 for i in groups[k]:
                     for g in self.granules[i]:
-                        seen[g["id"]] = _granule_entry(g)
+                        entry = _granule_entry(g)
+                        seen[_recorded_identity(entry)[1]] = entry
                 new_granules.append(list(seen.values()))
             method = "coarsen"
         else:
@@ -1712,11 +1801,16 @@ class ShardMap:
                     bucket = new_granules_map.setdefault(int(k), {})
                     for i in idxs:
                         entry = _granule_entry(sub_records[i])
-                        bucket[entry["id"]] = entry
+                        bucket[_recorded_identity(entry)[1]] = entry
 
             new_keys = sorted(new_granules_map)
             new_granules = [list(new_granules_map[k].values()) for k in new_keys]
             method = "refine"
+
+        # Reproject mints NEW shard membership, so it can mint a collision the
+        # source map did not have -- coarsen by merging sibling shards, refine
+        # by re-intersecting -- and owns the same invariant ``build`` does (#468).
+        _refuse_basename_collisions(new_keys, new_granules)
 
         meta = dict(self.metadata or {})
         meta["reproject"] = {

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -223,7 +223,12 @@ def _refuse_basename_collisions(shard_keys, granules) -> None:
         by_canonical: dict = {}
         for entry in entries:
             canonical, distinguishing = _recorded_identity(entry)
-            if canonical is None:
+            if not canonical:
+                # Empty as well as absent: an id of ``"/"`` canonicalizes to
+                # ``""``, and ``canonical_granule_id`` refuses to mint an
+                # identity from an empty name precisely so nothing gets a
+                # silently-wrong one -- reporting ``''`` as the collapsed id
+                # would be exactly that.
                 continue
             by_canonical.setdefault(canonical, {})[distinguishing] = (
                 entry.get("s3") or entry.get("https") or entry.get("id") or entry.get("datetime")

--- a/src/zagg/catalog/shardmap.py
+++ b/src/zagg/catalog/shardmap.py
@@ -178,7 +178,10 @@ def _recorded_identity(entry: dict):
     two agree (that agreement is *why* ``rec["id"]`` equals the basename — see
     :func:`zagg.telemetry.canonical_granule_id`), so on real catalogs the choice
     is not observable. Raster entries carry no href, and their identity is the
-    STAC item id or the acquisition datetime (:func:`zagg.telemetry.raster_granule_ids`).
+    STAC item id or the acquisition datetime (:func:`zagg.telemetry.raster_granule_ids`)
+    — which is why ``datetime`` distinguishes too: two acquisitions sharing an item
+    id record as one id there, so leaving it out let exactly the collapse this
+    guards against pass as one granule listed twice.
 
     The sibling ``assets`` (issue #425) are deliberately not distinguishing: a
     record's granule identity is the **primary alone**, which is the invariant
@@ -189,7 +192,12 @@ def _recorded_identity(entry: dict):
     href = entry.get("s3") or entry.get("https")
     named = href or entry.get("id") or entry.get("datetime")
     canonical = canonical_granule_id(named) if named else None
-    return canonical, (entry.get("id"), entry.get("s3"), entry.get("https"))
+    return canonical, (
+        entry.get("id"),
+        entry.get("s3"),
+        entry.get("https"),
+        entry.get("datetime"),
+    )
 
 
 def _refuse_basename_collisions(shard_keys, granules) -> None:
@@ -205,10 +213,10 @@ def _refuse_basename_collisions(shard_keys, granules) -> None:
     instead of guarding its violation at the leaf gate, which is what makes the
     leaf-side predicate variants (question (6) options (b)/(c)) unnecessary.
 
-    Entries agreeing on ``(id, s3, https)`` are one granule listed twice and
-    pass: :meth:`ShardMap.reproject`'s coarsen unions the granule lists of
-    sibling shards, where a granule spanning several children legitimately
-    arrives more than once.
+    Entries agreeing on every distinguishing field (:func:`_recorded_identity`)
+    are one granule listed twice and pass: :meth:`ShardMap.reproject`'s coarsen
+    unions the granule lists of sibling shards, where a granule spanning several
+    children legitimately arrives more than once.
     """
     collisions = []
     for key, entries in zip(shard_keys, granules):
@@ -218,7 +226,7 @@ def _refuse_basename_collisions(shard_keys, granules) -> None:
             if canonical is None:
                 continue
             by_canonical.setdefault(canonical, {})[distinguishing] = (
-                entry.get("s3") or entry.get("https") or entry.get("id")
+                entry.get("s3") or entry.get("https") or entry.get("id") or entry.get("datetime")
             )
         collisions += [
             (key, canonical, sorted(str(h) for h in named.values()))

--- a/src/zagg/sweep.py
+++ b/src/zagg/sweep.py
@@ -438,10 +438,18 @@ class SubmapFamily(SweepFamily):
         would advertise one arbitrary child's identity). ``grid_signature`` is
         safe regardless — all children of a node share ``child_order``.
         """
-        from zagg.catalog.shardmap import ShardMap
+        from zagg.catalog.shardmap import (
+            ShardMap,
+            _recorded_identity,
+            _refuse_basename_collisions,
+        )
 
         # Same-key union first (several windows of one shard), deduplicated by
         # granule id — the same rule reproject's coarsen applies across shards.
+        # Keyed like coarsen's, on everything that distinguishes one granule from
+        # another rather than on the id alone (issue #468): two granules whose
+        # recorded identity collapses must both survive the union to be seen,
+        # not have one silently overwrite the other here.
         buckets: dict[int, dict] = {}
         for p in payloads:
             for key, entries in zip(p["shard_keys"], p["granules"]):
@@ -453,7 +461,8 @@ class SubmapFamily(SweepFamily):
                     # never a bare KeyError.
                     if "id" not in entry:
                         raise ValueError("leaf sub-map granule entry missing required 'id' field")
-                    bucket[entry["id"]] = dict(entry)
+                    entry = dict(entry)
+                    bucket[_recorded_identity(entry)[1]] = entry
         keys = sorted(buckets)
         granules = [list(buckets[k].values()) for k in keys]
         signature = dict(payloads[0]["grid_signature"])
@@ -464,6 +473,13 @@ class SubmapFamily(SweepFamily):
         # keys agreeing rather than inheriting a stale build-side value.
         meta["granules_assigned"] = meta["total_granules"]
         folded = ShardMap(signature, keys, granules, meta)
+        # The union above mints shard membership just as build and reproject do,
+        # so it owns the same identity invariant (issue #468). Checked here for
+        # BOTH arms: the interior arm inherits the check from reproject anyway,
+        # and a shard-node fold that stayed silent while its parent refused
+        # would be incoherent. Note this reaches ``_merged``'s fail-open handler
+        # as a skipped rollup node -- see the PR's questions for review.
+        _refuse_basename_collisions(keys, granules)
         if int(signature["parent_order"]) == int(order):
             # Shard-node fold: already at the node's order — a window union,
             # not a reprojection; keep counts honest without a noop stamp.

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -2770,3 +2770,32 @@ class TestBasenameCollisions:
         # One granule out, not two: the prefixes -- and with them the collision
         # -- were discarded upstream of the check, not by it.
         assert {g["id"] for g in entries} == {"Gdup"}
+
+    def test_an_id_that_canonicalizes_to_empty_is_skipped(self):
+        # ``canonical_granule_id("/")`` strips the separator down to "", which
+        # is falsy but not None -- an ``is None`` guard let it through as a
+        # live bucket key and would report ``''`` as the collapsed granule id
+        # (issue #468 review finding (3)).
+        from zagg.telemetry import canonical_granule_id
+
+        assert canonical_granule_id("/") == ""
+        shardmap._refuse_basename_collisions(
+            [7], [[{"id": "/", "s3": None, "https": None}, {"id": "/", "s3": "s3://b/x/"}]]
+        )
+
+    def test_more_than_three_collisions_are_counted_and_truncated(self):
+        # The operator-facing message shows the first three groups and says so;
+        # a badly mis-scoped catalog hits this branch, not the single-pair one
+        # (issue #468 review finding (4)).
+        entries = [
+            {"id": f"G{n}.h5", "s3": f"s3://b/{p}/G{n}.h5", "https": None}
+            for n in range(4)
+            for p in ("p1", "p2")
+        ]
+        with pytest.raises(ValueError) as excinfo:
+            shardmap._refuse_basename_collisions([7], [entries])
+        message = str(excinfo.value)
+        assert "4 per-shard granule identity collision(s)" in message
+        assert message.rstrip().endswith("...")
+        # Three groups shown, the fourth only counted.
+        assert "'G2.h5'" in message and "'G3.h5'" not in message

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -2712,12 +2712,13 @@ class TestBasenameCollisions:
         with pytest.raises(ValueError, match="identity collision"):
             sm_fine.reproject(coarse_grid)
 
-    def test_coarsen_does_not_silently_drop_one_of_a_collided_pair(
-        self, catalog, fine_grid, coarse_grid
-    ):
+    def test_coarsen_names_both_members_of_the_collided_pair(self, catalog, fine_grid, coarse_grid):
         # The pre-#468 dedup keyed on the id alone, so the second granule
-        # overwrote the first and the collapse was unobservable. Assert the
-        # merge keeps both -- that is what leaves the check something to refuse.
+        # overwrote the first and the collapse was unobservable. Both hrefs
+        # reaching the message is the observable consequence of the merge
+        # keeping both; the keeping itself is pinned directly by
+        # test_the_union_keeps_both_members_of_a_collided_pair over in
+        # tests/test_sweep.py, on the one union the guard does not raise on.
         sm_fine = self._colliding_fine_map(catalog, fine_grid)
         try:
             sm_fine.reproject(coarse_grid)

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -2722,3 +2722,21 @@ class TestBasenameCollisions:
             assert "s3://b/p1/Gdup.h5" in str(e) and "s3://b/p2/Gdup.h5" in str(e)
         else:
             pytest.fail("coarsen must refuse the collided pair")
+
+    def test_two_acquisitions_sharing_an_item_id_collide(self):
+        # A raster entry carries no href, and its recorded identity is the item
+        # id or the acquisition datetime (``raster_granule_ids``). Two
+        # acquisitions sharing an item id record as ONE id, so the datetime is
+        # what distinguishes them -- without it this pair read as one granule
+        # listed twice and slipped through (issue #468 review finding (1)).
+        from zagg.telemetry import raster_granule_ids
+
+        a = {"id": "SCENE", "s3": None, "https": None, "datetime": "2025-06-01T00:00:00Z"}
+        b = {"id": "SCENE", "s3": None, "https": None, "datetime": "2025-06-02T00:00:00Z"}
+        assert raster_granule_ids([a, b]) == ["SCENE", "SCENE"], "the collapse must be real"
+        with pytest.raises(ValueError, match="identity collision"):
+            shardmap._refuse_basename_collisions([7], [[a, b]])
+
+    def test_one_acquisition_listed_twice_is_still_not_a_collision(self):
+        a = {"id": "SCENE", "s3": None, "https": None, "datetime": "2025-06-01T00:00:00Z"}
+        shardmap._refuse_basename_collisions([7], [[a, dict(a)]])

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -2679,8 +2679,11 @@ class TestBasenameCollisions:
     def test_an_entry_with_nothing_to_canonicalize_is_skipped(self):
         # Raster entries carry no href and may carry no id (their identity is
         # the acquisition datetime); nothing to name is nothing to collide.
+        # The two entries must DIFFER in their distinguishing fields, else the
+        # skip branch could be deleted and this would still pass -- they would
+        # dedup rather than collide (issue #468 review finding (3)).
         shardmap._refuse_basename_collisions(
-            [7], [[{"id": None, "s3": None, "https": None}, {"id": None, "datetime": "2025-06-01"}]]
+            [7], [[{"id": None, "s3": None, "https": None}, {"id": "", "s3": None, "https": None}]]
         )
 
     def _colliding_fine_map(self, catalog, fine_grid):
@@ -2778,9 +2781,12 @@ class TestBasenameCollisions:
         # (issue #468 review finding (3)).
         from zagg.telemetry import canonical_granule_id
 
-        assert canonical_granule_id("/") == ""
+        assert canonical_granule_id("/") == "" and canonical_granule_id("//") == ""
+        # BOTH must canonicalize to "" and differ in their distinguishing
+        # fields: with an ``is None`` guard they share the "" bucket and this
+        # raises, which is what makes the test fail against the unfixed code.
         shardmap._refuse_basename_collisions(
-            [7], [[{"id": "/", "s3": None, "https": None}, {"id": "/", "s3": "s3://b/x/"}]]
+            [7], [[{"id": "/", "s3": None, "https": None}, {"id": "//", "s3": None, "https": None}]]
         )
 
     def test_more_than_three_collisions_are_counted_and_truncated(self):
@@ -2799,3 +2805,25 @@ class TestBasenameCollisions:
         assert message.rstrip().endswith("...")
         # Three groups shown, the fourth only counted.
         assert "'G2.h5'" in message and "'G3.h5'" not in message
+
+    def test_a_collision_with_no_href_is_named_by_what_separates_it(self):
+        # The label fallback chain reached the id before the datetime, so a
+        # raster pair printed as ['SCENE', 'SCENE'] -- the same string twice,
+        # naming nothing -- under a message that asserted a prefix cause the
+        # raster path does not have (issue #468 review finding (2)).
+        a = {"id": "SCENE", "s3": None, "https": None, "datetime": "2025-06-01T00:00:00Z"}
+        b = {"id": "SCENE", "s3": None, "https": None, "datetime": "2025-06-02T00:00:00Z"}
+        with pytest.raises(ValueError) as excinfo:
+            shardmap._refuse_basename_collisions([7], [[a, b]])
+        message = str(excinfo.value)
+        assert "SCENE @ 2025-06-01T00:00:00Z" in message
+        assert "SCENE @ 2025-06-02T00:00:00Z" in message
+        # The prefix cause is offered as the usual case, not asserted as the only one.
+        assert "Usually one basename under two key prefixes" in message
+
+    def test_an_href_collision_is_still_named_by_its_hrefs(self):
+        a = {"id": "G.h5", "s3": "s3://b/p1/G.h5", "https": "https://h/p1/G.h5"}
+        b = {"id": "G.h5", "s3": "s3://b/p2/G.h5", "https": "https://h/p2/G.h5"}
+        with pytest.raises(ValueError) as excinfo:
+            shardmap._refuse_basename_collisions([7], [[a, b]])
+        assert "['s3://b/p1/G.h5', 's3://b/p2/G.h5']" in str(excinfo.value)

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -2740,3 +2740,33 @@ class TestBasenameCollisions:
     def test_one_acquisition_listed_twice_is_still_not_a_collision(self):
         a = {"id": "SCENE", "s3": None, "https": None, "datetime": "2025-06-01T00:00:00Z"}
         shardmap._refuse_basename_collisions([7], [[a, dict(a)]])
+
+    def test_refine_rebuilds_hrefs_from_the_catalog_so_it_cannot_collide(
+        self, catalog, fine_grid, coarse_grid
+    ):
+        # The refine arm looks each entry up in the catalog by id and rebuilds
+        # the entry from THAT record, so a source map's per-entry hrefs never
+        # reach the new map: a collided pair arrives as one identical entry and
+        # the check has nothing left to see. Pinning it because it bounds what
+        # the guard can promise -- only ``build`` and coarsen can surface an
+        # href collision (issue #468 review finding (2)).
+        sm = ShardMap.build(
+            _catalog([_item("Gdup", -76.62, -76.57)]), coarse_grid, backend="mortie"
+        )
+        cat = _catalog([_item("Gdup", -76.62, -76.57)])
+        collided = [
+            {"id": "Gdup", "s3": f"s3://b/{p}/Gdup.h5", "https": f"https://h/{p}/Gdup.h5"}
+            for p in ("p1", "p2")
+        ]
+        source = ShardMap(
+            sm.grid_signature,
+            list(sm.shard_keys),
+            [collided] + [list(g) for g in sm.granules[1:]],
+            dict(sm.metadata),
+        )
+        refined = source.reproject(fine_grid, catalog=cat)
+        entries = [g for shard in refined.granules for g in shard]
+        assert all(g["s3"] == "s3://b/Gdup.h5" for g in entries), "hrefs come from the catalog"
+        # One granule out, not two: the prefixes -- and with them the collision
+        # -- were discarded upstream of the check, not by it.
+        assert {g["id"] for g in entries} == {"Gdup"}

--- a/tests/test_shardmap.py
+++ b/tests/test_shardmap.py
@@ -2589,3 +2589,136 @@ class TestPairedAssetBuild:
         sm2 = ShardMap.from_json(path)
         assert sm2.granules == sm.granules
         assert sm2.metadata["pairless"] == sm.metadata["pairless"]
+
+
+def _item_under(gid, prefix, lon0, lon1, lat0=38.85, lat1=38.93):
+    """``_item`` with the hrefs moved under ``prefix`` -- the shape a per-shard
+    basename collision takes: one basename, two key prefixes (issue #468)."""
+    item = _item(gid, lon0, lon1, lat0, lat1)
+    item["assets"] = {
+        "data": {"href": f"https://h/{prefix}/{gid}.h5", "roles": ["data"]},
+        "data_s3": {"href": f"s3://b/{prefix}/{gid}.h5", "roles": ["data"]},
+    }
+    return item
+
+
+class TestBasenameCollisions:
+    """Per-shard granule identity is refused at construction (issue #468).
+
+    Post-#420 a granule is recorded by its driver-stripped basename, so two
+    granules of one shard differing only in href prefix collapse onto one
+    recorded id. PR #420 question (6) ruled that acceptable *because* the state
+    is impossible in every catalog zagg reads; these pin that the impossibility
+    is enforced where it is owned rather than assumed.
+    """
+
+    @pytest.fixture
+    def hp_grid(self):
+        return HealpixGrid(11, 17, layout="fullsphere")
+
+    @pytest.fixture
+    def fine_grid(self):
+        return HealpixGrid(12, 14, layout="fullsphere")
+
+    @pytest.fixture
+    def coarse_grid(self):
+        return HealpixGrid(11, 14, layout="fullsphere")
+
+    def test_build_refuses_one_basename_under_two_prefixes(self, hp_grid):
+        # Same footprint, so both land in every shard the granule touches.
+        cat = _catalog(
+            [
+                _item_under("Gdup", "p1", -76.62, -76.57),
+                _item_under("Gdup", "p2", -76.62, -76.57),
+            ]
+        )
+        with pytest.raises(ValueError, match="identity collision"):
+            ShardMap.build(cat, hp_grid, backend="mortie")
+
+    def test_refusal_names_the_shard_and_both_hrefs(self, hp_grid):
+        cat = _catalog(
+            [
+                _item_under("Gdup", "p1", -76.62, -76.57),
+                _item_under("Gdup", "p2", -76.62, -76.57),
+            ]
+        )
+        with pytest.raises(ValueError) as excinfo:
+            ShardMap.build(cat, hp_grid, backend="mortie")
+        message = str(excinfo.value)
+        assert "s3://b/p1/Gdup.h5" in message and "s3://b/p2/Gdup.h5" in message
+        assert "'Gdup.h5'" in message
+        # The shard the pair collided in, not just a count of them.
+        shards = ShardMap.build(
+            _catalog([_item("Gdup", -76.62, -76.57)]), hp_grid, backend="mortie"
+        )
+        assert f"shard {shards.shard_keys[0]} " in message
+
+    def test_build_refuses_ids_colliding_only_in_basename(self, hp_grid):
+        # The other spelling of the same collapse: the catalog ids themselves
+        # carry the prefix, so they differ while their basenames do not.
+        cat = _catalog(
+            [
+                _item_under("p1/Gdup", "p1", -76.62, -76.57),
+                _item_under("p2/Gdup", "p2", -76.62, -76.57),
+            ]
+        )
+        with pytest.raises(ValueError, match="identity collision"):
+            ShardMap.build(cat, hp_grid, backend="mortie")
+
+    def test_distinct_basenames_under_one_prefix_build(self, catalog, hp_grid):
+        # Control: the ordinary catalog is unaffected -- the check must refuse
+        # a collision, not a shard holding several granules.
+        sm = ShardMap.build(catalog, hp_grid, backend="mortie")
+        assert max(len(g) for g in sm.granules) > 1
+        assert sm.metadata["granules_assigned"] == 3
+
+    def test_the_same_granule_listed_twice_is_not_a_collision(self):
+        entry = {"id": "G.h5", "s3": "s3://b/p1/G.h5", "https": "https://h/p1/G.h5"}
+        shardmap._refuse_basename_collisions([7], [[entry, dict(entry)]])
+
+    def test_an_entry_with_nothing_to_canonicalize_is_skipped(self):
+        # Raster entries carry no href and may carry no id (their identity is
+        # the acquisition datetime); nothing to name is nothing to collide.
+        shardmap._refuse_basename_collisions(
+            [7], [[{"id": None, "s3": None, "https": None}, {"id": None, "datetime": "2025-06-01"}]]
+        )
+
+    def _colliding_fine_map(self, catalog, fine_grid):
+        """A fine map whose two sibling shards each hold one of a colliding
+        pair -- legal at the fine order, a collapse once coarsened."""
+        from mortie import clip2order
+
+        sm_fine = ShardMap.build(catalog, fine_grid, backend="mortie")
+        by_parent: dict = {}
+        for k in sm_fine.shard_keys:
+            parent = clip2order(11, np.asarray([k], dtype=np.uint64))
+            by_parent.setdefault(int(parent[0]), []).append(k)
+        siblings = next(ks for ks in by_parent.values() if len(ks) >= 2)[:2]
+        granules = [
+            [{"id": "Gdup.h5", "s3": f"s3://b/{p}/Gdup.h5", "https": f"https://h/{p}/Gdup.h5"}]
+            for p in ("p1", "p2")
+        ]
+        return ShardMap(sm_fine.grid_signature, siblings, granules, dict(sm_fine.metadata))
+
+    def test_coarsen_refuses_a_collision_the_source_order_did_not_have(
+        self, catalog, fine_grid, coarse_grid
+    ):
+        sm_fine = self._colliding_fine_map(catalog, fine_grid)
+        # Legal where it stands: one granule per shard, nothing to collide.
+        shardmap._refuse_basename_collisions(sm_fine.shard_keys, sm_fine.granules)
+        with pytest.raises(ValueError, match="identity collision"):
+            sm_fine.reproject(coarse_grid)
+
+    def test_coarsen_does_not_silently_drop_one_of_a_collided_pair(
+        self, catalog, fine_grid, coarse_grid
+    ):
+        # The pre-#468 dedup keyed on the id alone, so the second granule
+        # overwrote the first and the collapse was unobservable. Assert the
+        # merge keeps both -- that is what leaves the check something to refuse.
+        sm_fine = self._colliding_fine_map(catalog, fine_grid)
+        try:
+            sm_fine.reproject(coarse_grid)
+        except ValueError as e:
+            assert "s3://b/p1/Gdup.h5" in str(e) and "s3://b/p2/Gdup.h5" in str(e)
+        else:
+            pytest.fail("coarsen must refuse the collided pair")

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1308,3 +1308,58 @@ class TestHandlerSweepResponse:
             assert body["duration_s"] >= 0.0
             assert body["record"] is None
             assert (body["discover_s"] >= 0.0) if derived else (body["discover_s"] is None)
+
+
+class TestSubmapIdentityCollisions:
+    """The family fold is a third shardmap constructor path, so it owns the
+    per-shard identity invariant too (issue #468 review finding (1))."""
+
+    def _collided(self, gid="gDup"):
+        return [
+            {"id": gid, "s3": f"s3://bucket/{p}/{gid}", "https": f"https://host/{p}/{gid}"}
+            for p in ("p1", "p2")
+        ]
+
+    def test_the_union_keeps_both_members_of_a_collided_pair(self):
+        # Pre-#468 the union keyed on ``entry["id"]`` alone, so the second
+        # granule overwrote the first and the collapse was unobservable. It must
+        # survive the union to be seen at all.
+        from zagg.catalog.shardmap import _recorded_identity
+
+        pair = self._collided()
+        keyed = {_recorded_identity(e)[1]: e for e in pair}
+        assert len(keyed) == 2, "the distinguishing key must separate the pair"
+        assert len({e["id"] for e in pair}) == 1, "an id-keyed union would drop one"
+
+    def test_shard_node_fold_refuses_a_collided_pair(self):
+        from zagg.sweep import SubmapFamily
+
+        payload = {
+            "grid_signature": dict(SUBMAP_SIG),
+            "shard_keys": [morton_word("-311")],
+            "granules": [self._collided()],
+            "metadata": {"collection": "TEST_001"},
+        }
+        with pytest.raises(ValueError, match="identity collision"):
+            SubmapFamily().merge([payload], node="-311", order=SHARD_ORDER)
+
+    def test_a_refused_fold_is_a_named_skip_not_a_lost_node(self, caplog):
+        # ``_merged`` is fail-open, so the refusal lands as a skipped rollup
+        # node. Pin that the operator at least gets the collision named in the
+        # log rather than a bare "merge failed" -- the fail-open posture itself
+        # is raised for review on the PR, not changed here.
+        import logging as _logging
+
+        from zagg.sweep import SubmapFamily, _merged
+
+        payload = {
+            "grid_signature": dict(SUBMAP_SIG),
+            "shard_keys": [morton_word("-311")],
+            "granules": [self._collided()],
+            "metadata": {"collection": "TEST_001"},
+        }
+        counts = {"failed": 0}
+        with caplog.at_level(_logging.WARNING):
+            out = _merged(SubmapFamily(), [payload], "-311", SHARD_ORDER, counts)
+        assert out is None and counts["failed"] == 1
+        assert any("identity collision" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes #468. Refs #415, PR #420 ([question (6) ruling: option (a)](https://github.com/englacial/zagg/pull/420#issuecomment-5317015792)).

## What this does

Enforces the per-shard granule-identity invariant **where it is owned** — at shardmap construction — instead of leaving its violation to surface at the leaf gate.

Post-#420 a granule's recorded identity is its driver-stripped basename (`zagg.telemetry.canonical_granule_id`), so two granules assigned to one shard that differ only in href prefix collapse onto **one** recorded id. Question (6) priced the leaf-gate consequence (a genuine contraction reading as `id-multiset-drift` and rewriting) and ruled it acceptable **because** that state is impossible in every catalog zagg reads. This turns that "because" from an assumption into a construction-time refusal, which is what makes the leaf-side predicate variants — question (6) options (b)/(c) — permanently unnecessary. Nothing worker-side changes: the ruled leaf-gate behavior (loud warning + rewrite) stays exactly as shipped.

## Approach

Three helpers in `src/zagg/catalog/shardmap.py`:

- `_recorded_identity(entry)` → `(canonical, distinguishing)`. The canonical id is `canonical_granule_id` of the href the runner resolves (`s3` preferred, `https` fallback), falling back to the catalog id, then the acquisition datetime for raster entries which carry no href. `distinguishing` is `(id, s3, https, datetime)` — `datetime` included because two acquisitions sharing an item id record as one id under `raster_granule_ids`, so without it that collapse read as one granule listed twice. The sibling `assets` (issue #425) are excluded: a record's granule identity is the primary alone.
- `_collision_label(entry)` names one colliding entry by what tells it apart from its partner — the href when there is one, else `id @ datetime`. A raster pair shares its id, so naming both by id says nothing.
- `_refuse_basename_collisions(shard_keys, granules)` raises `ValueError` naming the shard, the collapsed canonical id, and both entries. Entries agreeing on every distinguishing field are one granule listed twice and pass; an entry with nothing to canonicalize (including an id that reduces to `""`) is skipped.

```
ShardMap: 1 per-shard granule identity collision(s) — granules assigned to one shard
record as ONE granule id, so the shard's catalog identity names fewer granules than it
reads (issue #468). Usually one basename under two key prefixes, in which case re-scope
the catalog query so each granule appears once, or de-collide the basenames; the entries
below are named by whatever separates them: shard 12094627905536 'Gdup.h5' <-
['s3://b/p1/Gdup.h5', 's3://b/p2/Gdup.h5']
```

Wired into the three paths that **mint shard membership**:

1. `ShardMap.build`, right after the per-shard granule lists are assembled.
2. `ShardMap.reproject`, after both the coarsen and refine arms. Coarsen can mint a collision the source map did not have: a pair that was cross-shard (and therefore legal) at the fine order lands in one shard once coarsened.
3. `zagg.sweep.SubmapFamily.merge`, the rollup fold — see question (7).

All three previously deduped on `entry["id"]` alone, which **silently dropped** one member of such a pair before anything could see it; they now dedup on the distinguishing tuple, so a granule spanning several children still counts once while two distinct granules survive to be refused.

**What the guard does not reach**: the refine arm looks each entry up by id and rebuilds it from the *catalog* record, so a source map's per-entry hrefs never reach the derived map and a planted collided pair emerges as one entry carrying the catalog's own href. The dedup-key change is therefore a no-op on that arm (kept for symmetry, and it is the correct key by construction). The `noop` arm is untouched (no new membership → no new collision), and so are `from_json` / `from_parquet` — see questions (2) and (5).

The guard costs ~0.46 s over 550,000 entries on the clean path, and its failure path is bounded: only the first four collision groups are retained while the rest are counted, so a wholly mis-scoped catalog costs 0.2 MB rather than 67 MB to report.

## Phases

- [x] **Phase 1** — the check, the wiring, and tests (`ed80207`).
- [x] **Phase 2** — fold the first review round's four findings (`ee61c13`, `ae23b44`, `8db57ba`).
- [x] **Phase 3** — fold the independent review's six findings (`382caba`, `129086f`).

## How it was tested

`tests/test_shardmap.py::TestBasenameCollisions` (17 tests) and `tests/test_sweep.py::TestSubmapIdentityCollisions` (3 tests):

- build refuses one basename under two prefixes (the realistic CMR shape: identical catalog ids, different key prefixes), and refuses the other spelling where the ids themselves carry the prefix;
- the refusal names the shard, the collapsed id, and both hrefs — and, for a collision with no href, both acquisition datetimes, with the cause clause hedged rather than asserting a prefix cause the raster path does not have;
- control: an ordinary multi-granule catalog builds unchanged (`granules_assigned == 3`);
- the same granule listed twice is not a collision, and neither is one acquisition listed twice;
- an entry with nothing to canonicalize is skipped, as is an id that canonicalizes to `""` — **both cases verified to fail against the pre-fix predicates**, by replaying the fixtures through copies of the guard carrying the old `is None` test and the deleted skip branch;
- two acquisitions sharing an item id collide — the test first asserts the collapse is real (`raster_granule_ids([a, b]) == ["SCENE", "SCENE"]`) so it cannot pass vacuously;
- four colliding groups exercise the truncation branch: the count says 4, three groups are shown, the fourth is only counted;
- coarsen refuses a collision the source order did not have — the fixture asserts the pair is *legal* at the fine order first, so the test proves the merge is what creates it;
- refine rebuilds hrefs from the catalog, so it cannot surface a collision (pins the guard's boundary);
- the sweep union keeps both members of a collided pair (the direct assertion that the id-keyed dedup would have dropped one), a shard-node fold refuses one, and a refused fold reaches `_merged` as a skip whose warning names the collision rather than a bare "merge failed".

Full local run on the pushed head `129086f`: `pytest -q --deselect tests/test_lambda_build.py` → **4417 passed, 38 skipped**. `ruff check src tests` clean apart from the pre-existing `N818` in `src/zagg/registry.py`; `ruff format --check` clean on every touched file.

## Questions for review

1. **Keyed on the href, not on `entry["id"]`.** The issue frames the collision on `rec["id"]`; this keys on the href the runner resolves, because that is what the recorded identity is derived from. For every catalog zagg reads the two agree — that agreement is *why* `rec["id"]` equals the basename — so on real catalogs the choice is unobservable. Related, from the review: the guard always prefers `s3` while `runner._resolve_urls` picks by driver, so an https-driver run whose https basenames collide (while its s3 basenames do not) is caught by neither the guard nor anything downstream. Canonicalizing both spellings would remove that assumption for one extra call per entry — but it also *widens* what the guard refuses, which is why I have not done it unasked.
2. **Scope: constructors that mint membership, not readers.** `from_json` / `from_parquet` load manifests built before this check existed; making them refuse would turn a historical map into an unreadable one. Should loading warn (not refuse) on a collision, or is silence right there?
3. **`shardmap.py` is 1,955 lines** — 755 over the ~1,200 ceiling and 655 over the pre-approved overage band (issues #351/#358 cover overages *below* 1,200), against 1,846 on `main`. The split is issue #430's scope, so I did not fold a module split into a small-fix. The review's point stands: "already over" argues for adding less, not for treating the ceiling as moot — the docstrings were trimmed accordingly, but this still needs a word.
4. **Unrelated pre-existing lint**, not touched: `ruff format --check` reformats a python block inside `tests/data/benchmark/README.md`, and `ruff check` reports `N818` on `src/zagg/registry.py`. Both are on `main` already.
5. **A pre-existing silent drop, surfaced but not fixed**: a legacy colliding manifest loaded via `from_json` and then refined loses one granule, upstream of anything this check can see. Fixing it means refusing at load or carrying the map's hrefs through refine — both scope changes beyond this small-fix.
6. **An entry with nothing to canonicalize is skipped silently.** It has no recorded identity at all, which is arguably worse than a collision. The review showed this is not exotic: `_resolve_urls` drops href-less records, so an entry with `s3` set and `https` `None` under an https driver contributes nothing to `granules_sha256` while the guard canonicalizes it from `s3` and sees an identity the run never records. Should that warn?
7. **The sweep fold now refuses, which changes an unattended path — this is the one I most want a ruling on.** `SubmapFamily.merge` is the third constructor path, and it had the same id-keyed silent drop (now fixed). But a refusal there reaches `_merged`'s fail-open handler and the rollup node is **skipped, not written**, where before it succeeded by silently collapsing. Issue #468 justified a hard raise as "build-time, human-present, laptop-context"; the sweep is none of those, and "re-scope the catalog query" is not a lever an operator has when the inputs are stored leaf sub-maps. Options: (a) keep the refusal and accept a skipped node, as it stands now; (b) warn-and-collapse in the sweep while build/reproject still refuse; (c) refuse but make `_merged` treat an identity collision as fatal rather than fail-open. I have kept (a) and made the skip legible — the warning names the collision — rather than choose.

## Process note

The per-phase self-review was run twice. The first pass was done in-session by the author after I killed two review subagents believing they had stalled — [a timing error of mine](https://github.com/englacial/zagg/pull/482#issuecomment-5327755612), since the waits I was measuring with ran concurrently rather than in sequence. The [independent fresh-context review](https://github.com/englacial/zagg/pull/482#pullrequestreview-3583746434) then ran properly on the folded head and found six further findings, two of them HIGH — including the sweep constructor path in question (7), a live silent drop the in-session pass had missed entirely. That is the argument for the convention, made at this PR's expense.

One deviation from §3 that I did not rewrite: the second fold round is two commits rather than one per finding (`382caba` covers findings (1)–(4), `129086f` covers (6) plus the failure-path bound), since the changes overlapped in the same helpers.
