### PR TITLE
Publish Lambda zips to Source Cooperative (issue #497 phases 1-2)

### DIFF
--- a/.github/scripts/distribute_zips.sh
+++ b/.github/scripts/distribute_zips.sh
@@ -53,6 +53,17 @@ case " $PUBLISHED_BUCKETS " in
   *" $BUCKET "*) ACL="--acl bucket-owner-full-control" ;;
 esac
 
+# A published bucket's root is another organization's namespace, and it is
+# outside the release role's grant, so writing there 403s mid-release with no
+# explanation. The workflow gates on the prefix too, but that gate is one
+# `gh variable set` away from being the only thing standing between a release
+# and the bucket root -- hold the invariant here as well, where the keys are
+# actually built.
+if [ -n "$ACL" ] && [ -z "$PREFIX" ]; then
+  echo "refusing to publish to $BUCKET root: --prefix is required for a published bucket" >&2
+  exit 2
+fi
+
 shopt -s nullglob
 # All four are globs (note the trailing * on the layer names) so nullglob drops
 # any that's missing -- the count check then catches it here, not at `aws s3 cp`.

--- a/.github/scripts/distribute_zips.sh
+++ b/.github/scripts/distribute_zips.sh
@@ -6,13 +6,21 @@
 # current at pip-install time. Idempotent: re-running a release overwrites that
 # minor's objects.
 #
-# Since issue #497 the destination is Source Cooperative, not the in-account
-# `sliderule-public-cors` bucket: that bucket cannot host public data under
-# NASA's clearance posture and is being retired (issue #499). --prefix produces
-# publish_mirror.sh's layout (<prefix>/<minor>/<zip>), and stand_up.sh already
-# reads it via DIST_PREFIX, so the write side and the read side match.
+# The destination is whatever --bucket says. publish.yml passes the in-account
+# `sliderule-public-cors` bucket with no prefix, which is what runs today.
+#
+# Since issue #497 this also SUPPORTS Source Cooperative: --prefix produces
+# publish_mirror.sh's layout (<prefix>/<minor>/<zip>), which stand_up.sh already
+# reads via DIST_PREFIX, and a published destination gets the owner ACL below.
+# publish.yml is not pointed at it yet -- that half of issue #497 phase 2 is
+# still to land, and the move matters because the dist bucket cannot host public
+# data under NASA's clearance posture and is being retired (issue #499).
 #
 # Usage:
+#   # today's release path
+#   distribute_zips.sh --minor 0.2 --tag 0.2.3 --bucket sliderule-public-cors \
+#       --dir ./zips [--region us-west-2]
+#   # the Source Cooperative destination (issue #497)
 #   distribute_zips.sh --minor 0.2 --tag 0.2.3 \
 #       --bucket us-west-2.opendata.source.coop --prefix englacial/zagg/lambda \
 #       --dir ./zips [--region us-west-2]

--- a/.github/scripts/distribute_zips.sh
+++ b/.github/scripts/distribute_zips.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 # Publish the release Lambda zips to the public distribution bucket (issue #25),
 # keyed by zagg MINOR version (0.N.x -> 0.N), with a per-minor SHA256SUMS and a
-# top-level versions.json index. stand_up.sh lists/reads versions.json to resolve
-# "latest" instead of being hard-pinned to whatever was current at pip-install
-# time. Idempotent: re-running a release overwrites that minor's objects.
+# versions.json index at the destination root. stand_up.sh lists/reads
+# versions.json to resolve "latest" instead of being hard-pinned to whatever was
+# current at pip-install time. Idempotent: re-running a release overwrites that
+# minor's objects.
+#
+# Since issue #497 the destination is Source Cooperative, not the in-account
+# `sliderule-public-cors` bucket: that bucket cannot host public data under
+# NASA's clearance posture and is being retired (issue #499). --prefix produces
+# publish_mirror.sh's layout (<prefix>/<minor>/<zip>), and stand_up.sh already
+# reads it via DIST_PREFIX, so the write side and the read side match.
 #
 # Usage:
-#   distribute_zips.sh --minor 0.2 --tag 0.2.3 --bucket sliderule-public-cors \
+#   distribute_zips.sh --minor 0.2 --tag 0.2.3 \
+#       --bucket us-west-2.opendata.source.coop --prefix englacial/zagg/lambda \
 #       --dir ./zips [--region us-west-2]
 #
 # --dir holds the four release zips (lambda_layer_{arm64,x86_64}.zip,
@@ -14,18 +22,35 @@
 # python3, sha256sum.
 set -euo pipefail
 
-MINOR="" TAG="" BUCKET="" DIR="" REGION="us-west-2"
+MINOR="" TAG="" BUCKET="" PREFIX="" DIR="" REGION="us-west-2"
 while [ $# -gt 0 ]; do
   case "$1" in
     --minor) MINOR="$2"; shift 2 ;;
     --tag) TAG="$2"; shift 2 ;;
     --bucket) BUCKET="$2"; shift 2 ;;
+    --prefix) PREFIX="${2%/}"; shift 2 ;;
     --dir) DIR="$2"; shift 2 ;;
     --region) REGION="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 : "${MINOR:?--minor required}" "${BUCKET:?--bucket required}" "${DIR:?--dir required}"
+
+BASE="s3://$BUCKET${PREFIX:+/$PREFIX}"
+
+# Source Cooperative requires every object be handed to the bucket owner (issue
+# #495 phase 1): without x-amz-acl: bucket-owner-full-control the first PUT is
+# AccessDenied. Keyed on the DESTINATION bucket, mirroring
+# zagg.store._PUBLISHED_BUCKETS on the fleet's side -- the header is not sent to
+# buckets we own, and the release role holds s3:PutObjectAcl on the published
+# destination only (benchmark_cicd.yaml, issue #497), so sending it
+# unconditionally would 403 against the in-account dist bucket. Expanded
+# unquoted (fixed flags, no spaces) so the empty default vanishes -- same idiom
+# as stand_up.sh's DIST_SIGN, since `set -u` + bash 3.2 rejects empty arrays.
+ACL=""
+case " us-west-2.opendata.source.coop " in
+  *" $BUCKET "*) ACL="--acl bucket-owner-full-control" ;;
+esac
 
 shopt -s nullglob
 # All four are globs (note the trailing * on the layer names) so nullglob drops
@@ -38,14 +63,18 @@ if [ "${#zips[@]}" -ne 4 ]; then
 fi
 
 for z in "${zips[@]}"; do
-  aws s3 cp "$z" "s3://$BUCKET/$MINOR/$(basename "$z")" --region "$REGION"
+  aws s3 cp "$z" "$BASE/$MINOR/$(basename "$z")" --region "$REGION" $ACL
 done
 
 ( cd "$DIR" && sha256sum lambda_layer_*.zip lambda_function_*.zip > SHA256SUMS )
-aws s3 cp "$DIR/SHA256SUMS" "s3://$BUCKET/$MINOR/SHA256SUMS" --region "$REGION"
+aws s3 cp "$DIR/SHA256SUMS" "$BASE/$MINOR/SHA256SUMS" --region "$REGION" $ACL
 
-# Merge this minor into the top-level index (read-modify-write; absent => seed).
-aws s3 cp "s3://$BUCKET/versions.json" ./versions.json --region "$REGION" 2>/dev/null \
+# Merge this minor into the root index (read-modify-write; absent => seed). The
+# read must be able to tell "not published yet" from "denied": the release role
+# holds an UNCONDITIONED s3:ListBucket on the destination (issue #497) so an
+# absent key answers 404 rather than 403 -- otherwise a permissions fault would
+# reseed the index here and silently drop every published minor from it.
+aws s3 cp "$BASE/versions.json" ./versions.json --region "$REGION" 2>/dev/null \
   || echo '{"minors": []}' > versions.json
 python3 - "$MINOR" "$TAG" <<'PY'
 import json, sys
@@ -59,6 +88,6 @@ if tag:
     d["latest_tag"] = tag
 json.dump(d, open("versions.json", "w"), indent=2)
 PY
-aws s3 cp ./versions.json "s3://$BUCKET/versions.json" --region "$REGION"
+aws s3 cp ./versions.json "$BASE/versions.json" --region "$REGION" $ACL
 
-echo "distributed minor $MINOR (tag ${TAG:-n/a}) -> s3://$BUCKET/$MINOR/"
+echo "distributed minor $MINOR (tag ${TAG:-n/a}) -> $BASE/$MINOR/"

--- a/.github/scripts/distribute_zips.sh
+++ b/.github/scripts/distribute_zips.sh
@@ -81,13 +81,32 @@ done
 ( cd "$DIR" && sha256sum lambda_layer_*.zip lambda_function_*.zip > SHA256SUMS )
 aws s3 cp "$DIR/SHA256SUMS" "$BASE/$MINOR/SHA256SUMS" --region "$REGION" $ACL
 
-# Merge this minor into the root index (read-modify-write; absent => seed). The
-# read must be able to tell "not published yet" from "denied": the release role
-# holds an UNCONDITIONED s3:ListBucket on the destination (issue #497) so an
-# absent key answers 404 rather than 403 -- otherwise a permissions fault would
-# reseed the index here and silently drop every published minor from it.
-aws s3 cp "$BASE/versions.json" ./versions.json --region "$REGION" 2>/dev/null \
-  || echo '{"minors": []}' > versions.json
+# Merge this minor into the index (read-modify-write). ONLY a genuinely absent
+# index seeds: the next statement PUTs this file back over the good one, so
+# treating any failure as "absent" turns a throttle, a 5xx, an expired session or
+# a typo'd --prefix into a silent republish of an empty index -- destructive
+# without a DeleteObject in sight, and recoverable only from bucket versioning we
+# do not control. Anything that is not a miss is fatal, with the CLI's own
+# message kept (never 2>/dev/null) so the release log says why.
+#
+# The miss has to answer 404, not 403: S3 returns NoSuchKey only to a caller
+# holding s3:ListBucket on the bucket, which the release role holds unconditioned
+# (issue #497). Cross-account that is necessary, not sufficient -- Source
+# Cooperative's bucket policy has to permit the list for our principal too; issue
+# #497 records unsigned ListObjectsV2 against the bucket, so it does.
+#
+# Two legitimate seeds: the first release ever published to a destination, and
+# the first release after the destination moves -- today's index lives at
+# sliderule-public-cors/versions.json, not under the new prefix, so the first
+# mirrored release seeds rather than merges.
+if ERR="$(aws s3 cp "$BASE/versions.json" ./versions.json --region "$REGION" 2>&1)"; then
+  :
+elif printf '%s' "$ERR" | grep -qE '404|Not Found|NoSuchKey|does not exist'; then
+  echo '{"minors": []}' > versions.json
+else
+  echo "ERROR: could not read $BASE/versions.json: $ERR" >&2
+  exit 1
+fi
 python3 - "$MINOR" "$TAG" <<'PY'
 import json, sys
 minor, tag = sys.argv[1], sys.argv[2]

--- a/.github/scripts/distribute_zips.sh
+++ b/.github/scripts/distribute_zips.sh
@@ -47,8 +47,9 @@ BASE="s3://$BUCKET${PREFIX:+/$PREFIX}"
 # unconditionally would 403 against the in-account dist bucket. Expanded
 # unquoted (fixed flags, no spaces) so the empty default vanishes -- same idiom
 # as stand_up.sh's DIST_SIGN, since `set -u` + bash 3.2 rejects empty arrays.
+PUBLISHED_BUCKETS="us-west-2.opendata.source.coop"   # == zagg.store._PUBLISHED_BUCKETS
 ACL=""
-case " us-west-2.opendata.source.coop " in
+case " $PUBLISHED_BUCKETS " in
   *" $BUCKET "*) ACL="--acl bucket-owner-full-control" ;;
 esac
 

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -311,44 +311,28 @@ Resources:
                 Resource: !Sub "arn:aws:s3:::${DistBucketName}/*"
               # Published destination (issue #497): the release role's half of
               # the identity model template.yaml's ExecutionRole carries for the
-              # fleet (issue #495) -- same statement shape, different trust
-              # domain, which is why this stays a SEPARATE role rather than a
-              # widened zagg-lambda-execution. The role already exists with the
-              # right trust (GitHub Actions OIDC, above); it needed S3
-              # permissions, not an identity.
+              # fleet (issue #495). Roles stay separate because the trust domains
+              # differ, and this one already had the right trust (GitHub Actions
+              # OIDC, above) -- it needed S3 permissions, not an identity.
               #
-              # Scoped to englacial/zagg/lambda/* -- the per-minor zips,
-              # SHA256SUMS and the versions.json index that distribute_zips.sh /
-              # publish_mirror.sh write. NOT englacial/zagg/benchmarks/*:
-              # whether the measurement artifacts migrate is question (1) of
-              # issue #497 and is unresolved, so the grant does not pre-empt it.
-              # DeleteObject is deliberately absent -- a re-published minor
-              # overwrites via PutObject and the mirror never prunes.
+              # Why this ACTION SET: see template.yaml's ExecutionRole published
+              # grant. The PutObject/PutObjectAcl pairing (issue #496), the
+              # object-scoped multipart pair covering the abort path, and the
+              # omission of bucket-wide ListBucketMultipartUploads are argued
+              # there once; do not restate them here. What differs on this role:
               #
-              # PutObjectAcl pairs with PutObject here: Source Cooperative
-              # requires x-amz-acl: bucket-owner-full-control, which S3 evaluates
-              # against s3:PutObjectAcl on both PutObject and
-              # CreateMultipartUpload -- without it a published PUT is
-              # AccessDenied (issue #496; the two halves are only correct
-              # together). NOT every writer sends it today: distribute_zips.sh
-              # does, for a published destination only; publish_mirror.sh sends
-              # no ACL on any of its five PUTs and is the ONLY writer of the two
-              # repo-root keys below, so those two are granted but not reachable
-              # under this role until that changes. Left as it stands because
-              # issue #497 does not name publish_mirror.sh -- raised for review
-              # instead. Granted HERE ONLY: the header is never sent to
-              # DistBucketName, whose objects we already own.
-              #
-              # The multipart actions cover the FAILURE path PutObject does not:
-              # the layer zips are large enough that the aws CLI uploads them
-              # multipart, and without AbortMultipartUpload the CLI's own
-              # cleanup 403s, leaving parts invisible to ListObjects and billed
-              # to Source Cooperative. ListMultipartUploadParts is object-scoped
-              # and stays with it. ListBucketMultipartUploads is deliberately
-              # NOT granted: it is bucket-wide (s3:prefix cannot constrain it),
-              # so Source Cooperative's bucket policy does not grant it and
-              # holding it here would be denied cross-account anyway (espg,
-              # 2026-08-20). Leaked parts age out on their 7-day lifecycle rule.
+              # - Scope stops at lambda/* plus the two exact repo-root keys
+              #   below. benchmarks/* is question (1) of issue #497 and is
+              #   unresolved, so this grant does not pre-empt it.
+              # - No DeleteObject, unlike the fleet's grant: a re-published minor
+              #   overwrites via PutObject, and the mirror never prunes.
+              # - The owner ACL is not sent by every writer yet.
+              #   distribute_zips.sh sends it, for a published destination only;
+              #   publish_mirror.sh sends none on any of its five PUTs and is the
+              #   ONLY writer of the two repo-root keys, so those are granted but
+              #   unreachable under this role until that changes. Left as it
+              #   stands -- issue #497 does not name publish_mirror.sh -- and
+              #   raised for review instead.
               - Sid: PublishToSourceCoop
                 Effect: Allow
                 Action:
@@ -359,31 +343,26 @@ Resources:
                   - s3:ListMultipartUploadParts
                 Resource:
                   - arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/lambda/*
-                  # The repo-root metadata publish_mirror.sh also writes (its
-                  # MIRROR_REPO_PREFIX block): the version-independent index and
-                  # the code license. Enumerated as exact keys rather than an
-                  # englacial/zagg/* wildcard so the grant cannot reach demo/
+                  # The repo-root metadata publish_mirror.sh writes (its
+                  # MIRROR_REPO_PREFIX block). Exact keys, not an
+                  # englacial/zagg/* wildcard, so the grant cannot reach demo/
                   # (the fleet's) or benchmarks/ (undecided).
                   - arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/README.md
                   - arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/LICENSE
-              # Unconditional by intent -- do NOT add an s3:prefix condition.
-              # S3 answers a GET on a missing key with 404 NoSuchKey only when
-              # the caller holds s3:ListBucket on the bucket; otherwise it
-              # answers 403 AccessDenied. A GetObject request carries no
-              # s3:prefix context key, so a StringLike on it never matches
-              # during a GET evaluation and every absent object would come back
-              # 403. distribute_zips.sh must be able to tell "not published yet"
-              # from "denied": it seeds the index only on a miss and treats every
-              # other read failure as fatal, so a 403 here stops the release
-              # rather than republishing an empty index.
+              # Unconditional by intent -- do NOT add an s3:prefix condition
+              # (template.yaml's ListBucket grant carries the mechanism: a GET
+              # evaluation has no s3:prefix context key, so absent objects would
+              # answer 403 instead of 404). Here that decides what
+              # distribute_zips.sh sees on a missing versions.json: only a miss
+              # seeds the index, every other read failure is fatal, so a
+              # conditioned grant would fail each release rather than corrupt the
+              # index.
               #
-              # Cross-account this grant is necessary, not sufficient -- Source
-              # Cooperative's bucket policy has to permit the list for our
-              # principal too, and issue #497 records unsigned ListObjectsV2
-              # against the bucket, so it does. The ListBucketMultipartUploads
-              # note above is the same two-sided rule with the opposite answer:
-              # that action is bucket-wide, their policy does not grant it, so
-              # holding it here would be denied whatever we write.
+              # Cross-account BOTH sides must grant. Source Cooperative's bucket
+              # policy permits this list for our principal (issue #497 records
+              # unsigned ListObjectsV2 against the bucket); it does not grant the
+              # bucket-wide ListBucketMultipartUploads, which is why that action
+              # is omitted above rather than merely unused.
               - Sid: ListSourceCoopBucket
                 Effect: Allow
                 Action: s3:ListBucket

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -325,12 +325,18 @@ Resources:
               # DeleteObject is deliberately absent -- a re-published minor
               # overwrites via PutObject and the mirror never prunes.
               #
-              # PutObjectAcl is load-bearing, not incidental: every write here
-              # carries x-amz-acl: bucket-owner-full-control, which S3 evaluates
+              # PutObjectAcl pairs with PutObject here: Source Cooperative
+              # requires x-amz-acl: bucket-owner-full-control, which S3 evaluates
               # against s3:PutObjectAcl on both PutObject and
-              # CreateMultipartUpload -- without it the first published PUT is
+              # CreateMultipartUpload -- without it a published PUT is
               # AccessDenied (issue #496; the two halves are only correct
-              # together). Granted HERE ONLY: the header is not sent to
+              # together). NOT every writer sends it today: distribute_zips.sh
+              # does, for a published destination only; publish_mirror.sh sends
+              # no ACL on any of its five PUTs and is the ONLY writer of the two
+              # repo-root keys below, so those two are granted but not reachable
+              # under this role until that changes. Left as it stands because
+              # issue #497 does not name publish_mirror.sh -- raised for review
+              # instead. Granted HERE ONLY: the header is never sent to
               # DistBucketName, whose objects we already own.
               #
               # The multipart actions cover the FAILURE path PutObject does not:

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -76,6 +76,12 @@ Resources:
       # blocks stay on; only the policy/restrict blocks are relaxed. NOTE: this
       # can't override ACCOUNT-level Block Public Access -- relax that separately
       # (see benchmark-cicd.md §10) if enabled.
+      # HISTORICAL, read this before trusting the block below: the LIVE bucket
+      # has all four Block Public Access flags true and anonymous GET 403s. That
+      # is not drift -- espg closed it deliberately, because NASA buckets have
+      # no clearance to host public data (issue #497). The bucket is being
+      # retired under issue #499; published artifacts go to Source Cooperative
+      # (the PublishToSourceCoop grant below).
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         IgnorePublicAcls: true
@@ -303,6 +309,71 @@ Resources:
                 Effect: Allow
                 Action: [s3:PutObject, s3:GetObject]
                 Resource: !Sub "arn:aws:s3:::${DistBucketName}/*"
+              # Published destination (issue #497): the release role's half of
+              # the identity model template.yaml's ExecutionRole carries for the
+              # fleet (issue #495) -- same statement shape, different trust
+              # domain, which is why this stays a SEPARATE role rather than a
+              # widened zagg-lambda-execution. The role already exists with the
+              # right trust (GitHub Actions OIDC, above); it needed S3
+              # permissions, not an identity.
+              #
+              # Scoped to englacial/zagg/lambda/* -- the per-minor zips,
+              # SHA256SUMS and the versions.json index that distribute_zips.sh /
+              # publish_mirror.sh write. NOT englacial/zagg/benchmarks/*:
+              # whether the measurement artifacts migrate is question (1) of
+              # issue #497 and is unresolved, so the grant does not pre-empt it.
+              # DeleteObject is deliberately absent -- a re-published minor
+              # overwrites via PutObject and the mirror never prunes.
+              #
+              # PutObjectAcl is load-bearing, not incidental: every write here
+              # carries x-amz-acl: bucket-owner-full-control, which S3 evaluates
+              # against s3:PutObjectAcl on both PutObject and
+              # CreateMultipartUpload -- without it the first published PUT is
+              # AccessDenied (issue #496; the two halves are only correct
+              # together). Granted HERE ONLY: the header is not sent to
+              # DistBucketName, whose objects we already own.
+              #
+              # The multipart actions cover the FAILURE path PutObject does not:
+              # the layer zips are large enough that the aws CLI uploads them
+              # multipart, and without AbortMultipartUpload the CLI's own
+              # cleanup 403s, leaving parts invisible to ListObjects and billed
+              # to Source Cooperative. ListMultipartUploadParts is object-scoped
+              # and stays with it. ListBucketMultipartUploads is deliberately
+              # NOT granted: it is bucket-wide (s3:prefix cannot constrain it),
+              # so Source Cooperative's bucket policy does not grant it and
+              # holding it here would be denied cross-account anyway (espg,
+              # 2026-08-20). Leaked parts age out on their 7-day lifecycle rule.
+              - Sid: PublishToSourceCoop
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:PutObjectAcl
+                  - s3:AbortMultipartUpload
+                  - s3:ListMultipartUploadParts
+                Resource:
+                  - arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/lambda/*
+                  # The repo-root metadata publish_mirror.sh also writes (its
+                  # MIRROR_REPO_PREFIX block): the version-independent index and
+                  # the code license. Enumerated as exact keys rather than an
+                  # englacial/zagg/* wildcard so the grant cannot reach demo/
+                  # (the fleet's) or benchmarks/ (undecided).
+                  - arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/README.md
+                  - arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/LICENSE
+              # Unconditional by intent -- do NOT add an s3:prefix condition.
+              # S3 answers a GET on a missing key with 404 NoSuchKey only when
+              # the caller holds s3:ListBucket on the bucket; otherwise it
+              # answers 403 AccessDenied. A GetObject request carries no
+              # s3:prefix context key, so a StringLike on it never matches
+              # during a GET evaluation and every absent object would come back
+              # 403. distribute_zips.sh reads versions.json with
+              # `aws s3 cp ... || echo '{"minors": []}'`, which cannot tell 403
+              # from 404 -- a 403 there would silently reseed the index and drop
+              # every previously published minor from it.
+              - Sid: ListSourceCoopBucket
+                Effect: Allow
+                Action: s3:ListBucket
+                Resource: arn:aws:s3:::us-west-2.opendata.source.coop
 
 Outputs:
   BenchmarkInvokeRoleArn:

--- a/deployment/aws/benchmark_cicd.yaml
+++ b/deployment/aws/benchmark_cicd.yaml
@@ -366,10 +366,18 @@ Resources:
               # answers 403 AccessDenied. A GetObject request carries no
               # s3:prefix context key, so a StringLike on it never matches
               # during a GET evaluation and every absent object would come back
-              # 403. distribute_zips.sh reads versions.json with
-              # `aws s3 cp ... || echo '{"minors": []}'`, which cannot tell 403
-              # from 404 -- a 403 there would silently reseed the index and drop
-              # every previously published minor from it.
+              # 403. distribute_zips.sh must be able to tell "not published yet"
+              # from "denied": it seeds the index only on a miss and treats every
+              # other read failure as fatal, so a 403 here stops the release
+              # rather than republishing an empty index.
+              #
+              # Cross-account this grant is necessary, not sufficient -- Source
+              # Cooperative's bucket policy has to permit the list for our
+              # principal too, and issue #497 records unsigned ListObjectsV2
+              # against the bucket, so it does. The ListBucketMultipartUploads
+              # note above is the same two-sided rule with the opposite answer:
+              # that action is bucket-wide, their policy does not grant it, so
+              # holding it here would be denied whatever we write.
               - Sid: ListSourceCoopBucket
                 Effect: Allow
                 Action: s3:ListBucket

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -426,6 +426,18 @@ the section-2 stack (`benchmark_cicd.yaml`). Their grants, for reference:
   - the same six `lambda:*` actions (incl. `lambda:GetLayerVersion`)
     on `process-shard` (+ `process-shard-deps`).
   - `s3:PutObject`/`s3:GetObject` on `s3://sliderule-public-cors/*` (distribute).
+  - `s3:GetObject`/`s3:PutObject`/`s3:PutObjectAcl` +
+    `s3:AbortMultipartUpload`/`s3:ListMultipartUploadParts` on
+    `s3://us-west-2.opendata.source.coop/englacial/zagg/lambda/*` (plus the
+    repo-root `README.md`/`LICENSE` keys), and an **unconditioned**
+    `s3:ListBucket` on that bucket — the Source Cooperative mirror (issue #497).
+    `PutObjectAcl` travels with `PutObject`: every write carries
+    `x-amz-acl: bucket-owner-full-control` and the two halves are only correct
+    together (issue #496). The `ListBucket` grant carries no `s3:prefix`
+    condition on purpose — with one, an absent key answers 403 instead of 404
+    and `distribute_zips.sh` would reseed `versions.json` instead of merging
+    into it. `englacial/zagg/benchmarks/*` is deliberately **not** granted
+    (issue #497 question (1) is open).
 
 **Verify:** `aws iam get-role --role-name zagg-benchmark-deploy` /
 `zagg-lambda-release`.
@@ -501,9 +513,17 @@ gh variable set BENCHMARK_TEST_STAGE_BUCKET  --body "sliderule-public"
 # Release (tier 3)
 gh variable set LAMBDA_RELEASE_ROLE_ARN   --body "arn:aws:iam::ACCOUNT_ID:role/zagg-lambda-release"
 gh variable set LAMBDA_PROD_FUNCTION_NAME --body "process-shard"
-gh variable set LAMBDA_DIST_BUCKET        --body "sliderule-public-cors"
+gh variable set LAMBDA_DIST_BUCKET        --body "us-west-2.opendata.source.coop"
+gh variable set LAMBDA_DIST_PREFIX        --body "englacial/zagg/lambda"
 gh variable set LAMBDA_AWS_REGION         --body "us-west-2"
 ```
+
+`LAMBDA_DIST_BUCKET`/`LAMBDA_DIST_PREFIX` are the Source Cooperative mirror since
+issue #497 — `sliderule-public-cors` cannot host public data under NASA's
+clearance posture and is being retired (issue #499). **Set them only after Source
+Cooperative grants `zagg-lambda-release` write access at `englacial/*`**: until
+every variable above exists, `distribute` (and with it `deploy-prod`) skips, and
+a release still attaches the zips to the GitHub Release.
 
 Protect the production deploy:
 

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -513,17 +513,16 @@ gh variable set BENCHMARK_TEST_STAGE_BUCKET  --body "sliderule-public"
 # Release (tier 3)
 gh variable set LAMBDA_RELEASE_ROLE_ARN   --body "arn:aws:iam::ACCOUNT_ID:role/zagg-lambda-release"
 gh variable set LAMBDA_PROD_FUNCTION_NAME --body "process-shard"
-gh variable set LAMBDA_DIST_BUCKET        --body "us-west-2.opendata.source.coop"
-gh variable set LAMBDA_DIST_PREFIX        --body "englacial/zagg/lambda"
+gh variable set LAMBDA_DIST_BUCKET        --body "sliderule-public-cors"
 gh variable set LAMBDA_AWS_REGION         --body "us-west-2"
 ```
 
-`LAMBDA_DIST_BUCKET`/`LAMBDA_DIST_PREFIX` are the Source Cooperative mirror since
-issue #497 — `sliderule-public-cors` cannot host public data under NASA's
-clearance posture and is being retired (issue #499). **Set them only after Source
-Cooperative grants `zagg-lambda-release` write access at `englacial/*`**: until
-every variable above exists, `distribute` (and with it `deploy-prod`) skips, and
-a release still attaches the zips to the GitHub Release.
+Until every variable above exists, `distribute` (and with it `deploy-prod`)
+skips, and a release still attaches the zips to the GitHub Release. The
+distribution destination moves to the Source Cooperative mirror under issue #497
+— `distribute_zips.sh` already takes the `--prefix` that mirror needs, and
+`sliderule-public-cors` cannot host public data under NASA's clearance posture
+(issue #499) — but `publish.yml` is not yet pointed at it.
 
 Protect the production deploy:
 

--- a/docs/deployment/benchmark-cicd.md
+++ b/docs/deployment/benchmark-cicd.md
@@ -431,13 +431,16 @@ the section-2 stack (`benchmark_cicd.yaml`). Their grants, for reference:
     `s3://us-west-2.opendata.source.coop/englacial/zagg/lambda/*` (plus the
     repo-root `README.md`/`LICENSE` keys), and an **unconditioned**
     `s3:ListBucket` on that bucket — the Source Cooperative mirror (issue #497).
-    `PutObjectAcl` travels with `PutObject`: every write carries
-    `x-amz-acl: bucket-owner-full-control` and the two halves are only correct
-    together (issue #496). The `ListBucket` grant carries no `s3:prefix`
-    condition on purpose — with one, an absent key answers 403 instead of 404
-    and `distribute_zips.sh` would reseed `versions.json` instead of merging
-    into it. `englacial/zagg/benchmarks/*` is deliberately **not** granted
-    (issue #497 question (1) is open).
+    `PutObjectAcl` travels with `PutObject`: a write carrying
+    `x-amz-acl: bucket-owner-full-control` needs both halves (issue #496).
+    `distribute_zips.sh` sends that header to a published destination;
+    `publish_mirror.sh` sends none, so the two repo-root keys it alone writes are
+    granted but not yet reachable under this role. The `ListBucket` grant carries
+    no `s3:prefix` condition on purpose — with one, an absent key answers 403
+    instead of 404, and `distribute_zips.sh` seeds `versions.json` only on a
+    genuine miss and treats any other read failure as fatal, so a conditioned
+    grant would fail every release. `englacial/zagg/benchmarks/*` is deliberately
+    **not** granted (issue #497 question (1) is open).
 
 **Verify:** `aws iam get-role --role-name zagg-benchmark-deploy` /
 `zagg-lambda-release`.

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -637,6 +637,19 @@ MIRROR_SCRIPT = REPO / "deployment" / "aws" / "publish_mirror.sh"
 SOURCE_COOP = "arn:aws:s3:::us-west-2.opendata.source.coop"
 
 
+def _cicd_roles():
+    """Every IAM role benchmark_cicd.yaml provisions.
+
+    Derived, not typed out: the sweeps below exist to catch a stray
+    ``s3:PutObjectAcl`` or a widened source.coop grant, and a role added to this
+    stack later is exactly where one would appear.
+    """
+    tpl = _load_cfn(CICD)
+    roles = [k for k, v in tpl["Resources"].items() if v.get("Type") == "AWS::IAM::Role"]
+    assert roles, f"no AWS::IAM::Role resources found in {CICD}"
+    return roles
+
+
 def _mirror_destination():
     """(bucket, prefix) publish_mirror.sh defaults to, read from its shell defaults.
 
@@ -691,7 +704,7 @@ def test_put_object_acl_is_granted_on_the_published_destination_only():
     # the same rule template.yaml's execution role follows for
     # sliderule-public-cors.
     published = _arns(_statement("ReleaseRole", "PublishToSourceCoop"))
-    for role in ("ReleaseRole", "DeployRole", "BenchmarkInvokeRole"):
+    for role in _cicd_roles():
         for stmt in _role_statements(role):
             if "s3:PutObjectAcl" in _actions(stmt):
                 assert _arns(stmt) == published, (
@@ -725,7 +738,7 @@ def test_release_role_does_not_pre_empt_the_benchmarks_prefix():
     # reach it -- nor the fleet's demo/ prefix (template.yaml, issue #495).
     reachable = {
         arn
-        for role in ("ReleaseRole", "DeployRole", "BenchmarkInvokeRole")
+        for role in _cicd_roles()
         for stmt in _role_statements(role)
         for arn in _arns(stmt)
         if isinstance(arn, str) and "source.coop" in arn

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -706,12 +706,13 @@ def test_published_list_bucket_is_unconditional():
     # 2026-08-20).
     assert _actions(bucket) == ["s3:ListBucket"]
     # An s3:prefix condition would make absent objects 403 instead of 404 (a
-    # GetObject evaluation carries no s3:prefix context key), and
-    # distribute_zips.sh cannot tell a 403 on versions.json from a clean miss --
-    # it would reseed the index and drop every published minor from it.
+    # GetObject evaluation carries no s3:prefix context key). distribute_zips.sh
+    # seeds versions.json only on a miss and treats any other read failure as
+    # fatal, so the condition would not corrupt the index -- it would fail every
+    # release instead, which is no better a place to discover it.
     assert "Condition" not in bucket, (
         "an s3:prefix condition on ListBucket makes absent objects 403 instead "
-        "of 404, which reseeds versions.json instead of merging into it"
+        "of 404, which distribute_zips.sh reads as a failed index read, not a miss"
     )
 
 

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -665,11 +665,14 @@ def test_release_role_reaches_exactly_the_mirror_keys():
 
 
 def test_published_grant_carries_the_acl_and_multipart_halves():
-    # PutObjectAcl is load-bearing, not incidental: every write carries
-    # x-amz-acl: bucket-owner-full-control, which S3 evaluates against
-    # s3:PutObjectAcl on PutObject AND on CreateMultipartUpload -- without it
-    # the first published PUT 403s (issue #496: the two halves are only correct
-    # together). The multipart pair covers the failure path PutObject does not:
+    # PutObjectAcl is load-bearing, not incidental: distribute_zips.sh sends
+    # x-amz-acl: bucket-owner-full-control to a published destination, and S3
+    # evaluates it against s3:PutObjectAcl on PutObject AND on
+    # CreateMultipartUpload -- without the grant that PUT 403s (issue #496: the
+    # two halves are only correct together). publish_mirror.sh sends no ACL, so
+    # the two repo-root keys it alone writes are not yet reachable under this
+    # role; that is raised on the PR, not fixed here (issue #497 does not name
+    # it). The multipart pair covers the failure path PutObject does not:
     # the CLI's own abort of an in-flight layer upload would otherwise 403 and
     # leak parts billed to Source Cooperative. DeleteObject is deliberately
     # absent -- a re-published minor overwrites, and the mirror never prunes.

--- a/tests/test_deploy_lambda.py
+++ b/tests/test_deploy_lambda.py
@@ -393,14 +393,38 @@ def _template_named_twins():
     return twins
 
 
-def _statement_arns(role, sid):
-    """The !Sub ARN strings of the role's Sid=<sid> policy statement."""
+def _role_statements(role):
+    """The inline policy statements of a benchmark_cicd.yaml CI/CD role."""
     tpl = _load_cfn(CICD)
-    statements = tpl["Resources"][role]["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
-    stmt = next(s for s in statements if s.get("Sid") == sid)
-    resource = stmt["Resource"]
+    return tpl["Resources"][role]["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
+
+
+def _statement(role, sid):
+    """The role's Sid=<sid> policy statement."""
+    return next(s for s in _role_statements(role) if s.get("Sid") == sid)
+
+
+def _actions(statement):
+    """A statement's Action entries, whether scalar or list.
+
+    Normalizing first is load-bearing: ``"s3:Foo" in statement["Action"]`` is a
+    substring test rather than a membership test when Action is a scalar string,
+    and this template carries both shapes.
+    """
+    action = statement.get("Action")
+    return action if isinstance(action, list) else [action]
+
+
+def _arns(statement):
+    """A statement's Resource ARNs, ``!Sub`` flattened."""
+    resource = statement["Resource"]
     items = resource if isinstance(resource, list) else [resource]
     return [item["Sub"] if isinstance(item, dict) else item for item in items]
+
+
+def _statement_arns(role, sid):
+    """The !Sub ARN strings of the role's Sid=<sid> policy statement."""
+    return _arns(_statement(role, sid))
 
 
 def _script_default_variants():
@@ -599,3 +623,113 @@ def test_role_statements_enumerate_exact_arns():
             assert "*" not in arn, (
                 f"{role}.{sid} in {CICD} must enumerate exact ARNs, found wildcard: {arn}"
             )
+
+
+# --- Source Cooperative publication grant (issue #497 phase 1) --------------
+# The EXISTING zagg-lambda-release role gets S3 write on zagg's Source
+# Cooperative prefix -- it already had the right trust domain (GitHub Actions
+# OIDC) and needed permissions, not an identity. Same statement shape as the
+# fleet's published grant in template.yaml (issue #495, asserted in
+# tests/test_lambda_build.py); the roles stay separate because the trust
+# domains genuinely differ.
+
+MIRROR_SCRIPT = REPO / "deployment" / "aws" / "publish_mirror.sh"
+SOURCE_COOP = "arn:aws:s3:::us-west-2.opendata.source.coop"
+
+
+def _mirror_destination():
+    """(bucket, prefix) publish_mirror.sh defaults to, read from its shell defaults.
+
+    Read from the script rather than restated, so the grant is pinned to the
+    destination the mirror actually writes and not to a copy of it that drifts.
+    """
+    text = MIRROR_SCRIPT.read_text()
+    bucket = re.search(r'^MIRROR_BUCKET="\$\{MIRROR_BUCKET:-([^}]+)\}"', text, re.MULTILINE)
+    prefix = re.search(r'^MIRROR_PREFIX="\$\{MIRROR_PREFIX:-([^}]+)\}"', text, re.MULTILINE)
+    assert bucket and prefix, f"MIRROR_BUCKET/MIRROR_PREFIX defaults not found in {MIRROR_SCRIPT}"
+    return bucket.group(1), prefix.group(1)
+
+
+def test_release_role_reaches_exactly_the_mirror_keys():
+    bucket, prefix = _mirror_destination()
+    # publish_mirror.sh's own repo-root block: MIRROR_REPO_PREFIX=${MIRROR_PREFIX%/lambda}.
+    repo_prefix = prefix.removesuffix("/lambda")
+    assert repo_prefix != prefix, f"{MIRROR_SCRIPT} no longer publishes under a lambda/ prefix"
+    assert _arns(_statement("ReleaseRole", "PublishToSourceCoop")) == [
+        f"arn:aws:s3:::{bucket}/{prefix}/*",
+        # Enumerated exact keys, not an englacial/zagg/* wildcard: the repo-root
+        # index + license are the only things outside lambda/ the mirror writes.
+        f"arn:aws:s3:::{bucket}/{repo_prefix}/README.md",
+        f"arn:aws:s3:::{bucket}/{repo_prefix}/LICENSE",
+    ]
+
+
+def test_published_grant_carries_the_acl_and_multipart_halves():
+    # PutObjectAcl is load-bearing, not incidental: every write carries
+    # x-amz-acl: bucket-owner-full-control, which S3 evaluates against
+    # s3:PutObjectAcl on PutObject AND on CreateMultipartUpload -- without it
+    # the first published PUT 403s (issue #496: the two halves are only correct
+    # together). The multipart pair covers the failure path PutObject does not:
+    # the CLI's own abort of an in-flight layer upload would otherwise 403 and
+    # leak parts billed to Source Cooperative. DeleteObject is deliberately
+    # absent -- a re-published minor overwrites, and the mirror never prunes.
+    assert sorted(_actions(_statement("ReleaseRole", "PublishToSourceCoop"))) == [
+        "s3:AbortMultipartUpload",
+        "s3:GetObject",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+    ]
+
+
+def test_put_object_acl_is_granted_on_the_published_destination_only():
+    # The canned ACL is not sent to the dist bucket (we already own those
+    # objects), so granting PutObjectAcl there would be unexplained privilege --
+    # the same rule template.yaml's execution role follows for
+    # sliderule-public-cors.
+    published = _arns(_statement("ReleaseRole", "PublishToSourceCoop"))
+    for role in ("ReleaseRole", "DeployRole", "BenchmarkInvokeRole"):
+        for stmt in _role_statements(role):
+            if "s3:PutObjectAcl" in _actions(stmt):
+                assert _arns(stmt) == published, (
+                    f"{role} grants s3:PutObjectAcl outside the published destination: "
+                    f"{_arns(stmt)}"
+                )
+
+
+def test_published_list_bucket_is_unconditional():
+    bucket = _statement("ReleaseRole", "ListSourceCoopBucket")
+    assert _arns(bucket) == [SOURCE_COOP]
+    # s3:ListBucket ONLY. ListBucketMultipartUploads is bucket-wide (s3:prefix
+    # cannot constrain it), so Source Cooperative's bucket policy does not grant
+    # it and holding it here would be denied cross-account anyway (espg,
+    # 2026-08-20).
+    assert _actions(bucket) == ["s3:ListBucket"]
+    # An s3:prefix condition would make absent objects 403 instead of 404 (a
+    # GetObject evaluation carries no s3:prefix context key), and
+    # distribute_zips.sh cannot tell a 403 on versions.json from a clean miss --
+    # it would reseed the index and drop every published minor from it.
+    assert "Condition" not in bucket, (
+        "an s3:prefix condition on ListBucket makes absent objects 403 instead "
+        "of 404, which reseeds versions.json instead of merging into it"
+    )
+
+
+def test_release_role_does_not_pre_empt_the_benchmarks_prefix():
+    # Whether zagg-bench-*/zagg-examples/* migrate to englacial/zagg/benchmarks/
+    # is question (1) of issue #497 and is unresolved, so the grant must not
+    # reach it -- nor the fleet's demo/ prefix (template.yaml, issue #495).
+    reachable = {
+        arn
+        for role in ("ReleaseRole", "DeployRole", "BenchmarkInvokeRole")
+        for stmt in _role_statements(role)
+        for arn in _arns(stmt)
+        if isinstance(arn, str) and "source.coop" in arn
+    }
+    assert not any(
+        arn.startswith(f"{SOURCE_COOP}/englacial/zagg/benchmarks") for arn in reachable
+    ), "issue #497 question (1) is unresolved -- the grant must not pre-empt benchmarks/"
+    assert not any(
+        arn in (f"{SOURCE_COOP}/englacial/*", f"{SOURCE_COOP}/englacial/zagg/*")
+        for arn in reachable
+    ), "the fine-grained split lives on our side -- do not grant the whole org prefix"

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -27,7 +27,9 @@ WORKFLOW = REPO / ".github" / "workflows" / "publish.yml"
 
 # A stub `aws` CLI: logs every `s3 cp`, fails the versions.json *download* unless
 # a seed exists in $SEED_DIR, and captures every *upload* into $CAPTURE_DIR so the
-# test can read back what the script produced.
+# test can read back what the script produced. The download failure carries the
+# CLI's real 404 wording, because the script now discriminates on it; $READ_ERROR
+# overrides it to stand in for a failure that is NOT a clean miss.
 STUB_AWS = """#!/bin/bash
 set -euo pipefail
 if [ "$1" = "s3" ] && [ "$2" = "cp" ]; then
@@ -37,6 +39,8 @@ if [ "$1" = "s3" ] && [ "$2" = "cp" ]; then
     # download: serve a seeded versions.json if present, else fail (not found).
     base="$(basename "$SRC")"
     if [ -f "$SEED_DIR/$base" ]; then cp "$SEED_DIR/$base" "$DST"; exit 0; fi
+    echo "${READ_ERROR:-fatal error: An error occurred (404) when calling the \
+HeadObject operation: Key \\"$SRC\\" does not exist}" >&2
     exit 1
   else
     # upload: capture under the destination key.
@@ -57,11 +61,15 @@ MIRROR_BUCKET = "us-west-2.opendata.source.coop"
 MIRROR_PREFIX = "englacial/zagg/lambda"
 
 
-def _run(tmp_path, *, seed_versions=None, bucket=MIRROR_BUCKET, prefix=MIRROR_PREFIX):
-    """Run the script against the stub and return (destination root, aws log).
+def _prepare(
+    tmp_path, *, seed_versions=None, bucket=MIRROR_BUCKET, prefix=MIRROR_PREFIX, read_error=None
+):
+    """Build the stub harness; return (argv, env, destination root).
 
     The root is the captured tree under ``prefix``, so a caller asserting on
     ``root / "0.3" / ...`` is asserting the prefixed key, not just the tail.
+    ``read_error`` makes the index download fail with something other than a
+    clean miss, for the callers that assert the script refuses to seed on it.
     """
     if not shutil.which("sha256sum"):
         pytest.skip("sha256sum not available")
@@ -94,13 +102,20 @@ def _run(tmp_path, *, seed_versions=None, bucket=MIRROR_BUCKET, prefix=MIRROR_PR
         "SEED_DIR": str(seed_dir),
         "CAPTURE_DIR": str(capture),
     }
+    if read_error is not None:
+        env["READ_ERROR"] = read_error
     argv = ["bash", str(SCRIPT), "--minor", "0.3", "--tag", "0.3.1", "--bucket", bucket]
     if prefix:
         argv += ["--prefix", prefix]
     argv += ["--dir", str(zips)]
+    return argv, env, (capture / prefix if prefix else capture)
+
+
+def _run(tmp_path, **kwargs):
+    """Run the script against the stub and return (destination root, aws log)."""
+    argv, env, root = _prepare(tmp_path, **kwargs)
     subprocess.run(argv, check=True, env=env, cwd=tmp_path)
-    log = (tmp_path / "aws.log").read_text()
-    return capture / prefix if prefix else capture, log
+    return root, (tmp_path / "aws.log").read_text()
 
 
 def test_uploads_four_zips_and_sums(tmp_path):
@@ -129,6 +144,25 @@ def test_versions_index_merges_and_sorts(tmp_path):
     # New minor merged; sorted numerically (0.10 > 0.3, not lexically); latest correct.
     assert index["minors"] == ["0.1", "0.2", "0.3", "0.10"]
     assert index["latest"] == "0.10"
+
+
+def test_a_read_failure_that_is_not_a_miss_never_reseeds_the_index(tmp_path):
+    # Fold review: the index read used to swallow every failure into the seed
+    # branch, and the very next statement PUTs the seed back over the good index.
+    # A throttle, a 5xx, an expired session or a typo'd --prefix would drop every
+    # published minor with no DeleteObject in sight. Only a miss may seed.
+    argv, env, root = _prepare(
+        tmp_path,
+        read_error=(
+            "fatal error: An error occurred (403) when calling the HeadObject "
+            "operation: Forbidden"
+        ),
+    )
+    result = subprocess.run(argv, env=env, cwd=tmp_path, capture_output=True, text=True)
+    assert result.returncode != 0
+    # ...and it says why: the CLI's own message survives instead of 2>/dev/null.
+    assert "versions.json" in result.stderr and "403" in result.stderr
+    assert not (root / "versions.json").exists(), "a failed read must not republish the index"
 
 
 def test_index_lives_under_the_prefix_not_the_bucket_root(tmp_path):

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -152,13 +152,8 @@ def test_a_read_failure_that_is_not_a_miss_never_reseeds_the_index(tmp_path):
     # branch, and the very next statement PUTs the seed back over the good index.
     # A throttle, a 5xx, an expired session or a typo'd --prefix would drop every
     # published minor with no DeleteObject in sight. Only a miss may seed.
-    argv, env, root = _prepare(
-        tmp_path,
-        read_error=(
-            "fatal error: An error occurred (403) when calling the HeadObject "
-            "operation: Forbidden"
-        ),
-    )
+    denied = "An error occurred (403) when calling the HeadObject operation: Forbidden"
+    argv, env, root = _prepare(tmp_path, read_error=f"fatal error: {denied}")
     result = subprocess.run(argv, env=env, cwd=tmp_path, capture_output=True, text=True)
     assert result.returncode != 0
     # ...and it says why: the CLI's own message survives instead of 2>/dev/null.

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -6,10 +6,11 @@ versions.json index at the destination root. The versions.json read-modify-write
 is the part with real logic, so it's covered against both the seed (absent) and
 merge paths.
 
-Since issue #497 the destination is Source Cooperative under a key prefix, so
-the ``--prefix`` layout and the ``bucket-owner-full-control`` ACL that Source
-Cooperative requires (issue #495 phase 1) are covered too -- including the
-in-account bucket case, where the ACL must NOT be sent.
+Since issue #497 the script also supports Source Cooperative under a key prefix
+(``publish.yml`` is not pointed at it yet), so the ``--prefix`` layout and the
+``bucket-owner-full-control`` ACL that destination requires (issue #495 phase 1)
+are covered too -- including the in-account bucket case that runs today, where
+the ACL must NOT be sent.
 """
 
 import json
@@ -54,9 +55,9 @@ exit 0
 """
 
 
-#: The release destination since issue #497: Source Cooperative, under the same
+#: The destination issue #497 prepares for -- Source Cooperative, under the same
 #: <prefix>/<minor>/<zip> layout publish_mirror.sh writes and stand_up.sh's
-#: DIST_PREFIX already reads.
+#: DIST_PREFIX already reads. Not yet what publish.yml passes.
 MIRROR_BUCKET = "us-west-2.opendata.source.coop"
 MIRROR_PREFIX = "englacial/zagg/lambda"
 

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -225,6 +225,11 @@ def test_errors_when_zip_count_wrong(tmp_path):
 # so retargeting the distribution destination silently breaks the prod deploy
 # unless BOTH jobs follow it. These pin the coupling itself rather than the
 # literal destination, which is a repo-variable and moves with the mirror.
+#
+# Fold review: they pin the *use* of each destination variable, not only its
+# declaration -- binding DIST_PREFIX in `env` and leaving `--layer-key` alone is
+# the likeliest way to half-apply the wiring, and it points publish-layer-version
+# at an un-prefixed key that is outside the grant.
 
 
 def _publish_jobs():
@@ -234,7 +239,15 @@ def _publish_jobs():
 
 
 def _step_with(job, needle):
-    return next(s for s in job["steps"] if needle in s.get("run", ""))
+    step = next((s for s in job["steps"] if needle in s.get("run", "")), None)
+    assert step is not None, f"no step of {job.get('name', '?')} runs {needle}"
+    return step
+
+
+def _arg(run, flag):
+    """The quoted value ``flag`` is given in a shell invocation ("" if absent)."""
+    match = re.search(rf'{re.escape(flag)}\s+"([^"]*)"', run)
+    return match.group(1) if match else ""
 
 
 def test_prod_deploy_gates_on_everything_distribute_does():
@@ -255,16 +268,30 @@ def test_prod_deploy_carries_every_destination_var_distribute_uses():
     # Whatever LAMBDA_DIST_* distribute writes to, deploy-prod must read from --
     # otherwise the layer key it publishes points at the old destination.
     jobs = _publish_jobs()
-    written = {
-        var
-        for var in re.findall(
-            r"vars\.(\w+)", _step_with(jobs["distribute"], "distribute_zips.sh")["run"]
-        )
-        if var.startswith("LAMBDA_DIST_")
-    }
-    read = {
-        var
-        for value in _step_with(jobs["deploy-prod"], "deploy_lambda.sh")["env"].values()
-        for var in re.findall(r"vars\.(\w+)", str(value))
-    }
+    dist = _step_with(jobs["distribute"], "distribute_zips.sh")["run"]
+    prod = _step_with(jobs["deploy-prod"], "deploy_lambda.sh")
+    written = {var for var in re.findall(r"vars\.(\w+)", dist) if var.startswith("LAMBDA_DIST_")}
+    # env NAME -> the vars.* it is bound to, so the binding can be followed into
+    # the command rather than stopping at the `env` block.
+    bound = {name: set(re.findall(r"vars\.(\w+)", str(v))) for name, v in prod["env"].items()}
+    read = set().union(*bound.values())
     assert written and written <= read, f"deploy-prod does not follow {written - read}"
+    # Bound is not used: a destination variable declared in `env` and never
+    # referenced by the command leaves the deploy pointing at the old layout.
+    for name, sources in bound.items():
+        if sources & written:
+            assert re.search(rf"\$\{{?{name}\b", prod["run"]), (
+                f"deploy-prod binds {name} but its command never uses it, so the "
+                f"layer it publishes does not follow {sorted(sources & written)}"
+            )
+    # ...and the prefix distribute writes UNDER has to reach the layer KEY
+    # specifically (the bucket reaches --layer-bucket instead). Vacuous until the
+    # workflow half of phase 2 lands and `distribute` grows its --prefix.
+    prefix_vars = set(re.findall(r"vars\.(\w+)", _arg(dist, "--prefix")))
+    layer_key = _arg(prod["run"], "--layer-key")
+    for name, sources in bound.items():
+        if sources & prefix_vars:
+            assert name in layer_key, (
+                f"deploy-prod's --layer-key ({layer_key!r}) is not built from {name}, so "
+                f"publish-layer-version reads the un-prefixed key distribute never wrote"
+            )

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -134,9 +134,12 @@ def test_versions_index_merges_and_sorts(tmp_path):
 def test_index_lives_under_the_prefix_not_the_bucket_root(tmp_path):
     # The mirror bucket's root is another organization's namespace -- the index
     # belongs beside the minors, and stand_up.sh reads it there (dist_root()).
+    # Asserted on the s3:// ARGUMENTS rather than as a substring of the log, so
+    # the test states the destination instead of relying on how the line reads.
     root, log = _run(tmp_path)
-    assert f"s3://{MIRROR_BUCKET}/{MIRROR_PREFIX}/versions.json" in log
-    assert f"s3://{MIRROR_BUCKET}/versions.json " not in log
+    targets = {arg for ln in log.splitlines() for arg in ln.split() if arg.startswith("s3://")}
+    index = f"s3://{MIRROR_BUCKET}/{MIRROR_PREFIX}/versions.json"
+    assert {t for t in targets if t.endswith("/versions.json")} == {index}
     assert (root / "versions.json").exists()
 
 

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -186,18 +186,11 @@ def test_errors_when_zip_count_wrong(tmp_path):
     assert "expected 4 zips" in result.stderr
 
 
-# --- publish.yml wiring (issue #497 phase 2) --------------------------------
-# The prod deploy publishes its layer version straight out of whatever
-# `distribute` staged, so the two jobs must agree on bucket AND prefix. They
-# skip together too: `deploy-prod` needs `distribute`, and the "no unstaged-layer
-# deploy" safety rests on that skip propagating.
-
-GATED_VARS = {
-    "LAMBDA_RELEASE_ROLE_ARN",
-    "LAMBDA_DIST_BUCKET",
-    "LAMBDA_DIST_PREFIX",
-    "LAMBDA_AWS_REGION",
-}
+# --- publish.yml release-job coupling (issue #497 phase 2) ------------------
+# `deploy-prod` publish-layer-versions straight out of what `distribute` staged,
+# so retargeting the distribution destination silently breaks the prod deploy
+# unless BOTH jobs follow it. These pin the coupling itself rather than the
+# literal destination, which is a repo-variable and moves with the mirror.
 
 
 def _publish_jobs():
@@ -210,29 +203,34 @@ def _step_with(job, needle):
     return next(s for s in job["steps"] if needle in s.get("run", ""))
 
 
-def test_release_jobs_gate_on_every_destination_var():
-    # An unset prefix would aim the release at the mirror bucket's ROOT --
-    # another organization's namespace -- so it is gated, not defaulted. A
-    # release before Source Cooperative grants the role (issue #497 question
-    # (4)) must SKIP and still attach zips to the GitHub Release.
+def test_prod_deploy_gates_on_everything_distribute_does():
+    # The "no unstaged-layer deploy" safety rests on distribute's skip
+    # propagating, so a var that can make distribute skip must make deploy-prod
+    # skip too -- a partial config must skip, never half-deploy prod.
     jobs = _publish_jobs()
-    for name in ("distribute", "deploy-prod"):
-        gated = set(re.findall(r"vars\.(\w+)", jobs[name]["if"]))
-        assert GATED_VARS <= gated, f"{name} does not gate on {GATED_VARS - gated}"
+    gates = {
+        name: set(re.findall(r"vars\.(\w+)", jobs[name]["if"]))
+        for name in jobs
+        if "if" in jobs[name]
+    }
+    assert gates["distribute"], "distribute is ungated -- a release with no AWS config would fail"
+    assert gates["distribute"] <= gates["deploy-prod"]
 
 
-def test_prod_deploy_reads_the_layer_key_distribute_wrote():
+def test_prod_deploy_carries_every_destination_var_distribute_uses():
+    # Whatever LAMBDA_DIST_* distribute writes to, deploy-prod must read from --
+    # otherwise the layer key it publishes points at the old destination.
     jobs = _publish_jobs()
-    assert (
-        '--prefix "${{ vars.LAMBDA_DIST_PREFIX }}"'
-        in _step_with(jobs["distribute"], "distribute_zips.sh")["run"]
-    )
-    # ...and the script really lays the objects out as <prefix>/<minor>/<zip>.
-    assert '"$BASE/$MINOR/$(basename "$z")"' in SCRIPT.read_text()
-    deploy = _step_with(jobs["deploy-prod"], "deploy_lambda.sh")
-    assert deploy["env"]["DIST_PREFIX"] == "${{ vars.LAMBDA_DIST_PREFIX }}"
-    assert deploy["env"]["DIST_BUCKET"] == "${{ vars.LAMBDA_DIST_BUCKET }}"
-    assert (
-        '--layer-key "${DIST_PREFIX:+$DIST_PREFIX/}${MINOR}/lambda_layer_arm64.zip"'
-        in (deploy["run"])
-    )
+    written = {
+        var
+        for var in re.findall(
+            r"vars\.(\w+)", _step_with(jobs["distribute"], "distribute_zips.sh")["run"]
+        )
+        if var.startswith("LAMBDA_DIST_")
+    }
+    read = {
+        var
+        for value in _step_with(jobs["deploy-prod"], "deploy_lambda.sh")["env"].values()
+        for var in re.findall(r"vars\.(\w+)", str(value))
+    }
+    assert written and written <= read, f"deploy-prod does not follow {written - read}"

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -158,6 +158,21 @@ def test_every_upload_hands_the_object_to_the_bucket_owner(tmp_path):
     assert downloads and all("--acl" not in ln for ln in downloads)
 
 
+def test_the_scripts_published_bucket_list_matches_the_fleets():
+    # Fold review: the list lives in two places -- here and in
+    # zagg.store._PUBLISHED_BUCKETS -- and the drift is silent in the expensive
+    # direction. If the mirror moves (or a second published bucket is added on
+    # the fleet's side) this script's `case` stops matching, $ACL stays empty,
+    # and the first PUT is AccessDenied at release time, on a tag, after PyPI
+    # has already published. The ACL half is exactly what issue #496 established
+    # you cannot get wrong by halves.
+    from zagg.store import _PUBLISHED_BUCKETS
+
+    match = re.search(r'^PUBLISHED_BUCKETS="([^"]*)"', SCRIPT.read_text(), re.MULTILINE)
+    assert match, f"PUBLISHED_BUCKETS not found in {SCRIPT}"
+    assert set(match.group(1).split()) == set(_PUBLISHED_BUCKETS)
+
+
 def test_no_acl_against_a_bucket_we_own(tmp_path):
     # Keyed on the destination, mirroring zagg.store._PUBLISHED_BUCKETS: the
     # release role holds s3:PutObjectAcl on the mirror ONLY, so sending the

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -183,6 +183,22 @@ def test_no_acl_against_a_bucket_we_own(tmp_path):
     assert (root / "versions.json").exists()
 
 
+def test_refuses_a_published_bucket_without_a_prefix(tmp_path):
+    # Fold review: the only thing keeping a release out of the mirror bucket's
+    # root -- another organization's namespace, and outside the grant -- was the
+    # workflow's `vars.LAMBDA_DIST_PREFIX != ''` gate. Flipping LAMBDA_DIST_BUCKET
+    # to the mirror is one `gh variable set`, so the script holds the invariant
+    # itself and the workflow gate is defence in depth. Refused before any upload:
+    # no --dir contents are needed to reach it.
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--minor", "0.3", "--bucket", MIRROR_BUCKET, "--dir", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "--prefix is required" in result.stderr
+
+
 def test_errors_when_zip_count_wrong(tmp_path):
     if not shutil.which("sha256sum"):
         pytest.skip("sha256sum not available")

--- a/tests/test_distribute_zips.py
+++ b/tests/test_distribute_zips.py
@@ -2,12 +2,19 @@
 
 Runs the real script with a stub ``aws`` on PATH (no network), and asserts it
 uploads the four zips + SHA256SUMS under the minor prefix and maintains the
-top-level versions.json index. The versions.json read-modify-write is the part
-with real logic, so it's covered against both the seed (absent) and merge paths.
+versions.json index at the destination root. The versions.json read-modify-write
+is the part with real logic, so it's covered against both the seed (absent) and
+merge paths.
+
+Since issue #497 the destination is Source Cooperative under a key prefix, so
+the ``--prefix`` layout and the ``bucket-owner-full-control`` ACL that Source
+Cooperative requires (issue #495 phase 1) are covered too -- including the
+in-account bucket case, where the ACL must NOT be sent.
 """
 
 import json
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -16,6 +23,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / ".github" / "scripts" / "distribute_zips.sh"
+WORKFLOW = REPO / ".github" / "workflows" / "publish.yml"
 
 # A stub `aws` CLI: logs every `s3 cp`, fails the versions.json *download* unless
 # a seed exists in $SEED_DIR, and captures every *upload* into $CAPTURE_DIR so the
@@ -24,7 +32,7 @@ STUB_AWS = """#!/bin/bash
 set -euo pipefail
 if [ "$1" = "s3" ] && [ "$2" = "cp" ]; then
   SRC="$3"; DST="$4"
-  echo "$SRC -> $DST" >> "$AWS_LOG"
+  echo "$*" >> "$AWS_LOG"
   if [[ "$SRC" == s3://* ]]; then
     # download: serve a seeded versions.json if present, else fail (not found).
     base="$(basename "$SRC")"
@@ -42,7 +50,19 @@ exit 0
 """
 
 
-def _run(tmp_path, *, seed_versions=None):
+#: The release destination since issue #497: Source Cooperative, under the same
+#: <prefix>/<minor>/<zip> layout publish_mirror.sh writes and stand_up.sh's
+#: DIST_PREFIX already reads.
+MIRROR_BUCKET = "us-west-2.opendata.source.coop"
+MIRROR_PREFIX = "englacial/zagg/lambda"
+
+
+def _run(tmp_path, *, seed_versions=None, bucket=MIRROR_BUCKET, prefix=MIRROR_PREFIX):
+    """Run the script against the stub and return (destination root, aws log).
+
+    The root is the captured tree under ``prefix``, so a caller asserting on
+    ``root / "0.3" / ...`` is asserting the prefixed key, not just the tail.
+    """
     if not shutil.which("sha256sum"):
         pytest.skip("sha256sum not available")
     bindir = tmp_path / "bin"
@@ -74,29 +94,17 @@ def _run(tmp_path, *, seed_versions=None):
         "SEED_DIR": str(seed_dir),
         "CAPTURE_DIR": str(capture),
     }
-    subprocess.run(
-        [
-            "bash",
-            str(SCRIPT),
-            "--minor",
-            "0.3",
-            "--tag",
-            "0.3.1",
-            "--bucket",
-            "sliderule-public-cors",
-            "--dir",
-            str(zips),
-        ],
-        check=True,
-        env=env,
-        cwd=tmp_path,
-    )
+    argv = ["bash", str(SCRIPT), "--minor", "0.3", "--tag", "0.3.1", "--bucket", bucket]
+    if prefix:
+        argv += ["--prefix", prefix]
+    argv += ["--dir", str(zips)]
+    subprocess.run(argv, check=True, env=env, cwd=tmp_path)
     log = (tmp_path / "aws.log").read_text()
-    return capture, log
+    return capture / prefix if prefix else capture, log
 
 
 def test_uploads_four_zips_and_sums(tmp_path):
-    capture, log = _run(tmp_path)
+    root, log = _run(tmp_path)
     for name in (
         "lambda_layer_arm64.zip",
         "lambda_layer_x86_64.zip",
@@ -104,23 +112,57 @@ def test_uploads_four_zips_and_sums(tmp_path):
         "lambda_function_x86_64_py312.zip",
         "SHA256SUMS",
     ):
-        assert (capture / "0.3" / name).exists(), f"{name} not uploaded under 0.3/"
+        assert (root / "0.3" / name).exists(), f"{name} not uploaded under {MIRROR_PREFIX}/0.3/"
 
 
 def test_versions_index_seeds_when_absent(tmp_path):
-    capture, _ = _run(tmp_path)  # no seed -> download fails -> seed {"minors": []}
-    index = json.loads((capture / "versions.json").read_text())
+    root, _ = _run(tmp_path)  # no seed -> download fails -> seed {"minors": []}
+    index = json.loads((root / "versions.json").read_text())
     assert index["minors"] == ["0.3"]
     assert index["latest"] == "0.3"
     assert index["latest_tag"] == "0.3.1"
 
 
 def test_versions_index_merges_and_sorts(tmp_path):
-    capture, _ = _run(tmp_path, seed_versions={"minors": ["0.1", "0.10", "0.2"]})
-    index = json.loads((capture / "versions.json").read_text())
+    root, _ = _run(tmp_path, seed_versions={"minors": ["0.1", "0.10", "0.2"]})
+    index = json.loads((root / "versions.json").read_text())
     # New minor merged; sorted numerically (0.10 > 0.3, not lexically); latest correct.
     assert index["minors"] == ["0.1", "0.2", "0.3", "0.10"]
     assert index["latest"] == "0.10"
+
+
+def test_index_lives_under_the_prefix_not_the_bucket_root(tmp_path):
+    # The mirror bucket's root is another organization's namespace -- the index
+    # belongs beside the minors, and stand_up.sh reads it there (dist_root()).
+    root, log = _run(tmp_path)
+    assert f"s3://{MIRROR_BUCKET}/{MIRROR_PREFIX}/versions.json" in log
+    assert f"s3://{MIRROR_BUCKET}/versions.json " not in log
+    assert (root / "versions.json").exists()
+
+
+def test_every_upload_hands_the_object_to_the_bucket_owner(tmp_path):
+    # Source Cooperative requires x-amz-acl: bucket-owner-full-control on every
+    # write (issue #495 phase 1); without it the first PUT is AccessDenied. It
+    # must reach the index too, not just the zips -- the index is re-PUT on
+    # every release.
+    _, log = _run(tmp_path)
+    uploads = [ln for ln in log.splitlines() if not ln.split()[2].startswith("s3://")]
+    assert len(uploads) == 6, f"expected 4 zips + SHA256SUMS + versions.json, got: {uploads}"
+    for line in uploads:
+        assert "--acl bucket-owner-full-control" in line, f"ACL missing on upload: {line}"
+    # ...and never on the READ: `aws s3 cp s3://... ./versions.json` takes no ACL.
+    downloads = [ln for ln in log.splitlines() if ln.split()[2].startswith("s3://")]
+    assert downloads and all("--acl" not in ln for ln in downloads)
+
+
+def test_no_acl_against_a_bucket_we_own(tmp_path):
+    # Keyed on the destination, mirroring zagg.store._PUBLISHED_BUCKETS: the
+    # release role holds s3:PutObjectAcl on the mirror ONLY, so sending the
+    # header at the in-account dist bucket would 403 rather than help.
+    root, log = _run(tmp_path, bucket="sliderule-public-cors", prefix="")
+    assert "--acl" not in log
+    assert (root / "0.3" / "SHA256SUMS").exists()
+    assert (root / "versions.json").exists()
 
 
 def test_errors_when_zip_count_wrong(tmp_path):
@@ -142,3 +184,55 @@ def test_errors_when_zip_count_wrong(tmp_path):
     )
     assert result.returncode != 0
     assert "expected 4 zips" in result.stderr
+
+
+# --- publish.yml wiring (issue #497 phase 2) --------------------------------
+# The prod deploy publishes its layer version straight out of whatever
+# `distribute` staged, so the two jobs must agree on bucket AND prefix. They
+# skip together too: `deploy-prod` needs `distribute`, and the "no unstaged-layer
+# deploy" safety rests on that skip propagating.
+
+GATED_VARS = {
+    "LAMBDA_RELEASE_ROLE_ARN",
+    "LAMBDA_DIST_BUCKET",
+    "LAMBDA_DIST_PREFIX",
+    "LAMBDA_AWS_REGION",
+}
+
+
+def _publish_jobs():
+    import yaml
+
+    return yaml.safe_load(WORKFLOW.read_text())["jobs"]
+
+
+def _step_with(job, needle):
+    return next(s for s in job["steps"] if needle in s.get("run", ""))
+
+
+def test_release_jobs_gate_on_every_destination_var():
+    # An unset prefix would aim the release at the mirror bucket's ROOT --
+    # another organization's namespace -- so it is gated, not defaulted. A
+    # release before Source Cooperative grants the role (issue #497 question
+    # (4)) must SKIP and still attach zips to the GitHub Release.
+    jobs = _publish_jobs()
+    for name in ("distribute", "deploy-prod"):
+        gated = set(re.findall(r"vars\.(\w+)", jobs[name]["if"]))
+        assert GATED_VARS <= gated, f"{name} does not gate on {GATED_VARS - gated}"
+
+
+def test_prod_deploy_reads_the_layer_key_distribute_wrote():
+    jobs = _publish_jobs()
+    assert (
+        '--prefix "${{ vars.LAMBDA_DIST_PREFIX }}"'
+        in _step_with(jobs["distribute"], "distribute_zips.sh")["run"]
+    )
+    # ...and the script really lays the objects out as <prefix>/<minor>/<zip>.
+    assert '"$BASE/$MINOR/$(basename "$z")"' in SCRIPT.read_text()
+    deploy = _step_with(jobs["deploy-prod"], "deploy_lambda.sh")
+    assert deploy["env"]["DIST_PREFIX"] == "${{ vars.LAMBDA_DIST_PREFIX }}"
+    assert deploy["env"]["DIST_BUCKET"] == "${{ vars.LAMBDA_DIST_BUCKET }}"
+    assert (
+        '--layer-key "${DIST_PREFIX:+$DIST_PREFIX/}${MINOR}/lambda_layer_arm64.zip"'
+        in (deploy["run"])
+    )


### PR DESCRIPTION
Closes #497. Refs #495 (the fleet's half of the same identity model), #499 (retirement of the dist bucket), #496 (the ACL / `PutObjectAcl` pairing).

## What this does

Phases 1 and 2 of issue #497: the **our-side, git-tracked** half of moving the Lambda deployment artifacts to Source Cooperative. Everything here is inert until Source Cooperative grants `arn:aws:iam::742127912612:role/zagg-lambda-release` write access at `englacial/*` (issue #497 question (4)), and **nothing goes live on merge** — the IAM change takes effect only when an account admin re-applies the `benchmark_cicd.yaml` stack, and the `distribute` job stays skipped until the repo variables are set. **No live-AWS command was run.**

Phase 2 landed **partially**, for an environment reason, not a design one — see "What did not land" below.

### Phase 1 — grant the existing `ReleaseRole` write access to Source Cooperative

`deployment/aws/benchmark_cicd.yaml`. No new role: `zagg-lambda-release` already exists with a stable explicit name (`RoleName: !Ref ReleaseRoleName`) and exactly the right trust domain (GitHub Actions OIDC, `sts:AssumeRoleWithWebIdentity`), so it needed S3 permissions, not an identity. It stays separate from the fleet's `zagg-lambda-execution` because the trust domains genuinely differ — a CI run cannot write datacubes and a person cannot publish releases.

Two statements, mirroring the shape *and* the reasoning of the `ExecutionRole` published-destination grant in `deployment/aws/template.yaml` (lines ~246-309):

```yaml
- Sid: PublishToSourceCoop
  Effect: Allow
  Action: [s3:GetObject, s3:PutObject, s3:PutObjectAcl,
           s3:AbortMultipartUpload, s3:ListMultipartUploadParts]
  Resource:
    - arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/lambda/*
    - arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/README.md
    - arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/LICENSE
- Sid: ListSourceCoopBucket
  Effect: Allow
  Action: s3:ListBucket
  Resource: arn:aws:s3:::us-west-2.opendata.source.coop
```

- The two repo-root keys are the ones `deployment/aws/publish_mirror.sh` also writes, from its `MIRROR_REPO_PREFIX="${MIRROR_PREFIX%/lambda}"` block — enumerated as **exact keys** rather than an `englacial/zagg/*` wildcard, so the grant cannot reach `demo/` (the fleet's, issue #495) or `benchmarks/`.
- **`englacial/zagg/benchmarks/*` is deliberately NOT granted** — that is question (1) of issue #497 and is unresolved. See "Questions for review".
- `s3:PutObjectAcl` travels with `s3:PutObject`: a write carrying `x-amz-acl: bucket-owner-full-control` is evaluated against `s3:PutObjectAcl` on both `PutObject` and `CreateMultipartUpload`, so the two halves are only correct together (issue #496). Granted on this destination only — the header is not sent to the dist bucket, whose objects we already own. **Not every writer sends it yet:** `distribute_zips.sh` does; `publish_mirror.sh` sends no ACL on any of its five PUTs and is the only writer of the two repo-root keys, so those two are granted but unreachable under this role until that changes. Adversarial review caught this; it is question (8) below, not fixed here, because `publish_mirror.sh` is a `deployment/aws/` script issue #497 does not name (CLAUDE.md §1).
- The multipart pair covers the failure path `PutObject` does not (the CLI's own abort of an in-flight layer upload would otherwise 403 and leak parts billed to Source Cooperative). `s3:ListBucketMultipartUploads` is deliberately **not** granted: it is bucket-wide, `s3:prefix` cannot constrain it, Source Cooperative's bucket policy does not grant it, so holding it our side would be denied cross-account anyway (espg, 2026-08-20).
- `s3:ListBucket` is **unconditioned by intent**. An `s3:prefix` condition makes absent objects 403 instead of 404, and `distribute_zips.sh` seeds `versions.json` only on a genuine miss and treats every other read failure as fatal — so a conditioned grant would fail every release rather than corrupt the index.
- `s3:DeleteObject` is deliberately absent (unlike the fleet's grant): a re-published minor overwrites via `PutObject`, and the mirror never prunes.

The comment block around these two statements is deliberately short: the ACL, multipart and unconditioned-`ListBucket` rationale is argued once in `template.yaml`'s `ExecutionRole` grant and cross-referenced here, with only what differs on this role stated locally (adversarial review, b3b849e).

Also recorded, per the issue's "worth recording" note: a comment on `DistBucket` saying the live bucket's Block Public Access flags are **deliberate, not drift** (NASA buckets have no clearance to host public data), so the `BlockPublicPolicy: false` / `RestrictPublicBuckets: false` properties below it no longer read as though public access were intended. Comment only — no property changed.

### Phase 2 — retarget the distribution script to source.coop

**Approach taken, and why:** retarget `.github/scripts/distribute_zips.sh` with a `--prefix`, rather than folding in `publish_mirror.sh`'s layout. It is the smaller and more reviewable of the two, because the read side already speaks this dialect — `deployment/aws/stand_up.sh` has carried `DIST_PREFIX` with `dist_key()` / `dist_root()` helpers since issue #174:

```bash
DIST_PREFIX="${DIST_PREFIX:-}"                       # keys: [PREFIX/]MINOR/ZIP
dist_key()   { local p="$DIST_PREFIX"; [ -n "$p" ] && p="$p/"; echo "${p}${1}/${2}"; }
dist_root()  { local p="$DIST_PREFIX"; [ -n "$p" ] && p="$p/"; echo "${p}${1}"; }
```

So `--prefix englacial/zagg/lambda` produces byte-for-byte the layout `publish_mirror.sh` writes and `stand_up.sh` already reads, and the write side and read side finally match. Folding in `publish_mirror.sh` instead would have dragged along its per-minor `README.md` generation and repo-root metadata block — more surface, no new capability.

- **`bucket-owner-full-control` on the PUTs** (issue #495 phase 1), on all six uploads: the four zips, `SHA256SUMS`, and `versions.json`. Never on the read.
- The ACL is **keyed on the destination bucket**, mirroring `zagg.store._PUBLISHED_BUCKETS`, not sent unconditionally — the release role holds `s3:PutObjectAcl` on the mirror only, so an unconditional `--acl` would 403 against the in-account dist bucket. Pinned by `test_the_scripts_published_bucket_list_matches_the_fleets`.
- **A published bucket without a `--prefix` is refused, in the script** (d6336ee, adversarial review): its root is another organization's namespace and outside the grant, and the workflow-side `vars.LAMBDA_DIST_PREFIX != ''` gate lives in the half that could not be pushed. The invariant now holds in a landed artifact, with the workflow gate as defence in depth.
- **Only a genuinely absent index seeds `versions.json`** (ca634f1, adversarial review). The read used to swallow every failure into the seed branch and the next statement re-PUT the seed over the good index — a throttle, a 5xx, an expired session or a typo'd `--prefix` would silently drop every published minor. Now a miss seeds, anything else is fatal, and the CLI's own message survives instead of `2>/dev/null`.
- `versions.json` moves to `PREFIX/versions.json`, not the bucket root — the mirror bucket's root is another organization's namespace.
- The change is **backward compatible**: no `--prefix` and a non-published bucket reproduce today's behaviour exactly.

### What did not land, and why

**`.github/workflows/publish.yml` is not in this branch.** The workflow half was written and tested locally, then reverted: this run cannot push it. Both routes are refused:

```
! [remote rejected] claude/497-source-coop-publish -> claude/497-source-coop-publish
  (refusing to allow an OAuth App to create or update workflow
   `.github/workflows/publish.yml` without `workflow` scope)
```

...and the REST contents API returns the same 403. This is an environment restriction on the run, not a judgement about the change. **Question (5) below carries the exact patch** so it can be applied in one pass.

Consequence for tests: the two tests originally written to pin the workflow *literals* were replaced with tests that pin the **coupling** — `deploy-prod` gates on everything `distribute` gates on, and carries every `LAMBDA_DIST_*` variable `distribute` uses. Adversarial review then showed the coupling pair pinned the *declaration* of each variable and not its *use*, so applying question (5)'s patch minus the `--layer-key` line left both green while `publish-layer-version` pointed at an un-prefixed key. Strengthened in 99f5551: a destination variable bound in `deploy-prod`'s `env` must be referenced by its command, and the variable `distribute` passes to `--prefix` must appear in `deploy-prod`'s `--layer-key` argument specifically. Verified by re-running that exact mutation (fails) and the complete patch (passes) against a working-tree copy of the workflow that was reverted and never staged. Both assertions hold on the tree as it stands.

## Phases

- [x] **Phase 1** — `ReleaseRole` grant in `deployment/aws/benchmark_cicd.yaml` + tests (a36e7e3)
- [x] **Phase 2** — `distribute_zips.sh` `--prefix` + conditional ACL, + tests (f6ff6f2, 551746d)
- [ ] **Phase 2, workflow half** — `publish.yml` wiring. Blocked on `workflow` push scope; patch in question (5).
- [ ] ~~Phase 3~~ — backfill 0.9 → 0.48, publish `versions.json`. **Out of scope**: an operator action against live AWS (CLAUDE.md §1). Question (2).
- [ ] ~~Phase 4~~ — default `template.yaml`'s `ArtifactBucket`/`LayerS3Key`/`FunctionS3Key` at the public location. **Out of scope**: depends on phase 3 having populated the mirror. Question (3).
- [ ] ~~Phase 5~~ — rule the dist bucket's disposition. **Out of scope**: an espg decision, and issue #499 already rules that bucket post-MVP. Question (4).

Adversarial self-review ran after each phase. First pass: two diff-scoped findings folded (f2f7a9d, 91b2037), one left standing (question (6)). Second pass, folded one commit per finding — the in-script prefix guard (d6336ee), the coupling tests' use-not-declaration pin (99f5551), the narrowed index read (ca634f1), the present-tense header and docstring (4e78f33), the untrue "every write carries the ACL" sentence (7785845), the duplicated grant rationale (b3b849e), and the hard-coded role triple (2bb227c). One finding left standing: question (8). The review's own disclosure about *how* it ran is on its thread and repeated under question (7).

## How it was tested

**Phase 1** — assertions in `tests/test_deploy_lambda.py`, which is where `benchmark_cicd.yaml` already has coverage (it loads the template as `CICD` for the issue #341 ARN-drift guards) — extended rather than a new module. They mirror `test_execution_role_is_the_published_identity` in `tests/test_lambda_build.py`, reusing the same action/ARN normalization so an IAM-identical rewrite cannot fail them spuriously:

- `test_release_role_reaches_exactly_the_mirror_keys` — the granted ARNs are **derived from `publish_mirror.sh`'s own `MIRROR_BUCKET`/`MIRROR_PREFIX` shell defaults**, not restated, so retargeting the mirror without moving the grant fails here.
- `test_published_grant_carries_the_acl_and_multipart_halves` — the exact five actions: the `PutObject`/`PutObjectAcl` pairing, the multipart pair, and the absence of `DeleteObject`.
- `test_put_object_acl_is_granted_on_the_published_destination_only` — sweeps **every `AWS::IAM::Role` the template provisions**, derived via `_cicd_roles()` rather than a typed triple, so a role added later is swept too (2bb227c). Mutation-checked: a fourth role carrying a stray `PutObjectAcl` on `benchmarks/*` fails this and the benchmarks guard below.
- `test_published_list_bucket_is_unconditional` — `s3:ListBucket` only, no `Condition`, no `ListBucketMultipartUploads`.
- `test_release_role_does_not_pre_empt_the_benchmarks_prefix` — no statement on any provisioned role reaches `benchmarks/`, `englacial/*`, or `englacial/zagg/*`.

**Phase 2** — `tests/test_distribute_zips.py`, extended (it already runs the real script against a stub `aws` on `PATH`, no network): the prefixed layout, the index living under the prefix, the ACL on all six uploads and on none of the reads, the no-ACL path for a bucket we own, the script/fleet published-bucket list agreeing, the refusal of a published bucket with no prefix, the refusal to reseed the index on a read failure that is not a miss, and the two `publish.yml` coupling guards.

`uv run pytest -v tests/test_distribute_zips.py tests/test_deploy_lambda.py tests/test_lambda_build.py` → **76 passed**. Full suite `uv run pytest` → **4617 passed, 38 skipped**. `bash -n` clean on `distribute_zips.sh` (the repo wires no shellcheck). `uv run ruff check tests` clean; both touched test modules `ruff format --check` clean.

**Two pre-existing failures, not touched** — both reproduce on `origin/main` at 8dbb2fe and are unrelated to this change, so they are flagged rather than fixed (CLAUDE.md §4):
- `ruff check src tests` → `N818 Exception name 'UnknownCapability' should be named with an Error suffix` at `src/zagg/registry.py:64`.
- `ruff format --check src tests` → `tests/data/benchmark/README.md:176` would be reformatted (a fenced Python block inside a fixture README).

## Questions for review

1. **Does `englacial/zagg/benchmarks/*` join the grant?** (Issue #497 question (1).) The grant deliberately stops at `lambda/*` + the two repo-root keys. **(a)** leave it out until `zagg-bench-88s/*`, `zagg-bench-conus/*`, `zagg-examples/*` are ruled on together with issue #499's sidecar destination — the current state; **(b)** add `arn:aws:s3:::us-west-2.opendata.source.coop/englacial/zagg/benchmarks/*` to `PublishToSourceCoop` now, accepting an unused grant until something writes there; **(c)** rule that they lapse, and the question closes permanently. Recommendation: **(a)**.

2. **Phase 3 (backfill 0.9 → 0.48) is an operator action.** It runs `publish_mirror.sh` against live AWS, which CLAUDE.md §1 forbids this run from doing. **(a)** run `./deployment/aws/publish_mirror.sh MINOR --run RUN_ID` per minor by hand once the grant lands; **(b)** add a one-shot `workflow_dispatch` backfill job in a follow-up PR so the release role does it under OIDC — no long-lived credentials, but a new workflow job to review; **(c)** skip the backfill and publish forward from the next release only, accepting the cliff. Recommendation: **(b)** as a follow-up, since it reuses the grant this PR adds. **Note:** either route needs question (8) settled first — `publish_mirror.sh` sends no owner ACL today, so under `zagg-lambda-release` it 403s on its first zip.

3. **Phase 4 has a live-AWS unknown this PR cannot settle.** `publish-layer-version` reads the layer zip with the *caller's* credentials from a same-region bucket. `us-west-2.opendata.source.coop` is in-region and the release role now holds `s3:GetObject` on the prefix, so the CI path should work — but an **external** user's standup holds no such grant and must read the zip anonymously at `publish-layer-version` time. **(a)** confirm against live AWS that an unsigned / foreign-principal `publish-layer-version` from that bucket succeeds, before defaulting `ArtifactBucket`; **(b)** have `stand_up.sh` download the zip and re-upload to the user's own `STAGING_BUCKET` (it already has that parameter), trading a hop for certainty; **(c)** defer phase 4 entirely. Recommendation: **(a)** first, falling back to **(b)**.

4. **Phase 5 (dist bucket disposition) is deliberately untouched.** This PR only adds the comment recording *why* it 403s. Confirm phase 5 is fully subsumed by issue #499 and this PR should not carry it.

5. **The `publish.yml` patch this run could not push.** Apply as-is, or say how you'd rather have it. Three edits:
   - `distribute` — add `vars.LAMBDA_DIST_PREFIX != ''` to the `if:`, and `--prefix "${{ vars.LAMBDA_DIST_PREFIX }}"` to the `distribute_zips.sh` invocation. The prefix is **gated, not defaulted**: an unset prefix would aim the release at the mirror bucket's root, which is another organization's namespace and denied. (Since d6336ee the script also refuses that itself, so a missed gate fails loudly instead of 403-ing mid-release.)
   - `deploy-prod` — add the same `vars.LAMBDA_DIST_PREFIX != ''` gate (it already gates on every var it consumes), add `DIST_PREFIX: ${{ vars.LAMBDA_DIST_PREFIX }}` to the step `env`, and change the layer key to `--layer-key "${DIST_PREFIX:+$DIST_PREFIX/}${MINOR}/lambda_layer_arm64.zip"`. **All three edits are required together** — `test_prod_deploy_carries_every_destination_var_distribute_uses` now fails if `DIST_PREFIX` is bound and the `--layer-key` line is left alone.
   - Then `gh variable set LAMBDA_DIST_BUCKET --body "us-west-2.opendata.source.coop"` and `gh variable set LAMBDA_DIST_PREFIX --body "englacial/zagg/lambda"` — **only after** the Source Cooperative grant lands. Until every variable exists, `distribute` (and with it `deploy-prod`) skips and the release still attaches zips to the GitHub Release, which is the behaviour issue #497 asked to preserve.

   `docs/deployment/benchmark-cicd.md` §9 already documents the new grant; its §11 `gh variable set` block was left pointing at `sliderule-public-cors` on purpose, so the docs do not describe wiring that is not in the tree. It needs the two-line update when the patch lands.

6. **A standing grant on a bucket being retired.** `DistributeZips` keeps `s3:PutObject`/`s3:GetObject` on `${DistBucketName}/*`. Once the variables flip to the mirror, nothing writes there — and issue #499 is retiring that bucket. Not removed here: it is a scope change past phases 1-2, and it is still the live release path until the workflow half lands. Flagged so issue #499's retirement PR inherits the pointer. (Thread left open on the diff.)

7. **The adversarial self-review did not run the way CLAUDE.md §2 specifies.** §2 requires a *separate subagent with fresh context* on an Opus-class model for review, and another for the fold. The first review/fold pass ran in the same context that wrote the diff, because no agent-spawning tool was available then. The **second** pass did run as separate review and fold subagents, and it found seven further issues in code the first pass had already reviewed and signed off — including one false factual claim in a comment (question (8)) and a test that passed under a mutation it was written to catch. That is the fresh-context rule earning its keep; treat anything only the first pass looked at as reviewed by its own author.

8. **Two granted keys nothing can currently write.** `PublishToSourceCoop` grants `englacial/zagg/README.md` and `englacial/zagg/LICENSE`. `publish_mirror.sh` is the only writer of those keys and sends **no** `x-amz-acl: bucket-owner-full-control` on any of its five PUTs, so under `zagg-lambda-release` it would 403 on its first PUT — two of the three granted resources are unreachable in practice, and question (2)'s option (a) does not work as written. The false comment asserting otherwise is corrected (7785845); the reachability is not, because `publish_mirror.sh` is a `deployment/aws/` script issue #497 does not name (CLAUDE.md §1), which makes it a scope change rather than a fold. **(a)** authorize adding `--acl bucket-owner-full-control` to `publish_mirror.sh`'s five PUTs in a follow-up, keyed on `$MIRROR_BUCKET` the way `distribute_zips.sh` keys on `$BUCKET` so a self-hosted override still works; **(b)** drop the two repo-root keys from the grant until a writer sends the header; **(c)** accept them as write-once-by-hand under a human's own credentials. Recommendation: **(a)** — it is the only option that also unblocks question (2), and the mirror script is the natural owner of those keys.

## Blocked externally, not on a PR

Issue #497 question (4) says the issue is **blocked until Source Cooperative grants both ARNs at `englacial/*`**. That is an external party, not an unmerged PR, so this PR carries `waiting`, not `blocked`. Phases 1-2 are our-side git-tracked IAM policy and CI wiring: they land regardless and are inert until that grant exists.