### PR TITLE
use mortie's flat toc constants after the 0.9.10 submodule retirement (issue #493)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,17 @@ dependencies = [
     # what PyPI has published (as 0.2.0 once was) fails resolution loudly — the
     # state build_layer.sh's MORTIE_SPEC derivation cites this block for.
     "h5coro-hidefix>=0.3.2",
-    # Floor 0.9.9 for the SEGMENTED toc reduce (espg/mortie#177, released in
-    # 0.9.9): tocs_reduce(words, offsets) is the per-group semilattice join the
+    # Floor 0.9.10 because mortie 0.9.10 RETIRED the `mortie.toc` submodule
+    # (espg/mortie#199, following #197 for `mortie.moc`): the name is now the
+    # `Toc` constructor, so statement-form `from mortie.toc import X` raises —
+    # its migration shim covers attribute access only, a callable cannot also
+    # be a module. The flat top-level spelling this repo now uses
+    # (`from mortie import Q_START_NS, Q_END_NS, TOC_MAX_NS`) exists only from
+    # 0.9.10; those three names are NOT top-level in 0.9.9, so this floor and
+    # the import style are one change, not two (issue #493).
+    # Previously floor 0.9.9 for the SEGMENTED toc reduce (espg/mortie#177,
+    # released in 0.9.9): tocs_reduce(words, offsets) is the per-group
+    # semilattice join the
     # spec §8.2/§8.3 temporal companions fold with — one Rust crossing for a
     # whole cell's centroid partition, where the scalar toc_reduce 0.9.6 ships
     # would be a Python loop per centroid (issue #410,
@@ -77,7 +86,7 @@ dependencies = [
     # route through (issue #199) — decimal_repr / to_decimal, the
     # _decimal_to_word parse-back, hive_path, and the MortonIndexScalar decimal
     # display.
-    "mortie>=0.9.9",
+    "mortie>=0.9.10",
     "earthaccess",
     "boto3",
     "fastparquet",

--- a/src/zagg/time_axis.py
+++ b/src/zagg/time_axis.py
@@ -22,8 +22,10 @@ acquisition group. Two encodings are defined:
 The point of the second one is honesty: a Sentinel-2 datatake is a
 ~seconds-long acquisition whose adjacent MGRS tiles are sensed seconds
 apart, which ``datetime64`` cannot represent and a toc range can. Word
-semantics — bit layout, sort order, merge law — are mortie's
-(``mortie.toc``), never restated here; this module owns zagg's half: the
+semantics — bit layout, sort order, merge law — are mortie's (the flat
+``mortie.time2toc`` / ``mortie.toc2time`` / ``mortie.toc_*`` kernels;
+``mortie.toc`` is the ``Toc`` constructor as of mortie 0.9.10, not a
+module), never restated here; this module owns zagg's half: the
 declaration grammar, the acquisition-group mapping, and the decode.
 """
 
@@ -326,7 +328,7 @@ def observation_words(values, *, epoch, scale: str, units: str) -> np.ndarray:
     convention, not something this encode can bridge.
     """
     import mortie
-    from mortie.toc import TOC_MAX_NS
+    from mortie import TOC_MAX_NS
 
     from zagg.windows import UNIT_SECONDS, parse_utc
 

--- a/tests/test_time_axis.py
+++ b/tests/test_time_axis.py
@@ -9,7 +9,7 @@ pre-§8 store still reads through.
 
 import numpy as np
 import pytest
-from mortie.toc import Q_END_NS, Q_START_NS
+from mortie import Q_END_NS, Q_START_NS
 
 from zagg.time_axis import (
     LEGACY_TIME_ATTRS,
@@ -340,7 +340,7 @@ class TestObservationWords:
         # mortie refuses at TOC_MAX_NS = 2^63 - 2^32 (its quantum-aligned span
         # ceiling), so a 2^63 - 1 bound here lets the last 4.29 s through and the
         # caller gets mortie's message instead of this one (issue #410 review).
-        from mortie.toc import TOC_MAX_NS
+        from mortie import TOC_MAX_NS
 
         from zagg.time_axis import _internal_ns
 


### PR DESCRIPTION
Closes #493.

mortie 0.9.10 retired the `mortie.toc` submodule (espg/mortie#199, following #197 for `mortie.moc`): the name is now the `Toc` constructor, and its migration shim covers **attribute access only** — a callable cannot also be a module, so statement-form `from mortie.toc import X` raises `ModuleNotFoundError`. mortie's CHANGELOG states this as a break rather than a deprecation.

zagg carried three such imports. One is runtime source, so this is not a test-only problem: `zagg.time_axis`'s toc encode path would raise on any environment with 0.9.10 installed.

| file:line | scope | effect under 0.9.10 |
|---|---|---|
| `src/zagg/time_axis.py:329` | runtime (function-local, toc encode path) | `ModuleNotFoundError` at encode |
| `tests/test_time_axis.py:12` | module level | **whole suite fails at collection** |
| `tests/test_time_axis.py:343` | function-local | test error |

## The change

All three move to the flat top-level spelling, which is the supported one:

```python
from mortie import TOC_MAX_NS            # was: from mortie.toc import TOC_MAX_NS
from mortie import Q_END_NS, Q_START_NS  # was: from mortie.toc import Q_END_NS, Q_START_NS
```

Plus one stale docstring in `src/zagg/time_axis.py` that pointed readers at `mortie.toc` as the module owning word semantics; it now names the flat kernels and notes what `mortie.toc` became.

## The floor bump — please confirm

`mortie>=0.9.9` → **`mortie>=0.9.10`**, and this is not optional cosmetics: **`Q_START_NS` / `Q_END_NS` / `TOC_MAX_NS` are not top-level names in 0.9.9.** Verified against both releases, so the import style and the floor are one change, not two — on 0.9.9 the new spelling would fail exactly as the old one fails on 0.9.10.

Verified against a clean `mortie==0.9.10` install in an isolated venv:

```
installed: 0.9.10
flat import OK: 2147483648 4294967296 9223372032559808512
OLD statement-form import correctly fails: ModuleNotFoundError
```

Flagging it explicitly under §4 since a dependency-floor change is the maintainer's call — but note the floor is already effectively forced: CI resolves mortie unpinned, so it installs 0.9.10 today regardless of what the manifest says. The manifest is currently the thing that is wrong, not the thing holding the line. zagg also wants 0.9.10 independently for the `Moc`/`Toc` objects the moczarr reader path now uses.

## How it was tested

- The break and the fix both reproduced against a clean `mortie==0.9.10` venv (output above).
- `ruff check` and `ruff format --check` clean on both touched files.
- Full-suite verification is deferred to CI: this checkout's venv still has mortie 0.9.9 installed, and upgrading it would disturb an environment in active use. CI installs unpinned mortie, so it exercises exactly the 0.9.10 path this fixes.

## Questions for review

1. **The floor bump** above — confirm `>=0.9.10`.
2. Discovered while verifying demo PR #492; **this currently breaks every open zagg PR whose CI runs after 0.9.10 published (14:31 UTC today)**. PR #491 shows green only because its last run predates the release. Recommend merging this ahead of the other open PRs so their CI reflects their own changes rather than this.
3. Left deliberately out of scope: a repo-wide audit for other mortie submodule imports found none beyond these three (`mortie.moc` has no statement-form importers; remaining `mortie.toc*` hits are flat kernel calls like `mortie.toc2time` / `mortie.toc_overlaps`, which are unaffected).
