### PR TITLE
small fixes 2026-08-18: spec 4.5 temporal-companion parity (issue #483)

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -944,9 +944,10 @@ staged sweep's finisher.
   the payload's §1.2 `locations` binding, exactly as a leaf does — with the
   words at the **heterogeneous orders** §9.1 makes normative.
 - **A temporal ragged field composes the same way, and its entry carries
-  `temporal`.** A `temporal:` declaration (§8.3) does not exclude a field
-  from the pyramid either: zagg's digest pyramids keep the companion
-  `"per-centroid"` at every level, symmetric with the located channel — the
+  `temporal`.** A **`"per-centroid"`** `temporal:` declaration (§8.3) does
+  not exclude a field from the pyramid either: zagg's digest pyramids keep
+  the companion `"per-centroid"` at every level, symmetric with the located
+  channel — the
   temporal k-way merge reduces the `{field}_times` words over the same
   centroid partition the digest merge produces (espg-ruled 2026-08-17,
   amending [ruling 3 on
@@ -963,7 +964,11 @@ staged sweep's finisher.
   sibling array and the fold has nowhere to write its words. An overview
   level of a temporal field therefore carries the `{field}_times` sibling,
   its §8.3 `temporal` declaration, and the payload's §8.3 `times` binding,
-  exactly as a leaf does.
+  exactly as a leaf does. The §8.2 dense `"per-cell"` shape is the
+  exception: a field declaring it is classed `none` whatever its reducer
+  (`zagg.semantics.field_composability`), that shape's fold law being the
+  word grammar's join over a cell group rather than the field's own reducer,
+  so it exists at native resolution only.
 - **`all_time`** — whether the `all.zarr` all-time fold is materialized at
   the declared orders (windowed stores only; a `schedule: none` store's
   single fold is already all-time).

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -942,10 +942,28 @@ staged sweep's finisher.
   nowhere to write its words. An overview level of a located field therefore
   carries the `{field}_locations` sibling, its §9 `located` declaration, and
   the payload's §1.2 `locations` binding, exactly as a leaf does — with the
-  words at the **heterogeneous orders** §9.1 makes normative. A **temporal**
-  companion (§8.3) is a different case and stays `class: "none"`: §8.4's
-  shape-coarsening reduction is not wired through the fold sites, so those
-  fields exist at native resolution only.
+  words at the **heterogeneous orders** §9.1 makes normative.
+- **A temporal ragged field composes the same way, and its entry carries
+  `temporal`.** A `temporal:` declaration (§8.3) does not exclude a field
+  from the pyramid either: zagg's digest pyramids keep the companion
+  `"per-centroid"` at every level, symmetric with the located channel — the
+  temporal k-way merge reduces the `{field}_times` words over the same
+  centroid partition the digest merge produces (espg-ruled 2026-08-17,
+  amending [ruling 3 on
+  issue #410](https://github.com/englacial/zagg/issues/410#issuecomment-5310502887);
+  §8.4 records the amendment and keeps its per-cell reduction licensed but
+  unused by this writer), so a temporal digest field folds through every
+  level and the class is `approximate` like any other digest field. Its
+  entry carries `temporal` — the companion **shape** (`"per-centroid"`),
+  which is all a level above the leaf can act on, the leaf's ingest column
+  never being re-read by any fold — keyed **only when set**, so a field
+  without the companion has an unchanged entry. The key is load-bearing
+  exactly as `location` is: the overview writer reconstructs a level's
+  arrays from this entry alone, so without it the overview template emits no
+  sibling array and the fold has nowhere to write its words. An overview
+  level of a temporal field therefore carries the `{field}_times` sibling,
+  its §8.3 `temporal` declaration, and the payload's §8.3 `times` binding,
+  exactly as a leaf does.
 - **`all_time`** — whether the `all.zarr` all-time fold is materialized at
   the declared orders (windowed stores only; a `schedule: none` store's
   single fold is already all-time).

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1111,12 +1111,14 @@ re-invoking the idempotent leaf, never a sweep-side fold from raw cells.
   declared later never rewrites a leaf). Each group holds the `morton`
   coordinate (the node's order-`r` descendant words, ascending) and one
   array per **composable** field (§4.5 classes; `none` fields are absent),
-  plus — for a field whose §4.5 entry carries `location` — that field's
-  `{field}_locations` sibling, row-aligned with its payload and carrying the
-  §9 declaration, exactly as an overview level does. The pair is written
-  together or not at all: the words are exact only *given* the centroid
-  partition the payload describes (§9.1), so a group holding a populated
-  payload against an empty sibling is non-conformant, not merely short.
+  plus **every channel sibling** that field's §4.5 entry declares — the
+  `{field}_locations` sibling for a `location` entry (carrying the §9
+  declaration), the `{field}_times` sibling for a `temporal` entry (carrying
+  the §8.3 declaration) — each row-aligned with its payload, exactly as an
+  overview level does. Each pair is written together or not at all: the
+  words are exact only *given* the centroid partition the payload describes
+  (§9.1, §8.3), so a group holding a populated payload against an empty
+  sibling is non-conformant, not merely short.
   A group's arrays are **single-chunk and unsharded** — `chunk_shape` equals
   `shape` (`4^(r - node)` cells), no `sharding_indexed` codec — whatever the
   leaf's own `chunk_inner`/sharding: a column group is small by construction,


### PR DESCRIPTION
Closes #483.

## What this does

Small-fixes bundle for 2026-08-18 (one entry). Prose-only spec fix: brings §4.5's temporal-companion sentence to parity with the 2026-08-17 amendment to [ruling 3 on issue #410](https://github.com/englacial/zagg/issues/410#issuecomment-5310502887) and documents the `temporal:` field-entry key the manifest actually carries.

## The fix

- [x] **#483 — spec §4.5 temporal-companion sentence + `temporal:` key** (`de702861`). Replaced the stale closing sentence of the located-field bullet (*"A temporal companion (§8.3) is a different case and stays `class: "none"` … those fields exist at native resolution only"*) with its own bullet mirroring the located one: the companion stays `"per-centroid"` at every level, the temporal k-way merge reduces `{field}_times` over the same centroid partition, class is `approximate`, and the entry carries `temporal` — the companion **shape**, keyed only when set, load-bearing for template reconstruction exactly as `location` is. The wording follows the writer's own behavior — the manifest pyramid entry's `temporal` key is written **only when set** by [`pyramid.py#L212-L213`](https://github.com/englacial/zagg/blob/deebf7ff/src/zagg/pyramid.py#L206-L213), which is the entry the overview writer reconstructs a level from; [`config.py#L2981-L2985`](https://github.com/englacial/zagg/blob/deebf7ff/src/zagg/config.py#L2981-L2985) applies the same keyed-only-when-set discipline in a *different* record, `output_field_signature`'s shard-map field signature — and the committed `temporal/` fixture (`h_tdigest` `class: "approximate"`, `temporal: "per-centroid"`).
  - Review fold, `7e03e885`: scoped the "does not exclude a field from the pyramid" claim to the **`"per-centroid"`** shape and stated the per-cell rule — a `temporal: "per-cell"` field is classed `none` whatever its reducer ([`semantics.py::field_composability`](https://github.com/englacial/zagg/blob/deebf7ff/src/zagg/semantics.py#L415-L416)), pinned by the fixture's `"observed": {"class": "none"}`.
  - Review fold, `3324dbe8`: §4.6's Structure bullet enumerated only the `location`-gated `{field}_locations` sibling for a column's resolution groups; extended it to **both** channel siblings, matching §7 and the committed golden `tests/data/spec/temporal/1/1/2/1/3/all.pyramid.zarr/4/` (which holds `h_tdigest_times`) — [`column.py`](https://github.com/englacial/zagg/blob/deebf7ff/src/zagg/column.py#L209) folds via the channel-generic `field_companions`.

No wire-format, attrs-grammar, or `spec`-marker change — §4's fixture rule is not triggered; the fixtures already reflect the truth and are byte-untouched. §8.4's "licensed but unused by this writer" posture for the per-cell reduction is cross-referenced, not altered. The §7 line about the dense per-cell `observed` array existing at native resolution only is correct (its fold law is the grammar's join, not the field's reducer) and untouched.

## How it was tested

Docs-only diff (`docs/specification.md`, +35/−10). `pytest -k spec` green (191 passed — includes the conformance-fixture suite, unaffected as expected). codespell clean on the touched lines (the one hit at line 1770, `re-declares`, is pre-existing and outside this diff).

## Questions for review

- None — the design was ruled 2026-08-17 (the (c) per-centroid-everywhere amendment); this is the documentation catch-up moczarr#44's sweep flagged ([question 2 there](https://github.com/espg/moczarr/pull/44)).

