### PR TITLE
small fixes 2026-08-21: sliderule-public-cors ListBucket grant; injected-credential contract docs

### DIFF
--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -243,6 +243,16 @@ Resources:
                   - s3:PutObject
                   - s3:DeleteObject
                 Resource: arn:aws:s3:::sliderule-public-cors/*
+              # Unconditional by intent -- do NOT add an s3:prefix condition,
+              # for the same reason as the source.coop grant below. Without
+              # bucket-level ListBucket, S3 answers a GET on a missing key with
+              # 403 AccessDenied rather than 404 NoSuchKey, and the sidecar read
+              # path catches only the 404 (obstore's NotFoundError subclasses
+              # FileNotFoundError) to select on_miss=fallback -- so an absent
+              # sidecar hard-errors instead of falling back (issue #502).
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: arn:aws:s3:::sliderule-public-cors
               # Published destination (issue #495): the same policy shape as
               # the staging grant above, pointed at Source Cooperative. This
               # retires the data.source.coop proxy hop and the egress it paid

--- a/deployment/aws/template.yaml
+++ b/deployment/aws/template.yaml
@@ -244,12 +244,11 @@ Resources:
                   - s3:DeleteObject
                 Resource: arn:aws:s3:::sliderule-public-cors/*
               # Unconditional by intent -- do NOT add an s3:prefix condition,
-              # for the same reason as the source.coop grant below. Without
-              # bucket-level ListBucket, S3 answers a GET on a missing key with
-              # 403 AccessDenied rather than 404 NoSuchKey, and the sidecar read
-              # path catches only the 404 (obstore's NotFoundError subclasses
-              # FileNotFoundError) to select on_miss=fallback -- so an absent
-              # sidecar hard-errors instead of falling back (issue #502).
+              # same reasoning as the source.coop grant below. Without
+              # bucket-level ListBucket an absent key answers 403 AccessDenied
+              # rather than 404 NoSuchKey, and the sidecar read path catches the
+              # 404 only, so a missing sidecar hard-errors instead of taking
+              # on_miss=fallback (issue #502).
               - Effect: Allow
                 Action: s3:ListBucket
                 Resource: arn:aws:s3:::sliderule-public-cors

--- a/src/zagg/store.py
+++ b/src/zagg/store.py
@@ -265,12 +265,12 @@ def open_object_store(
     suppresses it.
 
     The rest of the injected-credential contract is shared with
-    :func:`open_store` and documented there (issue #500): the canned ACL is a
-    ``setdefault`` default, so a caller-supplied ``client_options={
-    "default_headers": {"x-amz-acl": ...}}`` wins (``None`` strips the header);
-    any ACL-carrying PUT needs ``s3:PutObjectAcl`` on the target; and injected
-    ``credentials`` are resolved once at dispatch and never refreshed, so a long
-    run fails at write time in the tail rather than up front.
+    :func:`open_store` and documented there (issue #500): an ``x-amz-acl`` the
+    caller sets in ``client_options["default_headers"]`` wins over the canned
+    default, and ``None`` strips the header outright; any ACL-carrying PUT needs
+    ``s3:PutObjectAcl`` on the target; and injected ``credentials`` are resolved
+    once at dispatch and never refreshed, so a long run fails at write time in
+    the tail rather than up front.
     """
     if path.startswith("s3://"):
         if credentials is None and endpoint_url is None and not kwargs:

--- a/src/zagg/store.py
+++ b/src/zagg/store.py
@@ -179,9 +179,13 @@ def open_store(
 
     The permission requirement rides along: any ACL-carrying PUT needs
     ``s3:PutObjectAcl`` on the target, so overriding to a different canned value
-    carries the same requirement rather than a lesser one. Passing ``None`` as
-    the value strips the header instead of setting one -- the only way through
-    this path to send no ACL at all.
+    carries the same requirement rather than a lesser one. On those external
+    targets -- and only there, since the gate in :func:`_s3_object_store` is the
+    one thing that routes ``client_options`` through
+    :func:`_with_bucket_owner_acl` -- passing ``None`` as the value strips the
+    header instead of setting one. Anywhere else (our own buckets,
+    ``read_only=True``, ``skip_signature=True``, any ``endpoint_url``) no ACL is
+    sent to begin with, and a ``None`` reaches obstore raw, which rejects it.
 
     Injected ``credentials`` are never REFRESHED (issue #500, folded from #498).
     ``output_credentials`` are resolved once at dispatch and embedded in every

--- a/src/zagg/store.py
+++ b/src/zagg/store.py
@@ -168,6 +168,34 @@ def open_store(
     consumer-INPUT channel (somebody else's input bucket, as
     ``temporal.open_dataset`` opens it), not a write target of ours.
 
+    That header is a DEFAULT, not a fixture (issue #500). It is merged with
+    ``setdefault``, so a caller-supplied value WINS -- honoured as passed,
+    neither merged with ours nor overwritten (key case is irrelevant; see
+    :func:`_with_bucket_owner_acl`)::
+
+        open_store(path, credentials=creds,
+                   client_options={"default_headers": {"x-amz-acl": "private"}})
+
+    The permission requirement rides along: any ACL-carrying PUT needs
+    ``s3:PutObjectAcl`` on the target, so overriding to a different canned value
+    carries the same requirement rather than a lesser one. Passing ``None`` as
+    the value strips the header instead of setting one -- the only way through
+    this path to send no ACL at all.
+
+    Injected ``credentials`` are never REFRESHED (issue #500, folded from #498).
+    ``output_credentials`` are resolved once at dispatch and embedded in every
+    worker's invoke payload, so a worker inherits the dispatcher's clock rather
+    than starting its own: a run that outlasts its credential lifetime fails in
+    the tail, at write time, after the compute is already paid for, and
+    concentrated on the slowest shards. The ceiling depends on how the
+    credentials were obtained -- ``sts:AssumeRole`` from an already-assumed role
+    (SSO included) is role chaining, which AWS hard-caps at one hour and which
+    ``MaxSessionDuration`` cannot raise, while ``AssumeRoleWithWebIdentity`` is
+    not chaining and honours ``MaxSessionDuration`` up to 12 hours. This does
+    NOT affect the fleet's published writes, which go out under the ambient
+    execution role that Lambda rotates transparently; the limitation is specific
+    to the injected-credential escape hatch (issue #26).
+
     Returns
     -------
     Store
@@ -234,6 +262,14 @@ def open_object_store(
     bucket (issue #223). It is inert there (S3 interprets ``x-amz-acl`` only on
     object-creating requests); ``open_store(read_only=True)``, which can tell,
     suppresses it.
+
+    The rest of the injected-credential contract is shared with
+    :func:`open_store` and documented there (issue #500): the canned ACL is a
+    ``setdefault`` default, so a caller-supplied ``client_options={
+    "default_headers": {"x-amz-acl": ...}}`` wins (``None`` strips the header);
+    any ACL-carrying PUT needs ``s3:PutObjectAcl`` on the target; and injected
+    ``credentials`` are resolved once at dispatch and never refreshed, so a long
+    run fails at write time in the tail rather than up front.
     """
     if path.startswith("s3://"):
         if credentials is None and endpoint_url is None and not kwargs:

--- a/src/zagg/store.py
+++ b/src/zagg/store.py
@@ -154,7 +154,8 @@ def open_store(
         paced :data:`_S3_RETRY_CONFIG` policy (issue #186), or the shorter
         :data:`_S3_READONLY_RETRY_CONFIG` when ``read_only=True``; and
         ``skip_signature=True`` for anonymous reads of public buckets (no
-        AWS credentials needed, e.g. binder).
+        AWS credentials needed, e.g. binder); and ``client_options``, whose
+        ``default_headers`` is where the canned-ACL override lives (see Notes).
 
     Notes
     -----

--- a/src/zagg/store.py
+++ b/src/zagg/store.py
@@ -271,10 +271,13 @@ def open_object_store(
     The rest of the injected-credential contract is shared with
     :func:`open_store` and documented there (issue #500): an ``x-amz-acl`` the
     caller sets in ``client_options["default_headers"]`` wins over the canned
-    default, and ``None`` strips the header outright; any ACL-carrying PUT needs
-    ``s3:PutObjectAcl`` on the target; and injected ``credentials`` are resolved
-    once at dispatch and never refreshed, so a long run fails at write time in
-    the tail rather than up front.
+    default, and on an external target ``None`` strips the header; any
+    ACL-carrying PUT needs ``s3:PutObjectAcl`` on the target; and injected
+    ``credentials`` are resolved once at dispatch and never refreshed, so a long
+    run fails at write time in the tail rather than up front. The sentinel is
+    scoped, and the dominant call here is on the other side of that scope: an
+    ambient write to our own output store is not an external target, so no ACL
+    is sent to begin with and a ``None`` value would be rejected by obstore.
     """
     if path.startswith("s3://"):
         if credentials is None and endpoint_url is None and not kwargs:

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -269,6 +269,29 @@ class TestTemplateEnvironment:
         assert len(matches) == 1
         assert sorted(matches[0]["Action"]) == ["s3:DeleteObject", "s3:GetObject", "s3:PutObject"]
 
+    def test_execution_role_lists_the_public_cors_bucket(self):
+        # Bucket-level ListBucket is what makes S3 answer 404 NoSuchKey rather
+        # than 403 AccessDenied on an absent key. The sidecar read path catches
+        # the 404 ONLY -- obstore's NotFoundError subclasses FileNotFoundError,
+        # and that ``return None`` is what selects on_miss=fallback -- so
+        # without this grant a missing sidecar hard-errors where it should have
+        # quietly taken the slow route (issue #502).
+        role = self._load_template()["Resources"]["ExecutionRole"]["Properties"]
+        stmts = role["Policies"][0]["PolicyDocument"]["Statement"]
+        bucket = [s for s in stmts if s.get("Resource") == "arn:aws:s3:::sliderule-public-cors"]
+        assert len(bucket) == 1, "the execution role must list sliderule-public-cors"
+        # Normalized through the helper: the grant is IAM-identical whether it
+        # is written as a scalar or a one-element list, so neither shape should
+        # fail this spuriously.
+        assert _statement_actions(bucket[0]) == ["s3:ListBucket"]
+        # Unconditional on purpose, same reasoning as the source.coop grant: a
+        # GetObject evaluation carries no s3:prefix context key, so a condition
+        # on it never matches during a GET and every absent object 403s anyway.
+        assert "Condition" not in bucket[0], (
+            "an s3:prefix condition on ListBucket makes absent objects 403 "
+            "instead of 404, which defeats on_miss=fallback on the sidecar path"
+        )
+
     def test_execution_role_is_the_published_identity(self):
         # Issue #495 (revised): the fleet publishes to Source Cooperative as
         # ITSELF -- no assumable role, no injected credentials, no one-hour

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -261,7 +261,9 @@ class TestTemplateEnvironment:
         # virtual-index write-back + sidecar reads (zagg-index/*, issue #160)
         # AND worker-written output zarr stores (e.g. zagg-examples/*). This is
         # the STAGING half of the identity model in issue #495; the published
-        # half is asserted in the next test.
+        # half is asserted in test_execution_role_is_the_published_identity
+        # (named, not "the next test" -- issue #502 slotted a bucket-level
+        # ListBucket pin between them).
         arn = "arn:aws:s3:::sliderule-public-cors/*"
         role = self._load_template()["Resources"]["ExecutionRole"]["Properties"]
         stmts = role["Policies"][0]["PolicyDocument"]["Statement"]

--- a/tests/test_lambda_build.py
+++ b/tests/test_lambda_build.py
@@ -280,12 +280,20 @@ class TestTemplateEnvironment:
         # quietly taken the slow route (issue #502).
         role = self._load_template()["Resources"]["ExecutionRole"]["Properties"]
         stmts = role["Policies"][0]["PolicyDocument"]["Statement"]
-        bucket = [s for s in stmts if s.get("Resource") == "arn:aws:s3:::sliderule-public-cors"]
+        # Resource and Action both go through the normalizing helpers: the
+        # grant is IAM-identical whether either is written as a scalar or a
+        # one-element list, so neither shape should fail this spuriously --
+        # matching on the raw Resource would report the grant MISSING when it
+        # is present and correct. The list-of-one also keeps the bare-bucket
+        # ARN pinned (not .../*, and not a superset).
+        bucket = [
+            s for s in stmts if _statement_resources(s) == ["arn:aws:s3:::sliderule-public-cors"]
+        ]
         assert len(bucket) == 1, "the execution role must list sliderule-public-cors"
-        # Normalized through the helper: the grant is IAM-identical whether it
-        # is written as a scalar or a one-element list, so neither shape should
-        # fail this spuriously.
         assert _statement_actions(bucket[0]) == ["s3:ListBucket"]
+        # An explicit Deny here would pass every other assertion in this test
+        # while overriding the bucket policy's public ListBucket grant.
+        assert bucket[0]["Effect"] == "Allow"
         # Unconditional on purpose, same reasoning as the source.coop grant: a
         # GetObject evaluation carries no s3:prefix context key, so a condition
         # on it never matches during a GET and every absent object 403s anyway.


### PR DESCRIPTION
Closes #502
Closes #500

Two independent `small-fix` issues bundled per CLAUDE.md §5.

## What / approach

**Issue #502 — bucket-level `s3:ListBucket` on `sliderule-public-cors`.** The execution role in `deployment/aws/template.yaml` held `s3:GetObject`/`s3:PutObject`/`s3:DeleteObject` on `arn:aws:s3:::sliderule-public-cors/*` but nothing at the bucket level. Without `s3:ListBucket` on the bucket, S3 answers a GET on a missing key with **403 AccessDenied** rather than **404 NoSuchKey**. That distinction is load-bearing on the sidecar read path, which catches the 404 only:

```python
except FileNotFoundError:
    # obstore's NotFoundError subclasses FileNotFoundError (local + s3).
    return None
```

That `return None` is what selects `on_miss=fallback`; a 403 raises obstore's permission error, which does not subclass `FileNotFoundError`, so it propagates and the read hard-errors where it should have quietly taken the slow route. The fix is one unconditioned statement, mirroring the Source Cooperative `ListBucket` grant added under #495 for exactly the same 403-vs-404 reason — a GetObject evaluation carries no `s3:prefix` context key, so a condition on it never matches during a GET and every absent object comes back 403 anyway:

```yaml
- Effect: Allow
  Action: s3:ListBucket
  Resource: arn:aws:s3:::sliderule-public-cors
```

Issue #502 explicitly authorizes editing `deployment/aws/template.yaml`, which satisfies CLAUDE.md §1. Nothing was deployed.

Pinned by a new test in `tests/test_lambda_build.py` alongside the existing `ExecutionRole` policy assertions: the grant exists exactly once, its Resource normalizes to the bare bucket ARN, its Effect is `Allow`, its actions normalize to exactly `["s3:ListBucket"]`, and it carries no `Condition`.

**Issue #500 — docstrings on `open_store` / `open_object_store`.** Documentation only, no behavioural change. Three things a caller using injected credentials needs and cannot see from the signature:

1. **The `x-amz-acl` override.** External/published writes (`_PUBLISHED_BUCKETS` and injected-credential external targets) attach `x-amz-acl: bucket-owner-full-control` via `setdefault`, so a caller-supplied value wins — honoured as passed, neither merged nor overwritten.
2. **Its permission constraint.** Any ACL-carrying PUT needs `s3:PutObjectAcl` on the target, so overriding to a different canned value carries the same requirement rather than a lesser one.
3. **Injected credentials are never refreshed** (folded in from #498). `output_credentials` are resolved once at dispatch and embedded in every worker's invoke payload, so a worker inherits the dispatcher's clock: a long run fails in the tail, at write time, after the compute is paid for, concentrated on the slowest shards. The ceiling depends on how the credentials were obtained — `sts:AssumeRole` from an already-assumed role (SSO included) is role chaining, hard-capped at one hour and not raisable via `MaxSessionDuration`, while `AssumeRoleWithWebIdentity` is not chaining and honours `MaxSessionDuration` up to 12 hours. This does **not** affect the fleet's published writes, which go out under the ambient execution role that Lambda rotates transparently; the limitation is specific to the injected-credential escape hatch (#26).

`client_options` was also added to `open_store`'s `**kwargs` Parameters entry — it had never been named there, so the knob was undiscoverable from where callers actually look.

**One deliberate divergence from issue #500's text.** The issue states that suppressing the ACL header entirely "is not possible through this path (there is no 'send no ACL' value)". That has not been true since c60701d ("fold review: let a caller strip the ACL header and widen the endpoint exclusion", #495), which gave `_with_bucket_owner_acl` a `None` sentinel:

```python
headers.setdefault("x-amz-acl", _BUCKET_OWNER_ACL)
if headers["x-amz-acl"] is None:
    del headers["x-amz-acl"]
```

The docstrings document the code as it is — passing `None` strips the header — rather than repeating the issue's premise. Documenting a working suppression path as impossible would recreate the exact "only discoverable by reading `store.py`" failure #500 was filed to end. Called out here because it is a knowing departure from the issue text, not an oversight.

The sentinel is documented **scoped**, which is the shape the code actually has: it is interpreted only inside `_with_bucket_owner_acl`, and `_s3_object_store` routes `client_options` through that helper only behind

```python
if (
    _external_target(credentials, endpoint_url, bucket)
    and not read_only
    and not kwargs.get("skip_signature")
):
```

so on our own buckets, `read_only=True`, `skip_signature=True`, or any `endpoint_url`, no ACL is sent to begin with and a `None` value reaches obstore raw, which rejects it.

## Phases

- [x] Phase 1 — issue #502: add the unconditioned `s3:ListBucket` grant on `arn:aws:s3:::sliderule-public-cors` in `deployment/aws/template.yaml`, plus the pinning test in `tests/test_lambda_build.py`.
- [x] Phase 2 — issue #500: document the `x-amz-acl` override, its `s3:PutObjectAcl` constraint, and the never-refreshed injected-credential lifetime in the `open_store` / `open_object_store` docstrings.

Both phases went through the fresh-context adversarial review loop (CLAUDE.md §2). Round one: four findings, all folded, one commit each, with a reply and a resolve on every thread. Round two: four findings — three folded and resolved (`d78b5e1`, `71b5be7`, `3e94206`), and one left standing and unresolved because settling it needs a live-AWS call this run may not make; it is the first item under "Questions for review" below.

## Caveat carried over from issue #502

Whether this fires today is **unverified**: it needs both the sidecar backend reading from `sliderule-public-cors` *and* an absent sidecar, and production may default to inline+compiled, making it a benchmark-only arm. The mechanism is confirmed; the blast radius is not. The bucket is also slated for retirement under #499, so this may be fixed and then deleted. It is still a live one-line hazard fix, which is the reasoning the issue itself gives for doing it now rather than waiting on a post-MVP teardown.

## How it was tested

- Full suite: `uv run pytest -q` — **4605 passed, 38 skipped** in 408 s.
- `uv run pytest -v tests/test_lambda_build.py tests/test_deploy_lambda.py` — 60 passed, covering the new grant assertions.
- `uv run pytest -q tests/test_lambda_build.py tests/test_store.py` — 89 passed after the round-two folds.
- `uv run ruff check src tests` and `uv run ruff format --check src tests` — clean on every file this PR touches.

**Two pre-existing failures on `main`, untouched here (CLAUDE.md §4 — flag, don't fix). Both reproduce on a clean `origin/main` checkout with this branch stashed:**
- `ruff check`: `N818 Exception name 'UnknownCapability' should be named with an Error suffix` at `src/zagg/registry.py:64`. The PR lint bot runs `--select=E,F,W,I --ignore=E501`, which excludes `N`, so CI does not see it.
- `ruff format --check`: `tests/data/benchmark/README.md` would be reformatted (a fenced Python block inside the markdown).

## Questions for review

- **Is the issue #502 premise still true, or is the grant already covered by the bucket policy?** `sliderule-public-cors` is in-account (`deployment/aws/lambda_handler.py:21`), and same-account authorization is the **union** of identity and resource policy. `docs/deployment/benchmark-cicd.md` section 10 documents a `PublicReadList` statement granting `s3:GetObject` + `s3:ListBucket` to `Principal: "*"` on both the bare bucket ARN and `/*`. If that statement is live on the bucket today, the execution role already passes the `s3:ListBucket` test S3 uses to answer 404 rather than 403, and the hazard described in #502 has never fired. Deciding needs `aws s3api get-bucket-policy --bucket sliderule-public-cors`, which is a live-AWS call this run is forbidden to make (CLAUDE.md §1). Landing (a) below is the status quo of this PR minus a comment reword; (b) is a scope ruling and not the routine's to take (§6). Full reasoning is in the standing review thread on `deployment/aws/template.yaml`. Two options:
  - **(a) Keep the grant as defence-in-depth** and reword the `template.yaml` comment to claim only what it buys — the role becomes self-sufficient if the public policy is ever tightened or the bucket is recreated without it. In favour of (a): the grant is harmless and correct regardless of the bucket policy's current state, an identity-policy grant survives a change to that policy, and the bucket policy is not ours to rely on.
  - **(b) Verify the live policy and close #502 as already-mitigated**, dropping the statement and its test.
- Phase 2 documents the `None`-strips-the-header hatch that #495 added, rather than the "not possible through this path" framing in #500's text (see the divergence note above). Confirming that documenting the code over the issue is the wanted call — the alternative is to leave the suppression path undocumented, which seems strictly worse.
- Two smaller items were left standing rather than folded, because both widen scope beyond the finding that raised them: (1) documenting that passing `client_options` at all takes an ambient `s3://` call off the `_OBJECT_STORE_CACHE` fast path (the cache is gated on `not kwargs` — issue #287), and (2) applying the same `_statement_resources` normalization to the source.coop sibling test, which this PR does not otherwise touch. Say the word if either should land here rather than as a follow-up.
- The two pre-existing lint failures above are left alone per §4. Say the word if a follow-up `small-fix` issue for them would be useful; opening one is a side-effecting action and is not mine to take (§6).