### PR TITLE
small fixes 2026-08-19: sweep nudge for a dropped §10 section; the walk-as-tightener refresh contract

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2460,18 +2460,21 @@ that seam as follows:
 
 ### 10.5 Refresh contract — the walk is the only tightener
 
-**Contract.** The section is **always safe, eventually precise**: every claim
-it makes is true the moment it is written and *stays* true with no refresh at
-all, and a refresh only makes it **tighter**. Producers therefore need no
-coordination, and a reader never has to ask how recently the section was
-rebuilt in order to trust it.
+**Contract.** Across §10.4's **union** arm the section is **always safe,
+eventually precise**: every claim it makes is true the moment it is written
+and *stays* true with no refresh at all, and a refresh only makes it
+**tighter**. Producers therefore need no coordination on that arm, and a
+reader never has to ask how recently the section was rebuilt in order to
+trust it. §10.4's **overwrite** arm is the carve-out, and the last bullet
+below states what it costs.
 
-- **Adding observations keeps the claims true automatically.** Every
-  observation-adding producer composes its words through the §10.4 seam, and
-  tier 1's join only ever *grows* an envelope. Growing is conservative in the
-  direction §10.2 requires — the word must contain every instant in the shard
-  — so an appended observation lands inside that shard's word by
-  construction, whichever producer wrote it and in whatever order.
+- **Adding observations keeps the claims true automatically.** An
+  observation-adding producer that composes through §10.4's union arm joins
+  its words with the standing ones, and tier 1's join only ever *grows* an
+  envelope. Growing is conservative in the direction §10.2 requires — the
+  word must contain every instant in the shard — so an appended observation
+  lands inside that shard's word by construction, whichever producer wrote it
+  and in whatever order.
 - **Removing observations leaves a word over-wide, never wrong.** A rewrite
   that drops data leaves the shard claiming a window wider than the shard now
   holds. A reader opens that candidate and finds nothing in the window: a
@@ -2481,21 +2484,40 @@ rebuilt in order to trust it.
   tier 2. Tightening is what re-derives a shard's word from what its leaves
   hold *now* instead of joining it with what they held before, and tier 2's
   whole-coverage rule (§10.4) already denies the digest to any partial
-  producer. A producer MUST NOT publish a **narrowed** word for a shard unless
-  it derived that word from every leaf of the shard.
+  producer. **On the union arm a producer MUST NOT publish a narrowed word**
+  for a shard unless it derived that word from every leaf of the shard: the
+  join is how a partial producer stays safe, and reaching past it to narrow a
+  word is the one way to lose a candidate. The join itself satisfies this
+  rule by construction, so the MUST-NOT binds a producer that composes the
+  section by some other means.
 - **A pass that adds no observations MAY leave the section untouched.** It
   cannot falsify a claim it never widened, so preserving is always sound; what
   it forgoes is only the tightening. This is what makes §10.4's "a producer
   with no temporal contribution leaves an existing section standing" a
   permanent posture rather than a transitional one.
+- **The overwrite arm installs the incoming section verbatim.** §10.4's
+  wholesale overwrite — an unparsable or incompatible standing carrier, the D9
+  regenerable-cache rule — discards the standing section along with the stale
+  ranges, so there is no standing word left to join against and the producer's
+  own section is installed as written. A run-scoped producer that reaches that
+  arm therefore publishes words derived from the leaves *it* visited, which
+  for a shard whose other leaves it did not visit is **narrower** than the
+  word that was standing. This arm is a carve-out from the MUST-NOT above, not
+  a violation of it, and it is the one arm on which the section can lose a
+  candidate rather than merely fail to prune one.
 
-The one loss this contract does not prevent is a producer that **drops** the
-section instead of preserving it — a writer predating §10.4 that rebuilds the
-root carrier from the keys it knows. The succession rule forbids it but cannot
-bind code that shipped before the rule existed, so the loss is *bounded*
-rather than prevented: the section is a regenerable accelerator (D9), a reader
-that finds it absent falls back to opening every candidate — slow, and still
-correct — and one walk restores it.
+Two losses this contract bounds rather than prevents, worse one first. A
+producer that publishes a **narrowed** word — the overwrite arm above — leaves
+a `toc_overlaps` query pruning a shard that does hold data in the window: a
+missed candidate, not a wasted open, and the one §10 failure a reader has no
+way to notice. A producer that **drops** the section instead of preserving it
+— a writer predating §10.4 that rebuilds the root carrier from the keys it
+knows — is the milder one: the succession rule forbids it but cannot bind code
+that shipped before the rule existed, and an absent section reads as "this
+store publishes no temporal coverage" (§10), so a reader falls back to opening
+every candidate — slow, and still correct. Both are bounded by the section
+being a regenerable accelerator (D9) whose truth is in the leaves, and one
+whole-store walk repairs either.
 
 Conformance for an external reader is §7's `temporal/` fixture: its root
 `coverage.moc` carries this section, and the fixture's `temporal.expected.json`

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2480,16 +2480,29 @@ below states what it costs.
   holds. A reader opens that candidate and finds nothing in the window: a
   wasted open, never missed data — the same asymmetry a window edge's quantum
   already has (§10.2).
-- **Only a whole-store walk tightens**, and only a whole-store walk refreshes
-  tier 2. Tightening is what re-derives a shard's word from what its leaves
-  hold *now* instead of joining it with what they held before, and tier 2's
-  whole-coverage rule (§10.4) already denies the digest to any partial
-  producer. **On the union arm a producer MUST NOT publish a narrowed word**
-  for a shard unless it derived that word from every leaf of the shard: the
-  join is how a partial producer stays safe, and reaching past it to narrow a
-  word is the one way to lose a candidate. The join itself satisfies this
-  rule by construction, so the MUST-NOT binds a producer that composes the
-  section by some other means.
+- **Only a whole-store walk tightens.** Tightening is what re-derives a
+  shard's word from what its leaves hold *now* instead of joining it with what
+  they held before, and only a producer that read every leaf of a shard can do
+  that without narrowing the word below the shard's true extent. zagg's one
+  whole-store producer is the refresh walk
+  (`zagg.coverage.refresh_root_coverage`). **On the union arm a producer MUST
+  NOT publish a narrowed word** for a shard unless it derived that word from
+  every leaf of the shard: the join is how a partial producer stays safe, and
+  reaching past it to narrow a word is the one way to lose a candidate. The
+  join itself satisfies this rule by construction, so the MUST-NOT binds a
+  producer that composes the section by some other means.
+- **Tier 2 is a weaker rule, and it is not the walk's alone.** §10.4 replaces
+  the digest with whichever side's map covers the **merged map**, newest side
+  first. That is a test on the two maps meeting at the seam, not on the store:
+  a run-scoped producer whose own map happens to cover the merged one — a
+  fresh store's first sweep, where the standing map is empty, or any later run
+  that touched every shard the standing map lists — does install its digest,
+  and legitimately so, because it covered everything the composed map claims.
+  What §10.4 buys is that the digest covers every shard the **map lists**;
+  what the whole-store walk alone adds is that the map lists every shard the
+  **store** holds. A reader MUST NOT read the second from the first — §10.2's
+  escape hatch means an unlisted shard is *unknown*, so a digest can be whole
+  over the map and still describe less than the store.
 - **A pass that adds no observations MAY leave the section untouched.** It
   cannot falsify a claim it never widened, so preserving is always sound; what
   it forgoes is only the tightening. This is what makes §10.4's "a producer

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2458,6 +2458,13 @@ that seam as follows:
   `spec` string at all) claims no revision and is debris a producer MAY
   replace.
 
+Conformance for an external reader is §7's `temporal/` fixture: its root
+`coverage.moc` carries this section, and the fixture's `temporal.expected.json`
+records the shard word and the decoded digest so the containment and weight
+claims above (§10.2, §10.3) are pinned on committed bytes. §10.5 below is a
+contract on producer *behaviour*, and no fixture of committed bytes can pin
+one: its conformance is the prose.
+
 ### 10.5 Refresh contract — the walk is the only tightener
 
 **Contract.** Across §10.4's **union** arm the section is **always safe,
@@ -2531,8 +2538,3 @@ store publishes no temporal coverage" (§10), so a reader falls back to opening
 every candidate — slow, and still correct. Both are bounded by the section
 being a regenerable accelerator (D9) whose truth is in the leaves, and one
 whole-store walk repairs either.
-
-Conformance for an external reader is §7's `temporal/` fixture: its root
-`coverage.moc` carries this section, and the fixture's `temporal.expected.json`
-records the shard word and the decoded digest so the containment and weight
-claims above are pinned on committed bytes.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2458,6 +2458,45 @@ that seam as follows:
   `spec` string at all) claims no revision and is debris a producer MAY
   replace.
 
+### 10.5 Refresh contract — the walk is the only tightener
+
+**Contract.** The section is **always safe, eventually precise**: every claim
+it makes is true the moment it is written and *stays* true with no refresh at
+all, and a refresh only makes it **tighter**. Producers therefore need no
+coordination, and a reader never has to ask how recently the section was
+rebuilt in order to trust it.
+
+- **Adding observations keeps the claims true automatically.** Every
+  observation-adding producer composes its words through the §10.4 seam, and
+  tier 1's join only ever *grows* an envelope. Growing is conservative in the
+  direction §10.2 requires — the word must contain every instant in the shard
+  — so an appended observation lands inside that shard's word by
+  construction, whichever producer wrote it and in whatever order.
+- **Removing observations leaves a word over-wide, never wrong.** A rewrite
+  that drops data leaves the shard claiming a window wider than the shard now
+  holds. A reader opens that candidate and finds nothing in the window: a
+  wasted open, never missed data — the same asymmetry a window edge's quantum
+  already has (§10.2).
+- **Only a whole-store walk tightens**, and only a whole-store walk refreshes
+  tier 2. Tightening is what re-derives a shard's word from what its leaves
+  hold *now* instead of joining it with what they held before, and tier 2's
+  whole-coverage rule (§10.4) already denies the digest to any partial
+  producer. A producer MUST NOT publish a **narrowed** word for a shard unless
+  it derived that word from every leaf of the shard.
+- **A pass that adds no observations MAY leave the section untouched.** It
+  cannot falsify a claim it never widened, so preserving is always sound; what
+  it forgoes is only the tightening. This is what makes §10.4's "a producer
+  with no temporal contribution leaves an existing section standing" a
+  permanent posture rather than a transitional one.
+
+The one loss this contract does not prevent is a producer that **drops** the
+section instead of preserving it — a writer predating §10.4 that rebuilds the
+root carrier from the keys it knows. The succession rule forbids it but cannot
+bind code that shipped before the rule existed, so the loss is *bounded*
+rather than prevented: the section is a regenerable accelerator (D9), a reader
+that finds it absent falls back to opening every candidate — slow, and still
+correct — and one walk restores it.
+
 Conformance for an external reader is §7's `temporal/` fixture: its root
 `coverage.moc` carries this section, and the fixture's `temporal.expected.json`
 records the shard word and the decoded digest so the containment and weight

--- a/src/zagg/coverage.py
+++ b/src/zagg/coverage.py
@@ -279,7 +279,12 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     windows of one shard are one covered shard (the MOC is spatial — the
     builder de-duplicates words), and a malformed window label on a STAMPED
     leaf is skipped with a warning, like the foreign-order carve-out —
-    unstamped malformed debris stays silent, as ordinary debris does.
+    unstamped malformed debris stays silent, as ordinary debris does. That
+    skip also banks its shard as a TEMPORAL loss: only the label is
+    malformed, so the id before the first ``_`` still names a shard whose
+    other windows read fine, and publishing their join alone would narrow
+    the shard's word below §10.2's containment (the two carve-outs below it
+    name DIFFERENT shard ids, so neither can do that).
     """
     import obstore
     from obstore.exceptions import NotFoundError
@@ -361,6 +366,18 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
                         f"window label (frozen grammar, mortie#62) — it will NOT be "
                         f"listed in {ROOT_COVERAGE_NAME}"
                     )
+                    if toc_fields:
+                        # Only the LABEL is malformed: the id up to the first
+                        # `_` is still readable, and a sibling window of that
+                        # same shard reads fine and would be published alone.
+                        # §10.2's word must cover every leaf of a LISTED shard,
+                        # so bank the loss exactly as the read failure below
+                        # does — otherwise the walk narrows the shard's word to
+                        # the leaves it happened to parse, which costs a reader
+                        # a MISSED candidate rather than a wasted open (§10.5).
+                        lost = name.removesuffix(".zarr").split("_", 1)[0]
+                        toc_failed.add(lost)
+                        contributions.pop(lost, None)
                     continue
                 if not _is_decimal_id(decimal):
                     # Same posture, one grammar down: the name split succeeded

--- a/src/zagg/coverage.py
+++ b/src/zagg/coverage.py
@@ -254,13 +254,22 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     ``.zarr`` off the shard-order depth is checked for the D11 ``role`` attr and
     skipped when it carries one (never classified by position) — as is a
     ``{stem}.pyramid.zarr`` column (issue #383), the one derived family that
-    lives at the leaf's OWN node. A
-    supersedes it). A temporal-declaring store (spec §10, issue #480) also has
+    lives at the leaf's OWN node. A temporal-declaring store (spec §10, issue #480) also has
     its ``zagg-coverage-toc/1`` section rebuilt from this same walk —
     fail-open per SHARD, so an unreadable companion costs the section that
     shard and never the refresh; and a walk that lost any shard COMPOSES its
     rebuild with the standing section (§10.4) instead of replacing it, so the
-    escape hatch can never be the thing that deletes the section. A successful
+    escape hatch can never be the thing that deletes the section. THIS WALK IS
+    THE SECTION'S ONLY TIGHTENER, and its only tier-2 refresher (spec §10.5,
+    issue #487): every other producer composes through
+    :func:`zagg.hive.write_root_coverage`'s join, which only ever GROWS an
+    envelope, so their claims stay true without ever getting narrower. Nothing
+    NEEDS this call for correctness — an un-refreshed section is over-wide at
+    worst, costing a wasted candidate open and never a missed one — which is
+    what lets a no-observation pass preserve the section instead
+    (:func:`zagg.sweep_stages.run_finisher`); refresh buys PRECISION, and
+    repairs a section a pre-§10.4 producer dropped
+    (:func:`zagg.coverage_toc.warn_if_section_missing` names it for that). A successful
     refresh also re-arms the
     :func:`warn_if_stale` once-per-episode latch for this store. Returns the
     envelope written, or ``None`` — deleting any existing root object — when

--- a/src/zagg/coverage.py
+++ b/src/zagg/coverage.py
@@ -254,37 +254,39 @@ def refresh_root_coverage(store_root: str, **store_kwargs) -> dict | None:
     ``.zarr`` off the shard-order depth is checked for the D11 ``role`` attr and
     skipped when it carries one (never classified by position) — as is a
     ``{stem}.pyramid.zarr`` column (issue #383), the one derived family that
-    lives at the leaf's OWN node. A temporal-declaring store (spec §10, issue #480) also has
-    its ``zagg-coverage-toc/1`` section rebuilt from this same walk —
-    fail-open per SHARD, so an unreadable companion costs the section that
-    shard and never the refresh; and a walk that lost any shard COMPOSES its
-    rebuild with the standing section (§10.4) instead of replacing it, so the
-    escape hatch can never be the thing that deletes the section. THIS WALK IS
-    THE SECTION'S ONLY TIGHTENER, and its only tier-2 refresher (spec §10.5,
-    issue #487): every other producer composes through
-    :func:`zagg.hive.write_root_coverage`'s join, which only ever GROWS an
-    envelope, so their claims stay true without ever getting narrower. Nothing
-    NEEDS this call for correctness — an un-refreshed section is over-wide at
-    worst, costing a wasted candidate open and never a missed one — which is
-    what lets a no-observation pass preserve the section instead
-    (:func:`zagg.sweep_stages.run_finisher`); refresh buys PRECISION, and
-    repairs a section a pre-§10.4 producer dropped
-    (:func:`zagg.coverage_toc.warn_if_section_missing` names it for that). A successful
-    refresh also re-arms the
-    :func:`warn_if_stale` once-per-episode latch for this store. Returns the
-    envelope written, or ``None`` — deleting any existing root object — when
-    no stamped leaf exists (absence is truthful, a stale cache is not, and
-    the ranges envelope has no empty form). Windowed leaves (issue #246)
-    classify as data via the frozen first-``_`` name split; several stamped
-    windows of one shard are one covered shard (the MOC is spatial — the
-    builder de-duplicates words), and a malformed window label on a STAMPED
-    leaf is skipped with a warning, like the foreign-order carve-out —
-    unstamped malformed debris stays silent, as ordinary debris does. That
-    skip also banks its shard as a TEMPORAL loss: only the label is
-    malformed, so the id before the first ``_`` still names a shard whose
-    other windows read fine, and publishing their join alone would narrow
-    the shard's word below §10.2's containment (the two carve-outs below it
-    name DIFFERENT shard ids, so neither can do that).
+    lives at the leaf's OWN node. A temporal-declaring store (spec §10,
+    issue #480) also has its ``zagg-coverage-toc/1`` section rebuilt from
+    this same walk — fail-open per SHARD, so an unreadable companion costs
+    the section that shard and never the refresh; and a walk that lost any
+    shard COMPOSES its rebuild with the standing section (§10.4) instead of
+    replacing it, so the escape hatch can never be the thing that deletes
+    the section. THIS WALK IS THE SECTION'S ONLY TIGHTENER (spec §10.5,
+    issue #487): every other producer composes through the UNION arm of
+    :func:`zagg.hive.write_root_coverage`, whose join only ever GROWS an
+    envelope, so their claims stay true without ever getting narrower. It is
+    NOT the only tier-2 refresher — §10.4 installs whichever side's map
+    covers the MERGED map, which a run-scoped sweep's map often does — but it
+    is the only producer whose map is guaranteed to list the whole store.
+    Nothing NEEDS this call for correctness — an un-refreshed section is
+    over-wide at worst, costing a wasted candidate open and never a missed
+    one — which is what lets a no-observation pass preserve the section
+    instead (:func:`zagg.sweep_stages.run_finisher`); refresh buys PRECISION,
+    and repairs a section a pre-§10.4 producer dropped —
+    :func:`zagg.coverage_toc.warn_if_section_missing` names it for that. A
+    successful refresh also re-arms the :func:`warn_if_stale` once-per-episode
+    latch for this store. Returns the envelope written, or ``None`` — deleting
+    any existing root object — when no stamped leaf exists (absence is
+    truthful, a stale cache is not, and the ranges envelope has no empty
+    form). Windowed leaves (issue #246) classify as data via the frozen
+    first-``_`` name split; several stamped windows of one shard are one
+    covered shard (the MOC is spatial — the builder de-duplicates words), and
+    a malformed window label on a STAMPED leaf is skipped with a warning, like
+    the foreign-order carve-out — unstamped malformed debris stays silent, as
+    ordinary debris does. That skip also banks its shard as a TEMPORAL loss:
+    only the label is malformed, so the id before the first ``_`` still names
+    a shard whose other windows read fine, and publishing their join alone
+    would narrow the shard's word below §10.2's containment (the two
+    carve-outs below it name DIFFERENT shard ids, so neither can do that).
     """
     import obstore
     from obstore.exceptions import NotFoundError

--- a/src/zagg/coverage_toc.py
+++ b/src/zagg/coverage_toc.py
@@ -389,7 +389,11 @@ def warn_if_section_missing(store_root: str, envelope, manifest) -> bool:
     if not temporal_fields(manifest):
         return False
     section = envelope.get(TEMPORAL_KEY) if isinstance(envelope, dict) else None
-    if _usable(section) is not None or _preserved(section) is not None:
+    # Marked-revision first, in the order the docstring reads them: :func:`_usable`
+    # logs "ignoring a section with an unknown spec" — true at the merge seam it
+    # was written for, the opposite of what this seat decides — so the arm that
+    # HONORS a future revision must short-circuit before it is consulted.
+    if _preserved(section) is not None or _usable(section) is not None:
         return False
     logger.warning(
         f"coverage[toc]: {store_root} declares temporal fields but its root "

--- a/src/zagg/coverage_toc.py
+++ b/src/zagg/coverage_toc.py
@@ -340,6 +340,51 @@ def merge_temporal_sections(existing, incoming) -> dict | None:
     return merged
 
 
+def warn_if_section_missing(store_root: str, envelope, manifest) -> bool:
+    """Warn when a temporal-declaring store's root carries no §10 section.
+
+    The belt for the one gap the §10.4 succession rule cannot close (issue
+    #488): the rule binds producers that know it, and a pre-#481 producer —
+    an old laptop, a stale worker — rebuilds the root envelope from the keys
+    it knows and drops the section it never learned to copy. Severity is
+    bounded by D9 (the section is a regenerable accelerator: a reader that
+    loses it falls back to opening every candidate, slow and correct), so
+    this is a logged nudge naming :func:`zagg.coverage.refresh_root_coverage`
+    as the remedy — deliberately NOT a locking scheme, the #208 no-lock
+    ruling stands. Returns whether it warned.
+
+    Detection is DECLARATION-driven, like every other reach for the temporal
+    channel here (:func:`temporal_fields`): a store whose manifest declares
+    §8.3 ``"per-centroid"`` companions should have a section, and one that
+    declares none never should. That makes the check free — no leaf is
+    opened — at the cost of also firing on a temporal-declaring store whose
+    leaves genuinely hold no temporal row yet (freshly templated, or leaves
+    written before the declaration was added). The remedy named is right for
+    that store too: the walk rebuilds what is there, and writes no section
+    when the answer is honestly nothing.
+
+    A standing section at a revision this zagg cannot read is NOT missing —
+    §10.4 preserves it verbatim, and warning about it would invite an
+    operator to run a walk that downgrades nothing but says the same thing
+    again. Only an absent key, or an unmarked carrier (debris), warns.
+    """
+    from zagg.hive import ROOT_COVERAGE_NAME
+
+    if not temporal_fields(manifest):
+        return False
+    section = envelope.get(TEMPORAL_KEY) if isinstance(envelope, dict) else None
+    if _usable(section) is not None or _preserved(section) is not None:
+        return False
+    logger.warning(
+        f"coverage[toc]: {store_root} declares temporal fields but its root "
+        f"{ROOT_COVERAGE_NAME} carries no {TEMPORAL_COVERAGE_SPEC} section — a producer "
+        f"that predates spec §10.4 may have dropped it, and `when=` pruning degrades to "
+        f"opening every candidate until it is rebuilt; run "
+        f"zagg.coverage.refresh_root_coverage({store_root!r}) to restore it"
+    )
+    return True
+
+
 def section_unchanged(existing, incoming) -> bool:
     """Whether composing ``incoming`` into ``existing`` would change nothing.
 
@@ -497,4 +542,5 @@ __all__ = [
     "shards_overlapping",
     "temporal_cell_order",
     "temporal_fields",
+    "warn_if_section_missing",
 ]

--- a/src/zagg/coverage_toc.py
+++ b/src/zagg/coverage_toc.py
@@ -353,6 +353,22 @@ def warn_if_section_missing(store_root: str, envelope, manifest) -> bool:
     as the remedy — deliberately NOT a locking scheme, the #208 no-lock
     ruling stands. Returns whether it warned.
 
+    An absent section is an OBSERVATION, and the message says only that.
+    Two causes produce it and this seat cannot tell them apart: a producer
+    dropped it, or no walk has ever built one — only the walk writes a
+    section (:meth:`zagg.sweep.MocFamily.finish` and
+    :func:`zagg.coverage.refresh_root_coverage` are its two writers; the
+    runner's ingest and :func:`zagg.sweep_stages.run_finisher` both write
+    section-less root envelopes). In the default pipeline the walk does
+    precede the staged finisher — ``runner.py`` runs
+    :func:`zagg.sweep.sweep_after_run` over
+    :data:`zagg.sweep.DEFAULT_FAMILIES` (``moc`` among them) BEFORE
+    :func:`zagg.sweep_stages.stage_sweep_after_run` in the same post-run
+    hook — so a section missing at the finisher is genuinely anomalous
+    there. It is NOT anomalous for a store swept with ``--stages``
+    standalone, or one whose fail-open families sweep failed, and the same
+    remedy fixes every one of them.
+
     Detection is DECLARATION-driven, like every other reach for the temporal
     channel here (:func:`temporal_fields`): a store whose manifest declares
     §8.3 ``"per-centroid"`` companions should have a section, and one that
@@ -377,10 +393,10 @@ def warn_if_section_missing(store_root: str, envelope, manifest) -> bool:
         return False
     logger.warning(
         f"coverage[toc]: {store_root} declares temporal fields but its root "
-        f"{ROOT_COVERAGE_NAME} carries no {TEMPORAL_COVERAGE_SPEC} section — a producer "
-        f"that predates spec §10.4 may have dropped it, and `when=` pruning degrades to "
-        f"opening every candidate until it is rebuilt; run "
-        f"zagg.coverage.refresh_root_coverage({store_root!r}) to restore it"
+        f"{ROOT_COVERAGE_NAME} carries no {TEMPORAL_COVERAGE_SPEC} section — no walk has "
+        f"built one yet, or a producer dropped it; either way `when=` pruning degrades to "
+        f"opening every candidate until it is built, so run "
+        f"zagg.coverage.refresh_root_coverage({store_root!r})"
     )
     return True
 

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -1078,6 +1078,17 @@ def write_root_coverage(store_root: str, envelope: dict, **store_kwargs) -> dict
     rather than unioned (weights are counts), and a producer carrying no
     section leaves an existing one standing. Two stores with no temporal
     channel at all still write byte-identical bytes to a pre-#480 zagg.
+
+    THIS SEAM IS WHY NO CALLER HAS TO REFRESH (spec §10.5, issue #487). The
+    tier-1 join only ever GROWS an envelope, and growing is conservative in
+    the direction §10.2 needs, so every observation added through here lands
+    inside its shard's word by construction — the containment claim stays
+    true across any number of producers in any order, with no coordination.
+    Only a whole-store walk (:func:`zagg.coverage.refresh_root_coverage`)
+    TIGHTENS, and only it may narrow a word or replace the digest; a pass
+    that adds no observations may preserve the section untouched, which is
+    exactly what the staged sweep does
+    (:func:`zagg.sweep_stages.run_finisher`).
     """
     import obstore
 

--- a/src/zagg/hive.py
+++ b/src/zagg/hive.py
@@ -1079,16 +1079,28 @@ def write_root_coverage(store_root: str, envelope: dict, **store_kwargs) -> dict
     section leaves an existing one standing. Two stores with no temporal
     channel at all still write byte-identical bytes to a pre-#480 zagg.
 
-    THIS SEAM IS WHY NO CALLER HAS TO REFRESH (spec §10.5, issue #487). The
-    tier-1 join only ever GROWS an envelope, and growing is conservative in
-    the direction §10.2 needs, so every observation added through here lands
-    inside its shard's word by construction — the containment claim stays
-    true across any number of producers in any order, with no coordination.
-    Only a whole-store walk (:func:`zagg.coverage.refresh_root_coverage`)
-    TIGHTENS, and only it may narrow a word or replace the digest; a pass
-    that adds no observations may preserve the section untouched, which is
-    exactly what the staged sweep does
-    (:func:`zagg.sweep_stages.run_finisher`).
+    THE UNION ARM IS WHY NO CALLER HAS TO REFRESH (spec §10.5, issue #487).
+    On that arm the tier-1 join only ever GROWS an envelope, and growing is
+    conservative in the direction §10.2 needs, so every observation added
+    through it lands inside its shard's word by construction — the
+    containment claim stays true across any number of producers in any order,
+    with no coordination. Only a whole-store walk
+    (:func:`zagg.coverage.refresh_root_coverage`) TIGHTENS, and a pass that
+    adds no observations may preserve the section untouched, which is exactly
+    what the staged sweep does (:func:`zagg.sweep_stages.run_finisher`).
+
+    THE OVERWRITE ARM ABOVE IS THE CARVE-OUT, and callers passing a section
+    have to know it: `carried` is False there, so nothing is joined and the
+    caller's own section is installed VERBATIM. A run-scoped caller —
+    :meth:`zagg.sweep.MocFamily.finish`, which builds its section from the
+    leaves this run visited — therefore publishes a word NARROWER than the
+    standing one for any shard whose other window leaves it did not visit,
+    and replaces the digest with its own. §10.5 names that arm's cost: a
+    narrowed word prunes a shard that does hold data in the window, a MISSED
+    candidate rather than a wasted open. It is bounded by D9 (the carrier is
+    a regenerable cache — the arm only runs when the standing carrier was
+    already unusable, and one refresh walk restores precision), but it is not
+    the join's guarantee, and nothing here re-derives it.
     """
     import obstore
 

--- a/src/zagg/sweep_stages.py
+++ b/src/zagg/sweep_stages.py
@@ -277,7 +277,10 @@ def run_finisher(
        here was dropped by someone else. The written payload is checked by
        :func:`zagg.coverage_toc.warn_if_section_missing` — a
        temporal-declaring store whose root carries no section gets a logged
-       nudge at ``toc_section_missing`` (issue #488), never a refusal;
+       nudge at ``toc_section_missing`` (issue #488), never a refusal. That
+       key is ALWAYS in the returned dict, like every other one: a run with
+       an empty work set writes no root object and reports ``False``, so the
+       stage record's shape does not depend on the work set;
     2. the manifest RMW nesting per-entry actuals inside the level entries
        of ``pyramid.overviews`` (#381 point (7); readers MUST tolerate the
        added key). The leaf entry records the ``leaf-column`` law
@@ -317,6 +320,7 @@ def run_finisher(
     store_kwargs = dict(store_kwargs or {})
     out = {
         "root_moc": False,
+        "toc_section_missing": False,
         "manifest_updated": False,
         "objects_touched": 0,
         "touch_failures": 0,

--- a/src/zagg/sweep_stages.py
+++ b/src/zagg/sweep_stages.py
@@ -268,7 +268,16 @@ def run_finisher(
 
     1. the root ``coverage.moc`` refresh (GET-union-PUT, ``source:
        "sweep"``) — sequenced HERE, before any later scoped fan-out reads
-       it: the #380 read-side obligation the partition machinery deferred;
+       it: the #380 read-side obligation the partition machinery deferred.
+       This stage adds no observations, so it PRESERVES the spec §10
+       temporal section rather than refreshing it (issue #487: the staged
+       sweep preserves, the walk tightens — see
+       :func:`zagg.coverage.refresh_root_coverage`); preserving is what
+       makes the belt below meaningful, since a section that is missing
+       here was dropped by someone else. The written payload is checked by
+       :func:`zagg.coverage_toc.warn_if_section_missing` — a
+       temporal-declaring store whose root carries no section gets a logged
+       nudge at ``toc_section_missing`` (issue #488), never a refusal;
     2. the manifest RMW nesting per-entry actuals inside the level entries
        of ``pyramid.overviews`` (#381 point (7); readers MUST tolerate the
        added key). The leaf entry records the ``leaf-column`` law
@@ -292,6 +301,7 @@ def run_finisher(
     """
     import obstore
 
+    from zagg.coverage_toc import warn_if_section_missing
     from zagg.grids.morton import morton_word
     from zagg.hive import (
         AGGREGATION_CORE_NAME,
@@ -317,8 +327,9 @@ def run_finisher(
         envelope = build_root_coverage(
             [morton_word(d) for d in by_shard], shard_order, source="sweep"
         )
-        write_root_coverage(store_root, envelope, **store_kwargs)
+        written = write_root_coverage(store_root, envelope, **store_kwargs)
         out["root_moc"] = True
+        out["toc_section_missing"] = warn_if_section_missing(store_root, written, manifest)
     fresh = read_manifest(store_root, **store_kwargs)
     if fresh is None:
         raise ValueError(f"no {MANIFEST_NAME} at {store_root} — cannot record actuals")

--- a/src/zagg/sweep_stages.py
+++ b/src/zagg/sweep_stages.py
@@ -283,7 +283,9 @@ def run_finisher(
        nudge at ``toc_section_missing`` (issue #488), never a refusal. That
        key is ALWAYS in the returned dict, like every other one: a run with
        an empty work set writes no root object and reports ``False``, so the
-       stage record's shape does not depend on the work set;
+       stage record's shape does not depend on the work set. The check runs
+       against step 2's RE-READ manifest, not the caller's admission-time
+       copy, so it judges the declaration the store carries now;
     2. the manifest RMW nesting per-entry actuals inside the level entries
        of ``pyramid.overviews`` (#381 point (7); readers MUST tolerate the
        added key). The leaf entry records the ``leaf-column`` law
@@ -330,16 +332,24 @@ def run_finisher(
         "lease_released": False,
     }
     shard_order = int(manifest["shard_order"])
+    written = None
     if by_shard:
         envelope = build_root_coverage(
             [morton_word(d) for d in by_shard], shard_order, source="sweep"
         )
         written = write_root_coverage(store_root, envelope, **store_kwargs)
         out["root_moc"] = True
-        out["toc_section_missing"] = warn_if_section_missing(store_root, written, manifest)
     fresh = read_manifest(store_root, **store_kwargs)
     if fresh is None:
         raise ValueError(f"no {MANIFEST_NAME} at {store_root} — cannot record actuals")
+    if written is not None:
+        # Against `fresh`, never the caller's `manifest`: the declaration the
+        # check reads is the STORE's, and `manifest` was read at admission —
+        # before the lease, the stages, and however long the fan-out took. A
+        # temporal channel added mid-run would otherwise go un-nudged, and one
+        # removed mid-run nudged for a channel the store no longer has. The
+        # write above has to precede the re-read; the check does not.
+        out["toc_section_missing"] = warn_if_section_missing(store_root, written, fresh)
     now = _utcnow()
     changed = False
     for entry in (fresh.get("pyramid") or {}).get("overviews") or []:

--- a/src/zagg/sweep_stages.py
+++ b/src/zagg/sweep_stages.py
@@ -272,9 +272,12 @@ def run_finisher(
        This stage adds no observations, so it PRESERVES the spec §10
        temporal section rather than refreshing it (issue #487: the staged
        sweep preserves, the walk tightens — see
-       :func:`zagg.coverage.refresh_root_coverage`); preserving is what
-       makes the belt below meaningful, since a section that is missing
-       here was dropped by someone else. The written payload is checked by
+       :func:`zagg.coverage.refresh_root_coverage`). Preserving holds on
+       :func:`zagg.hive.write_root_coverage`'s UNION arm; an unparsable or
+       incompatible standing root is OVERWRITTEN there by design (D9
+       regenerable cache) and the stale section goes with the stale ranges,
+       so on that arm this very call is the dropper — which is why the
+       belt below names no cause. The written payload is checked by
        :func:`zagg.coverage_toc.warn_if_section_missing` — a
        temporal-declaring store whose root carries no section gets a logged
        nudge at ``toc_section_missing`` (issue #488), never a refusal. That

--- a/tests/test_coverage_toc.py
+++ b/tests/test_coverage_toc.py
@@ -638,6 +638,40 @@ class TestOnCommittedStores:
         # published: a partial rebuild composes, it does not overwrite.
         assert set(envelope["temporal"]["shards"]) == {"11213", "11214"}
 
+    def test_a_malformed_window_label_costs_its_shard_not_its_extent(self, tmp_path):
+        """A skipped SIBLING window must not narrow the shard's published word.
+
+        The walk's malformed-label carve-out drops a stamped leaf whose window
+        label breaks the frozen grammar — but only the LABEL is malformed, so
+        the id before the first ``_`` names a shard whose other windows read
+        fine. Publishing their join alone would be a word derived from some of
+        the shard's leaves, exactly the narrowing §10.2 forbids and §10.5 names
+        as the one loss that costs a MISSED candidate.
+        """
+        root = self._copy(tmp_path, "temporal")
+        standing = json.loads((Path(root) / "coverage.moc").read_text())
+        # Widen the standing word as a sibling window's data would have, and
+        # keep an instant that ONLY the widened word covers.
+        far_at = BASE_NS + 4000 * DAY_NS
+        far = int(np.asarray(time2toc(np.asarray([far_at], dtype=np.int64)))[0])
+        narrow = int(standing["temporal"]["shards"]["11213"])
+        wide = int(toc_merge(narrow, far))
+        standing["temporal"]["shards"]["11213"] = str(wide)
+        (Path(root) / "coverage.moc").write_text(json.dumps(standing, indent=1))
+        leaf_dir = Path(root) / "1" / "1" / "2" / "1" / "3"
+        shutil.copytree(leaf_dir / "11213.zarr", leaf_dir / "11213_bad$label.zarr")
+
+        envelope = refresh_root_coverage(root)
+        assert int(envelope["temporal"]["shards"]["11213"]) == wide
+        # The window only the widened word covers is still a candidate — the
+        # skipped sibling cost the shard PRECISION, never its containment. Had
+        # the walk published the join over the leaves it parsed, this query
+        # would prune a shard that holds data in the window: a MISSED
+        # candidate, the one §10.5 loss a reader cannot detect.
+        lo, hi = far_at, far_at + DAY_NS
+        assert bool(np.asarray(toc_overlaps(np.array([wide], dtype=np.uint64), lo, hi))[0])
+        assert not bool(np.asarray(toc_overlaps(np.array([narrow], dtype=np.uint64), lo, hi))[0])
+
     def test_a_second_pass_over_a_multi_shard_store_writes_nothing(self, tmp_path):
         """Sweep idempotence where the seam actually bites (§10.4).
 

--- a/tests/test_coverage_toc.py
+++ b/tests/test_coverage_toc.py
@@ -333,11 +333,13 @@ class TestMissingSectionWarning:
     def test_an_unreadable_future_revision_is_not_missing(self, caplog):
         """§10.4 preserves it verbatim, so nothing was dropped and a walk would
         only say the same thing again — warning here would invite a pointless
-        rebuild."""
+        rebuild. Silent at DEBUG too: the arm that HONORS the section must not
+        also emit :func:`_usable`'s "ignoring a section with an unknown spec",
+        which is the opposite claim (true at the merge seam, not at this one)."""
         env = self._envelope({"spec": "zagg-coverage-toc/2", "shards": {}})
-        with caplog.at_level("WARNING"):
+        with caplog.at_level("DEBUG"):
             assert warn_if_section_missing("s3://b/s", env, self._manifest("temporal")) is False
-        assert "refresh_root_coverage" not in caplog.text
+        assert caplog.text == ""
 
     @pytest.mark.parametrize("debris", [None, {}, {"shards": {}}, "not a dict"])
     def test_an_unmarked_carrier_is_debris_and_warns(self, debris, caplog):

--- a/tests/test_coverage_toc.py
+++ b/tests/test_coverage_toc.py
@@ -279,12 +279,15 @@ class TestAbsence:
 
 
 class TestMissingSectionWarning:
-    """Issue #488 — the belt for a producer that predates §10.4's succession rule.
+    """Issue #488 — the belt for a root that carries no §10 section.
 
-    A pre-#481 producer rebuilds the root envelope from the keys it knows and
-    drops the section it never learned to copy. The check is a logged nudge,
-    not a refusal: the section is a D9 regenerable accelerator, and losing it
-    only degrades ``when=`` pruning to opening every candidate.
+    Two causes reach the same state and the check cannot tell them apart: a
+    pre-#481 producer rebuilt the root envelope from the keys it knows and
+    dropped the section it never learned to copy, or no walk has built one
+    yet (only the walk writes a section). So the message asserts neither and
+    names both. It is a logged nudge, not a refusal: the section is a D9
+    regenerable accelerator, and losing it only degrades ``when=`` pruning to
+    opening every candidate.
     """
 
     def _manifest(self, name):
@@ -296,13 +299,18 @@ class TestMissingSectionWarning:
             env["temporal"] = section
         return env
 
-    def test_a_temporal_store_whose_root_lost_the_section_warns(self, caplog):
+    def test_a_temporal_store_whose_root_carries_no_section_warns(self, caplog):
         manifest = self._manifest("temporal")
         with caplog.at_level("WARNING"):
             assert warn_if_section_missing("s3://b/store", self._envelope(), manifest) is True
         # The remedy has to be IN the line: a warning that only says the
         # section is gone leaves the operator with nothing to run.
         assert "refresh_root_coverage" in caplog.text and "s3://b/store" in caplog.text
+        # ...and the line must not pick a cause it cannot know: an absent
+        # section is equally "never built" and "dropped", so both are named
+        # and the operator is not sent chasing a stale worker that may not
+        # exist.
+        assert "no walk has built one yet" in caplog.text and "dropped it" in caplog.text
 
     def test_a_store_declaring_no_temporal_field_never_warns(self, caplog):
         """The common case. A section it never had is not a section it lost."""

--- a/tests/test_coverage_toc.py
+++ b/tests/test_coverage_toc.py
@@ -30,8 +30,10 @@ from zagg.coverage_toc import (
     section_unchanged,
     shards_overlapping,
     temporal_fields,
+    warn_if_section_missing,
 )
-from zagg.hive import build_root_coverage, read_root_coverage, write_root_coverage
+from zagg.grids.morton import morton_word
+from zagg.hive import _decimal_order, build_root_coverage, read_root_coverage, write_root_coverage
 
 SPEC_DATA = Path(__file__).parent / "data" / "spec"
 #: A day on the toc scale, in internal ns — enough to keep the synthetic
@@ -274,6 +276,86 @@ class TestAbsence:
         fields = temporal_fields(manifest)
         assert set(fields) == {"h_tdigest"}
         assert fields["h_tdigest"]["sibling"] == "h_tdigest_times"
+
+
+class TestMissingSectionWarning:
+    """Issue #488 — the belt for a producer that predates §10.4's succession rule.
+
+    A pre-#481 producer rebuilds the root envelope from the keys it knows and
+    drops the section it never learned to copy. The check is a logged nudge,
+    not a refusal: the section is a D9 regenerable accelerator, and losing it
+    only degrades ``when=`` pruning to opening every candidate.
+    """
+
+    def _manifest(self, name):
+        return json.loads((SPEC_DATA / name / "morton_hive.json").read_text())
+
+    def _envelope(self, section=...):
+        env = build_root_coverage([morton_word("11213")], _decimal_order("11213"), source="sweep")
+        if section is not ...:
+            env["temporal"] = section
+        return env
+
+    def test_a_temporal_store_whose_root_lost_the_section_warns(self, caplog):
+        manifest = self._manifest("temporal")
+        with caplog.at_level("WARNING"):
+            assert warn_if_section_missing("s3://b/store", self._envelope(), manifest) is True
+        # The remedy has to be IN the line: a warning that only says the
+        # section is gone leaves the operator with nothing to run.
+        assert "refresh_root_coverage" in caplog.text and "s3://b/store" in caplog.text
+
+    def test_a_store_declaring_no_temporal_field_never_warns(self, caplog):
+        """The common case. A section it never had is not a section it lost."""
+        with caplog.at_level("WARNING"):
+            assert (
+                warn_if_section_missing("s3://b/s", self._envelope(), self._manifest("minimal"))
+                is False
+            )
+            assert warn_if_section_missing("s3://b/s", self._envelope(), None) is False
+        assert caplog.text == ""
+
+    def test_a_section_that_is_present_never_warns(self, caplog):
+        section = build_temporal_section(_contributions([1, 2]), ["h_tdigest"])
+        with caplog.at_level("WARNING"):
+            got = warn_if_section_missing(
+                "s3://b/s", self._envelope(section), self._manifest("temporal")
+            )
+        assert got is False and caplog.text == ""
+
+    def test_an_unreadable_future_revision_is_not_missing(self, caplog):
+        """§10.4 preserves it verbatim, so nothing was dropped and a walk would
+        only say the same thing again — warning here would invite a pointless
+        rebuild."""
+        env = self._envelope({"spec": "zagg-coverage-toc/2", "shards": {}})
+        with caplog.at_level("WARNING"):
+            assert warn_if_section_missing("s3://b/s", env, self._manifest("temporal")) is False
+        assert "refresh_root_coverage" not in caplog.text
+
+    @pytest.mark.parametrize("debris", [None, {}, {"shards": {}}, "not a dict"])
+    def test_an_unmarked_carrier_is_debris_and_warns(self, debris, caplog):
+        """An unmarked value claims no revision (:func:`_preserved`'s rule), so
+        it is exactly as missing as an absent key."""
+        with caplog.at_level("WARNING"):
+            got = warn_if_section_missing(
+                "s3://b/s", self._envelope(debris), self._manifest("temporal")
+            )
+        assert got is True and "refresh_root_coverage" in caplog.text
+
+    def test_a_refreshed_store_stops_warning(self, tmp_path):
+        """End to end on the committed fixture: strip the section, confirm the
+        warning fires, run the remedy the message names, confirm it stops."""
+        root = str(tmp_path / "temporal")
+        shutil.copytree(SPEC_DATA / "temporal", root)
+        manifest = json.loads((Path(root) / "morton_hive.json").read_text())
+        envelope = read_root_coverage(root)
+        assert envelope.pop("temporal")  # the fixture really does carry one
+        # PUT outright, which is what the pre-§10.4 producer does: routing this
+        # back through write_root_coverage would compose the standing section
+        # BACK IN — the succession rule working, which is not the shape here.
+        (Path(root) / "coverage.moc").write_text(json.dumps(envelope, indent=1))
+        assert warn_if_section_missing(root, read_root_coverage(root), manifest) is True
+        refresh_root_coverage(root)
+        assert warn_if_section_missing(root, read_root_coverage(root), manifest) is False
 
 
 class TestPartialReadsDropTheShard:

--- a/tests/test_sweep_stage.py
+++ b/tests/test_sweep_stage.py
@@ -361,16 +361,19 @@ def _standing_section(decimals):
     The staged sweep never writes one (it adds no observations, #487), so a
     test of the PRESERVE arm has to install the walk's output itself.
     """
-    from conftest import TOC_BASE
-    from mortie import time2toc
+    from conftest import TOC_BASE, toc_words
 
     from zagg.coverage_toc import build_temporal_section
 
     contributions = {}
     for i, dec in enumerate(decimals):
-        t = int(np.datetime64(TOC_BASE, "ns").astype("int64")) + i * 10**12
-        words = np.asarray([int(time2toc(t))], dtype=np.uint64)
-        contributions[dec] = [(int(words[0]), np.asarray([[t, 3.0]], dtype=np.float32), words)]
+        # One instant per shard, off the same base `_located_leaf_slabs` uses,
+        # packed by the shared fixture helper rather than a second hand-rolled
+        # copy of it.
+        when = np.datetime64(TOC_BASE, "ns") + np.timedelta64(1000 * i, "s")
+        words = toc_words(1, base=str(when))
+        value = float(when.astype("int64"))
+        contributions[dec] = [(int(words[0]), np.asarray([[value, 3.0]], dtype=np.float32), words)]
     return build_temporal_section(contributions, ["h_tdigest"], source="refresh")
 
 

--- a/tests/test_sweep_stage.py
+++ b/tests/test_sweep_stage.py
@@ -1131,6 +1131,17 @@ class TestFinisher:
         after = read_root_coverage(str(tmp_path / "s"))["temporal"]
         assert after["shards"] == env["temporal"]["shards"]
 
+    def test_the_nudge_reads_the_store_manifest_not_the_caller_copy(self, tmp_path, caplog):
+        """The caller's `manifest` was read at admission; the declaration can
+        have moved since. A temporal channel added mid-run is still nudged."""
+        m = _stage_store(tmp_path / "s", fields=TIMED_FIELDS)
+        stale = json.loads(json.dumps(m))
+        stale["pyramid"]["overview"]["fields"] = FIELDS  # no `temporal:` at admission
+        with caplog.at_level("WARNING"):
+            out = run_finisher(str(tmp_path / "s"), stale, _by_shard(), {}, run_id="A")
+        assert out["toc_section_missing"] is True
+        assert "refresh_root_coverage" in caplog.text
+
     def test_an_incompatible_standing_root_drops_the_section_and_nudges(self, tmp_path, caplog):
         """The overwrite arm: `write_root_coverage` discards an incompatible
         standing envelope (D9 regenerable cache) and the section goes with the

--- a/tests/test_sweep_stage.py
+++ b/tests/test_sweep_stage.py
@@ -1131,6 +1131,25 @@ class TestFinisher:
         after = read_root_coverage(str(tmp_path / "s"))["temporal"]
         assert after["shards"] == env["temporal"]["shards"]
 
+    def test_an_incompatible_standing_root_drops_the_section_and_nudges(self, tmp_path, caplog):
+        """The overwrite arm: `write_root_coverage` discards an incompatible
+        standing envelope (D9 regenerable cache) and the section goes with the
+        ranges, so the finisher's own write is the dropper here. The nudge
+        still fires — correctly, since the remedy is the same walk — and it is
+        the reason the message blames no one."""
+        m = _stage_store(tmp_path / "s", fields=TIMED_FIELDS, write_moc=False)
+        env = build_root_coverage([morton_word(d) for d in LEAVES], 3, source="refresh")
+        env["temporal"] = _standing_section(LEAVES)
+        env["encoding"] = "bitmap"  # the leaf sidecar's encoding at the root
+        # PUT outright: routing an incompatible envelope through the writer
+        # would only reproduce the overwrite one call early.
+        (tmp_path / "s" / "coverage.moc").write_text(json.dumps(env, indent=1))
+        with caplog.at_level("WARNING"):
+            out, _, _ = self._run(tmp_path / "s", m)
+        assert "incompatible envelope; overwriting" in caplog.text
+        assert out["toc_section_missing"] is True
+        assert "refresh_root_coverage" in caplog.text
+
     def test_finisher_is_idempotent(self, tmp_path):
         m = _stage_store(tmp_path / "s")
         _, first, _ = self._run(tmp_path / "s", m)

--- a/tests/test_sweep_stage.py
+++ b/tests/test_sweep_stage.py
@@ -1107,6 +1107,14 @@ class TestFinisher:
         assert out["toc_section_missing"] is False
         assert "refresh_root_coverage" not in caplog.text
 
+    def test_an_empty_work_set_still_reports_the_nudge_key(self, tmp_path):
+        """The stage record's shape must not depend on the work set: a
+        consumer indexing ``summary["finisher"]["toc_section_missing"]`` gets
+        a bool on every run, not a KeyError on the one that found no work."""
+        m = _stage_store(tmp_path / "s", fields=TIMED_FIELDS)
+        out = run_finisher(str(tmp_path / "s"), m, {}, {}, run_id="A")
+        assert out["root_moc"] is False and out["toc_section_missing"] is False
+
     def test_the_finisher_leaves_a_standing_section_alone(self, tmp_path, caplog):
         """The preserve arm, on the same store: once the walk has written the
         section, the staged sweep composes across it (#487) and stops nudging."""

--- a/tests/test_sweep_stage.py
+++ b/tests/test_sweep_stage.py
@@ -1088,10 +1088,12 @@ class TestFinisher:
         assert out["lease_released"] and calls == [1]
 
     def test_a_temporal_store_with_no_root_section_is_nudged(self, tmp_path, caplog):
-        """Issue #488. The finisher PRESERVES the §10 section (it adds no
-        observations, #487), so a section missing HERE was dropped by a
-        producer that predates §10.4 — the one gap the succession rule cannot
-        close, and the reason this is a nudge rather than a rebuild."""
+        """Issue #488. This store is the case the nudge cannot diagnose and
+        does not try to: the finisher PRESERVES the §10 section (it adds no
+        observations, #487) and no walk has run here, so the section was
+        never built — nobody dropped it. The message names both causes and
+        the one remedy that fixes either, which is why it is a nudge rather
+        than a rebuild."""
         m = _stage_store(tmp_path / "s", fields=TIMED_FIELDS)
         with caplog.at_level("WARNING"):
             out, _, _ = self._run(tmp_path / "s", m)

--- a/tests/test_sweep_stage.py
+++ b/tests/test_sweep_stage.py
@@ -355,6 +355,25 @@ def _stage_store(root, leaves=LEAVES, skip_columns=(), write_moc=True, fields=FI
     return manifest
 
 
+def _standing_section(decimals):
+    """A real §10 section over ``decimals``, built by the shipped builder.
+
+    The staged sweep never writes one (it adds no observations, #487), so a
+    test of the PRESERVE arm has to install the walk's output itself.
+    """
+    from conftest import TOC_BASE
+    from mortie import time2toc
+
+    from zagg.coverage_toc import build_temporal_section
+
+    contributions = {}
+    for i, dec in enumerate(decimals):
+        t = int(np.datetime64(TOC_BASE, "ns").astype("int64")) + i * 10**12
+        words = np.asarray([int(time2toc(t))], dtype=np.uint64)
+        contributions[dec] = [(int(words[0]), np.asarray([[t, 3.0]], dtype=np.float32), words)]
+    return build_temporal_section(contributions, ["h_tdigest"], source="refresh")
+
+
 def _by_shard(leaves=LEAVES):
     return {d: {None} for d in leaves}
 
@@ -1067,6 +1086,40 @@ class TestFinisher:
         calls = []
         out, _, _ = self._run(tmp_path / "s", m, released=lambda: calls.append(1) or True)
         assert out["lease_released"] and calls == [1]
+
+    def test_a_temporal_store_with_no_root_section_is_nudged(self, tmp_path, caplog):
+        """Issue #488. The finisher PRESERVES the §10 section (it adds no
+        observations, #487), so a section missing HERE was dropped by a
+        producer that predates §10.4 — the one gap the succession rule cannot
+        close, and the reason this is a nudge rather than a rebuild."""
+        m = _stage_store(tmp_path / "s", fields=TIMED_FIELDS)
+        with caplog.at_level("WARNING"):
+            out, _, _ = self._run(tmp_path / "s", m)
+        assert out["toc_section_missing"] is True
+        assert "refresh_root_coverage" in caplog.text
+
+    def test_a_store_with_no_temporal_channel_is_not_nudged(self, tmp_path, caplog):
+        m = _stage_store(tmp_path / "s")  # FIELDS: no `temporal:` declaration
+        with caplog.at_level("WARNING"):
+            out, _, _ = self._run(tmp_path / "s", m)
+        assert out["toc_section_missing"] is False
+        assert "refresh_root_coverage" not in caplog.text
+
+    def test_the_finisher_leaves_a_standing_section_alone(self, tmp_path, caplog):
+        """The preserve arm, on the same store: once the walk has written the
+        section, the staged sweep composes across it (#487) and stops nudging."""
+        from zagg.hive import read_root_coverage
+
+        m = _stage_store(tmp_path / "s", fields=TIMED_FIELDS)
+        env = build_root_coverage([morton_word(d) for d in LEAVES], 3, source="refresh")
+        env["temporal"] = _standing_section(LEAVES)
+        write_root_coverage(str(tmp_path / "s"), env)
+        with caplog.at_level("WARNING"):
+            out, _, _ = self._run(tmp_path / "s", m)
+        assert out["toc_section_missing"] is False
+        assert "refresh_root_coverage" not in caplog.text
+        after = read_root_coverage(str(tmp_path / "s"))["temporal"]
+        assert after["shards"] == env["temporal"]["shards"]
 
     def test_finisher_is_idempotent(self, tmp_path):
         m = _stage_store(tmp_path / "s")


### PR DESCRIPTION
Two small fixes, both on the spec §10 temporal section, both downstream of the same ruling (`preserve-don't-refresh` is the staged sweep's permanent posture).

Closes #488
Closes #487

## Phases

- [x] **Phase 1 — issue #488** (`a2d5d5b`): warn when a temporal-declaring store's root `coverage.moc` carries no §10 section.
- [x] **Phase 2 — issue #487** (`38da243`): document the walk-as-tightener refresh contract in §10 + the three docstrings the issue names.
- [x] **Fold the phase-1 adversarial review** — 6 findings, one commit each (`9d05ae6`, `8be2cec`, `e47e9d2`, `b9a3d66`, `e953364`, `ab1b345`); every inline thread replied to.
- [x] **Fold the phase-2 adversarial review** — 6 findings, one commit each (`2e8bf99`, `c0e386b`, `d5b3d45`, `45be6b1`, `7b78432`, `ce51de9`); every inline thread replied to.

## Phase 1 — the nudge (issue #488)

New `zagg.coverage_toc.warn_if_section_missing(store_root, envelope, manifest)`, wired into `sweep_stages.run_finisher` on the payload `write_root_coverage` actually returned, surfaced as `toc_section_missing` in the finisher's summary dict (always present, whatever the work set).

The gap it covers is the one §10.4's succession rule cannot close: the rule binds producers that know it, and a pre-#481 producer rebuilds the root envelope from the keys it knows and drops the section it never learned to copy. Severity is bounded by D9 — the section is a regenerable accelerator, so a reader that loses it falls back to opening every candidate: slow, correct, and fully repaired by one `refresh_root_coverage` walk. So this is a logged nudge naming that remedy, and explicitly **not** a locking scheme (the #208 no-lock ruling stands), exactly as the issue frames it.

Placed at the **staged-sweep finisher** and nowhere else, deliberately: that is the one root-writing seam where a section can go missing without anyone noticing. The finisher adds no observations, so it preserves rather than rebuilds (issue #487), and `MocFamily.finish` — the walk — writes the section itself, so telling *its* operator to run a walk would be circular advice.

**The message asserts no cause**, which the phase-1 review corrected. An absent section is an observation, and two causes reach it that this seat cannot tell apart: a producer dropped it, or no walk has built one yet (only the walk writes a section — `MocFamily.finish` and `refresh_root_coverage` are its two writers). In the default pipeline the walk *does* precede the staged finisher (`runner.py` runs `sweep_after_run` over `DEFAULT_FAMILIES`, `moc` among them, before `stage_sweep_after_run` in the same post-run hook), so a section missing at the finisher is genuinely anomalous there — but not for a store swept with `--stages` standalone, nor one whose fail-open families sweep failed. One remedy fixes all of them, so the line names both causes and blames neither:

```
… carries no zagg-coverage-toc/1 section — no walk has built one yet, or a
producer dropped it; either way `when=` pruning degrades to opening every
candidate until it is built, so run zagg.coverage.refresh_root_coverage(…)
```

Detection is **declaration-driven**, like every other reach for the temporal channel in this module (`temporal_fields`'s standing rule: never a member enumeration of the leaf), so the check is free — no leaf is opened. See question (1). A standing section at an **unknown revision is not "missing"**: §10.4 preserves it verbatim, so nothing was dropped; only an absent key or an *unmarked* carrier (debris, by `_preserved`'s own rule) warns.

## Phase 2 — the refresh contract (issue #487)

A new normative `### 10.5 Refresh contract — the walk is the only tightener` in `docs/specification.md`, stating the **always-safe, eventually-precise** invariant as bullets, plus the losses it bounds rather than prevents.

Prose only — **no grammar, wire format, or `spec` marker changed**, so the §7 conformance fixtures (`tools/generate_spec_fixtures.py` → `tests/data/spec/`) are untouched and `tests/test_spec_conformance.py` stays green (173 passed).

Cross-referencing docstring lines on the three functions the issue names: `sweep_stages.run_finisher` (landed with phase 1, since the finisher's preserve posture is what the check depends on), `hive.write_root_coverage`, and `coverage.refresh_root_coverage`. While editing the last one I also removed a dangling merge artifact sitting in it — the fragment `lives at the leaf's OWN node. A` / `supersedes it).`, a stray duplicate of the `(no union: the walk supersedes it)` clause seven lines above. An earlier pass worked around it rather than fixing it (`9ed4cd0`, "keep the new refresh sentence clear of the pre-existing fragment"); it is in the very docstring this issue names, so it is fixed here.

**Corrected by the phase-2 fold — §10.5 as first written described only one of §10.4's two arms.** `write_root_coverage` reaches the tier-1 join only on the **union** arm; on the **overwrite** arm `carried` is `False`, so the call is `merge_temporal_sections(None, incoming)`, which returns `dict(incoming)` and installs the producer's section verbatim with no `toc_merge` anywhere. The review reproduced a standing 2019–2021 word being replaced by a 2021-only one, flipping a January-2019 `toc_overlaps` query from `True` to `False`. §10.5 now scopes the join's guarantee to the union arm, gives the overwrite arm its own bullet naming what it costs, restates the MUST-NOT as a union-arm rule that shipped zagg satisfies, and names **narrowing** as the worse of the two losses the contract bounds — a missed candidate, not a wasted open — ahead of dropping. Tier 2's rule is restated as §10.4 actually writes it (whole-**merged-map**, not whole-**store**), with `refresh_root_coverage` named as the only whole-*store* producer rather than the only digest refresher. Still prose only: no wire format, attrs grammar, or `spec` marker moved, so the §7 fixtures still need no regeneration. See question (6) for the behavioural question this exposes, which is not decided here.

## Phase-1 review folds

Six findings, one commit each, every thread replied to. Two were substantive:

- **`9d05ae6`** — the warning asserted a cause it cannot know ("a producer that predates §10.4 may have dropped it"). Now names both causes and blames neither; the test that builds exactly the never-walked store had its docstring corrected to say so.
- **`e47e9d2`** — `run_finisher`'s docstring claimed "a section missing here was dropped by someone else", which is false on `write_root_coverage`'s **overwrite** arm: an unparsable or incompatible standing root is discarded by design (D9) and the stale section goes with the stale ranges, so on that arm *this very call* is the dropper. Docstring scoped to the union arm, and `test_an_incompatible_standing_root_drops_the_section_and_nudges` now pins the overwrite arm end to end.

Plus `8be2cec` (seed `toc_section_missing` in the `out` literal so the stage record's shape does not depend on the work set, + a test), `b9a3d66` (read the store's re-read manifest, not the caller's admission-time copy, + a test that fails on the old ordering), `e953364` (consult `_preserved` before `_usable`, so the arm that *honors* a future revision does not also emit `_usable`'s "ignoring a section with an unknown spec"), `ab1b345` (reuse `conftest.toc_words` instead of a second hand-rolled `time2toc` call — which, it turned out, had been packing a different instant).

## Phase-2 review folds

Six findings, one commit each, every thread replied to. All six landed on phase 2; five are prose, one is a real code bug.

- **`2e8bf99`** — §10.5's new MUST-NOT ("a producer MUST NOT publish a narrowed word … unless it derived it from every leaf") was violated by shipped zagg, because §10.4's overwrite arm is not a join (see the phase-2 note above). Scoped the contract to the union arm, added an overwrite-arm bullet, restated the MUST-NOT as one the code satisfies, and rewrote the closing paragraph to name narrowing as the worse loss.
- **`c0e386b`** — "only a whole-store walk refreshes tier 2" was false. `merge_temporal_sections` installs whichever side's map covers the *merged* map (`for side in (b, a): … set(side["shards"]) >= listed`), which a fresh store's first sweep and any run touching every listed shard both satisfy. Tier 2 now has its own bullet stating the map-versus-store distinction.
- **`d5b3d45`** — `write_root_coverage`'s new docstring paragraph reintroduced the overclaim `e47e9d2` had just removed from `run_finisher`, three paragraphs below the same docstring's own "OVERWRITTEN" sentence. Scoped to the union arm, with a second paragraph naming `MocFamily.finish` as the run-scoped caller that reaches the other one.
- **`45be6b1`** — **code bug, with a test.** `refresh_root_coverage`'s malformed-window-label `continue` discarded a stamped leaf without recording its shard in `toc_failed`, so a sibling window of the same shard was published alone — the tightener itself narrowing a word. Now banks the shard (the id up to the first `_` is recoverable) so the compose-with-standing path engages, mirroring the read-failure branch below it. New case `test_a_malformed_window_label_costs_its_shard_not_its_extent` fails on `ab1b345`.
- **`7b78432`** — inserting `### 10.5` had re-parented §10's closing conformance paragraph under it, where "the claims above" no longer named what the fixture pins. Moved back to close §10.4, with "(§10.2, §10.3)" made explicit and a sentence saying why no fixture can pin §10.5.
- **`ce51de9`** — reflowed the un-reflowed 92- and 87-column seams the phase-2 edit left in `refresh_root_coverage`'s ~75-column docstring, and folded `c0e386b`'s code-side knock-on ("its only tier-2 refresher") into the same rewrite of those lines.

One sub-point was declined and stands for review: `section_unchanged`'s docstring carries the same tier-2 misreading a level down ("A producer that walked only part of the store always builds a digest, and §10.4 always drops that digest at the seam"). It is pre-existing text in a function this PR does not touch, so under CLAUDE.md §4 it is flagged rather than fixed here.

## How it was tested

Twelve unit cases in `tests/test_coverage_toc.py::TestMissingSectionWarning` and six in `tests/test_sweep_stage.py::TestFinisher`, covering: the warn arm and both causes named in the line, the no-declaration arm, the section-present arm, the future-revision arm (silent at DEBUG too), four debris shapes, an empty work set, a stale caller manifest, the incompatible-standing-root overwrite arm, the preserve arm with a standing section installed, and an end-to-end pass on the committed `temporal/` fixture that strips the section by PUTting the envelope outright — the pre-§10.4 clobber shape — asserts the warning, runs the named remedy, and asserts it stops. Phase 2's fold adds one case on the `temporal/` fixture pinning that a skipped malformed-label sibling costs its shard's *precision* and never its containment.

- `pytest -q --deselect tests/test_lambda_build.py -p no:randomly` on `ce51de9` → **4511 passed, 38 skipped** (4510 on `ab1b345`; 4507 on `38da243`).
- `ruff check --select=E,F,W,I --ignore=E501 src tests` and `ruff format --check` on the touched files → clean. `tests/test_spec_conformance.py` → 173 passed, unchanged: no fixture was regenerated because no wire format, attrs grammar, or `spec` marker moved.

## Questions for review

1. **Is the declaration-driven detection the right bound, or should the check open one leaf?** A store that declares `temporal: "per-centroid"` but whose leaves were all written before the declaration existed warns on every staged sweep, forever, and the walk it names will never produce a section for it. Options: **(a)** what is implemented — free, declaration-only, accepts that false positive; **(b)** additionally require the finisher's `by_shard` to be non-empty; **(c)** open one leaf's declared sibling to confirm a companion really exists, at one GET per finish. (a) matches the module's standing "declaration is the discovery" rule; (c) matches the issue's literal wording ("when a store's leaves *carry* temporal companions"). Left at (a).

2. **Should the same nudge fire on the reader side?** The issue names a moczarr sibling issue (same detection, reader's seat), but zagg's own readers (`load_temporal_coverage`, `shards_overlapping`) return `None` silently by §10's absence posture, which is correct for them. Not touched here.

3. **§10.5 is written as a `Contract`, not as informative.** Its one MUST-NOT is now scoped to §10.4's union arm ("on the union arm a producer MUST NOT publish a narrowed word for a shard unless it derived that word from every leaf of the shard"), which the join satisfies by construction — so it binds an external producer composing the section by other means (moczarr), not any shipped zagg writer. Its original unscoped form *was* violated by shipped zagg, which the phase-2 review caught; see the phase-2 note and question (6). If you would rather §10.5 be purely informative, the fix is one heading word and dropping that MUST-NOT.

4. **Pre-existing, flagged not fixed** (CLAUDE.md §4): `ruff check src tests` under the repo's own config (`select = [E, F, W, I, N]`) reports `N818` on `src/zagg/registry.py:64` (`UnknownCapability` wants an `Error` suffix), and `ruff format --check` wants to reformat a python block inside `tests/data/benchmark/README.md`. Both are on `main` unchanged and neither is in CI's gate (the lint bot runs `--select=E,F,W,I`).

5. **One flaky test observed, not reproduced.** The first full-suite run on phase 1 failed `tests/test_client_transport.py::TestStatusPoller::test_invoke_fault_burns_an_attempt_and_retries`; three later full runs and a targeted run all pass, and the diff touches nothing in that path. Recording it rather than calling it clean.

6. **Should `write_root_coverage`'s overwrite arm keep discarding the temporal section?** *Raised by the phase-2 review; behavioural, pre-existing, and deliberately not decided in this PR.* The arm was written to treat the section like the ranges — stale carrier, stale section, both discarded under D9. But the two are not symmetric: a discarded section costs a reader a **slow** query (absent shard = unknown = candidate), while a section replaced by a run-scoped producer's narrower one costs a **missed** candidate, which no reader can detect. Reproduced against the shipped writer:

   ```
   existing coverage.moc at /tmp/… failed to parse (invalid literal for int()
   with base 10: 'z'); overwriting (regenerable cache — the sweep rebuilds
   authoritatively)
   standing word : 3092601599982677469 (2019-01-01 … 2021-12-31)
   published word: 3218745596920049117 (2021-01-01 … 2021-12-31)
   NARROWED (not a join): True
   2019 window overlaps standing word : True
   2019 window overlaps published word: False
   ```

   The trigger set is real but narrow: an unparsable root, an incompatible `spec`/`encoding`/`order`, or a `ranges` body that fails `root_coverage_words` — combined with a run-scoped producer (`MocFamily.finish`) that visited a subset of a windowed shard's leaves.

   Options:
   - **(a) Leave as-is and document it — what this PR does.** §10.5 names the arm, states that it installs the incoming section verbatim, and names the missed-candidate cost. Cheapest, changes no behaviour, and stays inside issue #487's documentation scope. The loss stays bounded by D9 and one refresh walk repairs it.
   - **(b) Preserve the standing section across the overwrite arm** — carry `existing[TEMPORAL_KEY]` through even when the carrier is discarded, on the grounds that the section's succession rule (§10.4) is independent of the *ranges'* validity: the ranges failing to parse says nothing about whether the temporal words are still true. Small change (`carried` stops gating the `existing.get(TEMPORAL_KEY)` argument), but it means a genuinely corrupt carrier can hand its section to the replacement.
   - **(c) Refuse the overwrite outright while a section is standing** — fail loud instead of silently narrowing. Safest for the reader, but it breaks the D9 "the sweep is the authoritative rebuilder, never die on garbage" posture the arm exists to hold, and would strand exactly the stores the escape hatch is for.

   My read is (b) if the arm should change at all — it is the option whose reasoning is about the section rather than about the carrier — but it is a behaviour change on shipped code raised on a docs issue, so it needs a maintainer call rather than mine (CLAUDE.md §6). No issue opened for it, per the same rule.

## Process note

The phases were worked slightly out of the §2 order: phase 2 (docs only) was written while the phase-1 adversarial review was still running, rather than strictly after folding it. All six phase-1 findings landed against phase-1 code and tests and none in a file phase 2 touched, so nothing was folded onto a moved target — but the deviation is recorded rather than left silent. The phase-2 review ran against the folded head.
